### PR TITLE
Add Support for Nested Checklists

### DIFF
--- a/Simplenote/Classes/UITextView+Simplenote.m
+++ b/Simplenote/Classes/UITextView+Simplenote.m
@@ -17,6 +17,8 @@
 
 @implementation UITextView (Simplenote)
 
+const int ChecklistItemLength = 3;
+
 - (BOOL)applyAutoBulletsWithReplacementText:(NSString *)replacementText replacementRange:(NSRange)replacementRange
 {
     // ReplacementText must be a TAB or NewLine
@@ -45,16 +47,20 @@
         return NO;
     }
     
-    NSUInteger bulletLength = stringToAppendToNewLine.length;
-    
-    NSInteger indexOfBullet             = [lineString rangeOfString:stringToAppendToNewLine].location;
+    NSUInteger bulletLength             = stringToAppendToNewLine.length;
+    BOOL isApplyingChecklist            = [cleanLineString hasPrefix:textAttachmentCode];
+    NSInteger indexOfBullet             = [lineString rangeOfString:isApplyingChecklist
+                                           ? textAttachmentCode
+                                           : stringToAppendToNewLine].location;
     NSRange newSelectedRange            = self.selectedRange;
     NSString *insertionString           = nil;
     NSRange insertionRange              = lineRange;
-    BOOL isApplyingChecklist = [lineString hasPrefix:textAttachmentCode];
     
     // Tab entered: Move the bullet along
     if (replacementText.isTabString) {
+        if (isApplyingChecklist) {
+            return NO;
+        }
         // Proceed only if the user is entering Tab's right by the first one
         //  -   Something
         //     ^
@@ -76,13 +82,16 @@
     // Attempt to apply the bullet
     } else  {
         // Substring: [0 - Bullet]
-        if (!isApplyingChecklist) {
-            NSRange bulletPrefixRange       = NSMakeRange(0, [lineString rangeOfString:stringToAppendToNewLine].location + bulletLength);
+        if (isApplyingChecklist) {
+            NSRange bulletPrefixRange       = NSMakeRange(0, [lineString rangeOfString:textAttachmentCode].location);
+            stringToAppendToNewLine         = [[lineString substringWithRange:bulletPrefixRange] stringByAppendingString:stringToAppendToNewLine];
+        } else {
+            NSRange bulletPrefixRange       = NSMakeRange(0, [lineString rangeOfString:stringToAppendToNewLine].location + 1);
             stringToAppendToNewLine         = [lineString substringWithRange:bulletPrefixRange];
         }
         
         // Do we need to append a whitespace?
-        if (lineRange.length > indexOfBullet + bulletLength) {
+        if (lineRange.length > indexOfBullet + bulletLength && !isApplyingChecklist) {
             unichar bulletTrailing      = [lineString characterAtIndex:indexOfBullet + bulletLength];
             
             if ([[NSCharacterSet whitespaceCharacterSet] characterIsMember:bulletTrailing]) {
@@ -94,7 +103,7 @@
         // Replacement + NewRange
         insertionString                 = [[NSString newLineString] stringByAppendingString:stringToAppendToNewLine];
         insertionRange                  = replacementRange;
-        newSelectedRange.location       += isApplyingChecklist ? 3 : insertionString.length;
+        newSelectedRange.location       += isApplyingChecklist ? [stringToAppendToNewLine length] - ChecklistItemLength : insertionString.length;
     }
     
     // Apply the Replacements

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -12,6 +12,10 @@
 
 @implementation NSMutableAttributedString (Styling)
 
+const int RegexExpectedMatchGroups  = 3;
+const int RegexGroupIndexPrefix     = 1;
+const int RegexGroupIndexContent    = 2;
+
 // Replaces checklist markdown syntax with SPTextAttachment images in an attributed string
 - (void)addChecklistAttachmentsForColor: (UIColor *)color  {
     // Sorry iOS 10 :(
@@ -37,11 +41,11 @@
     int positionAdjustment = 0;
     CGFloat fontSize = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline].pointSize + 4;
     for (NSTextCheckingResult *match in matches) {
-        if ([match numberOfRanges] < 3) {
+        if ([match numberOfRanges] < RegexExpectedMatchGroups) {
             continue;
         }
-        NSRange prefixRange = [match rangeAtIndex:1];
-        NSRange checkboxRange = [match rangeAtIndex:2];
+        NSRange prefixRange = [match rangeAtIndex:RegexGroupIndexPrefix];
+        NSRange checkboxRange = [match rangeAtIndex:RegexGroupIndexContent];
         
         NSString *markdownTag = [noteString substringWithRange:match.range];
         BOOL isChecked = [markdownTag localizedCaseInsensitiveContainsString:@"x"];

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -37,8 +37,14 @@
     int positionAdjustment = 0;
     CGFloat fontSize = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline].pointSize + 4;
     for (NSTextCheckingResult *match in matches) {
+        if ([match numberOfRanges] < 3) {
+            continue;
+        }
+        NSRange prefixRange = [match rangeAtIndex:1];
+        NSRange checkboxRange = [match rangeAtIndex:2];
+        
         NSString *markdownTag = [noteString substringWithRange:match.range];
-        BOOL isChecked = [markdownTag containsString:@"x"];
+        BOOL isChecked = [markdownTag localizedCaseInsensitiveContainsString:@"x"];
         
         SPTextAttachment *attachment = [[SPTextAttachment alloc] initWithColor:color];
         [attachment setIsChecked: isChecked];
@@ -46,10 +52,10 @@
         attachment.bounds = CGRectMake(0, -4.5, fontSize, fontSize);
         
         NSAttributedString *attachmentString = [NSAttributedString attributedStringWithAttachment:attachment];
-        NSRange adjustedRange = NSMakeRange(match.range.location - positionAdjustment, match.range.length);
+        NSRange adjustedRange = NSMakeRange(checkboxRange.location - positionAdjustment, checkboxRange.length);
         [self replaceCharactersInRange:adjustedRange withAttributedString:attachmentString];
         
-        positionAdjustment += markdownTag.length - 1;
+        positionAdjustment += markdownTag.length - 1 - prefixRange.length;
     }
 }
 

--- a/SimplenoteTests/SPChecklistTest.swift
+++ b/SimplenoteTests/SPChecklistTest.swift
@@ -6,7 +6,7 @@
 import XCTest
 
 class SPChecklistTest: XCTestCase {
-    func testRegexOnlyCapturesNewlines() {
+    func testChecklistShouldNotRenderWithinText() {
         let inlineChecklist = "This is a badly formed todo - [ ] Buy avocados"
         
         let regex = try! NSRegularExpression(pattern: CheckListRegExPattern, options: NSRegularExpression.Options.anchorsMatchLines)
@@ -14,6 +14,16 @@ class SPChecklistTest: XCTestCase {
         let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
         
         XCTAssertTrue(matches.count == 0)
+    }
+    
+    func testChecklistRenderWithPrefixedWhitespace() {
+        let inlineChecklist = "       - [ ] Buy avocados - [ ] "
+        
+        let regex = try! NSRegularExpression(pattern: CheckListRegExPattern, options: NSRegularExpression.Options.anchorsMatchLines)
+        
+        let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
+        
+        XCTAssertTrue(matches.count == 1)
     }
     
     func testMatchProperlyFormattedChecklistSyntax() {


### PR DESCRIPTION
I missed in the original checklists PR that GitHub checklists can be nested, so I'm adding support for that in the app:

<img width="241" alt="screen shot 2019-01-18 at 8 34 05 am" src="https://user-images.githubusercontent.com/789137/51400210-b60e9300-1afc-11e9-82cd-649f18888dee.png">

**To Test**
* Create a checklist at any position on a line. It should insert at the proper position.
* Pressing enter should 'autobullet' a new checklist item on next line at the same position.
* Selecting multiple lines and/or one line of text and then inserting a checklist should still work as expected.