### PR TITLE
Adding support for sorting the tags list alphabetically.

### DIFF
--- a/Simplenote/Classes/SPOptionsViewController.h
+++ b/Simplenote/Classes/SPOptionsViewController.h
@@ -26,3 +26,5 @@ extern NSString *const SPCondensedNoteListPref;
 extern NSString *const SPCondensedNoteListPreferenceChangedNotification;
 extern NSString *const SPAlphabeticalSortPref;
 extern NSString *const SPAlphabeticalSortPreferenceChangedNotification;
+extern NSString *const SPAlphabeticalTagSortPref;
+extern NSString *const SPAlphabeticalTagSortPreferenceChangedNotification;

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -680,9 +680,17 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 - (NSArray *)sortDescriptors
 {
     BOOL isAlphaSort = [[NSUserDefaults standardUserDefaults] boolForKey:SPAlphabeticalTagSortPref];
-    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:isAlphaSort ? @"name" : @"index" ascending:YES];
+    NSSortDescriptor *sortDescriptor;
+    if (isAlphaSort) {
+        sortDescriptor = [[NSSortDescriptor alloc]
+                          initWithKey:@"name"
+                          ascending:YES
+                          selector:@selector(localizedCaseInsensitiveCompare:)];
+    } else {
+        sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"index" ascending:YES];
+    }
+
     NSArray *sortDescriptors = @[sortDescriptor];
-    
     return sortDescriptors;
 }
 
@@ -692,6 +700,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 	if (![self.fetchedResultsController performFetch:&error])
     {
 	    NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+        abort();
 	}
     
     [self.tableView reloadData];
@@ -880,6 +889,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
     NSError *error;
     if (![[self fetchedResultsController] performFetch:&error]) {
         NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
+        abort();
     }
     
     [self.tableView reloadData];


### PR DESCRIPTION
A popular user request, we're adding a new setting that will sort the tags list alphabetically. I've also added a few more groups to the settings view in order to categorize the settings a bit more:

![simulator screen shot - iphone xr - 2018-11-27 at 14 56 49](https://user-images.githubusercontent.com/789137/49117255-eb150c80-f254-11e8-93d6-3b536c430763.png)

**To Test**
* Open the app, and tap `EDIT` in the notes list. You should be able to rearrange the tags as desired with drag and drop.
* Go to settings and enable `Sort Alphabetically` in the `TAGS` section. Returning to the tags list should now show the tags sorted alphabetically.
* Tap `EDIT`, you should not be able to reorder the items unless you disable the alphabetical sort again.
* Test that other settings work as expected, since they have been rearranged.