### PR TITLE
Adds .bundle/config file

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,4 @@
+---
+BUNDLE_PATH: "vendor/bundle"
+BUNDLE_RETRY: "3"
+BUNDLE_JOBS: "3"

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,8 @@ Simplenote/DerivedSources/
 Simplenote/config.plist
 
 # Bundler
+/vendor/
 /vendor/bundle/
-.bundle/
 
 # Dependencies
 /vendor/


### PR DESCRIPTION
## Fix
Two changes in this PR:

1. `.bundle/config` was added back to the project per @jkmassel's request so Bundler uses project-specific gems (ref: https://github.com/Automattic/simplenote-macos/pull/323#pullrequestreview-234800065)
2. `.gitignore` was updated to not exclude the `.bundle` dir.

## Test

1. From a freshly cloned repo, verify bundle install, and/or rake dependencies works properly
2. Open Simplenote.xcworkspace in Xcode 10.2 and verify it builds/installs/runs

@jkmassel should be a quick review for you 🙇 