### PR TITLE
Fix linking addresses, phone numbers, etc in the note editor

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -96,7 +96,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
         _noteEditorTextView = [[SPEditorTextView alloc] init];
         
         // Add Link Data Detector:
-        _noteEditorTextView.dataDetectorTypes = UIDataDetectorTypeLink;
+        _noteEditorTextView.dataDetectorTypes = UIDataDetectorTypeAll;
 
         // Note:
         // Disable SmartDashes / Quotes in iOS 11.0, due to a glitch that broke sync. (Fixed in iOS 11.1).

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -94,8 +94,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
         // Editor
         _noteEditorTextView = [[SPEditorTextView alloc] init];
-        
-        // Add Link Data Detector:
         _noteEditorTextView.dataDetectorTypes = UIDataDetectorTypeAll;
 
         // Note:


### PR DESCRIPTION
To fix #246 I removed the custom linkifier for the text editor in favor of the default iOS one. I missed that we needed to update the `DetectorType` back to `All` in order to auto-link things like addresses and phone numbers.

**To Test**
* Add a url, link and phone number to a note.
* Dismiss the keyboard.
* Links should be added to all the things :) 