### PR TITLE
Revert smart dash and quotes removal

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -100,11 +100,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
         // Data Detectors:
         // Disabled by default. This will be entirely handled by SPTextLinkifier
         _noteEditorTextView.dataDetectorTypes = UIDataDetectorTypeNone;
-
-        if (@available(iOS 11.0, *)) {
-            _noteEditorTextView.smartDashesType = UITextSmartDashesTypeNo;
-            _noteEditorTextView.smartQuotesType = UITextSmartQuotesTypeNo;
-        }
         
         // TagView
         _tagView = _noteEditorTextView.tagView;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -100,7 +100,16 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
         // Data Detectors:
         // Disabled by default. This will be entirely handled by SPTextLinkifier
         _noteEditorTextView.dataDetectorTypes = UIDataDetectorTypeNone;
-        
+
+        // Note:
+        // Disable SmartDashes / Quotes in iOS 11.0, due to a glitch that broke sync. (Fixed in iOS 11.1).
+        if (@available(iOS 11.0, *)) {
+            if ([[[UIDevice currentDevice] systemVersion] floatValue] < 11.1) {
+                _noteEditorTextView.smartDashesType = UITextSmartDashesTypeNo;
+                _noteEditorTextView.smartQuotesType = UITextSmartQuotesTypeNo;
+            }
+        }
+
         // TagView
         _tagView = _noteEditorTextView.tagView;
         _noteEditorTextView.tagView.tagDelegate = self;


### PR DESCRIPTION
Apple fixed the issue with smart dashes in iOS 11.1. I think we should add back the smart dash support since it is no longer an issue to honor the user's typing settings.

This reverts commit 67f0b676c3c9b835d9c3b6a80800a562d3b646da.