### PR TITLE
Fix Note Editor from Clearing with Small Swipe

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -564,12 +564,15 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     
     [self.navigationController popToRootViewControllerAnimated:YES];
     
-    [[self.navigationController transitionCoordinator] animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {} completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        // clear the current note after pop animation completes if it wasn't cancelled
-        if (!context.isCancelled) {
-            [self clearNote];
-        }
-    }];
+    [[self.navigationController transitionCoordinator]
+         animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {}
+         completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+            // clear the current note after pop animation completes if it wasn't cancelled
+            if (!context.isCancelled) {
+                [self clearNote];
+            }
+         }
+     ];
 }
 
 - (void)updateNote:(Note *)note {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -564,15 +564,12 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     
     [self.navigationController popToRootViewControllerAnimated:YES];
     
-    [[self.navigationController transitionCoordinator] animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        
-    } completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-      
-        // clear the current note after pop animation completes
-        [self clearNote];
-        
+    [[self.navigationController transitionCoordinator] animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {} completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        // clear the current note after pop animation completes if it wasn't cancelled
+        if (!context.isCancelled) {
+            [self clearNote];
+        }
     }];
-    
 }
 
 - (void)updateNote:(Note *)note {


### PR DESCRIPTION
Fixing an ancient issue, #89. The issue was that if you did too small of a swipe from the editor, it would still clear out the note editor even though the transition animation was cancelled!

Before:
![before](https://user-images.githubusercontent.com/789137/32127299-aeaf97f4-bb2a-11e7-92b7-bcd83df8da60.gif)

After:
![after](https://user-images.githubusercontent.com/789137/32127300-aec72824-bb2a-11e7-932f-fb9c32a20503.gif)
