### PR TITLE
Spotlight: Handling App Upgrades

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,7 +27,7 @@ abstract_target 'Automattic' do
 		# Automattic
 		#
 		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.1.0'
-		pod 'Simperium', '0.8.17'
+		pod 'Simperium', '0.8.18'
 		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '479d05f7d6b963c9b44040e6ea9f190e8bd9a47a'
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 	end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,17 +23,17 @@ PODS:
     - hoedown/standard (= 3.0.3)
   - hoedown/standard (3.0.3)
   - Reachability (3.2)
-  - Simperium (0.8.17):
-    - Simperium/DiffMatchPach (= 0.8.17)
-    - Simperium/JRSwizzle (= 0.8.17)
-    - Simperium/SocketTrust (= 0.8.17)
-    - Simperium/SPReachability (= 0.8.17)
-    - Simperium/SSKeychain (= 0.8.17)
-  - Simperium/DiffMatchPach (0.8.17)
-  - Simperium/JRSwizzle (0.8.17)
-  - Simperium/SocketTrust (0.8.17)
-  - Simperium/SPReachability (0.8.17)
-  - Simperium/SSKeychain (0.8.17)
+  - Simperium (0.8.18):
+    - Simperium/DiffMatchPach (= 0.8.18)
+    - Simperium/JRSwizzle (= 0.8.18)
+    - Simperium/SocketTrust (= 0.8.18)
+    - Simperium/SPReachability (= 0.8.18)
+    - Simperium/SSKeychain (= 0.8.18)
+  - Simperium/DiffMatchPach (0.8.18)
+  - Simperium/JRSwizzle (0.8.18)
+  - Simperium/SocketTrust (0.8.18)
+  - Simperium/SPReachability (0.8.18)
+  - Simperium/SSKeychain (0.8.18)
   - SSKeychain (1.2.2)
   - SVProgressHUD (1.1.2)
   - UIDeviceIdentifier (0.5.0)
@@ -48,7 +48,7 @@ DEPENDENCIES:
   - GoogleAnalytics (= 3.14.0)
   - HockeySDK (~> 3.8.0)
   - hoedown (~> 3.0.3)
-  - Simperium (= 0.8.17)
+  - Simperium (= 0.8.18)
   - SSKeychain (= 1.2.2)
   - SVProgressHUD (= 1.1.2)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
@@ -80,13 +80,13 @@ SPEC CHECKSUMS:
   HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
   hoedown: c1327bbbc96d269595ed86bf97f1d09867ec7529
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  Simperium: 0111b16b6d72bc598a99e244ef87025ae433b27e
+  Simperium: 285f68e419bbf076b0ef271ba0f9dd21529678d6
   SSKeychain: 88767e903ee8d274ed380e364d96b7a101235286
   SVProgressHUD: 3afb875b9eb23acd1bed9b82495695c68621a8b2
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-Ratings-iOS: b04108f7a45867844ba47a240bb6295ca747eebf
 
-PODFILE CHECKSUM: 2d182e50997cbe1e2b8976426df9b496171dd193
+PODFILE CHECKSUM: 4176cafdb2d6836a57703535773142ae341ab460
 
 COCOAPODS: 1.1.1

--- a/Simplenote/Classes/CSSearchable+Helpers.swift
+++ b/Simplenote/Classes/CSSearchable+Helpers.swift
@@ -18,7 +18,8 @@ extension CSSearchableItemAttributeSet {
             note.createPreview()
         }
         title = note.titlePreview
-        let index = note.preview.index(note.preview.startIndex, offsetBy: note.titlePreview.utf16.count)
+
+        let index = note.preview.index(note.preview.startIndex, offsetBy: note.titlePreview.characters.count)
         contentDescription = note.preview.substring(from: index)
     }
     

--- a/Simplenote/Classes/CSSearchable+Helpers.swift
+++ b/Simplenote/Classes/CSSearchable+Helpers.swift
@@ -39,7 +39,7 @@ extension CSSearchableIndex {
         let item = CSSearchableItem(note: note)
         indexSearchableItems([item]) { error in
             if let error = error {
-                NSLog("Couldn't index note in spotlight: \(error.localizedDescription)");
+                NSLog("Couldn't index note in spotlight: \(error.localizedDescription)")
             }
         }
     }
@@ -51,7 +51,7 @@ extension CSSearchableIndex {
         
         indexSearchableItems(items) { error in
             if let error = error {
-                NSLog("Couldn't index notes in spotlight: \(error.localizedDescription)");
+                NSLog("Couldn't index notes in spotlight: \(error.localizedDescription)")
             }
         }
     }
@@ -67,7 +67,7 @@ extension CSSearchableIndex {
         
         deleteSearchableItems(withIdentifiers: ids) { error in
             if let error = error {
-                NSLog("Couldn't delete notes from spotlight index: \(error.localizedDescription)");
+                NSLog("Couldn't delete notes from spotlight index: \(error.localizedDescription)")
             }
         }
     }

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -291,7 +291,10 @@
 	
     // Integrity Check: Fallback to GhostData, if needed
     [SPIntegrityHelper reloadInconsistentNotesIfNeeded:self.simperium];
-    
+
+    // Index (All of the) Spotlight Items if the user upgraded
+    [self indexSpotlightItemsIfNeeded];
+
     return YES;
 }
 
@@ -720,7 +723,33 @@
     }
 }
 
-- (void)indexSpotlightItems {
+
+#pragma mark ================================================================================
+#pragma mark Spotlight
+#pragma mark ================================================================================
+
+- (void)indexSpotlightItemsIfNeeded
+{
+    // This process should be executed *just once*, and only if the user is already logged in (AKA "Upgrade")
+    NSString *kSpotlightDidRunKey = @"SpotlightDidRunKey";
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+
+    if ([defaults boolForKey:kSpotlightDidRunKey] == true) {
+        return;
+    }
+
+    [defaults setBool:true forKey:kSpotlightDidRunKey];
+    [defaults synchronize];
+
+    if (self.simperium.user.authenticated == false) {
+        return;
+    }
+
+    [self indexSpotlightItems];
+}
+
+- (void)indexSpotlightItems
+{
     NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
     [context setParentContext:self.simperium.managedObjectContext];
     

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -295,8 +295,8 @@
     return YES;
 }
 
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler {
-
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
+{
     NSString *uniqueIdentifier = userActivity.userInfo[CSSearchableItemActivityIdentifier];
     if (uniqueIdentifier == nil) {
         return false;
@@ -729,6 +729,7 @@
     }];
 }
 
+
 #pragma mark ================================================================================
 #pragma mark URL scheme
 #pragma mark ================================================================================
@@ -773,7 +774,8 @@
     return true;
 }
 
-- (void)presentNote:(Note *)note {
+- (void)presentNote:(Note *)note
+{
     // Hide any modals
     [self dismissAllModalsAnimated:NO completion:nil];
     
@@ -793,6 +795,7 @@
         [self showPasscodeLockIfNecessary];
     });
 }
+
 
 #pragma mark ================================================================================
 #pragma mark Passcode Lock

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -638,26 +638,29 @@
 {
     if ([bucket.name isEqualToString:NSStringFromClass([Note class])]) {
         // Note change
-        Note *note;
         switch (change) {
-            case SPBucketChangeUpdate:
+            case SPBucketChangeTypeUpdate:
+            {
                 if ([key isEqualToString:_noteEditorViewController.currentNote.simperiumKey]) {
                     [_noteEditorViewController didReceiveNewContent];
                 }
-                note = [bucket objectForKey:key];
+                Note *note = [bucket objectForKey:key];
                 if (note && !note.deleted) {
                     [[CSSearchableIndex defaultSearchableIndex] indexSearchableNote:note];
                 } else {
                     [[CSSearchableIndex defaultSearchableIndex] deleteSearchableItemsWithIdentifiers:@[key] completionHandler:nil];
                 }
+            }
                 break;
-            case SPBucketChangeInsert:
+            case SPBucketChangeTypeInsert:
                 break;
-			case SPBucketChangeDelete:
+			case SPBucketChangeTypeDelete:
+            {
                 if ([key isEqualToString:_noteEditorViewController.currentNote.simperiumKey]) {
 					[_noteEditorViewController didDeleteCurrentNote];
 				}
                 [[CSSearchableIndex defaultSearchableIndex] deleteSearchableItemsWithIdentifiers:@[key] completionHandler:nil];
+            }
 				break;
             default:
                 break;
@@ -665,7 +668,8 @@
     } else if ([bucket.name isEqualToString:NSStringFromClass([Tag class])]) {
         // Tag deleted
         switch (change) {
-            case SPBucketChangeDelete: {
+            case SPBucketChangeTypeDelete:
+            {
                 // if selected tag is deleted, swap the note list view controller
                 if ([key isEqual:self.selectedTag]) {
                     self.selectedTag = nil;


### PR DESCRIPTION
### Details:
In this PR we're adding a simple mechanism to index all of the user's notes, whenever he upgrades from an older App version.

We're also bumping up the Simperium dependency to its latest version.

### Testing:
1. Check out develop [at this precise point](https://github.com/Automattic/simplenote-ios/commit/896de09703e1611ef50350a165560b2f865c67ca). (Reason: Spotlight was not supported there!)
2. Fresh install the app and log into your account
3. Install this branch (`issue/spotlight-upgrade-path`) on top of it
4. Verify that your notes were effectively indexed

@roundhill you game for a review?

cc @michalkosmowski  (Again, thank you Michal!)