### PR TITLE
Fix markdown table rendering

### DIFF
--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -16,7 +16,12 @@
 + (NSString *)renderHTMLFromMarkdownString:(NSString *)markdown
 {
     hoedown_renderer *renderer = hoedown_html_renderer_new(HOEDOWN_HTML_SKIP_HTML, 0);
-    hoedown_document *document = hoedown_document_new(renderer, HOEDOWN_EXT_AUTOLINK | HOEDOWN_EXT_FENCED_CODE | HOEDOWN_EXT_FOOTNOTES, 16);
+    hoedown_document *document = hoedown_document_new(renderer,
+                                                      HOEDOWN_EXT_AUTOLINK |
+                                                      HOEDOWN_EXT_FENCED_CODE |
+                                                      HOEDOWN_EXT_FOOTNOTES |
+                                                      HOEDOWN_EXT_TABLES,
+                                                      16);
     hoedown_buffer *html = hoedown_buffer_new(16);
     
     NSData *markdownData = [markdown dataUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Adding the hoedown table extension. Fixes #189.

**To Test:**
1. Create a markdown note, and add a table such as:
```
| 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|
| a | b | c | d | e |
```
2. Swipe to preview the note, it should have proper formatting:
<img width="375" alt="screen shot 2018-08-28 at 11 01 02 am" src="https://user-images.githubusercontent.com/789137/44741449-fa4bb900-aab1-11e8-9315-cae0f2319384.png">