### PR TITLE
Issues/80: Action sheet buttons should now work correctly on iPad.

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -50,8 +50,6 @@
     // sheets
     SPActivityView *noteActivityView;
     SPActionSheet *noteActionSheet;
-    UIPopoverController *noteActionPopover;
-    UIPopoverArrowDirection *sharePopover;
     SPActionSheet *versionActionSheet;
     UIActionSheet *deleteActionSheet;
     

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -689,6 +689,14 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     }
 }
 
+// The activity sheet breaks when transitioning from a popover to a modal-style
+// presentation, so we'll tell it not to change its presentation if the
+// view's size class changes.
+- (UIModalPresentationStyle)adaptivePresentationStyleForPresentationController:(UIPresentationController *)controller
+{
+    return UIModalPresentationNone;
+}
+
 #pragma mark - SPInteractivePushViewControllerProvider (Markdown Preview)
 
 - (UIViewController *)nextViewControllerForInteractivePush
@@ -1418,6 +1426,10 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
         popoverVC.popoverPresentationController.sourceRect = ((UIView *)sender).bounds;
         popoverVC.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
         popoverVC.popoverPresentationController.delegate = self;
+
+        UIColor *actionSheetColor = [[self.theme colorForKey:@"actionSheetBackgroundColor"] colorWithAlphaComponent:0.97];
+        popoverVC.popoverPresentationController.backgroundColor = actionSheetColor;
+
         [self presentViewController:popoverVC animated:YES completion:nil];
     } else {
         noteActionSheet = [SPActionSheet showActionSheetInView:self.navigationController.view
@@ -1430,10 +1442,9 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 }
 
 - (void)dismissActivityView {
-    
-    // Popover Scenario:
-    [noteActionPopover dismissPopoverAnimated:NO];
-    noteActionPopover = nil;
+    if (self.presentedViewController) {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }
 
     // ActionSheet Scenario
     [noteActionSheet dismiss];
@@ -1666,11 +1677,11 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
                                                                       applicationActivities:nil];
     
     if ([UIDevice isPad]) {
-        noteActionPopover = [[UIPopoverController alloc] initWithContentViewController:acv];
-        [noteActionPopover presentPopoverFromRect:[self presentationRectForActionButton]
-                                           inView:self.view
-                         permittedArrowDirections:UIPopoverArrowDirectionAny
-                                         animated:YES];
+        acv.modalPresentationStyle = UIModalPresentationPopover;
+        acv.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
+        acv.popoverPresentationController.sourceRect = [self presentationRectForActionButton];
+        acv.popoverPresentationController.sourceView = self.view;
+        [self presentViewController:acv animated:YES completion:nil];
     } else {
         [self.navigationController presentViewController:acv animated:YES completion:nil];
     }
@@ -1692,13 +1703,13 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     
     UIActivityViewController *acv = [[UIActivityViewController alloc] initWithActivityItems:@[publishURL]
                                                                       applicationActivities:@[safariActivity]];
-    
+
     if ([UIDevice isPad]) {
-        noteActionPopover = [[UIPopoverController alloc] initWithContentViewController:acv];
-        [noteActionPopover presentPopoverFromRect:[self presentationRectForActionButton]
-                                           inView:self.view
-                         permittedArrowDirections:UIPopoverArrowDirectionAny
-                                         animated:YES];
+        acv.modalPresentationStyle = UIModalPresentationPopover;
+        acv.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
+        acv.popoverPresentationController.sourceRect = [self presentationRectForActionButton];
+        acv.popoverPresentationController.sourceView = self.view;
+        [self presentViewController:acv animated:YES completion:nil];
     } else {
         [self.navigationController presentViewController:acv animated:YES completion:nil];
     }


### PR DESCRIPTION
Fixes #79 and #80. 

The action button popover had been changed from using UIPopoverController (deprecated) to presenting with a modal presentation style. Because it now presents as a view controller, this was blocking the subsequent presentation of other view controllers. We now dismiss the action popover before displaying share / collaborate.

Also blocked the popover from adapting its style whilst presented to fix a layout issue when:

* Viewing the app on iPad with another app in a narrow multitasking split on the right.
* Show the popover
* Rotate to portrait

Normally the popover would adapt to show as a modal, but it doesn't lay itself back out correctly. The simplest fix seems to be to retain the popover presentation in this layout.

I've also updated the background colour of the popover to make the contrast match the action sheet (#79).

### To test:

* On iPad, try using the Send and Collaborate buttons in the note action popover!

Needs review: @jleandroperez 