### PR TITLE
Ensure note editor is scrolled to the top when loading

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -24,6 +24,7 @@ extern NSString *const CheckListRegExPattern;
 @property (nonatomic, strong) SPTagView *tagView;
 
 - (void)scrollToBottom;
+- (void)scrollToTop;
 - (void)processChecklists;
 - (NSString *)getPlainTextContent;
 - (void)insertOrRemoveChecklist;

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -241,6 +241,12 @@ NSInteger const ChecklistCursorAdjustment = 2;
     }
 }
 
+- (void)scrollToTop {
+    CGFloat yOffset = self.bounds.origin.y - self.contentInset.top;
+    CGPoint scrollOffset = CGPointMake(0, yOffset);
+    [self setContentOffset:scrollOffset animated:NO];
+}
+
 #pragma mark Notifications
 
 - (void)didEndEditing:(NSNotification *)notification {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -598,6 +598,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     }
     
     _currentNote = note;
+    [_noteEditorTextView scrollToTop];
     
     // push off updating note text in order to speed up animated transition
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Fixes #271. The `TextView` used in the note editor was preserving its scroll offset between viewing of notes. I've fixed this by ensuring that the note editor is scrolled to the top when we are setting a new note.

![note-select-top](https://user-images.githubusercontent.com/789137/51715329-1f0a7500-1fed-11e9-96bb-6d84a3535630.gif)

**To Test**
* Create two notes that are long enough to cause vertical scrolling.
* Open one of the notes, and scroll down to the bottom.
* Return to the notes list and select the other note. It should be loaded at the top of the editor and the animation should look nice.
* Return to the notes list, and select a note that doesn't cause any vertical scroll. It should load and animate as expected.
* Ensure the above works on an iPhone X type device with a notch.