### PR TITLE
Fixes PIN Lock Issues

### DIFF
--- a/External/DTPinLock/DTPinLockController.m
+++ b/External/DTPinLock/DTPinLockController.m
@@ -18,7 +18,7 @@
 
 @interface DTPinLockController ()
 
-@property (nonatomic, assign) BOOL biometryUnlockWasSuccessful;
+@property (nonatomic, assign) BOOL biometryUnlockDidDismiss;
 
 - (void) switchToConfirmPageAnimated:(BOOL)animated;
 - (void) setupDigitViews;
@@ -159,7 +159,7 @@
     }
     
     // Prevent duplicate biometry prompts
-    if (self.biometryUnlockWasSuccessful) {
+    if (self.biometryUnlockDidDismiss) {
         return;
     }
     
@@ -181,9 +181,10 @@
                                       dispatch_async(dispatch_get_main_queue(), ^{
                                           [self dismissKeyboard];
                                           [self didFinishUnlocking];
-                                          self.biometryUnlockWasSuccessful = YES;
                                       });
                                   }
+                                  
+                                  self.biometryUnlockDidDismiss = YES;
                               }];
         }
     }

--- a/External/DTPinLock/DTPinLockController.m
+++ b/External/DTPinLock/DTPinLockController.m
@@ -148,6 +148,7 @@
 
 - (void)appDidEnterForeground:(NSNotification *)notification
 {
+    [hiddenTextField becomeFirstResponder];
     [self displayTouchIDIfAppropriate];
 }
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -347,6 +347,11 @@
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {
+    // For the passcode lock, store the current clock time for comparison when returning to the app
+    if ([self passcodeLockIsEnabled] && [self.window isKeyWindow]) {
+        [SPPinLockManager storeLastUsedTime];
+    }
+    
     [self.tagListViewController removeKeyboardObservers];
     [self showPasscodeLockIfNecessary];
     UIViewController *viewController = self.window.rootViewController;
@@ -354,11 +359,6 @@
     
     // Save any pending changes
     [self.noteEditorViewController save];
-    
-    // For the passcode lock, store the current clock time for comparison when returning to the app
-    if ([self passcodeLockIsEnabled]) {
-        [SPPinLockManager storeLastUsedTime];
-    }
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application


### PR DESCRIPTION
Testers found a few issues with the new pin lock bypass:

 * You could dismiss the passcode lock screen by pressing the cancel button of touch or face id 😱 
 * It was possible to get the passcode lock in a situation where the keyboard wasn't showing and you'd be stuck on the screen.

Fixes include not storing the last used time if the Passcode window is visible, and to ensure the keyboard is showing when the application enters the foreground.

**To Test**
* Test the passcode lock with and without biometry enabled. Pressing cancel for touch or face id should still require you to enter your passcode.
* The timeout settings should still work as expected.
* The keyboard should always show at the passcode lock screen.