### PR TITLE
Update Fabric Build Config

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1284,7 +1284,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"Distribution AppStore\" != \"${CONFIGURATION}\" ]]; then\n   echo \"Skipping Fabric\";\n   exit 0;\nfi\n\n\"${PODS_ROOT}/Fabric/run\"\n";
+			shellScript = "FABRIC_API_KEY=$(defaults read ${SRCROOT}/Simplenote/config.plist FabricApiKey);\nFABRIC_BUILD_KEY=$(defaults read ${SRCROOT}/Simplenote/config.plist FabricBuildKey);\n\nif [ ${FABRIC_API_KEY} == \"not-required\" ] || [ ${FABRIC_BUILD_KEY} == \"not-required\" ]; then\necho \"Could not find fabric keys. Check your config.plist.\";\nexit 0;\nfi\n\n\"${PODS_ROOT}/Fabric/run\" ${FABRIC_API_KEY} ${FABRIC_BUILD_KEY}\n";
 		};
 		B596467F1C46BD83001537E5 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -230,8 +230,6 @@
     NSString *email = self.simperium.user.email;
     NSString *key = [SPCredentials simplenoteCrashlyticsKey];
 
-    [Fabric with:@[CrashlyticsKit]];
-
     [Crashlytics startWithAPIKey:key];
     [[Crashlytics sharedInstance] setObjectValue:email forKey:@"email"];
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -230,6 +230,8 @@
     NSString *email = self.simperium.user.email;
     NSString *key = [SPCredentials simplenoteCrashlyticsKey];
 
+    [Fabric with:@[CrashlyticsKit]];
+    
     [Crashlytics startWithAPIKey:key];
     [[Crashlytics sharedInstance] setObjectValue:email forKey:@"email"];
 

--- a/Simplenote/config.plist
+++ b/Simplenote/config.plist
@@ -20,5 +20,9 @@
 	<string>not-required</string>
 	<key>SimplenoteiTunesReviewURL</key>
 	<string>not-required</string>
+	<key>FabricApiKey</key>
+	<string>not-required</string>
+	<key>FabricBuildKey</key>
+	<string>not-required</string>
 </dict>
 </plist>


### PR DESCRIPTION
We'll now pull the keys from the `config.plist` for fabric. We also don't need to worry about the fabric key that used to be in `Simplenote-Info.plist` because we only use Crashlytics.

**To Test**
* Update your `config.plist` with the proper fabric keys, and run the app for release (or comment out the `USE_CRASHLYTICS` flags in `SPAppDelegate.m`.
* Cause a crash somewhere :)
* Next time you run the app, you should see crashlytics sending the crash data in the log.

I think we'll need to confirm that the dsym files are being properly uploaded to crashliytics as well after this change.