### PR TITLE
Fixes for note editor text selection

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -12,10 +12,7 @@
 
 extern NSString *const CheckListRegExPattern;
 
-@interface SPEditorTextView : SPTextView {
-    BOOL touchBegan;
-	CGPoint tappedPoint;
-}
+@interface SPEditorTextView : SPTextView
 
 @property (nonatomic) BOOL editing;
 @property (nonatomic) BOOL lockContentOffset;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -428,7 +428,9 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     [navigationButtonContainer addSubview:keyboardButton];
     [navigationButtonContainer addSubview:newButton];
     [navigationButtonContainer addSubview:actionButton];
-    [navigationButtonContainer addSubview:checklistButton];
+    if (@available(iOS 11.0, *)) {
+        [navigationButtonContainer addSubview:checklistButton];
+    }
     
     [self setVisibleRightBarButtonsForEditingMode:NO];
     [self sizeNavigationContainer];


### PR DESCRIPTION
Fixes #280, #281

For checklists we added a `UITapGestureRecognizer` on the editor `UITextView`. We already had been doing some tricks using `touchesBegan`, `touchesEnded` etc so I believe there were conflicts in using two 'touch listeners'. 

The `touchesBegan` workaround appeared to be something for iOS 7 (we target 10 now), so I removed them and moved some of its logic to the `UITapGestureRecongnizer`.

**To Test**
* In general make sure text editing works as expected in the editor. Scrolling and checklists should still work properly. Tapping to change cursor location should work everywhere in a note.
* Double-tapping a word should select it. Note: You can't do this unless the editor is active, which I think is expected.
* Tapping on the same cursor location twice should show the pop-up menu for text selection. #281 
* I've added a fix for iOS 10 users, they shouldn't see the checklist button in the toolbar because we can't render checkboxes on iOS 10.