### PR TITLE
Don’t dismiss presented views in the Editor if it is showing the pin lock.

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -130,10 +130,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
                                                  selector:@selector(didReceiveVoiceOverNotification:)
                                                      name:UIAccessibilityVoiceOverStatusChanged
                                                    object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(applicationWillResignActive:)
-                                                     name:UIApplicationWillResignActiveNotification
-                                                   object:nil];
     }
     
     return self;
@@ -284,10 +280,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 {
     [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
     [self refreshNavBarSizeWithCoordinator:coordinator];
-}
-
-- (void)applicationWillResignActive:(NSNotification *)notification {
-    [self dismissActivityView];
 }
 
 - (void)refreshNavBarSizeWithCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
@@ -1443,7 +1435,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 }
 
 - (void)dismissActivityView {
-    if (self.presentedViewController && ![[SPAppDelegate sharedDelegate] isPresentingPinLock]) {
+    if (self.presentedViewController) {
         [self dismissViewControllerAnimated:YES completion:nil];
     }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -21,7 +21,6 @@
 #import "SPObjectManager.h"
 #import "SPAddCollaboratorsViewController.h"
 #import "JSONKit+Simplenote.h"
-#import "DTPinLockController.h"
 #import "SPHorizontalPickerView.h"
 #import "SPVersionPickerViewCell.h"
 #import "SPPopoverContainerViewController.h"

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -21,6 +21,7 @@
 #import "SPObjectManager.h"
 #import "SPAddCollaboratorsViewController.h"
 #import "JSONKit+Simplenote.h"
+#import "DTPinLockController.h"
 #import "SPHorizontalPickerView.h"
 #import "SPVersionPickerViewCell.h"
 #import "SPPopoverContainerViewController.h"
@@ -1443,7 +1444,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 }
 
 - (void)dismissActivityView {
-    if (self.presentedViewController) {
+    if (self.presentedViewController && ![[SPAppDelegate sharedDelegate] isPresentingPinLock]) {
         [self dismissViewControllerAnimated:YES completion:nil];
     }
 

--- a/Simplenote/Classes/SPTagsListViewController.h
+++ b/Simplenote/Classes/SPTagsListViewController.h
@@ -34,5 +34,6 @@
 
 @property (nonatomic, retain) NSFetchedResultsController *fetchedResultsController;
 
+- (void)removeKeyboardObservers;
 
 @end

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -106,11 +106,6 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
            forCellReuseIdentifier:cellWithIconIdentifier];
     [self.tableView setTableHeaderView:[self buildTableHeaderView]];
     
-    // Register for keyboard notifications
-    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
-    [nc addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-    
     _tagImage = [[UIImage imageNamed:@"icon_tag"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     _settingsImage = [[UIImage imageNamed:@"icon_settings"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     _allNotesImage = [[UIImage imageNamed:@"icon_allnotes"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -124,6 +119,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
     [[UIMenuController sharedMenuController] setMenuItems:@[renameItem]];
     [[UIMenuController sharedMenuController] update];
     
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(menuDidChangeVisibility:) name:UIMenuControllerDidHideMenuNotification object:nil];
     [nc addObserver:self selector:@selector(menuDidChangeVisibility:) name:UIMenuControllerDidShowMenuNotification object:nil];
 
@@ -133,6 +129,11 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+    
+    // Register for keyboard notifications
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    [nc addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
+    [nc addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
 
     CGRect tableViewFrame = self.tableView.frame;
     tableViewFrame.size.height = self.view.frame.size.height - SPSettingsButtonHeight;
@@ -144,6 +145,15 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
                                       SPSettingsButtonHeight);
 
     [self updateHeaderButtonHighlight];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    
+    // un-register for keyboard notifications
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    [nc removeObserver: self name:UIKeyboardWillHideNotification object:nil];
+    [nc removeObserver: self name:UIKeyboardWillShowNotification object:nil];
 }
 
 - (VSTheme *)theme {
@@ -733,6 +743,9 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 #pragma mark KeyboardNotifications	
 
 - (void)keyboardWillShow:(NSNotification *)notification {
+    if ([[SPAppDelegate sharedDelegate] isPresentingPinLock]) {
+        return;
+    }
     
     CGRect keyboardFrame = [(NSValue *)[notification.userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     
@@ -750,6 +763,9 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 }
 
 - (void)keyboardWillHide:(NSNotification *)notification {
+    if ([[SPAppDelegate sharedDelegate] isPresentingPinLock]) {
+        return;
+    }
     
     CGRect newFrame = self.tableView.frame;
     newFrame.size.height = self.view.superview.frame.size.height - self.view.frame.origin.y - SPSettingsButtonHeight;

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -747,10 +747,6 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 #pragma mark KeyboardNotifications	
 
 - (void)keyboardWillShow:(NSNotification *)notification {
-    if ([[SPAppDelegate sharedDelegate] isPresentingPinLock]) {
-        return;
-    }
-    
     CGRect keyboardFrame = [(NSValue *)[notification.userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     
     CGFloat keyboardHeight = MIN(keyboardFrame.size.height, keyboardFrame.size.width);
@@ -767,10 +763,6 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 }
 
 - (void)keyboardWillHide:(NSNotification *)notification {
-    if ([[SPAppDelegate sharedDelegate] isPresentingPinLock]) {
-        return;
-    }
-    
     CGRect newFrame = self.tableView.frame;
     newFrame.size.height = self.view.superview.frame.size.height - self.view.frame.origin.y - SPSettingsButtonHeight;
 

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -150,7 +150,6 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     
-    
     [self removeKeyboardObservers];
 }
 

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -150,7 +150,12 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     
-    // un-register for keyboard notifications
+    
+    [self removeKeyboardObservers];
+}
+
+- (void)removeKeyboardObservers
+{
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc removeObserver: self name:UIKeyboardWillHideNotification object:nil];
     [nc removeObserver: self name:UIKeyboardWillShowNotification object:nil];

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -42,6 +42,7 @@
 - (NSString *)getPin:(BOOL)checkLegacy;
 - (void)setPin:(NSString *)newPin;
 - (void)removePin;
+- (BOOL)isPresentingPinLock;
 
 + (SPAppDelegate *)sharedDelegate;
 

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -43,7 +43,6 @@
 - (NSString *)getPin:(BOOL)checkLegacy;
 - (void)setPin:(NSString *)newPin;
 - (void)removePin;
-- (BOOL)isPresentingPinLock;
 
 + (SPAppDelegate *)sharedDelegate;
 

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -18,6 +18,7 @@
 @interface SPAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
+@property (strong, nonatomic) UIWindow *pinLockWindow;
 
 @property (strong, nonatomic, readonly) Simperium						*simperium;
 @property (strong, nonatomic, readonly) NSManagedObjectContext			*managedObjectContext;
@@ -42,7 +43,6 @@
 - (NSString *)getPin:(BOOL)checkLegacy;
 - (void)setPin:(NSString *)newPin;
 - (void)removePin;
-- (BOOL)isPresentingPinLock;
 
 + (SPAppDelegate *)sharedDelegate;
 

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -43,6 +43,7 @@
 - (NSString *)getPin:(BOOL)checkLegacy;
 - (void)setPin:(NSString *)newPin;
 - (void)removePin;
+- (BOOL)isPresentingPinLock;
 
 + (SPAppDelegate *)sharedDelegate;
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -850,7 +850,7 @@
     
     NSString *pin = [self getPin:YES];
     
-    if (!pin || pin.length == 0 || [[self topMostController] class] == [DTPinLockController class]) {
+    if (!pin || pin.length == 0 || [self isPresentingPinLock]) {
         return;
 	}
     
@@ -911,6 +911,11 @@
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setBool:allowTouchIDInsteadOfPin forKey:kSimplenoteUseTouchIDKey];
     [userDefaults synchronize];
+}
+
+- (BOOL)isPresentingPinLock
+{
+    return [[self topMostController] class] == [DTPinLockController class];
 }
 
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -876,6 +876,7 @@
                      completion:^(BOOL finished) {
                          [self.window makeKeyAndVisible];
                          [self.pinLockWindow removeFromSuperview];
+                         self.pinLockWindow = nil;
                      }];
 }
 
@@ -905,6 +906,7 @@
 - (void)removePin
 {
     [SSKeychain deletePasswordForService:kSimplenotePinKey account:kSimplenotePinKey];
+    [self setAllowTouchIDInsteadOfPin:NO];
 }
 
 - (BOOL)allowTouchIDInsteadOfPin

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -7,7 +7,6 @@
 //
 
 #import "SPAppDelegate.h"
-#import <Contacts/Contacts.h>
 #import "Simplenote-Swift.h"
 
 #import "SPConstants.h"
@@ -40,6 +39,7 @@
 #import "GAI.h"
 #import "SPTracker.h"
 
+@import Contacts;
 @import SSKeychain;
 @import Simperium;
 @import WordPress_AppbotX;

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -326,6 +326,7 @@
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {
+    [self.tagListViewController removeKeyboardObservers];
     [self showPasscodeLockIfNecessary];
     UIViewController *viewController = self.window.rootViewController;
     [viewController.view setNeedsLayout];


### PR DESCRIPTION
#120 was caused by the editor view controller attempting to dismiss views that it presented. The problem was that this could include the PIN lock controller too! I've added a check in the app delegate for when it is showing the PIN lock, which seems to have resolved the issue.

**To test**
* Enable the pin lock and go to the editor view
* Press the home button, then return to the app
* You should see the PIN lock entry

Also check that the app works as expected when you leave it with modals open, on both iPhone and iPad.

@frosty you touched this code before so I'm hoping you can review!

Fixes #120