### PR TITLE
Updating Insert Checklist Behavior in Note Editor

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -15,7 +15,6 @@ extern NSString *const CheckListRegExPattern;
 @interface SPEditorTextView : SPTextView {
     BOOL touchBegan;
 	CGPoint tappedPoint;
-    VSTheme *theme;
 }
 
 @property (nonatomic) BOOL editing;

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -27,6 +27,6 @@ extern NSString *const CheckListRegExPattern;
 - (void)scrollToBottom;
 - (void)processChecklists;
 - (NSString *)getPlainTextContent;
-- (void)insertNewChecklist;
+- (void)insertOrRemoveChecklist;
 
 @end

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -483,8 +483,8 @@ NSInteger const ChecklistCursorAdjustment = 2;
         NSArray *stringLines = [lineString componentsSeparatedByString:@"\n"];
         for (int i=0; i < [stringLines count]; i++) {
             NSString *line = stringLines[i];
-            // Skip any empty lines, except the first one
-            if (i != 0 && [line length] == 0) {
+            // Skip the last line if it is empty
+            if (i == [stringLines count] - 1 && [line length] == 0) {
                 continue;
             }
             

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -44,9 +44,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
     
     self = [super init];
     if (self) {
-        
-        theme = [[VSThemeManager sharedManager] theme];
-        
         self.alwaysBounceHorizontal = NO;
         self.alwaysBounceVertical = YES;
         self.scrollEnabled = YES;
@@ -55,7 +52,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         
         // add tag view
         
-        CGFloat tagViewHeight = [theme floatForKey:@"tagViewHeight"];
+        CGFloat tagViewHeight = [self.theme floatForKey:@"tagViewHeight"];
         _tagView = [[SPTagView alloc] initWithFrame:CGRectMake(0, 0, 0, tagViewHeight)];
         _tagView.isAccessibilityElement = NO;
         
@@ -63,7 +60,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         
         UIEdgeInsets contentInset = self.contentInset;
         contentInset.bottom += 2 * tagViewHeight;
-        contentInset.top += [theme floatForKey:@"noteTopPadding"];
+        contentInset.top += [self.theme floatForKey:@"noteTopPadding"];
         self.contentInset = contentInset;
         
         [self addObserver:self
@@ -93,6 +90,10 @@ NSInteger const ChecklistCursorAdjustment = 2;
     return self;
 }
 
+- (VSTheme *)theme {
+    return [[VSThemeManager sharedManager] theme];
+}
+
 - (NSDictionary *)typingAttributes {
     
     return [self.interactiveTextStorage.tokens objectForKey:SPDefaultTokenName];
@@ -109,11 +110,11 @@ NSInteger const ChecklistCursorAdjustment = 2;
     
     [super layoutSubviews];
     
-    CGFloat padding = [theme floatForKey:@"noteSidePadding" contextView:self];
+    CGFloat padding = [self.theme floatForKey:@"noteSidePadding" contextView:self];
     if (@available(iOS 11.0, *)) {
         padding += self.safeAreaInsets.left;
     }
-    CGFloat maxWidth = [theme floatForKey:@"noteMaxWidth"];
+    CGFloat maxWidth = [self.theme floatForKey:@"noteMaxWidth"];
     CGFloat width = self.bounds.size.width;
     
     if (width - 2 * padding > maxWidth && maxWidth > 0)
@@ -436,7 +437,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         return;
     }
     
-    [self.textStorage addChecklistAttachmentsForColor:[theme colorForKey:@"textColor"]];
+    [self.textStorage addChecklistAttachmentsForColor:[self.theme colorForKey:@"textColor"]];
 }
 
 // Processes content of note editor, and replaces special string attachments with their plain

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -484,7 +484,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         for (int i=0; i < [stringLines count]; i++) {
             NSString *line = stringLines[i];
             // Skip the last line if it is empty
-            if (i == [stringLines count] - 1 && [line length] == 0) {
+            if (i != 0 && i == [stringLines count] - 1 && [line length] == 0) {
                 continue;
             }
             

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1355,7 +1355,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 }
 
 - (void)insertChecklistAction:(id)sender {
-    [_noteEditorTextView insertNewChecklist];
+    [_noteEditorTextView insertOrRemoveChecklist];
 }
 
 - (void)actionButtonAction:(id)sender {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -602,6 +602,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     // push off updating note text in order to speed up animated transition
     dispatch_async(dispatch_get_main_queue(), ^{
         _noteEditorTextView.attributedText = [note.content attributedString];
+        [_noteEditorTextView processChecklists];
     });
     
     [self resetNavigationBarToIdentityWithAnimation:NO completion:nil];


### PR DESCRIPTION
Based on beta feedback, users expect the insert checklist button to add a checkbox to the current line. Previously, it would always insert a new line and insert a new checkbox. It should also now toggle a checkbox on or off depending on whether a checkbox exists at the current line:

![jan-07-2019 12-40-28](https://user-images.githubusercontent.com/789137/50793515-54893180-127d-11e9-91be-36b593125e88.gif)

I've also added a fix for https://github.com/Automattic/simplenote-ios/issues/263

**To Test**
* Test inserting a checkbox using the toolbar button at various cursor positions.
* If the cursor is on a line with an existing checkbox, that checkbox should be removed and the cursor position should adjust accordingly.
* If the cursor is on a line without an existing checkbox, a checkbox should be inserted and the cursor position should adjusted accordingly.