### PR TITLE
Update Markdown Preview CSS

### DIFF
--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -38,6 +38,7 @@
     NSString *headerStart =
         @"<html><head>"
             "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+            "<link href=\"https://fonts.googleapis.com/css?family=Noto+Serif\" rel=\"stylesheet\">"
             "<style media=\"screen\" type=\"text/css\">\n";
     NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\">";
     

--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -39,7 +39,7 @@
         @"<html><head>"
             "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
             "<style media=\"screen\" type=\"text/css\">\n";
-    NSString *headerEnd = @"</style></head><body><div class=\"note\"><div id=\"static_content\">";
+    NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\">";
     
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     NSString *path = [self cssPathForTheme:theme];
@@ -61,7 +61,7 @@
 
 + (NSString *)htmlFooter
 {
-    return @"</div></div></body></html>";
+    return @"</div></body></html>";
 }
 
 @end

--- a/Simplenote/Resources/markdown-dark.css
+++ b/Simplenote/Resources/markdown-dark.css
@@ -5,8 +5,6 @@
 }
 
 body {
-    line-height: 1.4;
-    font-size: 14px;
     background: transparent;
 }
 
@@ -22,224 +20,170 @@ html {
     margin: 0;
     padding: 0;
     background: #2d3034;
-}
-
-body {
-    font-family: "SanFranciscoDisplay-Regular", sans-serif;
     color: #dbdee0;
     text-rendering: optimizeLegibility;
 }
 
-h1 {
-    font-weight: 100;
-    font-size: 36px;
-    line-height: 1.2;
-    color: #dbdee0;
-    margin: 0 0 0.1em 0;
-    padding: 0 0 1em 0;
+::-webkit-scrollbar {
+    width: 6px;
 }
 
-h3 {
-    margin: 0.25em 0 1em 0;
-    font-weight: normal;
+::-webkit-scrollbar-track {
+    background-color: transparent;
 }
 
-legend, h2 {
-    font-weight: 200;
-    font-size: 30px;
-    color: #899198;
-    padding: 1em 0 1em 0;
+::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background: #84878a;
 }
 
-h4 {
-    font-size: 20px;
-    font-weight: normal;
-    line-height: 1.2;
-    margin: 0 0 0.25em 0;
-    color: #899198;
+/* Same styles as app.simplenote.com/publish */
+.note-detail-markdown {
+    user-select: auto;
+    font-family: 'Noto Serif', serif;
+    font-size: 18px;
+    line-height: 1.7;
+    word-wrap: break-word;
+    padding: 20px 20px 20px 24px;
 }
 
-h5 {
-    font-size: 0.9em;
-    font-weight: normal;
-    line-height: 1.5;
-    margin: 0 0 0 0;
-    color: #899198;
+.note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+.note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+.note-detail-markdown #title {
+    line-height: 1.15;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    margin: 1.7em 0 1em 0;
+}
+
+.note-detail-markdown h1, .note-detail-markdown #title {
+    font-size: 2em;
+}
+
+.note-detail-markdown h1:first-of-type, .note-detail-markdown #title:first-of-type {
+    margin-top: 0;
+}
+
+.note-detail-markdown h2 {
+    font-size: 1.8em;
+}
+
+.note-detail-markdown h3 {
+    font-size: 1.4em;
+}
+
+.note-detail-markdown h4 {
+    font-size: 1.2em;
+}
+
+.note-detail-markdown h5, .note-detail-markdown h6 {
+    font-size: 1em;
     text-transform: uppercase;
-    letter-spacing: 1;
 }
 
-ul {
-    list-style-type: none;
+.note-detail-markdown #title {
+    margin-bottom: 0.5em;
+    font-weight: bold;
 }
 
-ol {
-    padding: 0 0 0 2em;
-    list-style-type: decimal;
+.note-detail-markdown p, .note-detail-markdown ul, .note-detail-markdown ol,
+.note-detail-markdown blockquote, .note-detail-markdown pre, .note-detail-markdown table,
+.note-detail-markdown code, .note-detail-markdown img {
+    margin-bottom: 1.7em;
+    box-sizing: border-box;
 }
 
-ol li {
-    margin: 0 0 0.5em 0;
+.note-detail-markdown ul, .note-detail-markdown ol {
+    margin-left: 2em;
 }
 
-a {
-    cursor: pointer;
-    color: #232323;
-    text-decoration: none;
-}
-
-a:link, a:visited, a {
-    text-decoration: none;
-    color: #232323;
-}
-
-a:focus, a:hover {
-    color: #333;
-    border-bottom: 1px solid #fcfcfc;
-}
-
-a.img {
-    border: 0;
-}
-
-.note {
-    padding-top: 4px;
-    padding-bottom: 20px;
-    margin-bottom: 20px;
-    line-height: 1.4em;
-}
-
-.note a {
-    text-decoration: underline;
-}
-
-.note h3 {
-    margin: 0;
-}
-
-.note img {
+.note-detail-markdown img {
+    display: block;
+    margin: 0 auto;
     max-width: 100%;
     height: auto;
 }
 
-.note #static_content {
-    display: block;
-    font-size: 16px;
-    width: 100%;
-    height: 100%;
-    word-wrap: break-word;
-    font-size: 18px;
-    font-family: "SanFranciscoDisplay-Regular", sans-serif;
-    color: #dbdee0;
-    font-weight: 400;
-    line-height: 1.4em;
-    box-sizing: border-box;
-    padding: 16px;
+.note-detail-markdown a {
+    color: #4895d9;
 }
 
-.note #static_content h1, .note #static_content h2, .note #static_content h3,
-.note #static_content h4 {
-    line-height: 1.1em;
-    color: #dbdee0;
-    font-weight: 300;
-    padding: 0;
-}
-
-.note #static_content a {
-    color: #448ac9;
-    text-decoration: none;
-}
-
-.note #static_content a:hover {
-    text-decoration: underline;
+.note-detail-markdown hr {
     border: 0;
+    margin: 3.4em 0;
+    color: #4895d9;
+    height: 1em;
 }
 
-.note #static_content h1 {
-    margin-bottom: 1em;
+.note-detail-markdown hr:before {
+    content: '...';
+    display: block;
+    width: 100%;
+    letter-spacing: 2em;
+    text-indent: 2em;
+    z-index: 1;
+    line-height: .5;
     text-align: center;
-    font-size: 2em;
 }
 
-.note #static_content h2 {
-    margin-bottom: .5em;
-    font-size: 1.4em;
+.note-detail-markdown blockquote {
+    font-style: italic;
+    border-left: 4px solid currentColor;
+    margin-left: 0;
+    padding-left: 1.7em;
 }
 
-.note #static_content h3 {
-    margin-bottom: .6em;
-    font-size: 1.2em;
+.note-detail-markdown code {
+    color: #84878a;
 }
 
-.note #static_content h4 {
-    margin-bottom: .71em;
-    font-size: 1.1em;
+.note-detail-markdown pre {
+    padding: 1em;
+    border-radius: 3px;
+    background: #f6f7f8;
 }
 
-.note #static_content p, .note #static_content dd, .note #static_content dt,
-.note #static_content pre, .note #static_content ul, .note #static_content ol,
-.note #static_content table.text, .note #static_content div.warn {
-    padding-bottom: 17.6px;
-    line-height: 1.45em;
-}
-
-.note #static_content ul, .note #static_content ol {
-    padding-left: 24.8864px;
-}
-
-.note #static_content ul ul, .note #static_content ul ol, .note #static_content ol ul,
-.note #static_content ol ol {
+.note-detail-markdown pre code {
+    font-size: 85%;
+    color: #616870;
+    background: transparent;
+    width: 100%;
+    overflow-x: auto;
+    display: block;
     margin-bottom: 0;
 }
 
-.note #static_content ul {
-    list-style-type: square;
-}
-
-.note #static_content ol {
-    list-style-type: decimal;
-}
-
-.note #static_content dt {
-    font-weight: bold;
-}
-
-.note #static_content dd {
-    padding-left: 24.8864px;
-}
-
-.note #static_content blockquote {
-    border-left: 3px solid #5b6780;
-    margin-left: 11.4432px;
-    padding: 0 12.4432px 0 10.4432px;
-    color: #899198;
-}
-
-.note #static_content hr {
+.note-detail-markdown table {
+    border-collapse: collapse;
+    border-spacing: 0;
     display: block;
-    border-width: 0;
-    height: 1px;
-    background: #899198;
-    margin-bottom: 14.6px;
+    width: 100%;
 }
 
-.note #static_content pre, .note #static_content code {
-    white-space: pre-wrap;
-    font-size: 16px;
+.note-detail-markdown table tr:nth-child(2n) {
+    background-color: #383d41;
 }
 
-/* iPad regular */
-@media only screen and (min-width: 694px) {
-    .note #static_content {
-        padding-left: 64px;
-        padding-right: 64px;
+.note-detail-markdown table th, .note-detail-markdown table td {
+    border: 1px solid #575e65;
+    padding: 6px 13px;
+}
+
+.note-detail-markdown table th {
+    font-weight: 600;
+}
+
+@media only screen and (max-width: 480px) {
+    .note-detail-markdown {
+        font-size: 16px;
     }
-}
-
-/* iPad landscape full width */
-@media only screen and (min-width: 1024px) {
-    .note #static_content {
-        padding-left: 192px;
-        padding-right: 192px;
+    
+    .note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+    .note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+    .note-detail-markdown #title {
+        margin: 1.19em 0 0.7em 0;
+    }
+    
+    .note-detail-markdown #title {
+        margin-bottom: 0;
     }
 }

--- a/Simplenote/Resources/markdown-default.css
+++ b/Simplenote/Resources/markdown-default.css
@@ -5,8 +5,6 @@
 }
 
 body {
-    line-height: 1.4;
-    font-size: 14px;
     background: transparent;
 }
 
@@ -21,226 +19,172 @@ img {
 html {
     margin: 0;
     padding: 0;
-    background: #fcfcfc;
-}
-
-body {
-    font-family: "SanFranciscoDisplay-Regular", sans-serif;
+    background: #FFFFFF;
     color: #2d3034;
     text-rendering: optimizeLegibility;
 }
 
-h1 {
-    font-weight: 100;
-    font-size: 36px;
-    line-height: 1.2;
-    color: #333;
-    margin: 0 0 0.1em 0;
-    padding: 0 0 1em 0;
+::-webkit-scrollbar {
+    width: 6px;
 }
 
-h3 {
-    margin: 0.25em 0 1em 0;
-    font-weight: normal;
+::-webkit-scrollbar-track {
+    background-color: transparent;
 }
 
-legend, h2 {
-    font-weight: 200;
-    font-size: 30px;
-    color: #666;
-    padding: 1em 0 1em 0;
+::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background: #84878a;
 }
 
-h4 {
-    font-size: 20px;
-    font-weight: normal;
-    line-height: 1.2;
-    margin: 0 0 0.25em 0;
-    color: #666;
+/* Same styles as app.simplenote.com/publish */
+.note-detail-markdown {
+    user-select: auto;
+    font-family: 'Noto Serif', serif;
+    font-size: 18px;
+    line-height: 1.7;
+    word-wrap: break-word;
+    padding: 20px 20px 20px 24px;
 }
 
-h5 {
-    font-size: 0.9em;
-    font-weight: normal;
-    line-height: 1.5;
-    margin: 0 0 0 0;
-    color: #666;
+.note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+.note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+.note-detail-markdown #title {
+    line-height: 1.15;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    margin: 1.7em 0 1em 0;
+}
+
+.note-detail-markdown h1, .note-detail-markdown #title {
+    font-size: 2em;
+}
+
+.note-detail-markdown h1:first-of-type, .note-detail-markdown #title:first-of-type {
+    margin-top: 0;
+}
+
+.note-detail-markdown h2 {
+    font-size: 1.8em;
+}
+
+.note-detail-markdown h3 {
+    font-size: 1.4em;
+}
+
+.note-detail-markdown h4 {
+    font-size: 1.2em;
+}
+
+.note-detail-markdown h5, .note-detail-markdown h6 {
+    font-size: 1em;
     text-transform: uppercase;
-    letter-spacing: 1;
 }
 
-ul {
-    list-style-type: none;
+.note-detail-markdown #title {
+    margin-bottom: 0.5em;
+    font-weight: bold;
 }
 
-ol {
-    padding: 0 0 0 2em;
-    list-style-type: decimal;
+.note-detail-markdown p, .note-detail-markdown ul, .note-detail-markdown ol,
+.note-detail-markdown blockquote, .note-detail-markdown pre, .note-detail-markdown table,
+.note-detail-markdown code, .note-detail-markdown img {
+    margin-bottom: 1.7em;
+    box-sizing: border-box;
 }
 
-ol li {
-    margin: 0 0 0.5em 0;
+.note-detail-markdown ul, .note-detail-markdown ol {
+    margin-left: 2em;
 }
 
-a {
-    cursor: pointer;
-    color: #aaa;
-    text-decoration: none;
-}
-
-a:link, a:visited, a {
-    text-decoration: none;
-    color: #aaa;
-}
-
-a:focus, a:hover {
-    color: #333;
-    border-bottom: 1px solid #9a9c9f;
-}
-
-a.img {
-    border: 0;
-}
-
-.note {
-    padding-top: 4px;
-    padding-bottom: 20px;
-    margin-bottom: 20px;
-    line-height: 1.4em;
-}
-
-.note a {
-    text-decoration: underline;
-}
-
-.note h3 {
-    margin: 0;
-}
-
-.note img {
+.note-detail-markdown img {
+    display: block;
+    margin: 0 auto;
     max-width: 100%;
     height: auto;
 }
 
-.note #static_content {
-    display: block;
-    font-size: 16px;
-    width: 100%;
-    height: 100%;
-    word-wrap: break-word;
-    font-size: 18px;
-    font-family: "Source Sans Pro", sans-serif;
-    color: #2d3034;
-    font-weight: 400;
-    line-height: 1.4em;
-    color: #333;
-    box-sizing: border-box;
-    padding: 16px;
+.note-detail-markdown a {
+    color: #4895d9;
 }
 
-.note #static_content h1, .note #static_content h2, .note #static_content h3,
-.note #static_content h4 {
-    line-height: 1.1em;
-    color: #2d3034;
-    font-weight: 300;
-    padding: 0;
-}
-
-.note #static_content a {
-    color: #448ac9;
-    text-decoration: none;
-}
-
-.note #static_content a:hover {
-    text-decoration: underline;
+.note-detail-markdown hr {
     border: 0;
+    margin: 3.4em 0;
+    color: #4895d9;
+    height: 1em;
 }
 
-.note #static_content h1 {
-    margin-bottom: 1em;
+.note-detail-markdown hr:before {
+    content: '...';
+    display: block;
+    width: 100%;
+    letter-spacing: 2em;
+    text-indent: 2em;
+    z-index: 1;
+    line-height: .5;
     text-align: center;
-    font-size: 2em;
 }
 
-.note #static_content h2 {
-    margin-bottom: .5em;
-    font-size: 1.4em;
+.note-detail-markdown blockquote {
+    font-style: italic;
+    border-left: 4px solid currentColor;
+    margin-left: 0;
+    padding-left: 1.7em;
 }
 
-.note #static_content h3 {
-    margin-bottom: .6em;
-    font-size: 1.2em;
+.note-detail-markdown code {
+    color: #899199;
 }
 
-.note #static_content h4 {
-    margin-bottom: .71em;
-    font-size: 1.1em;
+.note-detail-markdown pre {
+    padding: 1em;
+    border-radius: 3px;
+    background: #f6f7f8;
 }
 
-.note #static_content p, .note #static_content dd, .note #static_content dt,
-.note #static_content pre, .note #static_content ul, .note #static_content ol,
-.note #static_content table.text, .note #static_content div.warn {
-    padding-bottom: 17.6px;
-    line-height: 1.45em;
-}
-
-.note #static_content ul, .note #static_content ol {
-    padding-left: 24.8864px;
-}
-
-.note #static_content ul ul, .note #static_content ul ol, .note #static_content ol ul,
-.note #static_content ol ol {
+.note-detail-markdown pre code {
+    font-size: 85%;
+    color: #616870;
+    background: transparent;
+    width: 100%;
+    overflow-x: auto;
+    display: block;
     margin-bottom: 0;
 }
 
-.note #static_content ul {
-    list-style-type: square;
-}
-
-.note #static_content ol {
-    list-style-type: decimal;
-}
-
-.note #static_content dt {
-    font-weight: bold;
-}
-
-.note #static_content dd {
-    padding-left: 24.8864px;
-}
-
-.note #static_content blockquote {
-    border-left: 3px solid #d0d0d0;
-    margin-left: 11.4432px;
-    padding: 0 12.4432px 0 10.4432px;
-    color: #4c4c4c;
-}
-
-.note #static_content hr {
+.note-detail-markdown table {
+    border-collapse: collapse;
+    border-spacing: 0;
     display: block;
-    border-width: 0;
-    height: 1px;
-    background: #F0F0F0;
-    margin-bottom: 14.6px;
+    width: 100%;
 }
 
-.note #static_content pre, .note #static_content code {
-    white-space: pre-wrap;
-    font-size: 16px;
+.note-detail-markdown table tr:nth-child(2n) {
+    background-color: #f6f7f8;
 }
 
-/* iPad regular */
-@media only screen and (min-width: 694px) {
-    .note #static_content {
-        padding-left: 64px;
-        padding-right: 64px;
+.note-detail-markdown table th, .note-detail-markdown table td {
+    border: 1px solid #c0c4c8;
+    padding: 6px 13px;
+}
+
+.note-detail-markdown table th {
+    font-weight: 600;
+}
+
+@media only screen and (max-width: 480px) {
+    .note-detail-markdown {
+        font-size: 16px;
+    }
+    
+    .note-detail-markdown h1, .note-detail-markdown h2, .note-detail-markdown h3,
+    .note-detail-markdown h4, .note-detail-markdown h5, .note-detail-markdown h6,
+    .note-detail-markdown #title {
+        margin: 1.19em 0 0.7em 0;
+    }
+    
+    .note-detail-markdown #title {
+        margin-bottom: 0;
     }
 }
 
-/* iPad landscape full width */
-@media only screen and (min-width: 1024px) {
-    .note #static_content {
-        padding-left: 192px;
-        padding-right: 192px;
-    }
-}


### PR DESCRIPTION
We recently updated the CSS on app.simplenote.com when you view a published note w/ markdown to have more of a 'personal publisher' feel. This PR updates the CSS for the markdown preview to exactly match it.

Screenshots:
![simulator screen shot - iphone x - 2018-04-05 at 14 47 47](https://user-images.githubusercontent.com/789137/38393701-806aa13e-38e0-11e8-890d-2fa53c3c51c3.png)
![simulator screen shot - iphone x - 2018-04-05 at 14 48 10](https://user-images.githubusercontent.com/789137/38393702-807da09a-38e0-11e8-85a0-dfdbe21a467b.png)

