### PR TITLE
Updates Markdown localization strings with English placeholders.

### DIFF
--- a/Simplenote/Classes/SPMarkdownPreviewViewController.m
+++ b/Simplenote/Classes/SPMarkdownPreviewViewController.m
@@ -24,7 +24,7 @@
 {
     [super viewDidLoad];
     
-    self.title = NSLocalizedString(@"markdown-preview-title", @"Title of Markdown preview screen");
+    self.title = NSLocalizedString(@"Preview", @"Title of Markdown preview screen");
     
     [self configureWebView];
     [self applyStyle];
@@ -65,7 +65,7 @@
     self.webView.backgroundColor = backgroundColor;
     self.webView.opaque = NO;
 
-    UIBarButtonItem *backButton = [UIBarButtonItem backBarButtonWithTitle:NSLocalizedString(@"markdown-back-button-title", @"Title of Back button for Markdown preview")
+    UIBarButtonItem *backButton = [UIBarButtonItem backBarButtonWithTitle:NSLocalizedString(@"Back", @"Title of Back button for Markdown preview")
                                                                     target:self
                                                                     action:@selector(backButtonAction:)];
 

--- a/Simplenote/en.lproj/Localizable.strings
+++ b/Simplenote/en.lproj/Localizable.strings
@@ -391,5 +391,5 @@
 "How can we help?" = "How can we help?";
 
 /* Markdown Preview */
-"markdown-preview-title" = "Preview";
-"markdown-back-button-title" = "Back";
+"Preview" = "Preview";
+"Back" = "Back";


### PR DESCRIPTION
See title :)

Some users reported an issue where these strings weren't localized to their language and they were seeing the placeholder strings:

<img width="464" alt="screen shot 2016-08-26 at 21 26 54" src="https://cloud.githubusercontent.com/assets/4780/18019410/d5cb7ec2-6bd3-11e6-86da-eeaa9d3aefb5.png">

So I've changed the placeholder strings to be in English, so it should at least be more readable.

Needs review: @jleandroperez 