### PR TITLE
Add a cancel button to the toolbar for iPads.

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -26,6 +26,7 @@ typedef enum {
     // Navigation Bar
     UIBarButtonItem *addButton;
     UIBarButtonItem *sidebarButton;
+    UIBarButtonItem *iPadCancelButton;
     
     // the container is only used to limit the width of the search bar.
     SPTitleView *searchBarContainer;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -281,20 +281,27 @@
     }
     
     if (bSearching) {
+        // Add a Cancel button to the toolbar, only needed for iPads
+        if ([UIDevice isPad]) {
+            if (!iPadCancelButton) {
+                iPadCancelButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", @"Verb - dismiss the notes search view")
+                                                 style:UIBarButtonItemStylePlain
+                                                target:self
+                                                action:@selector(cancelSearchButtonAction:)];
+            }
+            
+            [self.navigationItem setRightBarButtonItem:iPadCancelButton animated:YES];
+        } else {
+           [self.navigationItem setRightBarButtonItem:nil animated:YES];
+        }
         
-        [self.navigationItem setRightBarButtonItem:nil animated:YES];
         [self.navigationItem setLeftBarButtonItem:nil animated:YES];
-        
     } else if (tagFilterType == SPTagFilterTypeDeleted) {
-        
         [self.navigationItem setRightBarButtonItem:emptyTrashButton animated:YES];
         [self.navigationItem setLeftBarButtonItem:sidebarButton animated:YES];
-        
-    }else {
-
+    } else {
         [self.navigationItem setRightBarButtonItem:addButton animated:YES];
         [self.navigationItem setLeftBarButtonItem:sidebarButton animated:YES];
-
     }
     
     self.navigationItem.titleView = searchBarContainer;


### PR DESCRIPTION
Fixes #170. Apparently the iPad doesn't show a cancel button for search views. This adds a UIBarButton item for iPads when the user is searching notes.

**To Test**
* Run the app on an iPad.
* Tap on the search view, you should see a cancel button appear.
* Tap on the cancel button, the search view should cancel and the regular toolbar buttons should appear again.
* Also test searching on an iPhone to ensure I didn't muck that up ;)

![simulator screen shot - ipad pro 9 7-inch - 2017-11-03 at 13 50 56](https://user-images.githubusercontent.com/789137/32395519-abf3a9be-c09e-11e7-8414-877b09c4f910.png)
