### PR TITLE
iOS 11 / iPhone X Fixes

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1E2337828456992D0A53E514 /* Pods_Automattic_Simplenote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE6E920DC2B6ABC021AF145F /* Pods_Automattic_Simplenote.framework */; };
+		373897BC1F8328DE00CEDF91 /* SPTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373897BB1F8328DE00CEDF91 /* SPTitleView.swift */; };
 		37582B781DBFCD8D00695F36 /* SPBorderedTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 37582B771DBFCD8D00695F36 /* SPBorderedTableView.m */; };
 		46A3C96217DFA81A002865AE /* SPTagListViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = E22A17C917A2D5AD00383575 /* SPTagListViewCell.m */; };
 		46A3C96317DFA81A002865AE /* NSString+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 467D9C771788D0FF00785EF3 /* NSString+Metadata.m */; };
@@ -187,6 +188,7 @@
 		17C421D01BE0BABE00752B56 /* SPMarkdownPreviewViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPMarkdownPreviewViewController.h; path = Classes/SPMarkdownPreviewViewController.h; sourceTree = "<group>"; };
 		17C421D11BE0BABE00752B56 /* SPMarkdownPreviewViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPMarkdownPreviewViewController.m; path = Classes/SPMarkdownPreviewViewController.m; sourceTree = "<group>"; };
 		36966A74C74B55D0F708DD57 /* Pods_Automattic_SimplenoteShare.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Automattic_SimplenoteShare.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		373897BB1F8328DE00CEDF91 /* SPTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPTitleView.swift; path = Classes/SPTitleView.swift; sourceTree = "<group>"; };
 		37582B761DBFCD8D00695F36 /* SPBorderedTableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPBorderedTableView.h; path = Classes/SPBorderedTableView.h; sourceTree = "<group>"; };
 		37582B771DBFCD8D00695F36 /* SPBorderedTableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPBorderedTableView.m; path = Classes/SPBorderedTableView.m; sourceTree = "<group>"; };
 		37CD04B91A60538B00C4A8E0 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -725,6 +727,7 @@
 				E2465A2117AD70810097B19B /* SPToggle.h */,
 				E2465A2217AD70810097B19B /* SPToggle.m */,
 				E2922AB3180C7322003AF914 /* Tag View */,
+				373897BB1F8328DE00CEDF91 /* SPTitleView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1349,6 +1352,7 @@
 				46A3C97917DFA81A002865AE /* UIBarButtonItem+Images.m in Sources */,
 				46A3C97B17DFA81A002865AE /* SPInteractiveTextStorage.m in Sources */,
 				E2B0862F1806FFB3001ED52D /* SPTagCompletionPill.m in Sources */,
+				373897BC1F8328DE00CEDF91 /* SPTitleView.swift in Sources */,
 				46A3C97C17DFA81A002865AE /* DTPinErrorView.m in Sources */,
 				46A3C97D17DFA81A002865AE /* NSTextStorage+Highlight.m in Sources */,
 				B5B8AE831ABA0C7B0082775D /* SPLoginViewController.m in Sources */,

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -11,6 +11,7 @@
 #import "VSThemeManager.h"
 #import "SPInteractiveTextStorage.h"
 #import "NSString+Attributed.h"
+#import "UIDevice+Extensions.h"
 #import "VSTheme+Extensions.h"
 
 @interface SPEditorTextView ()
@@ -93,6 +94,10 @@
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     
     CGFloat padding = [theme floatForKey:@"noteSidePadding" contextView:self];
+    if ([UIDevice isPhoneX]
+        && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+        padding = [theme floatForKey:@"noteSidePaddingPhoneX" contextView:self];
+    }
     CGFloat maxWidth = [theme floatForKey:@"noteMaxWidth"];
     CGFloat width = self.bounds.size.width;
     

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -582,7 +582,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     // push off updating note text in order to speed up animated transition
     dispatch_async(dispatch_get_main_queue(), ^{
         _noteEditorTextView.attributedText = [note.content attributedString];
-        _noteEditorTextView.contentOffset = CGPointMake(0, -_noteEditorTextView.contentInset.top);
     });
     
     [self resetNavigationBarToIdentityWithAnimation:NO completion:nil];

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -10,6 +10,7 @@
 #import "SPBorderedTableView.h"
 #import "SPTransitionController.h"
 #import "SPSidebarContainerViewController.h"
+#import "Simplenote-Swift.h"
 @class Note, SPEmptyListView;
 
 typedef enum {
@@ -27,7 +28,7 @@ typedef enum {
     UIBarButtonItem *sidebarButton;
     
     // the container is only used to limit the width of the search bar.
-    UIView *searchBarContainer;
+    SPTitleView *searchBarContainer;
     UISearchBar *searchBar;
     UIBarButtonItem *emptyTrashButton;
         

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -253,9 +253,20 @@
     }
         
     if (!searchBar) {
-        searchBar = [[UISearchBar alloc] init];
-        searchBarContainer = [[SPTitleView alloc] init];
-        searchBarContainer.translatesAutoresizingMaskIntoConstraints = NO;
+        // titleView was changed to use autolayout in iOS 11
+        if (@available(iOS 11.0, *)) {
+            searchBar = [[UISearchBar alloc] init];
+            searchBarContainer = [[SPTitleView alloc] init];
+            searchBarContainer.translatesAutoresizingMaskIntoConstraints = NO;
+        } else {
+            CGFloat searchBarHeight = 44.0;
+            searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0,
+                                                                      0,
+                                                                      self.view.frame.size.width,
+                                                                      searchBarHeight)];
+            searchBarContainer = [[SPTitleView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, searchBarHeight)];
+            searchBarContainer.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        }
         searchBarContainer.clipsToBounds = NO;
         searchBar.center = searchBarContainer.center;
         

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -34,7 +34,6 @@
 #import "UIDevice+Extensions.h"
 #import "UIView+Subviews.h"
 #import "UIImage+Colorization.h"
-#import "Simplenote-Swift.h"
 
 #import <Simperium/Simperium.h>
 @import WordPress_AppbotX;
@@ -130,12 +129,6 @@
     }
     
     return self;
-}
-
-- (void)viewWillAppear:(BOOL)animated {
-    
-    [super viewWillAppear:animated];
-    searchBarContainer.frame = CGRectMake(0, 0, self.view.frame.size.width, 44);
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -258,23 +251,15 @@
         UIOffset titleOffset = [UIDevice isPad] ? UIOffsetMake(7, 0) : UIOffsetZero;
         [emptyTrashButton setTitlePositionAdjustment:titleOffset forBarMetrics:UIBarMetricsDefault];
     }
-    
         
     if (!searchBar) {
-        
-        CGFloat const kSearchBarHeight = 44.0;
-        
-        searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0,
-                                                                  0,
-                                                                  self.view.frame.size.width,
-                                                                  kSearchBarHeight)];
-        searchBarContainer = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, kSearchBarHeight)];
-
-        searchBarContainer.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        searchBar = [[UISearchBar alloc] init];
+        searchBarContainer = [[SPTitleView alloc] init];
+        searchBarContainer.translatesAutoresizingMaskIntoConstraints = NO;
         searchBarContainer.clipsToBounds = NO;
         searchBar.center = searchBarContainer.center;
         
-        searchBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        searchBar.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
         searchBar.searchTextPositionAdjustment = UIOffsetMake(5, 1);
         searchBar.searchBarStyle = UISearchBarStyleMinimal;
 
@@ -282,7 +267,6 @@
 
         searchBar.delegate = self;
         [searchBarContainer addSubview:searchBar];
-
     }
     
     if (bSearching) {

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -70,7 +70,6 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
         customView.showTopBorder = NO;
         customView.showRightBorder = NO;
         self.view = customView;
-        
     }
 }
 
@@ -89,6 +88,9 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
     self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     
     [self.view addSubview:self.tableView];
+    if (@available(iOS 11.0, *)) {
+        self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    }
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;

--- a/Simplenote/Classes/SPTitleView.swift
+++ b/Simplenote/Classes/SPTitleView.swift
@@ -1,0 +1,17 @@
+//
+//  SPTitleView.swift
+//  Simplenote
+//
+//  Created by Dan Roundhill on 10/2/17.
+//  Copyright © 2017 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class SPTitleView: UIView {
+
+    override var intrinsicContentSize: CGSize {
+        return UILayoutFittingExpandedSize
+    }
+
+}

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -372,6 +372,9 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
         
         CGRect finalEditorPosition = editorController.noteEditorTextView.frame;
         finalEditorPosition.origin.y += editorController.noteEditorTextView.contentInset.top + editorController.noteEditorTextView.frame.origin.y;
+        if (@available(iOS 11.0, *)) {
+            finalEditorPosition.origin.y += self.tableView.safeAreaInsets.top;
+        }
         finalEditorPosition.origin.x = 0;
         finalEditorPosition.size.width = editorController.view.frame.size.width;
         

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -237,6 +237,11 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     
     CGFloat padding = [theme floatForKey:@"noteSidePadding" contextView:self.tableView];
+    if ([UIDevice isPhoneX]
+        && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+        padding = [theme floatForKey:@"noteSidePaddingPhoneX" contextView:self.tableView];
+    }
+    
     CGFloat maxWidth = [theme floatForKey:@"noteMaxWidth"];
     
     if (width - 2 * padding > maxWidth && maxWidth > 0)

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -237,8 +237,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     
     CGFloat padding = [theme floatForKey:@"noteSidePadding" contextView:self.tableView];
-    if ([UIDevice isPhoneX]
-        && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+    if ([UIDevice isPhoneX] && [UIDevice isLandscape]) {
         padding = [theme floatForKey:@"noteSidePaddingPhoneX" contextView:self.tableView];
     }
     

--- a/Simplenote/Classes/UIBarButtonItem+Images.m
+++ b/Simplenote/Classes/UIBarButtonItem+Images.m
@@ -13,7 +13,7 @@
 
 static CGFloat const UIBarButtonSidePaddingPad      = 9.0;
 static CGFloat const UIBarButtonSidePaddingPhone    = 13.0;
-
+static CGFloat const UIBarButtonWidth               = 44.0;
 
 @implementation UIBarButtonItem (Images)
 
@@ -29,13 +29,12 @@ static CGFloat const UIBarButtonSidePaddingPhone    = 13.0;
 
 + (UIBarButtonItem *)barButtonContainingCustomViewWithImage:(UIImage *)image imageAlignment:(UIBarButtonImageAlignment)imageAlignment target:(id)target selector:(SEL)action
 {
-    CGFloat buttonWidth = 44.0;
     CGFloat sideAdjustment = [UIDevice isPad] ? UIBarButtonSidePaddingPad : UIBarButtonSidePaddingPhone;
     
     UIButton *button = [[UIButton alloc] initWithFrame:CGRectMake(imageAlignment == UIBarButtonImageAlignmentLeft ? -sideAdjustment : 0,
                                                                   -1,
-                                                                  MAX(buttonWidth, image.size.width),
-                                                                  MAX(buttonWidth, image.size.height))];
+                                                                  UIBarButtonWidth,
+                                                                  image.size.height)];
     button.isAccessibilityElement = NO;
 
     // use UIImageRenderingModeAlwaysTemplate to get button to adopt tint color

--- a/Simplenote/Classes/UIDevice+Extensions.h
+++ b/Simplenote/Classes/UIDevice+Extensions.h
@@ -11,5 +11,9 @@
 @interface UIDevice (Extensions)
 
 + (BOOL)isPad;
++ (BOOL)isPhone;
++ (BOOL)isPhoneX;
++ (BOOL)isLandscape;
++ (BOOL)isPhoneLandscape;
 
 @end

--- a/Simplenote/Classes/UIDevice+Extensions.m
+++ b/Simplenote/Classes/UIDevice+Extensions.m
@@ -15,4 +15,26 @@
     return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad;
 }
 
++ (BOOL)isPhone
+{
+    return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone;
+}
+
++ (BOOL)isPhoneX
+{
+    CGFloat maxScreenWidth = MAX([[UIScreen mainScreen] bounds].size.width,
+                              [[UIScreen mainScreen] bounds].size.height);
+    return self.isPhone && maxScreenWidth == 812.0;
+}
+
++ (BOOL)isLandscape
+{
+    return UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation);
+}
+
++ (BOOL)isPhoneLandscape
+{
+    return self.isPhone && self.isLandscape;
+}
+
 @end

--- a/Simplenote/Simplenote-DB5.plist
+++ b/Simplenote/Simplenote-DB5.plist
@@ -46,6 +46,8 @@
 		<integer>15</integer>
 		<key>noteSidePadding~regular</key>
 		<integer>64</integer>
+		<key>noteSidePaddingPhoneX</key>
+		<integer>59</integer>
 		<key>noteTopPadding</key>
 		<string>8</string>
 		<key>noteVerticalPadding</key>


### PR DESCRIPTION
iOS 11 changed the way that a few layout properties work, including `contentInset` which messed up the rendering of a few areas of the app. This PR attempts to fix those things, including what I reported here: https://github.com/Automattic/simplenote-ios/pull/161#issuecomment-333606701

There was also some rendering issues on iPhone X in landscape which I addressed here as well. I still think we may need another PR for more iPhone X fixes as we discover them :)

Refs #157