### PR TITLE
Add Pin Lock Timeout Option

### DIFF
--- a/External/DTPinLock/DTPinLockController.m
+++ b/External/DTPinLock/DTPinLockController.m
@@ -162,6 +162,11 @@
 
 - (void)displayTouchIDIfAppropriate
 {
+    // Don't show biometry prompt if user-set timeout hasn't expired yet
+    if ([SPPinLockManager shouldBypassPinLock]) {
+        return;
+    }
+    
     BOOL appIsActive = [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
     BOOL localAuthIsAvailable = !![LAContext class];
     BOOL modeIsUnlockWithTouchID = mode == PinLockControllerModeUnlockAllowTouchID;

--- a/External/DTPinLock/DTPinLockController.m
+++ b/External/DTPinLock/DTPinLockController.m
@@ -18,7 +18,7 @@
 
 @interface DTPinLockController ()
 
-@property (nonatomic, assign) BOOL wasInBackground;
+@property (nonatomic, assign) BOOL biometryUnlockWasSuccessful;
 
 - (void) switchToConfirmPageAnimated:(BOOL)animated;
 - (void) setupDigitViews;
@@ -116,7 +116,6 @@
         
         if (mode == PinLockControllerModeUnlockAllowTouchID) {
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidEnterForeground:) name:UIApplicationDidBecomeActiveNotification object:nil];
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
         }
     }
     
@@ -147,23 +146,20 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)appDidEnterBackground:(NSNotification *)notification
-{
-    self.wasInBackground = YES;
-}
-
 - (void)appDidEnterForeground:(NSNotification *)notification
 {
-    if (self.wasInBackground == YES) {
-        self.wasInBackground = NO;
-        [self displayTouchIDIfAppropriate];
-    }
+    [self displayTouchIDIfAppropriate];
 }
 
 - (void)displayTouchIDIfAppropriate
 {
     // Don't show biometry prompt if user-set timeout hasn't expired yet
     if ([SPPinLockManager shouldBypassPinLock]) {
+        return;
+    }
+    
+    // Prevent duplicate biometry prompts
+    if (self.biometryUnlockWasSuccessful) {
         return;
     }
     
@@ -185,6 +181,7 @@
                                       dispatch_async(dispatch_get_main_queue(), ^{
                                           [self dismissKeyboard];
                                           [self didFinishUnlocking];
+                                          self.biometryUnlockWasSuccessful = YES;
                                       });
                                   }
                               }];

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		051E7EA368E0DBAE2EE92CB9 /* Pods_SimplenoteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6184665CE9AF426D43E2C02 /* Pods_SimplenoteTests.framework */; };
+		371A8630213DF00E002E9120 /* SPPinLockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371A862F213DF00E002E9120 /* SPPinLockManager.swift */; };
 		373897BC1F8328DE00CEDF91 /* SPTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373897BB1F8328DE00CEDF91 /* SPTitleView.swift */; };
 		37582B781DBFCD8D00695F36 /* SPBorderedTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 37582B771DBFCD8D00695F36 /* SPBorderedTableView.m */; };
 		3762530620F54FFB00C1F239 /* SPAboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3762530520F54FFB00C1F239 /* SPAboutViewController.swift */; };
@@ -198,6 +199,7 @@
 		183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Automattic_SimplenoteShare.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		30BBEDD4EB11FC7D576AE690 /* Pods-SimplenoteTests.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		3318C36BBA08D53624E27EFC /* Pods_Automattic_Simplenote.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Automattic_Simplenote.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		371A862F213DF00E002E9120 /* SPPinLockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPPinLockManager.swift; sourceTree = "<group>"; };
 		373897BB1F8328DE00CEDF91 /* SPTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPTitleView.swift; path = Classes/SPTitleView.swift; sourceTree = "<group>"; };
 		37582B761DBFCD8D00695F36 /* SPBorderedTableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPBorderedTableView.h; path = Classes/SPBorderedTableView.h; sourceTree = "<group>"; };
 		37582B771DBFCD8D00695F36 /* SPBorderedTableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPBorderedTableView.m; path = Classes/SPBorderedTableView.m; sourceTree = "<group>"; };
@@ -723,6 +725,7 @@
 				B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */,
 				37E10E7920B3477800864E43 /* WPAuthHandler.h */,
 				37E10E7620B3368700864E43 /* WPAuthHandler.m */,
+				371A862F213DF00E002E9120 /* SPPinLockManager.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1514,6 +1517,7 @@
 				B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */,
 				46A3C9AF17DFA81A002865AE /* NSString+Condensing.m in Sources */,
 				B50F47A41D1D78EA00822748 /* SPRatingsHelper.m in Sources */,
+				371A8630213DF00E002E9120 /* SPPinLockManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simplenote/Classes/SPOptionsViewController.h
+++ b/Simplenote/Classes/SPOptionsViewController.h
@@ -10,7 +10,7 @@
 #import "DTPinLockController.h"
 #import "SPTableViewController.h"
 
-@interface SPOptionsViewController : SPTableViewController <PinLockDelegate> {
+@interface SPOptionsViewController : SPTableViewController <PinLockDelegate, UIPickerViewDelegate, UIPickerViewDataSource> {
     
     //Preferences
     NSNumber *sortOrderPref;

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -342,7 +342,6 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     break;
                 }
                 case SPOptionsSecurityRowRowBiometry: {
-                    // Let the timeout row render the cell (next switch statement) if biometry is unavailable
                     if ([self biometryIsAvailable]) {
                         cell.textLabel.text = self.biometryTitle;
                         cell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -355,6 +354,8 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                         
                         break;
                     }
+                    
+                    // No break here so we intentionally render the Timeout cell if biometry is disabled
                 }
                 case SPOptionsSecurityRowTimeout: {
                     cell.textLabel.text = NSLocalizedString(@"Lock Timeout", @"Setting for when the passcode lock should enable");

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -153,7 +153,6 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     [self.doneToolbar sizeToFit];
     
     UIBarButtonItem *doneButtonItem = [[UIBarButtonItem alloc] initWithTitle: NSLocalizedString(@"Done", @"Done toolbar button")                                                                                    style:UIBarButtonItemStylePlain target:self                                                                 action:@selector(pinTimeoutDoneAction:)];
-    
     UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace                                                                                    target:nil action:nil];
     
     fixedSpace.width = self.doneToolbar.frame.size.width;

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -235,8 +235,9 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
         }
             
         case SPOptionsViewSectionsSecurity: {
-            int rowsToRemove = [self pinLockIsEnabled] ? 1 : 2;
-            return self.biometryIsAvailable ? SPOptionsSecurityRowRowCount : SPOptionsSecurityRowRowCount - rowsToRemove;
+            int rowsToRemove = self.biometryIsAvailable ? 0 : 1;
+            int disabledPinLockRows = [self biometryIsAvailable] ? 2 : 1;
+            return [self pinLockIsEnabled] ? SPOptionsSecurityRowRowCount - rowsToRemove : disabledPinLockRows;
         }
             
         case SPOptionsViewSectionsAbout: {
@@ -341,14 +342,19 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     break;
                 }
                 case SPOptionsSecurityRowRowBiometry: {
-                    cell.textLabel.text = self.biometryTitle;
-                    cell.selectionStyle = UITableViewCellSelectionStyleNone;
-
-                    BOOL isBiometryOn = [[SPAppDelegate sharedDelegate] allowBiometryInsteadOfPin];
-
-                    self.biometrySwitch.on = isBiometryOn;
-                    cell.accessoryView = self.biometrySwitch;
-                    cell.tag = kTagTouchID;
+                    // Let the timeout row render the cell (next switch statement) if biometry is unavailable
+                    if ([self biometryIsAvailable]) {
+                        cell.textLabel.text = self.biometryTitle;
+                        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+                        
+                        BOOL isBiometryOn = [[SPAppDelegate sharedDelegate] allowBiometryInsteadOfPin];
+                        
+                        self.biometrySwitch.on = isBiometryOn;
+                        cell.accessoryView = self.biometrySwitch;
+                        cell.tag = kTagTouchID;
+                        
+                        break;
+                    }
                 }
                 case SPOptionsSecurityRowTimeout: {
                     cell.textLabel.text = NSLocalizedString(@"Lock Timeout", @"Setting for when the passcode lock should enable");
@@ -358,6 +364,8 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     
                     NSInteger timeoutPref = [[NSUserDefaults standardUserDefaults] integerForKey:kPinTimeoutPreferencesKey];
                     [cell.detailTextLabel setText:timeoutPickerOptions[timeoutPref]];
+                    
+                    break;
                 }
                     
                 default:

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -27,21 +27,27 @@ NSString *const SPAlphabeticalSortPreferenceChangedNotification     = @"SPAlphab
 NSString *const SPThemePref                                         = @"SPThemePref";
 
 @interface SPOptionsViewController ()
-@property (nonatomic, strong) UISwitch  *condensedNoteListSwitch;
-@property (nonatomic, strong) UISwitch  *alphabeticalSortSwitch;
-@property (nonatomic, strong) UISwitch  *themeListSwitch;
-@property (nonatomic, strong) UISwitch  *biometrySwitch;
-@property (nonatomic, assign) BOOL      biometryIsAvailable;
-@property (nonatomic, copy) NSString    *biometryTitle;
+@property (nonatomic, strong) UISwitch      *condensedNoteListSwitch;
+@property (nonatomic, strong) UISwitch      *alphabeticalSortSwitch;
+@property (nonatomic, strong) UISwitch      *themeListSwitch;
+@property (nonatomic, strong) UISwitch      *biometrySwitch;
+@property (nonatomic, assign) BOOL          biometryIsAvailable;
+@property (nonatomic, copy) NSString        *biometryTitle;
+@property (nonatomic, strong) UITextField   *pinTimeoutTextField;
+@property (nonatomic, strong) UIPickerView  *pinTimeoutPickerView;
+@property (nonatomic, strong) UIToolbar     *doneToolbar;
 @end
 
-@implementation SPOptionsViewController
+@implementation SPOptionsViewController {
+    NSArray *timeoutPickerOptions;
+}
 
 #define kTagAlphabeticalSort    1
 #define kTagCondensedNoteList   2
 #define kTagTheme               3
 #define kTagPasscode            4
-#define kTagTouchID             5
+#define kTagTimeout             5
+#define kTagTouchID             6
 
 typedef NS_ENUM(NSInteger, SPOptionsViewSections) {
     SPOptionsViewSectionsPreferences    = 0,
@@ -68,7 +74,8 @@ typedef NS_ENUM(NSInteger, SPOptionsPreferencesRow) {
 typedef NS_ENUM(NSInteger, SPOptionsSecurityRow) {
     SPOptionsSecurityRowRowPasscode     = 0,
     SPOptionsSecurityRowRowBiometry     = 1,
-    SPOptionsSecurityRowRowCount        = 2
+    SPOptionsSecurityRowTimeout         = 2,
+    SPOptionsSecurityRowRowCount        = 3
 };
 
 typedef NS_ENUM(NSInteger, SPOptionsAboutRow) {
@@ -99,6 +106,15 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 {
     [super viewDidLoad];
     
+    timeoutPickerOptions = @[NSLocalizedString(@"Off", @"Instant passcode lock timeout"),
+                       NSLocalizedString(@"15 Seconds", @"15 seconds passcode lock timeout"),
+                       NSLocalizedString(@"30 Seconds", @"30 seconds passcode lock timeout"),
+                       NSLocalizedString(@"1 Minute", @"1 minute passcode lock timeout"),
+                       NSLocalizedString(@"2 Minutes", @"2 minutes passcode lock timeout"),
+                       NSLocalizedString(@"3 Minutes", @"3 minutes passcode lock timeout"),
+                       NSLocalizedString(@"4 Minutes", @"4 minutes passcode lock timeout"),
+                       NSLocalizedString(@"5 Minutes", @"5 minutes passcode lock timeout")];
+    
     self.navigationController.navigationBar.translucent = YES;
     self.navigationItem.title = NSLocalizedString(@"Settings", @"Title of options screen");
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
@@ -125,6 +141,29 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     [self.biometrySwitch addTarget:self
                            action:@selector(touchIdSwitchDidChangeValue:)
                  forControlEvents:UIControlEventValueChanged];
+    
+    self.pinTimeoutPickerView = [UIPickerView new];
+    self.pinTimeoutPickerView.delegate = self;
+    self.pinTimeoutPickerView.dataSource = self;
+    [self.pinTimeoutPickerView selectRow:[[NSUserDefaults standardUserDefaults] integerForKey:kPinTimeoutPreferencesKey] inComponent:0 animated:NO];
+    
+    self.doneToolbar = [UIToolbar new];
+    self.doneToolbar.barStyle = UIBarStyleDefault;
+    self.doneToolbar.translucent = NO;
+    [self.doneToolbar sizeToFit];
+    
+    UIBarButtonItem *doneButtonItem = [[UIBarButtonItem alloc] initWithTitle: NSLocalizedString(@"Done", @"Done toolbar button")                                                                                    style:UIBarButtonItemStylePlain target:self                                                                 action:@selector(pinTimeoutDoneAction:)];
+    
+    UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace                                                                                    target:nil action:nil];
+    
+    fixedSpace.width = self.doneToolbar.frame.size.width;
+    [self.doneToolbar setItems:[NSArray arrayWithObjects:fixedSpace, doneButtonItem, nil]];
+    
+    self.pinTimeoutTextField = [UITextField new];
+    self.pinTimeoutTextField.frame = CGRectMake(0, 0, 0, 0);
+    self.pinTimeoutTextField.inputView = self.pinTimeoutPickerView;
+    self.pinTimeoutTextField.inputAccessoryView = self.doneToolbar;
+    [self.view addSubview:self.pinTimeoutTextField];
     
     // Listen to Theme Notifications
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -197,7 +236,8 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
         }
             
         case SPOptionsViewSectionsSecurity: {
-            return self.biometryIsAvailable ? SPOptionsSecurityRowRowCount : SPOptionsSecurityRowRowCount - 1;
+            int rowsToRemove = [self pinLockIsEnabled] ? 1 : 2;
+            return self.biometryIsAvailable ? SPOptionsSecurityRowRowCount : SPOptionsSecurityRowRowCount - rowsToRemove;
         }
             
         case SPOptionsViewSectionsAbout: {
@@ -291,9 +331,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                 case SPOptionsSecurityRowRowPasscode: {
                     cell.textLabel.text = NSLocalizedString(@"Passcode", @"A 4-digit code to lock the app when it is closed");
                     
-                    NSString *pin = [[SPAppDelegate sharedDelegate] getPin:NO];
-                    
-                    if (pin != nil && pin.length > 0)
+                    if ([self pinLockIsEnabled])
                         cell.detailTextLabel.text = NSLocalizedString(@"On", nil);
                     else
                         cell.detailTextLabel.text = NSLocalizedString(@"Off", nil);
@@ -312,6 +350,15 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     self.biometrySwitch.on = isBiometryOn;
                     cell.accessoryView = self.biometrySwitch;
                     cell.tag = kTagTouchID;
+                }
+                case SPOptionsSecurityRowTimeout: {
+                    cell.textLabel.text = NSLocalizedString(@"Lock Timeout", @"Setting for when the passcode lock should enable");
+                    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+                    cell.accessoryView = nil;
+                    cell.tag = kTagTimeout;
+                    
+                    NSInteger timeoutPref = [[NSUserDefaults standardUserDefaults] integerForKey:kPinTimeoutPreferencesKey];
+                    [cell.detailTextLabel setText:timeoutPickerOptions[timeoutPref]];
                 }
                     
                 default:
@@ -369,6 +416,12 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     return cell;
 }
 
+- (BOOL)pinLockIsEnabled {
+    NSString *pin = [[SPAppDelegate sharedDelegate] getPin:NO];
+    
+    return pin != nil && pin.length > 0;
+}
+
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
@@ -380,6 +433,9 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             switch (cell.tag) {
                 case kTagPasscode: {
                     [self showPinLockViewController];
+                    break;
+                case kTagTimeout:
+                    [self.pinTimeoutTextField becomeFirstResponder];
                     break;
                 }
             }
@@ -614,6 +670,10 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
         theSwitch.tintColor     = [theme colorForKey:@"switchTintColor"];
     }
     
+    [self.pinTimeoutPickerView setBackgroundColor:[theme colorForKey:@"backgroundColor"]];
+    [self.doneToolbar setTintColor:[theme colorForKey:@"tintColor"]];
+    [self.doneToolbar setBarTintColor:[theme colorForKey:@"backgroundColor"]];
+    
     // Refresh the Table
     [self.tableView applyDefaultGroupedStyling];
 }
@@ -647,6 +707,35 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 - (BOOL)themePref
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:SPThemePref];
+}
+
+#pragma mark - Picker view delegate
+- (NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView {
+    return 1;
+}
+
+- (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component {
+    return [timeoutPickerOptions count];
+}
+
+- (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component {
+    [self.pinTimeoutTextField setText:timeoutPickerOptions[row]];
+    
+    [[NSUserDefaults standardUserDefaults] setInteger:row forKey:kPinTimeoutPreferencesKey];
+    [self.tableView reloadData];
+}
+
+- (void)pinTimeoutDoneAction:(id)sender
+{
+    [self.pinTimeoutTextField resignFirstResponder];
+}
+
+- (NSAttributedString *)pickerView:(UIPickerView *)pickerView attributedTitleForRow:(NSInteger)row forComponent:(NSInteger)component {
+    VSTheme *theme = [[VSThemeManager sharedManager] theme];
+    NSAttributedString *attributedTitle =
+    [[NSAttributedString alloc] initWithString:timeoutPickerOptions[row] attributes:@{NSForegroundColorAttributeName:[theme colorForKey:@"textColor"]}];
+    
+    return attributedTitle;
 }
 
 @end

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -739,8 +739,8 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 
 - (NSAttributedString *)pickerView:(UIPickerView *)pickerView attributedTitleForRow:(NSInteger)row forComponent:(NSInteger)component {
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
-    NSAttributedString *attributedTitle =
-    [[NSAttributedString alloc] initWithString:timeoutPickerOptions[row] attributes:@{NSForegroundColorAttributeName:[theme colorForKey:@"textColor"]}];
+    NSDictionary *attributes = @{NSForegroundColorAttributeName:[theme colorForKey:@"textColor"]};
+    NSAttributedString *attributedTitle = [[NSAttributedString alloc] initWithString:timeoutPickerOptions[row] attributes:attributes];
     
     return attributedTitle;
 }

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -312,42 +312,10 @@
     // Dismiss the pin lock window if the user has returned to the app before their preferred timeout length
     if (self.pinLockWindow != nil
         && [self.pinLockWindow isKeyWindow]
-        && [self shouldBypassPinLock]) {
+        && [SPPinLockManager shouldBypassPinLock]) {
         // Bring the main window to the front, which 'dismisses' the pin lock window
         [self.window makeKeyAndVisible];
     }
-}
-
-- (BOOL)shouldBypassPinLock {
-    NSString *lastUsedString = [SPKeychain passwordForService:kSimplenotePasscodeServiceName account:kShareExtensionAccountName];
-    if (lastUsedString == nil) {
-        return NO;
-    }
-    
-    long lastUsedSeconds = lastUsedString.longLongValue;
-    if (lastUsedSeconds == 0) {
-        return NO;
-    }
-    
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-    long nowSeconds = (long)ts.tv_sec;
-    long intervalSinceLastUsed = nowSeconds - lastUsedSeconds;
-    NSInteger maxTimeoutSeconds = [self getPinLockTimeoutSeconds];
-
-    return intervalSinceLastUsed < maxTimeoutSeconds;
-}
-
-// Returns the number of seconds of the 'Timeout Lock' setting selected in SPOptionsViewController
-- (NSInteger)getPinLockTimeoutSeconds {
-    NSInteger timeoutPref = [[NSUserDefaults standardUserDefaults] integerForKey:kPinTimeoutPreferencesKey];
-    NSArray *timeoutValues = @[@0, @15, @30, @60, @120, @180, @240, @300];
-    
-    if (timeoutPref > timeoutValues.count) {
-        return 0;
-    }
-    
-    return [timeoutValues[timeoutPref] integerValue];
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -308,13 +308,15 @@
     return YES;
 }
 
-- (void)applicationWillEnterForeground:(UIApplication *)application {
+- (void)applicationDidBecomeActive:(UIApplication *)application {
     // Dismiss the pin lock window if the user has returned to the app before their preferred timeout length
     if (self.pinLockWindow != nil
         && [self.pinLockWindow isKeyWindow]
         && [SPPinLockManager shouldBypassPinLock]) {
         // Bring the main window to the front, which 'dismisses' the pin lock window
         [self.window makeKeyAndVisible];
+        [self.pinLockWindow removeFromSuperview];
+        self.pinLockWindow = nil;
     }
 }
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -355,10 +355,7 @@
     
     // For the passcode lock, store the current clock time for comparison when returning to the app
     if ([self passcodeLockIsEnabled]) {
-        struct timespec ts;
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-        NSString *nowTime = [NSString stringWithFormat:@"%ld", (long)ts.tv_sec];
-        [SPKeychain setPassword:nowTime forService:kSimplenotePasscodeServiceName account:kShareExtensionAccountName];
+        [SPPinLockManager storeLastUsedTime];
     }
 }
 

--- a/Simplenote/SPConstants.h
+++ b/Simplenote/SPConstants.h
@@ -40,3 +40,6 @@ extern NSString *const kSignInErrorNotificationName;
 extern NSString *const kSimplenotePublishURL;
 extern NSString *const kSimplenoteDarkThemeName;
 extern NSString *const kSimplenoteDefaultThemeName;
+
+extern NSString *const kAppLastUsedDatePreferencesKey;
+extern NSString *const kPinTimeoutPreferencesKey;

--- a/Simplenote/SPConstants.h
+++ b/Simplenote/SPConstants.h
@@ -22,6 +22,7 @@ extern NSString *const kShareExtensionAccountName;
 extern NSString *const kShareExtensionGroupName;
 extern NSString *const kShareExtensionServiceName;
 extern NSString *const kSimplenoteWPServiceName;
+extern NSString *const kSimplenotePasscodeServiceName;
 
 extern NSString *const kOnePasswordSimplenoteTitle;
 extern NSString *const kOnePasswordSimplenoteURL;
@@ -41,5 +42,4 @@ extern NSString *const kSimplenotePublishURL;
 extern NSString *const kSimplenoteDarkThemeName;
 extern NSString *const kSimplenoteDefaultThemeName;
 
-extern NSString *const kAppLastUsedDatePreferencesKey;
 extern NSString *const kPinTimeoutPreferencesKey;

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -50,3 +50,6 @@ NSString *const kSignInErrorNotificationName        = @"SPSignInErrorNotificatio
 NSString *const kSimplenotePublishURL               = @"http://simp.ly/publish/";
 NSString *const kSimplenoteDarkThemeName            = @"dark";
 NSString *const kSimplenoteDefaultThemeName         = @"default";
+
+NSString *const kAppLastUsedDatePreferencesKey      = @"kAppLastUsedDatePreferencesKey";
+NSString *const kPinTimeoutPreferencesKey           = @"kPinTimeoutPreferencesKey";

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -44,6 +44,7 @@ NSString *const kSimplenotePinLegacyKey             = @"PIN";
 NSString *const kSimplenoteUseBiometryKey           = @"SimplenoteUseTouchID";
 NSString *const kSimplenoteMarkdownDefaultKey       = @"MarkdownDefault";
 NSString *const kSimplenoteWPServiceName            = @"simplenote-wpcom";
+NSString *const kSimplenotePasscodeServiceName      = @"simplenote-passcode";
 
 NSString *const kSignInErrorNotificationName        = @"SPSignInErrorNotificationName";
 
@@ -51,5 +52,4 @@ NSString *const kSimplenotePublishURL               = @"http://simp.ly/publish/"
 NSString *const kSimplenoteDarkThemeName            = @"dark";
 NSString *const kSimplenoteDefaultThemeName         = @"default";
 
-NSString *const kAppLastUsedDatePreferencesKey      = @"kAppLastUsedDatePreferencesKey";
 NSString *const kPinTimeoutPreferencesKey           = @"kPinTimeoutPreferencesKey";

--- a/Simplenote/SPPinLockManager.swift
+++ b/Simplenote/SPPinLockManager.swift
@@ -38,4 +38,11 @@ class SPPinLockManager: NSObject {
         
         return timeoutValues[timeoutPref]
     }
+    
+    @objc static func storeLastUsedTime() {
+        var ts = timespec.init()
+        clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
+        let nowTime = String.init(format: "%ld", ts.tv_sec)
+        SPKeychain.setPassword(nowTime, forService: kSimplenotePasscodeServiceName, account: kShareExtensionAccountName)
+    }
 }

--- a/Simplenote/SPPinLockManager.swift
+++ b/Simplenote/SPPinLockManager.swift
@@ -10,12 +10,12 @@ import Foundation
 class SPPinLockManager: NSObject {
     @objc static func shouldBypassPinLock() -> Bool {
         let lastUsedString = SPKeychain.password(forService: kSimplenotePasscodeServiceName, account: kShareExtensionAccountName)
-        if (lastUsedString == nil) {
+        if lastUsedString == nil {
             return false
         }
         
         let lastUsedSeconds = Int(lastUsedString!);
-        if (lastUsedSeconds == 0) {
+        if lastUsedSeconds == 0 {
             return false
         }
         
@@ -32,7 +32,7 @@ class SPPinLockManager: NSObject {
         let timeoutPref = UserDefaults.standard.integer(forKey: kPinTimeoutPreferencesKey)
         let timeoutValues = [0, 15, 30, 60, 120, 180, 240, 300]
         
-        if (timeoutPref > timeoutValues.count) {
+        if timeoutPref > timeoutValues.count {
             return 0
         }
         
@@ -42,7 +42,7 @@ class SPPinLockManager: NSObject {
     @objc static func storeLastUsedTime() {
         var ts = timespec.init()
         clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
-        let nowTime = String.init(format: "%ld", ts.tv_sec)
+        let nowTime = String(format: "%ld", ts.tv_sec)
         SPKeychain.setPassword(nowTime, forService: kSimplenotePasscodeServiceName, account: kShareExtensionAccountName)
     }
 }

--- a/Simplenote/SPPinLockManager.swift
+++ b/Simplenote/SPPinLockManager.swift
@@ -1,0 +1,41 @@
+//
+//  SPPinLockManager.swift
+//  Simplenote
+//
+//  Helper functions for accessing the apps pin lock settings
+//
+
+import Foundation
+
+class SPPinLockManager: NSObject {
+    @objc static func shouldBypassPinLock() -> Bool {
+        let lastUsedString = SPKeychain.password(forService: kSimplenotePasscodeServiceName, account: kShareExtensionAccountName)
+        if (lastUsedString == nil) {
+            return false
+        }
+        
+        let lastUsedSeconds = Int(lastUsedString!);
+        if (lastUsedSeconds == 0) {
+            return false
+        }
+        
+        var ts = timespec.init()
+        clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
+        let nowSeconds = ts.tv_sec
+        let intervalSinceLastUsed = Int(nowSeconds) - lastUsedSeconds!
+        let maxTimeoutSeconds = getPinLockTimeoutSeconds()
+        
+        return intervalSinceLastUsed < maxTimeoutSeconds;
+    }
+    
+    static func getPinLockTimeoutSeconds() -> Int {
+        let timeoutPref = UserDefaults.standard.integer(forKey: kPinTimeoutPreferencesKey)
+        let timeoutValues = [0, 15, 30, 60, 120, 180, 240, 300]
+        
+        if (timeoutPref > timeoutValues.count) {
+            return 0
+        }
+        
+        return timeoutValues[timeoutPref]
+    }
+}


### PR DESCRIPTION
Adding a new setting for the pin lock timeout that will dismiss the lock screen if the chosen amount of time hasn't passed yet. I'm not particularly fond of how much code it took to add this feature, but it does appear to work nicely :)

Screenshot:
![simulator screen shot - iphone 7 - 2018-08-22 at 13 57 35](https://user-images.githubusercontent.com/789137/44490743-fb916780-a613-11e8-9871-005f614ea73d.png)

**To Test**
* Enable the passcode lock in Settings.
* Leave the app and come back, you should immediately see the passcode lock.
* Change the `Lock Timeout` setting to something other than `Off`.
* Leave the app and come back within the timeframe that you set. You should return to the app where you left off with no pin lock presented.
* Setting it back to `Off` should imeddiately show the pin lock again when returning to the app.

I've been 🤔 about this related to security. I suppose you could change the clock of the device to try and match when the user last left the app to bypass the lock screen, but you'd have to know when they last left the app so I'm not too worried about that. Any other security considerations the reviewer may have is most welcome!

Fixes #215