### PR TITLE
Updating SSKeychain 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ use_frameworks!
 abstract_target 'Automattic' do
 	# Shared Dependencies
 	#
-	pod 'SSKeychain', '1.2.2'
+	pod 'SAMKeychain', '1.5.2'
 
 	# Main Target
 	#

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,6 +23,7 @@ PODS:
     - hoedown/standard (= 3.0.3)
   - hoedown/standard (3.0.3)
   - Reachability (3.2)
+  - SAMKeychain (1.5.2)
   - Simperium (0.8.19):
     - Simperium/DiffMatchPach (= 0.8.19)
     - Simperium/JRSwizzle (= 0.8.19)
@@ -34,7 +35,6 @@ PODS:
   - Simperium/SocketTrust (0.8.19)
   - Simperium/SPReachability (0.8.19)
   - Simperium/SSKeychain (0.8.19)
-  - SSKeychain (1.2.2)
   - SVProgressHUD (1.1.2)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-AppbotX (1.0.6)
@@ -48,8 +48,8 @@ DEPENDENCIES:
   - GoogleAnalytics (= 3.14.0)
   - HockeySDK (~> 3.8.0)
   - hoedown (~> 3.0.3)
+  - SAMKeychain (= 1.5.2)
   - Simperium (= 0.8.19)
-  - SSKeychain (= 1.2.2)
   - SVProgressHUD (= 1.1.2)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-Ratings-iOS (= 0.0.2)
@@ -80,13 +80,13 @@ SPEC CHECKSUMS:
   HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
   hoedown: c1327bbbc96d269595ed86bf97f1d09867ec7529
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
+  SAMKeychain: 1865333198217411f35327e8da61b43de79b635b
   Simperium: f72ecf0b5c6e9e4b70be9f575c7d88e7de7b112c
-  SSKeychain: 88767e903ee8d274ed380e364d96b7a101235286
   SVProgressHUD: 3afb875b9eb23acd1bed9b82495695c68621a8b2
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-Ratings-iOS: b04108f7a45867844ba47a240bb6295ca747eebf
 
-PODFILE CHECKSUM: d19d1d9c1954c3f2e5620a89fae172ceb587f48b
+PODFILE CHECKSUM: 0fda9886a82c8a61adc629fbefbde69dafe16cf6
 
 COCOAPODS: 1.3.1

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1177,7 +1177,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-resources.sh",
-				$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle,
+				"$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -1232,7 +1232,7 @@
 				"${BUILT_PRODUCTS_DIR}/Automattic-Tracks-iOS/AutomatticTracks.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
-				"${BUILT_PRODUCTS_DIR}/SSKeychain/SSKeychain.framework",
+				"${BUILT_PRODUCTS_DIR}/SAMKeychain/SAMKeychain.framework",
 				"${BUILT_PRODUCTS_DIR}/SVProgressHUD/SVProgressHUD.framework",
 				"${BUILT_PRODUCTS_DIR}/Simperium/Simperium.framework",
 				"${BUILT_PRODUCTS_DIR}/UIDeviceIdentifier/UIDeviceIdentifier.framework",
@@ -1246,7 +1246,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AutomatticTracks.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SSKeychain.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SAMKeychain.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SVProgressHUD.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Simperium.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UIDeviceIdentifier.framework",

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -40,7 +40,7 @@
 #import "SPTracker.h"
 
 @import Contacts;
-@import SSKeychain;
+@import SAMKeychain;
 @import Simperium;
 @import WordPress_AppbotX;
 
@@ -102,7 +102,7 @@
     if (legacyAuthToken && [username length] > 0) {
         [[NSUserDefaults standardUserDefaults] setObject:username forKey:@"SPUsername"];
         [[NSUserDefaults standardUserDefaults] synchronize];
-        [SSKeychain setPassword:legacyAuthToken forService:[SPCredentials simperiumAppID] account:username];
+        [SAMKeychain setPassword:legacyAuthToken forService:[SPCredentials simperiumAppID] account:username];
     }
     
     // Clear legacy data
@@ -615,7 +615,7 @@
 {
     // Store the Token: Required by the Share Extension!
     NSString *token = simperium.user.authToken;
-    [SSKeychain setPassword:token forService:kShareExtensionServiceName account:kShareExtensionAccountName];
+    [SAMKeychain setPassword:token forService:kShareExtensionServiceName account:kShareExtensionAccountName];
     
     // Tracker!
     [SPTracker refreshMetadataWithEmail:simperium.user.email];
@@ -624,7 +624,7 @@
 - (void)simperiumDidLogout:(Simperium *)simperium
 {
     // Nuke Extension Token
-    [SSKeychain deletePasswordForService:kShareExtensionServiceName account:kShareExtensionAccountName];
+    [SAMKeychain deletePasswordForService:kShareExtensionServiceName account:kShareExtensionAccountName];
     
     // Tracker!
     [SPTracker refreshMetadataForAnonymousUser];
@@ -882,7 +882,7 @@
 
 - (NSString *)getPin:(BOOL)checkLegacy
 {
-    NSString *pin   = [SSKeychain passwordForService:kSimplenotePinKey account:kSimplenotePinKey];
+    NSString *pin   = [SAMKeychain passwordForService:kSimplenotePinKey account:kSimplenotePinKey];
     
     if (checkLegacy && (!pin || pin.length == 0)) {
         
@@ -900,12 +900,12 @@
 
 - (void)setPin:(NSString *)newPin
 {
-    [SSKeychain setPassword:newPin forService:kSimplenotePinKey account:kSimplenotePinKey];
+    [SAMKeychain setPassword:newPin forService:kSimplenotePinKey account:kSimplenotePinKey];
 }
 
 - (void)removePin
 {
-    [SSKeychain deletePasswordForService:kSimplenotePinKey account:kSimplenotePinKey];
+    [SAMKeychain deletePasswordForService:kSimplenotePinKey account:kSimplenotePinKey];
     [self setAllowBiometryInsteadOfPin:NO];
 }
 

--- a/SimplenoteShare/ShareViewController.swift
+++ b/SimplenoteShare/ShareViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import Social
-import SSKeychain
+import SAMKeychain
 
 
 /// Simplenote's Share Extension.
@@ -17,7 +17,7 @@ open class ShareViewController: SLComposeServiceViewController
 {
     // MARK: - Private Properties
     fileprivate var simperiumToken: String? {
-        return SSKeychain.password(forService: kShareExtensionServiceName, account: kShareExtensionAccountName)
+        return SAMKeychain.password(forService: kShareExtensionServiceName, account: kShareExtensionAccountName)
     }
     
     

--- a/SimplenoteShare/Simplenote-Share-Bridging-Header.h
+++ b/SimplenoteShare/Simplenote-Share-Bridging-Header.h
@@ -3,6 +3,6 @@
 //
 
 
-#import <SSKeychain/SSKeychain.h>
+#import <SAMKeychain/SAMKeychain.h>
 
 #import "SPConstants.h"


### PR DESCRIPTION
### Details:
Building Simplenote in Xcode 9 results in the following (runtime!) console warning:

```
objc[23721]: Class SSKeychain is implemented in both /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/StoreServices.framework/StoreServices (0x11a3fa938) and /Users/lantean/Library/Developer/CoreSimulator/Devices/8F8D4868-CF5E-4E1E-8231-BA915B1FFEDB/data/Containers/Bundle/Application/E294E09E-7CEF-4355-BCD0-B76D5351BD4F/Simplenote.app/Frameworks/SSKeychain.framework/SSKeychain (0x105dabfa0). One of the two will be used. Which one is undefined.
```

In this PR we're updating SSKeychain dependency, to it's latest stable release. Note that because of this namespacing collision, the library has been renamed to SAMKeychain.

Needs Review: @frosty 
Thanks in advance!!

### Testing:
- Log into Simplenote.com
- Relaunch the app and verify the credentials persist
- Verify that the PIN Lockcode screen works as expected.