### PR TITLE
Fix tag autocomplete tap

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -25,7 +25,7 @@ NSString *const TextAttachmentCharacterCode = @"\U0000fffc"; // Represents the g
 // One unicode character plus a space
 NSInteger const ChecklistCursorAdjustment = 2;
 
-@interface SPEditorTextView ()
+@interface SPEditorTextView ()<UIGestureRecognizerDelegate>
 
 @property (strong, nonatomic) NSArray *textCommands;
 @property (nonatomic) UITextLayoutDirection verticalMoveDirection;
@@ -82,6 +82,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc]
                                                         initWithTarget:self
                                                         action:@selector(onTextTapped:)];
+        tapGestureRecognizer.delegate = self;
         tapGestureRecognizer.cancelsTouchesInView = NO;
         
         [self addGestureRecognizer:tapGestureRecognizer];
@@ -164,6 +165,11 @@ NSInteger const ChecklistCursorAdjustment = 2;
     // God, forgive me. After enabling edit mode, "former" linkified substrings are rendered with a black color.
     // This forces UITextView to render those substrings with the same color as the rest of the TextView.
     self.textColor = self.textColor;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    // Limit a recognized touch to the SPTextView, so that taps on tags still work as expected
+    return [touch.view isKindOfClass:[SPTextView class]];
 }
 
 - (BOOL)becomeFirstResponder {


### PR DESCRIPTION
I'm back with another fix for the `UIGestureRecognier` that I added for the Checklists release 😥 

A bug was reported via Twitter that you can't tap on the tag autocomplete text that appears as you tap a tag.

Turns out the `UIGestureRecongizer` was stealing the taps and processing them as if they were taps on the `UITextView` for the editor.

I've fixed this by limiting the gesture recognizer for the SPTextView to only process touches directly upon itself.

**To Test**
* Open a note.
* Tap on the tags field at the bottom.
* Start typing out an existing tag name, you should see it appear above the tags field.
* Tapping on the tag suggestion should add it to the tags list as a new chip.
* All other editing of a note should still work, including checklists