### PR TITLE
Disabling Smart Dashes + Quotes

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -100,6 +100,11 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
         // Data Detectors:
         // Disabled by default. This will be entirely handled by SPTextLinkifier
         _noteEditorTextView.dataDetectorTypes = UIDataDetectorTypeNone;
+
+        if (@available(iOS 11.0, *)) {
+            _noteEditorTextView.smartDashesType = UITextSmartDashesTypeNo;
+            _noteEditorTextView.smartQuotesType = UITextSmartQuotesTypeNo;
+        }
         
         // TagView
         _tagView = _noteEditorTextView.tagView;


### PR DESCRIPTION
### Details:
I've stumbled upon this exact same issue in the Aztec Editor. In this PR we're disabling Smart Quotes + Smart Dashes, since both of them trigger a replacement that's not being picked up by any of the callbacks.

This effectively fixes the Out of Sync bug reported in #159

Needs Review: @roundhill 
Thanks in advance sir!
