### PR TITLE
Fix Settings Button Placement on iPhone X

### DIFF
--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -136,16 +136,25 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [nc addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+}
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
+    CGFloat safeBottomInset = 0;
+    if (@available(iOS 11.0, *)) {
+        safeBottomInset = self.view.safeAreaInsets.bottom;
+    }
+    
     CGRect tableViewFrame = self.tableView.frame;
-    tableViewFrame.size.height = self.view.frame.size.height - SPSettingsButtonHeight;
+    tableViewFrame.size.height = self.view.frame.size.height - SPSettingsButtonHeight - safeBottomInset;
     self.tableView.frame = tableViewFrame;
-
+    
     settingsButton.frame = CGRectMake(tableViewFrame.origin.x,
                                       tableViewFrame.size.height,
                                       tableViewFrame.size.width,
                                       SPSettingsButtonHeight);
-
+    
     [self updateHeaderButtonHighlight];
 }
 
@@ -648,6 +657,10 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 }
 
 - (void)containerViewController:(SPSidebarContainerViewController *)container didChangeContentInset:(UIEdgeInsets)contentInset {
+
+    if (@available(iOS 11.0, *)) {
+        contentInset.bottom = self.tableView.contentInset.bottom;
+    }
     
     self.tableView.contentInset = contentInset;
     self.tableView.scrollIndicatorInsets = contentInset;


### PR DESCRIPTION
I've been finding it troublesome to tap the Settings button on the iPhone X:

<img width="416" alt="screen shot 2018-02-28 at 2 02 41 pm" src="https://user-images.githubusercontent.com/789137/36815750-90050b14-1c90-11e8-8c61-41ffe871cfc4.png">

This PR uses `safeAreaInsets` to move the button up to a safely tappable area:

<img width="414" alt="screen shot 2018-02-28 at 1 56 32 pm" src="https://user-images.githubusercontent.com/789137/36815820-c05ee3ac-1c90-11e8-91c6-c7333f8cef96.png">

I also fixed an issue where the tableview insets were inaccurate for the bottom of the tags list table view.