### PR TITLE
fix #139, #55 Chinese input.

### DIFF
--- a/Simplenote/Classes/SPTagEntryField.m
+++ b/Simplenote/Classes/SPTagEntryField.m
@@ -85,27 +85,6 @@
 }
 
 - (void)onTextChanged:(UITextField *)textField {
-    BOOL endEditing = NO;
-
-    NSString *text = textField.text;
-    if ([text hasPrefix:@" "]) {
-        text = nil;
-        endEditing = YES;
-    } else if ([text rangeOfString:@" "].location != NSNotFound) {
-        text = [text substringWithRange:NSMakeRange(0, [text rangeOfString:@" "].location)];
-        endEditing = YES;
-    }
-
-    text = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-
-    if (text) {
-        [super setText:text];
-    }
-
-    if (endEditing) {
-        [self.delegate textFieldShouldReturn:self];
-    }
-
     dispatch_async(dispatch_get_main_queue(), ^{
         if ([tagDelegate respondsToSelector:@selector(tagEntryFieldDidChange:)]) {
             [tagDelegate tagEntryFieldDidChange:self];


### PR DESCRIPTION
Fixed [#139](https://github.com/Automattic/simplenote-ios/issues/139), [#55](https://github.com/Automattic/simplenote-ios/issues/55).

1. UITextfield conforms to UITextInput protocol. When inputing text in ideographic language, undetermined text is store as markedText. I guess explicitly setting the text of a UITextField may cause information lost about the markedText. I guess the glitch came from here. 
2. When text changed, `[SPTagEntryField onTextChanged:textField]` is called after `[delegate  textField:textField shouldChangeCharactersInRange:range replacementString:string]` . The latter already handled input with spaces, so I guess it’s not necessary to handle spaces in SPTagEntryField onTextChanged:textField]. 