### PR TITLE
Add Alert Dialog Warning Upon Signout with Unsynced Notes

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		B5BE054E1AB75902002417BF /* NSProcessInfo+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BE054C1AB75902002417BF /* NSProcessInfo+Util.m */; };
 		B5BE05541AB75C3B002417BF /* Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BE05521AB75C3B002417BF /* Settings.m */; };
 		B5C9F71E193E75FE00FD2491 /* SPDebugViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5C9F71C193E75FE00FD2491 /* SPDebugViewController.m */; };
+		B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D3FCCE201F96AC00A813B7 /* StatusChecker.m */; };
 		B5D43FED1BA8CBBE00EF5104 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5D43FEB1BA8CBBE00EF5104 /* LaunchScreen.xib */; };
 		B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 174838281BBDCAA400E834AF /* SPMarkdownParser.m */; };
 		B5EB1EEF1C204EBD0080A1B3 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EB1EEE1C204EBD0080A1B3 /* ShareViewController.swift */; };
@@ -308,6 +309,8 @@
 		B5D3ADAF1FC8C0A200F84B31 /* SimplenoteShare-Development.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SimplenoteShare-Development.entitlements"; sourceTree = "<group>"; };
 		B5D3ADB01FC8C0A300F84B31 /* SimplenoteShare-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SimplenoteShare-Internal.entitlements"; sourceTree = "<group>"; };
 		B5D3ADB21FC8C11A00F84B31 /* Simplenote.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Simplenote.entitlements; sourceTree = "<group>"; };
+		B5D3FCCE201F96AC00A813B7 /* StatusChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = StatusChecker.m; path = Classes/StatusChecker.m; sourceTree = "<group>"; };
+		B5D3FCCF201F96AC00A813B7 /* StatusChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StatusChecker.h; path = Classes/StatusChecker.h; sourceTree = "<group>"; };
 		B5D43FEB1BA8CBBE00EF5104 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LaunchScreen.xib; path = ../LaunchScreen.xib; sourceTree = "<group>"; };
 		B5EB1EEC1C204EBD0080A1B3 /* SimplenoteShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SimplenoteShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5EB1EEE1C204EBD0080A1B3 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
@@ -707,6 +710,8 @@
 			children = (
 				B5BE053F1AB75225002417BF /* SPIntegrityHelper.h */,
 				B5BE05401AB75225002417BF /* SPIntegrityHelper.m */,
+				B5D3FCCF201F96AC00A813B7 /* StatusChecker.h */,
+				B5D3FCCE201F96AC00A813B7 /* StatusChecker.m */,
 				B51EC6F91B8FCEA900DFB4A5 /* SPTextLinkifier.h */,
 				B51EC6FA1B8FCEA900DFB4A5 /* SPTextLinkifier.m */,
 				B5BE05431AB7522F002417BF /* JSONKit+Simplenote.h */,
@@ -1444,6 +1449,7 @@
 				46A3C98417DFA81A002865AE /* SPHorizontalPickerView.m in Sources */,
 				46A3C98617DFA81A002865AE /* SPEntryListViewController.m in Sources */,
 				B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */,
+				B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */,
 				46A3C98717DFA81A002865AE /* MagnifierView.m in Sources */,
 				46A3C98817DFA81A002865AE /* Simplenote.xcdatamodeld in Sources */,
 				B518899E1E0D5EF800E71B83 /* SPContactsManager.swift in Sources */,

--- a/Simplenote/Classes/SPObjectManager.h
+++ b/Simplenote/Classes/SPObjectManager.h
@@ -26,7 +26,6 @@
 - (Tag *)tagForName:(NSString *)tagName;
 - (void)moveTagFromIndex:(NSInteger)fromIndex toIndex:(NSInteger)toIndex;
 
-- (BOOL)hasUnsyncedNotes;
 - (void)trashNote:(Note *)note;
 - (void)restoreNote:(Note *)note;
 - (void)permenentlyDeleteNote:(Note *)note;

--- a/Simplenote/Classes/SPObjectManager.h
+++ b/Simplenote/Classes/SPObjectManager.h
@@ -26,6 +26,7 @@
 - (Tag *)tagForName:(NSString *)tagName;
 - (void)moveTagFromIndex:(NSInteger)fromIndex toIndex:(NSInteger)toIndex;
 
+- (BOOL)hasUnsyncedNotes;
 - (void)trashNote:(Note *)note;
 - (void)restoreNote:(Note *)note;
 - (void)permenentlyDeleteNote:(Note *)note;

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -13,7 +13,7 @@
 #import "Note.h"
 #import "Tag.h"
 #import "NSString+Metadata.h"
-#import "JSONKit+Simplenote.h"
+
 
 @implementation SPObjectManager
 
@@ -35,24 +35,6 @@
 - (NSArray *)notes {
     
     return [[SPAppDelegate sharedDelegate].simperium.managedObjectContext fetchAllObjectsForEntityName:@"Note"];
-}
-
-// Unsycned notes have version "0" in the ghost data
-- (BOOL)hasUnsyncedNotes
-{
-    for (Note *note in self.notes) {
-        NSDictionary *parsedGhost   = [note.ghostData objectFromJSONString];
-        id version = [parsedGhost objectForKey:@"version"];
-        if (version == nil) {
-            continue;
-        }
-        
-        if ([version integerValue] == 0) {
-            return YES;
-        }
-    }
-    
-    return NO;
 }
 
 - (NSArray *)tags {

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -13,6 +13,7 @@
 #import "Note.h"
 #import "Tag.h"
 #import "NSString+Metadata.h"
+#import "JSONKit+Simplenote.h"
 
 @implementation SPObjectManager
 
@@ -35,6 +36,25 @@
     
     return [[SPAppDelegate sharedDelegate].simperium.managedObjectContext fetchAllObjectsForEntityName:@"Note"];
 }
+
+// Unsycned notes have version "0" in the ghost data
+- (BOOL)hasUnsyncedNotes
+{
+    for (Note *note in self.notes) {
+        NSDictionary *parsedGhost   = [note.ghostData objectFromJSONString];
+        id version = [parsedGhost objectForKey:@"version"];
+        if (version == nil) {
+            continue;
+        }
+        
+        if ([version integerValue] == 0) {
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+
 - (NSArray *)tags {
     
     // sort by index

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -13,7 +13,7 @@
 #import "UIView+ImageRepresentation.h"
 #import "UITableView+Styling.h"
 #import "VSThemeManager.h"
-#import "SPObjectManager.h"
+#import "StatusChecker.h"
 #import "SPTracker.h"
 #import "SPDebugViewController.h"
 #import "UIDevice+Extensions.h"
@@ -472,40 +472,43 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 - (void)signOutAction:(id)sender
 {
     // Safety first: Check for unsynced notes before they are deleted!
-    if ([[SPObjectManager sharedManager] hasUnsyncedNotes]) {
-        UIAlertController* alert = [UIAlertController
-                                    alertControllerWithTitle:NSLocalizedString(@"Unsynced Notes Detected", @"Alert title displayed in settings when an account has unsynced notes")
-                                    message:NSLocalizedString(@"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App.", @"Alert message displayed when an account has unsynced notes")
-                                    preferredStyle:UIAlertControllerStyleAlert];
-        
-        UIAlertAction* signOutAction = [UIAlertAction
-                                        actionWithTitle:NSLocalizedString(@"Sign Out", @"Verb: Sign out of the app")
-                                        style:UIAlertActionStyleDestructive
-                                        handler:^(UIAlertAction * action) {
-                                            [SPTracker trackUserSignedOut];
-                                            [[SPAppDelegate sharedDelegate] logoutAndReset:sender];
-                                        }];
-        UIAlertAction* viewWebAction = [UIAlertAction
-                                        actionWithTitle:NSLocalizedString(@"Visit Web App", @"Visit app.simplenote.com in the browser")
-                                        style:UIAlertActionStyleDefault
-                                        handler:^(UIAlertAction * action) {
-                                            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://app.simplenote.com"] options:@{} completionHandler:nil];
-                                        }];
-        UIAlertAction* cancelAction = [UIAlertAction
-                                       actionWithTitle:NSLocalizedString(@"Cancel", @"Verb, cancel an alert dialog")
-                                       style:UIAlertActionStyleCancel
-                                       handler:^(UIAlertAction * action) {
-                                           [alert dismissViewControllerAnimated:YES completion:nil];
-                                           
-                                       }];
-        [alert addAction:signOutAction];
-        [alert addAction:viewWebAction];
-        [alert addAction:cancelAction];
-        [self presentViewController:alert animated:YES completion:nil];
-    } else {
+    Simperium *simperium = [[SPAppDelegate sharedDelegate] simperium];
+
+    if ([StatusChecker hasUnsentChanges:simperium] == false) {
         [SPTracker trackUserSignedOut];
         [[SPAppDelegate sharedDelegate] logoutAndReset:sender];
+        return;
     }
+
+    UIAlertController* alert = [UIAlertController
+                                alertControllerWithTitle:NSLocalizedString(@"Unsynced Notes Detected", @"Alert title displayed in settings when an account has unsynced notes")
+                                message:NSLocalizedString(@"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App.", @"Alert message displayed when an account has unsynced notes")
+                                preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction* signOutAction = [UIAlertAction
+                                    actionWithTitle:NSLocalizedString(@"Sign Out", @"Verb: Sign out of the app")
+                                    style:UIAlertActionStyleDestructive
+                                    handler:^(UIAlertAction * action) {
+                                        [SPTracker trackUserSignedOut];
+                                        [[SPAppDelegate sharedDelegate] logoutAndReset:sender];
+                                    }];
+    UIAlertAction* viewWebAction = [UIAlertAction
+                                    actionWithTitle:NSLocalizedString(@"Visit Web App", @"Visit app.simplenote.com in the browser")
+                                    style:UIAlertActionStyleDefault
+                                    handler:^(UIAlertAction * action) {
+                                        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://app.simplenote.com"] options:@{} completionHandler:nil];
+                                    }];
+    UIAlertAction* cancelAction = [UIAlertAction
+                                   actionWithTitle:NSLocalizedString(@"Cancel", @"Verb, cancel an alert dialog")
+                                   style:UIAlertActionStyleCancel
+                                   handler:^(UIAlertAction * action) {
+                                       [alert dismissViewControllerAnimated:YES completion:nil];
+
+                                   }];
+    [alert addAction:signOutAction];
+    [alert addAction:viewWebAction];
+    [alert addAction:cancelAction];
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -486,7 +486,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                 preferredStyle:UIAlertControllerStyleAlert];
 
     UIAlertAction* signOutAction = [UIAlertAction
-                                    actionWithTitle:NSLocalizedString(@"Sign Out", @"Verb: Sign out of the app")
+                                    actionWithTitle:NSLocalizedString(@"Delete Notes", @"Verb: Delete notes and sign out of the app")
                                     style:UIAlertActionStyleDestructive
                                     handler:^(UIAlertAction * action) {
                                         [SPTracker trackUserSignedOut];

--- a/Simplenote/Classes/StatusChecker.h
+++ b/Simplenote/Classes/StatusChecker.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+
+
+@class Simperium;
+
+#pragma mark ================================================================================
+#pragma mark StatusChecker
+#pragma mark ================================================================================
+
+@interface StatusChecker : NSObject
+
++ (BOOL)hasUnsentChanges:(Simperium *)simperium;
+
+@end

--- a/Simplenote/Classes/StatusChecker.m
+++ b/Simplenote/Classes/StatusChecker.m
@@ -1,0 +1,53 @@
+#import "StatusChecker.h"
+#import "Note.h"
+@import Simperium;
+
+
+
+#pragma mark ================================================================================
+#pragma mark Workaround: Exposing Private SPBucket methods
+#pragma mark ================================================================================
+
+@interface SPBucket ()
+- (BOOL)hasLocalChangesForKey:(NSString *)key;
+@end
+
+
+#pragma mark ================================================================================
+#pragma mark Constants
+#pragma mark ================================================================================
+
+static NSString *kEntityName = @"Note";
+
+
+#pragma mark ================================================================================
+#pragma mark StatusChecker
+#pragma mark ================================================================================
+
+@implementation StatusChecker
+
++ (BOOL)hasUnsentChanges:(Simperium *)simperium
+{    
+    if (simperium.user.authenticated == false) {
+        return false;
+    }
+
+    SPBucket *bucket = [simperium bucketForName:kEntityName];
+    NSArray *allNotes = [bucket allObjects];
+    NSDate *startDate = [NSDate date];
+
+    NSLog(@"<> Status Checker: Found %ld Entities [%f seconds elapsed]", (unsigned long)allNotes.count, startDate.timeIntervalSinceNow);
+    
+    // Compare the Ghost Content string, against the Entity Content
+    for (Note *note in allNotes) {
+        if ([bucket hasLocalChangesForKey:note.simperiumKey]) {
+            NSLog(@"<> Status Checker: FOUND entities with local changes [%f seconds elapsed]", startDate.timeIntervalSinceNow);
+            return true;
+        }
+    }
+
+    NSLog(@"<> Status Checker: No entities with local changes [%f seconds elapsed]", startDate.timeIntervalSinceNow);
+    return false;
+}
+
+@end


### PR DESCRIPTION
Some users are losing notes when they sign out because for one reason or another they have unsynced notes. This is a quick solution to that which searches for unsynced notes upon signout and warns the user if so. An option is presented to view the web app to reconcile their unsynced notes:

![simulator screen shot - iphone x - 2018-01-25 at 09 51 42](https://user-images.githubusercontent.com/789137/35403875-f6f9b7d4-01b5-11e8-99ba-9c901a9742b0.png)

The most reliable way I found to check if a note was unsynced was if its `ghostData` object had a `version` of `0`.

**To Test**
* Take the app offline, and create a note.
* Visit settings tap signout. You should see the alert dialog.
* Verify all of the buttons work as expected.
* Also verify that you don't see the prompt if all of your notes have synced.