### PR TITLE
#34 Add Print to the sharing action sheet

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1660,7 +1660,9 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     
     [SPTracker trackEditorNoteContentShared];
 	   
-    UIActivityViewController *acv = [[UIActivityViewController alloc] initWithActivityItems:@[_currentNote.content]
+    UISimpleTextPrintFormatter *print = [[UISimpleTextPrintFormatter alloc] initWithText:_currentNote.content];
+
+    UIActivityViewController *acv = [[UIActivityViewController alloc] initWithActivityItems:@[_currentNote.content, print]
                                                                       applicationActivities:nil];
     
     if ([UIDevice isPad]) {


### PR DESCRIPTION
#34 
Add a "UISimpleTextPrintFormatter" to the action sheet that allows the users to print notes. 

```objective-c
UISimpleTextPrintFormatter *print = [[UISimpleTextPrintFormatter alloc] initWithText:_currentNote.content];
UIActivityViewController *acv = [[UIActivityViewController alloc] initWithActivityItems:@[_currentNote.content, print]
                                                                      applicationActivities:nil];
```
