### PR TITLE
Fixing Warnings!

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1211,10 +1211,9 @@
 			};
 			buildConfigurationList = E29ADD3317848E8500E55842 /* Build configuration list for PBXProject "Simplenote" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				sv,
 				ja,

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1130,7 +1130,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     [self save];
 }
 
-- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction
 {
     if (![URL containsHttpScheme]) {
         return YES;

--- a/Simplenote/Classes/SPOnboardingViewController.m
+++ b/Simplenote/Classes/SPOnboardingViewController.m
@@ -281,9 +281,10 @@ NSString * const SPOnboardingDidFinish = @"SPOnboardDidFinish";
     pageControl.currentPage = scrollView.contentOffset.x / scrollView.bounds.size.width;
 }
 
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
-    
-    contentScrollView.contentOffset = CGPointMake(contentScrollView.frame.size.width * pageControl.currentPage, 0);
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        self->contentScrollView.contentOffset = CGPointMake(self->contentScrollView.frame.size.width * self->pageControl.currentPage, 0);
+    } completion:nil];
 }
 
 - (void)getStartedButtonAction:(id)sender {

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -794,7 +794,7 @@
 #pragma mark URL scheme
 #pragma mark ================================================================================
 
-- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {    
     // Support opening Simplenote and optionally creating a new note
     if ([[url host] isEqualToString:@"new"]) {


### PR DESCRIPTION
### Details:
In this PR we're fixing several warnings caused by deprecated methods. 
Detailed testing steps below.

Thanks in advance!!



### Testing: URL Handler
1. Launch Simplenote on the device
2. Log into your account
3. Switch over to Safari
4. Open the URL `simplenote://new`

- [x] Verify Simplenote shows up, and a new note is onscreen

### Testing: WordPress SSO
1. Fresh Install
- [x] Verify Login with WordPress works correctly

### Testing: Onboarding
1. Fresh install **on an iPad Device**
2. With the Onboarding UI onscreen (blue background) rotate the device
- [x] Verify the text always remains centered
- [x] Try switching to pages 2 ... N, and verify that rotation works well

### Testing: Text Interaction
1. Log into a testing account
2. Edit a new note and type `www.automattic.com` anywhere
3. Dismiss the keyboard
4. Press over the URL (long press!)

- [x] Verify Safari is pushed onscreen
