### PR TITLE
Allow swiping to cancel delete/restore in notes list

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -941,7 +941,8 @@
     BOOL showSidePanelOveride = bShouldShowSidePanel;
     bShouldShowSidePanel = NO;
 
-    return !(self.tableView.dragging || bSearching) || showSidePanelOveride;
+    // Checking for self.tableView.isEditing prevents showing the sidebar when you use swipe to cancel delete/restore.
+    return !(self.tableView.dragging || self.tableView.isEditing || bSearching) || showSidePanelOveride;
 }
 
 - (void)resetNavigationBar {


### PR DESCRIPTION
This fixes #173. Panning to show the sidebar conflicts with the swipe-to-cancel. This change disables the sidebar by adding a check for `isEditing` in `-shouldShowSidebar`.