### PR TITLE
Fixing Add Note Location on iPad

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -341,11 +341,8 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
                                       SPBarButtonYOriginAdjustment,
                                       buttonWidth,
                                       buttonHeight);
-    
-    CGFloat newButtonImageWidth = [newButton imageForState:UIControlStateNormal].size.width;
-    CGFloat newButtonPadding = isPad ? (buttonWidth - newButtonImageWidth) : buttonWidth;
-    
-    newButton.frame = CGRectMake(previousXOrigin - newButtonPadding,
+        
+    newButton.frame = CGRectMake(previousXOrigin - buttonWidth,
                                  SPBarButtonYOriginAdjustment,
                                  buttonWidth,
                                  buttonHeight);

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>4422</string>
+	<string>4423</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>
@@ -62,6 +62,8 @@
 	<string>This app requires contacts access to properly share data with other users.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app does not require Photo Library access.</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/SimplenoteShare/Info.plist
+++ b/SimplenoteShare/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4422</string>
+	<string>4423</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
### Steps:
1. Launch Simplenote on iPad 9.7 / 12.9
2. Log into your account
3. Open any note's details

Verify that the New Note button's location is correct.

Found this glitch while taking screenshots for the new release!
cc @roundhill 