### PR TITLE
Fixing duplicate symbol issues

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1474,7 +1474,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 120A86031FEA806F779515C0 /* Pods-Automattic-Simplenote.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
@@ -1520,7 +1520,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 50598176A2CE081E99C2E695 /* Pods-Automattic-Simplenote.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
@@ -1556,6 +1556,7 @@
 		B50789F61C1F4F5A009F097A /* Distribution AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1613,7 +1614,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B6C1D37AEEF2D6D7B8CA1407 /* Pods-Automattic-Simplenote.distribution appstore.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
@@ -1653,6 +1654,7 @@
 		B50789FA1C1F4F63009F097A /* Distribution Internal */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1710,7 +1712,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A0290D16DDD82B07B4D2B5B5 /* Pods-Automattic-Simplenote.distribution internal.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
@@ -1752,6 +1754,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 142BB042A41077A3F1E05F57 /* Pods-Automattic-SimplenoteShare.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_ENTITLEMENTS = SimplenoteShare/SimplenoteShare.entitlements;
@@ -1779,6 +1782,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EC63A736071A5E8129D97C5B /* Pods-Automattic-SimplenoteShare.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_ENTITLEMENTS = SimplenoteShare/SimplenoteShare.entitlements;
@@ -1806,6 +1810,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3ADF01B37A9429A7D6FAC94C /* Pods-Automattic-SimplenoteShare.distribution internal.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-Beta";
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_ENTITLEMENTS = SimplenoteShare/SimplenoteShare.entitlements;
@@ -1834,6 +1839,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D805D59818FC99438F2F637 /* Pods-Automattic-SimplenoteShare.distribution appstore.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CODE_SIGN_ENTITLEMENTS = "SimplenoteShare/SimplenoteShare-AppStore.entitlements";
@@ -1866,6 +1872,7 @@
 		E29ADD6217848E8500E55842 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1913,6 +1920,7 @@
 		E29ADD6317848E8500E55842 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";

--- a/Simplenote/Classes/SPInteractiveTextStorage.h
+++ b/Simplenote/Classes/SPInteractiveTextStorage.h
@@ -1,8 +1,8 @@
-
 #import <UIKit/UIKit.h>
 
-NSString *const SPDefaultTokenName;
-NSString *const SPHeadlineTokenName;
+
+extern NSString *const SPDefaultTokenName;
+extern NSString *const SPHeadlineTokenName;
 
 @interface SPInteractiveTextStorage : NSTextStorage
 

--- a/Simplenote/Classes/SPInteractiveTextStorage.m
+++ b/Simplenote/Classes/SPInteractiveTextStorage.m
@@ -13,7 +13,7 @@ NSString *const SPHeadlineTokenName = @"SPHeadlineTokenName";
 
 @implementation SPInteractiveTextStorage
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self) {

--- a/Simplenote/Classes/SPOptionsViewController.h
+++ b/Simplenote/Classes/SPOptionsViewController.h
@@ -22,7 +22,7 @@
 
 @end
 
-NSString *const SPCondensedNoteListPref;
-NSString *const SPCondensedNoteListPreferenceChangedNotification;
-NSString *const SPAlphabeticalSortPref;
-NSString *const SPAlphabeticalSortPreferenceChangedNotification;
+extern NSString *const SPCondensedNoteListPref;
+extern NSString *const SPCondensedNoteListPreferenceChangedNotification;
+extern NSString *const SPAlphabeticalSortPref;
+extern NSString *const SPAlphabeticalSortPreferenceChangedNotification;

--- a/Simplenote/Classes/SPTransitionController.h
+++ b/Simplenote/Classes/SPTransitionController.h
@@ -8,10 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const SPTransitionControllerPopGestureTriggeredNotificationName;
-
-//NSString *const SPTransitionControllerWillPopView;
-//NSString *const SPTransitionControllerDidPopView;
+extern NSString *const SPTransitionControllerPopGestureTriggeredNotificationName;
 
 
 @protocol SPTransitionControllerDelegate <NSObject>

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -761,50 +761,6 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     }
     
     return;
-    
-    
-    if (sender.numberOfTouches < 2)
-        return;
-    
-    CGPoint point1 = [sender locationOfTouch:0 inView:sender.view];
-    CGPoint point2 = [sender locationOfTouch:1 inView:sender.view];
-    CGFloat distance = sqrt((point1.x - point2.x) * (point1.x - point2.x) + (point1.y - point2.y) * (point1.y - point2.y));
-    
-    if (sender.state == UIGestureRecognizerStateBegan) {
-        
-        if (self.hasActiveInteraction || _transitioning)
-            return;
-        
-        self.initialPinchDistance = distance;
-        self.hasActiveInteraction = TRUE;
-        [self.delegate interactionBegan];
-        return;
-    }
-    
-    if (!self.hasActiveInteraction)
-        return;
-    
-    if (sender.state == UIGestureRecognizerStateChanged) {
-        
-        CGFloat distanceDelta = distance - self.initialPinchDistance;
-        if (self.navigationOperation == UINavigationControllerOperationPop)
-            distanceDelta = -distanceDelta;
-    
-        CGFloat dimension = sqrt(sender.view.bounds.size.width*sender.view.bounds.size.width + sender.view.bounds.size.height*sender.view.bounds.size.height) * 0.25;
-        percentComplete = MAX(MIN((distanceDelta / dimension), 1.0), 0.0);
-        
-        [self animateTransitionSnapshotsToPercentCompletion:percentComplete animated:NO decrementUseCount:NO];
-        return;
-    }
-    
-    if (sender.state == UIGestureRecognizerStateCancelled) {
-        
-        [self endInteractionWithSuccess:FALSE];
-        return;
-    } else {
-        [self endInteractionWithSuccess:TRUE];
-        return;
-    }
 }
 
 - (void)postPopGestureNotification {

--- a/Simplenote/Classes/SPTransitionSnapshot.h
+++ b/Simplenote/Classes/SPTransitionSnapshot.h
@@ -8,17 +8,17 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const SPAnimationAlphaValueName;
-NSString *const SPAnimationFrameValueName;
+extern NSString *const SPAnimationAlphaValueName;
+extern NSString *const SPAnimationFrameValueName;
 
-NSString *const SPAnimationInitialValueName;
-NSString *const SPAnimationFinalValueName;
+extern NSString *const SPAnimationInitialValueName;
+extern NSString *const SPAnimationFinalValueName;
 
-NSString *const SPAnimationDurationName;
-NSString *const SPAnimationDelayName;
-NSString *const SPAnimationSpringDampingName;
-NSString *const SPAnimationInitialVeloctyName;
-NSString *const SPAnimationOptionsName;
+extern NSString *const SPAnimationDurationName;
+extern NSString *const SPAnimationDelayName;
+extern NSString *const SPAnimationSpringDampingName;
+extern NSString *const SPAnimationInitialVeloctyName;
+extern NSString *const SPAnimationOptionsName;
 
 @interface SPTransitionSnapshot : NSObject {
     

--- a/Simplenote/Classes/SPTransitionSnapshot.m
+++ b/Simplenote/Classes/SPTransitionSnapshot.m
@@ -22,7 +22,7 @@ NSString *const SPAnimationOptionsName = @"SPAnimationOptionsName";
 
 @implementation SPTransitionSnapshot
 
-- (id)initWithSnapshot:(UIView *)snapshot animatedValues:(NSDictionary *)animatedValues animationProperties:(NSDictionary *)animationProperties superView:(UIView *)superView {
+- (instancetype)initWithSnapshot:(UIView *)snapshot animatedValues:(NSDictionary *)animatedValues animationProperties:(NSDictionary *)animationProperties superView:(UIView *)superView {
     
     self = [super init];
     if (self) {

--- a/Simplenote/DB5/VSThemeManager.h
+++ b/Simplenote/DB5/VSThemeManager.h
@@ -10,9 +10,9 @@
 #import "VSTheme.h"
 #import "VSThemeLoader.h"
 
-NSString *const VSThemeManagerThemeWillChangeNotification;
-NSString *const VSThemeManagerThemeDidChangeNotification;
-NSString *const VSThemeManagerThemePrefKey;
+extern NSString *const VSThemeManagerThemeWillChangeNotification;
+extern NSString *const VSThemeManagerThemeDidChangeNotification;
+extern NSString *const VSThemeManagerThemePrefKey;
 
 @interface VSThemeManager : NSObject
 


### PR DESCRIPTION
### Details:
As a side effect of the new warnings, we're getting few symbol collisions. In this PR we're simply adding the `extern` modifier, when needed.
