### PR TITLE
Restore Editor Scroll Bounce

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -90,12 +90,6 @@
     
     [super layoutSubviews];
     
-    if (@available(iOS 11.0, *)) {
-        CGRect viewFrame = self.frame;
-        viewFrame.size.height = self.bounds.size.height - self.safeAreaInsets.bottom;
-        self.frame = viewFrame;
-    }
-    
     // Set content insets on side
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -190,7 +190,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
                                 tagViewHeight);
 
     [self.view addSubview:_noteEditorTextView];
-    _noteEditorTextView.frame = self.view.frame;
+    _noteEditorTextView.frame = self.view.bounds;
     _noteEditorTextView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     _noteEditorTextView.delegate = self;
     

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -171,14 +171,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 }
 
-- (void)viewWillLayoutSubviews {
-    if (@available(iOS 11.0, *)) {
-        CGRect viewFrame = _noteEditorTextView.frame;
-        viewFrame.size.height = self.view.frame.size.height - self.view.safeAreaInsets.bottom;
-        _noteEditorTextView.frame = viewFrame;
-    }
-}
-
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -214,10 +206,14 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     [self sizeNavigationContainer];
 }
 
-
 - (void)viewDidAppear:(BOOL)animated {
     
     [super viewDidAppear:animated];
+    if (@available(iOS 11.0, *)) {
+        CGRect viewFrame = _noteEditorTextView.frame;
+        viewFrame.size.height = self.view.bounds.size.height - self.view.safeAreaInsets.bottom;
+        _noteEditorTextView.frame = viewFrame;
+    }
     
     if (!_currentNote)
         [self newButtonAction:nil];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -171,6 +171,14 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 }
 
+- (void)viewWillLayoutSubviews {
+    if (@available(iOS 11.0, *)) {
+        CGRect viewFrame = _noteEditorTextView.frame;
+        viewFrame.size.height = self.view.frame.size.height - self.view.safeAreaInsets.bottom;
+        _noteEditorTextView.frame = viewFrame;
+    }
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -182,7 +190,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
                                 tagViewHeight);
 
     [self.view addSubview:_noteEditorTextView];
-    _noteEditorTextView.frame = self.view.bounds;
+    _noteEditorTextView.frame = self.view.frame;
     _noteEditorTextView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     _noteEditorTextView.delegate = self;
     

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -30,6 +30,7 @@
 #import "VSTheme+Extensions.h"
 #import "SPInteractivePushPopAnimationController.h"
 
+#define kEditorTransitionOffset 8
 
 NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SPTransitionControllerPopGestureTriggeredNotificationName";
 
@@ -174,7 +175,13 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
         _snapshotTextView.textContainer.lineFragmentPadding = 0;
     }
     
-     _snapshotTextView.frame = CGRectMake(0, 0, width, [[UIScreen mainScreen] bounds].size.height);
+    CGFloat snapHeight = self.tableView.frame.size.height;
+    if (@available(iOS 11.0, *)) {
+        // Adjust the height of the transition preview for safeAreaInsets.
+        // Fixes awkward looking transition at the bottom of the editor on iPhone X
+        snapHeight -= self.tableView.safeAreaInsets.top + self.tableView.safeAreaInsets.bottom + kEditorTransitionOffset;
+    }
+    _snapshotTextView.frame = CGRectMake(0, 0, width, snapHeight);
     
     NSString *content = preview ? note.preview : note.content;
     if (content.length > transitionControllerMaxTextLength)


### PR DESCRIPTION
A regression in 4.5 caused the editor to stop scrolling. We were adjusting the frame incorrectly in `layoutSubviews` which was overkill and also killed the bounce.

This moves the same code out to the view controller instead of in the TextView.

I also fixed a weird animation glitch that was happening only on the iPhone X.

**To Test**
* Open a note, small or large. The editor should bounce when you scroll up/down.
* Open a long note on the iPhone X. The animation should look smooth!

Fixes #185 