### PR TITLE
Fixes #68

### DIFF
--- a/External/DTPinLock/DTPinLockController.m
+++ b/External/DTPinLock/DTPinLockController.m
@@ -506,8 +506,8 @@
 
 - (void)cancel:(id)sender
 {
-    [self.view endEditing:YES];
-    
+    [self dismissKeyboard];
+  
 	// if there is a delegate method, then we let it deal with it
 	if (pinLockDelegate && [pinLockDelegate respondsToSelector:@selector(pinLockControllerDidCancel)])
 	{


### PR DESCRIPTION
#68 
Keyboard couldn't be dismissed because `textFieldShouldEndEditing` returned false on iPad, when cancel button pressed.

```Objective-C
- (BOOL)textFieldShouldEndEditing:(UITextField *)textField
{
    if (shouldDismissKeyboard) {
        return YES;
    }
    
    // Don't allow keyboard to be dismissed on iPad
    return UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad;
}
```