### PR TITLE
Fix PIN lock not showing after reboot

### DIFF
--- a/Simplenote/SPPinLockManager.swift
+++ b/Simplenote/SPPinLockManager.swift
@@ -19,12 +19,22 @@ class SPPinLockManager: NSObject {
             return false
         }
         
+        let maxTimeoutSeconds = getPinLockTimeoutSeconds()
+        // User has timeout set to 'Off' setting (0)
+        if (maxTimeoutSeconds == 0) {
+            return false
+        }
+        
         var ts = timespec.init()
         clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
-        let nowSeconds = ts.tv_sec
-        let intervalSinceLastUsed = Int(nowSeconds) - lastUsedSeconds!
-        let maxTimeoutSeconds = getPinLockTimeoutSeconds()
+        let nowSeconds = max(0, Int(ts.tv_sec)) // The running clock time of the device
         
+        // User may have recently rebooted their device, so we'll enforce lock screen
+        if (lastUsedSeconds! > nowSeconds) {
+            return false
+        }
+        
+        let intervalSinceLastUsed = nowSeconds - lastUsedSeconds!
         return intervalSinceLastUsed < maxTimeoutSeconds;
     }
     


### PR DESCRIPTION
Fixes #234 with some additional logic to account for when the device was rebooted.

We were missing some logic:

 * The `shouldBypassPinLock` method should bail early if the user hasn't set a timeout.
 * When the device restarts, it starts the monotonic clock over. We should show the pin lock if the last stored time is greater than the current clock count.

**To Test**
* Enable passcode lock timeout, and reboot your device. You should see the passcode lock after starting the app.
* Repeat but with the passcode lock timeout turned to `Off`. The passcode lock should also appear.
* The passcode lock should still operate normally in other conditions.