### PR TITLE
Updates Simperium lib from 0.8.19 to 0.8.21

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ abstract_target 'Automattic' do
 		# Automattic
 		#
 		pod 'Automattic-Tracks-iOS', '0.3.4'
-		pod 'Simperium', '0.8.19'
+		pod 'Simperium', '0.8.21'
 		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '479d05f7d6b963c9b44040e6ea9f190e8bd9a47a'
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -19,17 +19,17 @@ PODS:
   - HockeySDK/DefaultLib (5.1.4)
   - Reachability (3.2)
   - SAMKeychain (1.5.2)
-  - Simperium (0.8.19):
-    - Simperium/DiffMatchPach (= 0.8.19)
-    - Simperium/JRSwizzle (= 0.8.19)
-    - Simperium/SocketTrust (= 0.8.19)
-    - Simperium/SPReachability (= 0.8.19)
-    - Simperium/SSKeychain (= 0.8.19)
-  - Simperium/DiffMatchPach (0.8.19)
-  - Simperium/JRSwizzle (0.8.19)
-  - Simperium/SocketTrust (0.8.19)
-  - Simperium/SPReachability (0.8.19)
-  - Simperium/SSKeychain (0.8.19)
+  - Simperium (0.8.21):
+    - Simperium/DiffMatchPach (= 0.8.21)
+    - Simperium/JRSwizzle (= 0.8.21)
+    - Simperium/SocketTrust (= 0.8.21)
+    - Simperium/SPReachability (= 0.8.21)
+    - Simperium/SSKeychain (= 0.8.21)
+  - Simperium/DiffMatchPach (0.8.21)
+  - Simperium/JRSwizzle (0.8.21)
+  - Simperium/SocketTrust (0.8.21)
+  - Simperium/SPReachability (0.8.21)
+  - Simperium/SSKeychain (0.8.21)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
   - WordPress-AppbotX (1.0.6)
@@ -43,7 +43,7 @@ DEPENDENCIES:
   - Gridicons (~> 0.18)
   - HockeySDK (= 5.1.4)
   - SAMKeychain (= 1.5.2)
-  - Simperium (= 0.8.19)
+  - Simperium (= 0.8.21)
   - SVProgressHUD (= 2.2.5)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-Ratings-iOS (= 0.0.2)
@@ -84,12 +84,12 @@ SPEC CHECKSUMS:
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SAMKeychain: 1865333198217411f35327e8da61b43de79b635b
-  Simperium: f72ecf0b5c6e9e4b70be9f575c7d88e7de7b112c
+  Simperium: 57f3c6f603416030212721a8af69f1f61fc92ce6
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
 
-PODFILE CHECKSUM: 7b805ad8dbe84862069c23e8ed6224e4e0bc28e7
+PODFILE CHECKSUM: 7707c8919e51d417e7a41dcc87b53605d1089782
 
 COCOAPODS: 1.6.1


### PR DESCRIPTION
### Fix
Updated the Simperium lib to the latest version. This should address the potential memory leak referenced here: https://github.com/Automattic/simplenote-macos/issues/206.

Fixes: #307 

### Test
Run the app on device. Make sure you are able to:
* Sign in/out
* Update notes
* Create new notes
* Delete notes
* Add tags
* etc

In short, test out all corners of the app and make sure everything is still working as expected. Verify any updates to notes on https://app.simplenote.com/new

