### PR TITLE
Update Tracks to send `userID` Field.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,7 +16,7 @@ abstract_target 'Automattic' do
 	target 'Simplenote' do
 		# Third Party
 		#
-		pod '1PasswordExtension', '1.8.4'
+		pod '1PasswordExtension', '1.8.5'
 		pod 'Gridicons', '0.16'
 		pod 'HockeySDK', '5.1.4'
 		pod 'SVProgressHUD', '2.2.5'
@@ -25,7 +25,7 @@ abstract_target 'Automattic' do
 
 		# Automattic
 		#
-		pod 'Automattic-Tracks-iOS', '0.3.5-beta.1'
+		pod 'Automattic-Tracks-iOS', '0.3.4'
 		pod 'Simperium', '0.8.19'
 		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '479d05f7d6b963c9b44040e6ea9f190e8bd9a47a'
 		pod 'WordPress-Ratings-iOS', '0.0.2'

--- a/Podfile
+++ b/Podfile
@@ -18,14 +18,14 @@ abstract_target 'Automattic' do
 		#
 		pod '1PasswordExtension', '1.8.4'
 		pod 'Gridicons', '0.16'
-		pod 'HockeySDK', '~>3.8.0'
-		pod 'SVProgressHUD', '1.1.2'
+		pod 'HockeySDK', '5.1.4'
+		pod 'SVProgressHUD', '2.2.5'
 		pod 'Fabric', '1.7.0'
 		pod 'Crashlytics', '3.9'
 
 		# Automattic
 		#
-		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.1.0'
+		pod 'Automattic-Tracks-iOS', '0.3.5-beta.1'
 		pod 'Simperium', '0.8.19'
 		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '479d05f7d6b963c9b44040e6ea9f190e8bd9a47a'
 		pod 'WordPress-Ratings-iOS', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,19 @@
 PODS:
   - 1PasswordExtension (1.8.4)
-  - Automattic-Tracks-iOS (0.1.0):
-    - CocoaLumberjack (~> 2.2.0)
+  - Automattic-Tracks-iOS (0.3.5-beta.1):
+    - CocoaLumberjack (~> 3.5.2)
     - Reachability (~> 3.1)
-    - UIDeviceIdentifier (~> 0.4)
-  - CocoaLumberjack (2.2.0):
-    - CocoaLumberjack/Default (= 2.2.0)
-    - CocoaLumberjack/Extensions (= 2.2.0)
-  - CocoaLumberjack/Core (2.2.0)
-  - CocoaLumberjack/Default (2.2.0):
-    - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.2.0):
-    - CocoaLumberjack/Default
+    - UIDeviceIdentifier (~> 1.1.4)
+  - CocoaLumberjack (3.5.3):
+    - CocoaLumberjack/Core (= 3.5.3)
+  - CocoaLumberjack/Core (3.5.3)
   - Crashlytics (3.9.0):
     - Fabric (~> 1.7.0)
   - Fabric (1.7.0)
   - Gridicons (0.16)
-  - HockeySDK (3.8.6):
-    - HockeySDK/AllFeaturesLib (= 3.8.6)
-  - HockeySDK/AllFeaturesLib (3.8.6)
+  - HockeySDK (5.1.4):
+    - HockeySDK/DefaultLib (= 5.1.4)
+  - HockeySDK/DefaultLib (5.1.4)
   - Reachability (3.2)
   - SAMKeychain (1.5.2)
   - Simperium (0.8.19):
@@ -32,27 +27,28 @@ PODS:
   - Simperium/SocketTrust (0.8.19)
   - Simperium/SPReachability (0.8.19)
   - Simperium/SSKeychain (0.8.19)
-  - SVProgressHUD (1.1.2)
-  - UIDeviceIdentifier (0.5.0)
+  - SVProgressHUD (2.2.5)
+  - UIDeviceIdentifier (1.1.4)
   - WordPress-AppbotX (1.0.6)
   - WordPress-Ratings-iOS (0.0.2)
 
 DEPENDENCIES:
   - 1PasswordExtension (= 1.8.4)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.1.0`)
+  - Automattic-Tracks-iOS (= 0.3.5-beta.1)
   - Crashlytics (= 3.9)
   - Fabric (= 1.7.0)
   - Gridicons (= 0.16)
-  - HockeySDK (~> 3.8.0)
+  - HockeySDK (= 5.1.4)
   - SAMKeychain (= 1.5.2)
   - Simperium (= 0.8.19)
-  - SVProgressHUD (= 1.1.2)
+  - SVProgressHUD (= 2.2.5)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-Ratings-iOS (= 0.0.2)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - 1PasswordExtension
+    - Automattic-Tracks-iOS
     - CocoaLumberjack
     - Crashlytics
     - Fabric
@@ -66,37 +62,31 @@ SPEC REPOS:
     - WordPress-Ratings-iOS
 
 EXTERNAL SOURCES:
-  Automattic-Tracks-iOS:
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.1.0
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
 
 CHECKOUT OPTIONS:
-  Automattic-Tracks-iOS:
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.1.0
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: e775a29310c65851e5a6cec1afc349ab4e334e47
-  Automattic-Tracks-iOS: 5b76290a74355cc8be18e5177b4af58774a63a46
-  CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
+  Automattic-Tracks-iOS: 3032acd3450dcd397b06acd9853292534343674a
+  CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   Crashlytics: 64aad5dd97249dd3ff94b979fea140144590cdd3
   Fabric: e6be012366472553807dada21243c5ab8d904151
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
-  HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
+  HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SAMKeychain: 1865333198217411f35327e8da61b43de79b635b
   Simperium: f72ecf0b5c6e9e4b70be9f575c7d88e7de7b112c
-  SVProgressHUD: 3afb875b9eb23acd1bed9b82495695c68621a8b2
-  UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
+  SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
+  UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
 
-PODFILE CHECKSUM: b521e1b6abb9ec6907f7524a8b431e58c05b5f6a
+PODFILE CHECKSUM: ef5315f9be8e6007ef85339226c3bc5a5db42fe0
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,15 @@
 PODS:
-  - 1PasswordExtension (1.8.4)
-  - Automattic-Tracks-iOS (0.3.5-beta.1):
-    - CocoaLumberjack (~> 3.5.2)
+  - 1PasswordExtension (1.8.5)
+  - Automattic-Tracks-iOS (0.3.4):
+    - CocoaLumberjack (~> 3.4.1)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 1.1.4)
-  - CocoaLumberjack (3.5.3):
-    - CocoaLumberjack/Core (= 3.5.3)
-  - CocoaLumberjack/Core (3.5.3)
+  - CocoaLumberjack (3.4.2):
+    - CocoaLumberjack/Default (= 3.4.2)
+    - CocoaLumberjack/Extensions (= 3.4.2)
+  - CocoaLumberjack/Default (3.4.2)
+  - CocoaLumberjack/Extensions (3.4.2):
+    - CocoaLumberjack/Default
   - Crashlytics (3.9.0):
     - Fabric (~> 1.7.0)
   - Fabric (1.7.0)
@@ -33,8 +36,8 @@ PODS:
   - WordPress-Ratings-iOS (0.0.2)
 
 DEPENDENCIES:
-  - 1PasswordExtension (= 1.8.4)
-  - Automattic-Tracks-iOS (= 0.3.5-beta.1)
+  - 1PasswordExtension (= 1.8.5)
+  - Automattic-Tracks-iOS (= 0.3.4)
   - Crashlytics (= 3.9)
   - Fabric (= 1.7.0)
   - Gridicons (= 0.16)
@@ -72,9 +75,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/appbotx.git
 
 SPEC CHECKSUMS:
-  1PasswordExtension: e775a29310c65851e5a6cec1afc349ab4e334e47
-  Automattic-Tracks-iOS: 3032acd3450dcd397b06acd9853292534343674a
-  CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
+  1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
+  Automattic-Tracks-iOS: 67d00f2f20e1978ee09154f26cdf3475d158508c
+  CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Crashlytics: 64aad5dd97249dd3ff94b979fea140144590cdd3
   Fabric: e6be012366472553807dada21243c5ab8d904151
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
@@ -87,6 +90,6 @@ SPEC CHECKSUMS:
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
 
-PODFILE CHECKSUM: ef5315f9be8e6007ef85339226c3bc5a5db42fe0
+PODFILE CHECKSUM: 1b6583bb255701d07740719d0615f928fdd363c5
 
 COCOAPODS: 1.6.1

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1291,7 +1291,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/HockeySDK/HockeySDKResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -1300,7 +1300,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		730A1CB888B6254066EA8CAA /* [CP] Embed Pods Frameworks */ = {
@@ -1309,7 +1309,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/1PasswordExtension/OnePasswordExtension.framework",
 				"${BUILT_PRODUCTS_DIR}/Automattic-Tracks-iOS/AutomatticTracks.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
@@ -1338,7 +1338,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		8B35298C563815CEF59EC87B /* [CP] Check Pods Manifest.lock */ = {

--- a/Simplenote/Classes/SPAutomatticTracker.m
+++ b/Simplenote/Classes/SPAutomatticTracker.m
@@ -61,7 +61,7 @@ static NSString *const TracksAuthenticatedUserTypeKey       = @"simplenote:user_
 - (void)refreshMetadataWithEmail:(NSString *)email
 {
     NSParameterAssert(self.tracksService);
-    [self.tracksService switchToAuthenticatedUserWithUsername:email userID:@"" skipAliasEventCreation:NO];
+    [self.tracksService switchToAuthenticatedUserWithUsername:@"" userID:email skipAliasEventCreation:NO];
 }
 
 - (void)refreshMetadataForAnonymousUser

--- a/Simplenote/Classes/SPAutomatticTracker.m
+++ b/Simplenote/Classes/SPAutomatticTracker.m
@@ -1,11 +1,3 @@
-//
-//  SPAutomatticTracker.m
-//  Simplenote
-//
-//  Created by Jorge Leandro Perez on 10/9/15.
-//  Copyright © 2015 Automattic. All rights reserved.
-//
-
 #import "SPAutomatticTracker.h"
 #import "TracksService.h"
 
@@ -61,7 +53,7 @@ static NSString *const TracksAuthenticatedUserTypeKey       = @"simplenote:user_
 - (void)refreshMetadataWithEmail:(NSString *)email
 {
     NSParameterAssert(self.tracksService);
-    [self.tracksService switchToAuthenticatedUserWithUsername:@"" userID:email skipAliasEventCreation:NO];
+    [self.tracksService switchToAuthenticatedUserWithUsername:email userID:email skipAliasEventCreation:NO];
 }
 
 - (void)refreshMetadataForAnonymousUser
@@ -76,6 +68,11 @@ static NSString *const TracksAuthenticatedUserTypeKey       = @"simplenote:user_
     NSParameterAssert(self.tracksService);
     
     [self.tracksService trackEventName:name withCustomProperties:properties];
+    if (properties == nil) {
+        NSLog(@"🔵 Tracked: %@", name);
+    } else {
+        NSLog(@"🔵 Tracked: %@, properties: %@", name, properties);
+    }
 }
 
 - (NSString *)anonymousID

--- a/Simplenote/Classes/SPAutomatticTracker.m
+++ b/Simplenote/Classes/SPAutomatticTracker.m
@@ -2,20 +2,24 @@
 #import "TracksService.h"
 
 
-
 static NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksUserDefaultsAnonymousUserIDKey";
+static NSString *const TracksUserDefaultsLoggedInUserIDKey  = @"TracksUserDefaultsLoggedInUserIDKey";
 static NSString *const TracksEventNamePrefix                = @"spios";
 static NSString *const TracksAuthenticatedUserTypeKey       = @"simplenote:user_id";
 
 
 @interface SPAutomatticTracker ()
-@property (nonatomic, strong) TracksContextManager  *contextManager;
-@property (nonatomic, strong) TracksService         *tracksService;
-@property (nonatomic, strong) NSString              *anonymousID;
+@property (nonatomic, strong) TracksContextManager *contextManager;
+@property (nonatomic, strong) TracksService        *tracksService;
+@property (nonatomic, strong) NSString             *anonymousID;
+@property (nonatomic, strong) NSString             *loggedInID;
 @end
 
 
 @implementation SPAutomatticTracker
+
+@synthesize loggedInID = _loggedInID;
+@synthesize anonymousID = _anonymousID;
 
 - (instancetype)init
 {
@@ -47,19 +51,42 @@ static NSString *const TracksAuthenticatedUserTypeKey       = @"simplenote:user_
 }
 
 
-
 #pragma mark - Public Methods
 
 - (void)refreshMetadataWithEmail:(NSString *)email
 {
     NSParameterAssert(self.tracksService);
-    [self.tracksService switchToAuthenticatedUserWithUsername:email userID:email skipAliasEventCreation:NO];
+
+    NSMutableDictionary *userProperties = [NSMutableDictionary new];
+    userProperties[@"platform"] = @"iOS";
+    userProperties[@"accessibility_voice_over_enabled"] = @(UIAccessibilityIsVoiceOverRunning());
+    userProperties[@"is_rtl_language"] = @(UIApplication.sharedApplication.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft);
+
+    [self.tracksService.userProperties removeAllObjects];
+    [self.tracksService.userProperties addEntriesFromDictionary:userProperties];
+
+    if (self.loggedInID.length == 0) {
+        // No previous username logged
+        self.loggedInID = email;
+        self.anonymousID = nil;
+        [self.tracksService switchToAuthenticatedUserWithUsername:@"" userID:email skipAliasEventCreation:NO];
+    } else if ([self.loggedInID isEqualToString:email]){
+        // Username did not change from last call to this method → just make sure Tracks client has it
+        [self.tracksService switchToAuthenticatedUserWithUsername:@"" userID:email skipAliasEventCreation:YES];
+    } else {
+        // Username changed for some reason → switch back to anonymous first
+        [self.tracksService switchToAnonymousUserWithAnonymousID:self.anonymousID];
+        [self.tracksService switchToAuthenticatedUserWithUsername:@"" userID:email skipAliasEventCreation:NO];
+        self.loggedInID = email;
+        self.anonymousID = nil;
+    }
 }
 
 - (void)refreshMetadataForAnonymousUser
 {
     NSParameterAssert(self.tracksService);
     [self.tracksService switchToAnonymousUserWithAnonymousID:self.anonymousID];
+    self.loggedInID = nil;
 }
 
 - (void)trackEventWithName:(NSString *)name properties:(NSDictionary *)properties
@@ -75,22 +102,58 @@ static NSString *const TracksAuthenticatedUserTypeKey       = @"simplenote:user_
     }
 }
 
+
+#pragma mark - Private property getter + setters
+
 - (NSString *)anonymousID
 {
-    if (_anonymousID.length != 0) {
-        return _anonymousID;
+    if (_anonymousID == nil || _anonymousID.length == 0) {
+        NSString *anonymousID = [[NSUserDefaults standardUserDefaults] stringForKey:TracksUserDefaultsAnonymousUserIDKey];
+        if (anonymousID == nil) {
+            anonymousID = [[NSUUID UUID] UUIDString];
+            [[NSUserDefaults standardUserDefaults] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
+        }
+
+        _anonymousID = anonymousID;
     }
-    
-    NSString *anonymousID = [[NSUserDefaults standardUserDefaults] stringForKey:TracksUserDefaultsAnonymousUserIDKey];
-    if (anonymousID == nil) {
-        anonymousID = [[NSUUID UUID] UUIDString];
-        [[NSUserDefaults standardUserDefaults] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-    }
-    
-    _anonymousID = anonymousID;
-    
+
     return _anonymousID;
+}
+
+- (void)setAnonymousID:(NSString *)anonymousID
+{
+    _anonymousID = anonymousID;
+
+    if (anonymousID == nil) {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:TracksUserDefaultsAnonymousUserIDKey];
+        return;
+    }
+
+    [[NSUserDefaults standardUserDefaults] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
+}
+
+- (NSString *)loggedInID
+{
+    if (_loggedInID == nil || _loggedInID.length == 0) {
+        NSString *loggedInID = [[NSUserDefaults standardUserDefaults] stringForKey:TracksUserDefaultsLoggedInUserIDKey];
+        if (loggedInID != nil) {
+            _loggedInID = loggedInID;
+        }
+    }
+
+    return _loggedInID;
+}
+
+- (void)setLoggedInID:(NSString *)loggedInID
+{
+    _loggedInID = loggedInID;
+
+    if (loggedInID == nil) {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:TracksUserDefaultsLoggedInUserIDKey];
+        return;
+    }
+
+    [[NSUserDefaults standardUserDefaults] setObject:loggedInID forKey:TracksUserDefaultsLoggedInUserIDKey];
 }
 
 @end


### PR DESCRIPTION
Swapping `username` argument with `userID` so Tracks events will still be recorded (for users that have opted in).

**To Test**
Enable analytics in the app settings, and open or create a note. You should see the event show in the live view in Tracks after 5 minutes or so, and it should have the `userid` field populated.