### PR TITLE
Support Face ID for iPhone X

### DIFF
--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -278,7 +278,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     cell.textLabel.text = NSLocalizedString(@"Touch ID", @"Offer to enable Touch ID support if available and passcode is on.");
                     cell.selectionStyle = UITableViewCellSelectionStyleNone;
 
-                    BOOL isTouchIDTurnedOn = [[SPAppDelegate sharedDelegate] allowTouchIDInsteadOfPin];
+                    BOOL isBiometryOn = [[SPAppDelegate sharedDelegate] allowBiometryInsteadOfPin];
 
                     self.touchIDSwitch.on = isTouchIDTurnedOn;
                     cell.accessoryView = self.touchIDSwitch;
@@ -421,7 +421,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     [SPTracker trackSettingsPinlockEnabled:NO];
     
     [[SPAppDelegate sharedDelegate] removePin];
-    [[SPAppDelegate sharedDelegate] setAllowTouchIDInsteadOfPin:false];
+    [[SPAppDelegate sharedDelegate] setAllowBiometryInsteadOfPin:NO];
     
     [self.tableView reloadData];
 	[self.navigationController dismissViewControllerAnimated:YES completion:nil];
@@ -433,7 +433,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     // Make sure the UI is consistent
     NSString *pin = [[SPAppDelegate sharedDelegate] getPin:false];
     if (pin.length == 0) {
-        [[SPAppDelegate sharedDelegate] setAllowTouchIDInsteadOfPin:false];
+        [[SPAppDelegate sharedDelegate] setAllowBiometryInsteadOfPin:NO];
     }
     
     [self.tableView reloadData];
@@ -495,7 +495,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 
 - (void)touchIdSwitchDidChangeValue:(UISwitch *)sender
 {
-    [[SPAppDelegate sharedDelegate] setAllowTouchIDInsteadOfPin:sender.on];
+    [[SPAppDelegate sharedDelegate] setAllowBiometryInsteadOfPin:sender.on];
     
     NSString *pin = [[SPAppDelegate sharedDelegate] getPin:NO];
     if (pin.length == 0) {

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -33,7 +33,7 @@
 @property (strong, nonatomic) NSString									*selectedTag;
 @property (assign, nonatomic) BOOL										bSigningUserOut;
 
-@property (assign, nonatomic) BOOL                                      allowTouchIDInsteadOfPin;
+@property (assign, nonatomic) BOOL                                      allowBiometryInsteadOfPin;
 
 - (void)showOptions;
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -856,8 +856,8 @@
         return;
 	}
     
-    BOOL useTouchID = self.allowTouchIDInsteadOfPin;
-    DTPinLockController *controller = [[DTPinLockController alloc] initWithMode:useTouchID ? PinLockControllerModeUnlockAllowTouchID :PinLockControllerModeUnlock];
+    BOOL useBiometry = self.allowBiometryInsteadOfPin;
+    DTPinLockController *controller = [[DTPinLockController alloc] initWithMode:useBiometry ? PinLockControllerModeUnlockAllowTouchID :PinLockControllerModeUnlock];
 	controller.pinLockDelegate = self;
 	controller.pin = pin;
     controller.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
@@ -906,21 +906,21 @@
 - (void)removePin
 {
     [SSKeychain deletePasswordForService:kSimplenotePinKey account:kSimplenotePinKey];
-    [self setAllowTouchIDInsteadOfPin:NO];
+    [self setAllowBiometryInsteadOfPin:NO];
 }
 
-- (BOOL)allowTouchIDInsteadOfPin
+- (BOOL)allowBiometryInsteadOfPin
 {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    BOOL useTouchID = [userDefaults boolForKey:kSimplenoteUseTouchIDKey];
+    BOOL useTouchID = [userDefaults boolForKey:kSimplenoteUseBiometryKey];
 
     return useTouchID;
 }
 
-- (void)setAllowTouchIDInsteadOfPin:(BOOL)allowTouchIDInsteadOfPin
+- (void)setAllowBiometryInsteadOfPin:(BOOL)allowBiometryInsteadOfPin
 {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    [userDefaults setBool:allowTouchIDInsteadOfPin forKey:kSimplenoteUseTouchIDKey];
+    [userDefaults setBool:allowBiometryInsteadOfPin forKey:kSimplenoteUseBiometryKey];
     [userDefaults synchronize];
 }
 

--- a/Simplenote/SPConstants.h
+++ b/Simplenote/SPConstants.h
@@ -32,7 +32,7 @@ extern NSString *const kSelectedTagKey;
 extern NSString *const kSelectedNoteKey;
 extern NSString *const kSimplenotePinKey;
 extern NSString *const kSimplenotePinLegacyKey;
-extern NSString *const kSimplenoteUseTouchIDKey;
+extern NSString *const kSimplenoteUseBiometryKey;
 extern NSString *const kSimplenoteMarkdownDefaultKey;
 
 extern NSString *const kSimplenotePublishURL;

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -37,7 +37,7 @@ NSString *const kSelectedTagKey                     = @"SPSelectedTag";
 NSString *const kSelectedNoteKey                    = @"SPSelectedNote";
 NSString *const kSimplenotePinKey                   = @"SimplenotePin";
 NSString *const kSimplenotePinLegacyKey             = @"PIN";
-NSString *const kSimplenoteUseTouchIDKey            = @"SimplenoteUseTouchID";
+NSString *const kSimplenoteUseBiometryKey           = @"SimplenoteUseTouchID";
 NSString *const kSimplenoteMarkdownDefaultKey       = @"MarkdownDefault";
 
 NSString *const kSimplenotePublishURL               = @"http://simp.ly/publish/";

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -62,6 +62,8 @@
 	<string>This app requires contacts access to properly share data with other users.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app does not require Photo Library access.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>This app requires Face ID access to secure your notes.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIPrerenderedIcon</key>


### PR DESCRIPTION
This PR updates some UI and code to better support both Touch ID and Face ID (coming with iPhone X). 

While Face ID uses the same `LAContext` methods as Touch ID, I've updated any UI that references Touch ID to instead reference Face ID when appropriate. I've also tweaked the names of some methods and variables to use the term 'biometry' instead of 'touchID', so they more appropriately cover both types of authentication.

Finally, I've added a definition for `NSFaceIDUsageDescription` to the Info.plist, as I expect the app will  either crash or be able to utilize Face ID at all if this isn't present.

To test:

* Ensure Touch ID authentication still works as it did.
* Ensure the Touch ID setting in Settings is still correct on a Touch ID capable device.
* Try modifying these lines to set Face ID available to YES to test the alternative code path before we have access to an iPhone X: https://github.com/Automattic/simplenote-ios/pull/165/files#diff-ede834af434c1ec45f56abdc16ea99e9R152

Needs review: @jleandroperez 