### PR TITLE
Fixes Collaboration Crash

### DIFF
--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSContactsUsageDescription</key>
+	<string>This app requires contacts access to properly share data with other users.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
### Testing:
1. Open a specific note.
2. Press the "Info" button on the top of the screen.
3. Press the "Collaborate" button in the panel that is displayed from the bottom.
4. Press the top right "Done" button

As a result, the app shouldn't crash anymore. Props to @Chanryma for reporting this one.

Closes #96

Needs Review: @roundhill 
Thanks in advance Dan!!
