### PR TITLE
fix the tags position issue in iPhone X.

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -814,6 +814,11 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     void (^animations)() = ^void() {
         CGRect newFrame            = _noteEditorTextView.frame;
         newFrame.size.height       = self.view.frame.size.height - (bVoiceoverEnabled ? _tagView.frame.size.height : 0) - visibleHeight;
+        if (@available(iOS 11.0, *)) {
+            if (!isEditing) {
+                newFrame.size.height -= self.view.safeAreaInsets.bottom;
+            }
+        }
         _noteEditorTextView.frame  = newFrame;
         
         if (bVoiceoverEnabled) {


### PR DESCRIPTION
[issue 255](https://github.com/Automattic/simplenote-ios/issues/255)

In note editor we didn't count in the safeAreaInsets when recalculating the editor frame after the keyboard toggling.
Tried to fix that.

BTW, do you guys think if the note editor should expand to the bottom of screen or not  in iPhone X?