### PR TITLE
New Tracks Event for Checklist Button

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1357,6 +1357,8 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 - (void)insertChecklistAction:(id)sender {
     [_noteEditorTextView insertOrRemoveChecklist];
+    
+    [SPTracker trackEditorChecklistInserted];
 }
 
 - (void)actionButtonAction:(id)sender {

--- a/Simplenote/Classes/SPTracker.h
+++ b/Simplenote/Classes/SPTracker.h
@@ -14,6 +14,7 @@
 + (void)refreshMetadataForAnonymousUser;
 
 #pragma mark - Note Editor
++ (void)trackEditorChecklistInserted;
 + (void)trackEditorNoteCreated;
 + (void)trackEditorNoteDeleted;
 + (void)trackEditorNoteRestored;

--- a/Simplenote/Classes/SPTracker.m
+++ b/Simplenote/Classes/SPTracker.m
@@ -107,6 +107,11 @@
     [self trackAutomatticEventWithName:@"editor_activities_accessed" properties:nil];
 }
 
++ (void)trackEditorChecklistInserted
+{
+    [self trackAutomatticEventWithName:@"editor_checklist_inserted" properties:nil];
+}
+
 + (void)trackEditorCollaboratorsAccessed
 {
     [self trackAutomatticEventWithName:@"editor_collaborators_accessed" properties:nil];


### PR DESCRIPTION
Adding a new tracks event for when the checklist button is tapped on the toolbar.

**To Test**
* Ensure analytics is enabled in the app settings.
* Open a note and tap on the checklist button.
* Confirm the event shows up in the tracks live event view. The event is `spios_editor_checklist_inserted`