### PR TITLE
Disable Javascript in Markdown Webview

### DIFF
--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -35,7 +35,10 @@
 
 + (NSString *)htmlHeader
 {
-    NSString *headerStart = @"<html><head><style media=\"screen\" type=\"text/css\">\n";
+    NSString *headerStart =
+        @"<html><head>"
+            "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+            "<style media=\"screen\" type=\"text/css\">\n";
     NSString *headerEnd = @"</style></head><body><div class=\"note\"><div id=\"static_content\">";
     
     VSTheme *theme = [[VSThemeManager sharedManager] theme];


### PR DESCRIPTION
We received a report that javascript could be executed in the markdown preview by using a tricky markdown link that includes a `javascript://` uri. 

I've updated the markdown preview to use `WKWebView` in place of `UIWebView` which allows js to be disabled. We're targeting iOS 9 so we're ok to use it as it was added in iOS 8.

**To Test**
* Create a note as markdown formatted, it should preview correctly with links, headers, text formatting, images, etc.
* DM me and I'll send you the markdown code that would previously execute javascript.
* No js should be executed.

cc @frosty, would you mind reviewing this one?