### PR TITLE
Additional iPhone X Layout Fixes

### DIFF
--- a/Simplenote/Classes/SPActionSheet.m
+++ b/Simplenote/Classes/SPActionSheet.m
@@ -412,6 +412,10 @@ static CGFloat SPActionSheetCancelButtonIndexNone = -1;
                                      boxFrame.origin.y + padding,
                                      contentWidth + 2 * moveDistance,
                                      contentHeight + moveDistance);
+    if (@available(iOS 11.0, *)) {
+        contentFrame.origin.y -= view.safeAreaInsets.bottom;
+        contentFrame.size.height += view.safeAreaInsets.bottom;
+    }
     contentView.frame = contentFrame;
     contentView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
     

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -116,7 +116,15 @@
     CGFloat yOrigin = self.contentSize.height - height + self.contentInset.top;
     yOrigin = MAX(yOrigin, self.contentOffset.y + self.bounds.size.height - height);
     
-    CGRect footerViewFrame = CGRectMake(0, yOrigin, self.bounds.size.width, height);
+    CGFloat tagPadding = 0;
+    if (@available(iOS 11.0, *)) {
+        tagPadding = self.safeAreaInsets.left;
+    }
+    
+    CGRect footerViewFrame = CGRectMake(tagPadding,
+                                        yOrigin,
+                                        self.bounds.size.width - 2 * tagPadding,
+                                        height);
     _tagView.frame = footerViewFrame;
 }
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -90,6 +90,12 @@
     
     [super layoutSubviews];
     
+    if (@available(iOS 11.0, *)) {
+        CGRect viewFrame = self.frame;
+        viewFrame.size.height = self.bounds.size.height - self.safeAreaInsets.bottom;
+        self.frame = viewFrame;
+    }
+    
     // Set content insets on side
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -100,9 +100,8 @@
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     
     CGFloat padding = [theme floatForKey:@"noteSidePadding" contextView:self];
-    if ([UIDevice isPhoneX]
-        && UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
-        padding = [theme floatForKey:@"noteSidePaddingPhoneX" contextView:self];
+    if (@available(iOS 11.0, *)) {
+        padding += self.safeAreaInsets.left;
     }
     CGFloat maxWidth = [theme floatForKey:@"noteMaxWidth"];
     CGFloat width = self.bounds.size.width;

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -638,8 +638,6 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 }
 
 - (BOOL)containerViewControllerShouldShowSidePanel:(SPSidebarContainerViewController *)container {
-    
-    self.tableView.frame = self.view.bounds;
 
     dispatch_async(dispatch_get_main_queue(), ^{
         if (!bVisible)

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -237,8 +237,8 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     
     CGFloat padding = [theme floatForKey:@"noteSidePadding" contextView:self.tableView];
-    if ([UIDevice isPhoneX] && [UIDevice isLandscape]) {
-        padding = [theme floatForKey:@"noteSidePaddingPhoneX" contextView:self.tableView];
+    if (@available(iOS 11.0, *)) {
+        padding += self.tableView.safeAreaInsets.left;
     }
     
     CGFloat maxWidth = [theme floatForKey:@"noteMaxWidth"];

--- a/Simplenote/Simplenote-DB5.plist
+++ b/Simplenote/Simplenote-DB5.plist
@@ -46,8 +46,6 @@
 		<integer>15</integer>
 		<key>noteSidePadding~regular</key>
 		<integer>64</integer>
-		<key>noteSidePaddingPhoneX</key>
-		<integer>59</integer>
 		<key>noteTopPadding</key>
 		<string>8</string>
 		<key>noteVerticalPadding</key>


### PR DESCRIPTION
I noticed the tags editor wasn't aligned with the rest of the editor text when in landscape on the iPhone X. I fixed it by taking advantage of iOS 11's `safeAreaInset`. It also allows space for the home indicator now.

Before:
![simulator screen shot - iphone x - 2017-11-03 at 16 09 41](https://user-images.githubusercontent.com/789137/32399237-abc0e502-c0b1-11e7-9965-8c9c5a6fe955.png)

After:
![simulator screen shot - iphone x - 2017-11-05 at 09 36 39](https://user-images.githubusercontent.com/789137/32417339-dc61a71c-c20c-11e7-9b01-8f9f4a5cd9e8.png)


