### PR TITLE
Fix editor going off screen after switching themes

### DIFF
--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -787,17 +787,12 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     // HACK:
     // Yes, another one. Reference: http://stackoverflow.com/questions/17070582/using-uiappearance-and-switching-themes
     // This is required, so UINavigationBar picks up the new style
-    for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
-        if ([window.class.description isEqual:@"UITextEffectsWindow"]) {
-            // HACKS ON HACKS :(
-            // We shouldn't be messing with the UITextEffectsWindow (Soft Keyboard), see #268
-            continue;
-        }
-        
-        for (UIView *view in window.subviews) {
-            [view removeFromSuperview];
-            [window addSubview:view];
-        }
+    // The linked solution loops through all app windows, but we need
+    // to only update views in the keyWindow. See #269.
+    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+    for (UIView *view in keyWindow.subviews) {
+        [view removeFromSuperview];
+        [keyWindow addSubview:view];
     }
 }
 

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -788,6 +788,12 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     // Yes, another one. Reference: http://stackoverflow.com/questions/17070582/using-uiappearance-and-switching-themes
     // This is required, so UINavigationBar picks up the new style
     for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
+        if ([window.class.description isEqual:@"UITextEffectsWindow"]) {
+            // HACKS ON HACKS :(
+            // We shouldn't be messing with the UITextEffectsWindow (Soft Keyboard), see #268
+            continue;
+        }
+        
         for (UIView *view in window.subviews) {
             [view removeFromSuperview];
             [window addSubview:view];


### PR DESCRIPTION
Fixes #268 

Changing themes after you have loaded the soft keyboard would cause the editor to scroll off the screen:

![editor-bug](https://user-images.githubusercontent.com/789137/50934730-69e99180-141e-11e9-9b69-48d3f59e2161.gif)

We have a pretty awful hack here that reattaches views to the windows of the app in order to reapply the new theme coloring. I poked around for alternative solutions but didn't come up with much, so this may be a necessary evil:

https://github.com/Automattic/simplenote-ios/blob/c589afcbb6419644d5f4cedebfc2637c7dffe15e/Simplenote/Classes/SPOptionsViewController.m#L785-L796

The issue was caused by that code messing with the view in a window called `UITextEffectsWindow`, which appears to be where the soft keyboard lives. I've fixed it by checking for that class and not doing anything to its views at all.

Alternative solutions are most welcome here!

