### PR TITLE
Fix CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the Orbs located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.25
+  ios: wordpress-mobile/ios@dev:ios-updates
 
 workflows:
   simplenote_ios:
@@ -13,4 +13,3 @@ workflows:
           workspace: Simplenote.xcworkspace
           scheme: Simplenote
           device: iPhone XS
-ios-version: "12.2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,25 @@ version: 2.1
 
 orbs:
   # This uses the Orbs located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@dev:ios-updates
+  ios: wordpress-mobile/ios@0.0.26
 
-workflows:
-  simplenote_ios:
-    jobs:
+jobs:
+  Test:
+    executor:
+      name: ios/default
+      xcode-version: "10.2.0"
+    steps:
+      - checkout
+      - run:
+          name: Copy demo config.plist
+          command: cp Simplenote/config-demo.plist Simplenote/config.plist
       - ios/test:
-          name: Test
           xcode-version: "10.2.0"
           workspace: Simplenote.xcworkspace
           scheme: Simplenote
           device: iPhone XS
+
+workflows:
+  simplenote_ios:
+    jobs:
+      - Test

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ Icon
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-*.xcworkspace
 !default.xcworkspace
 xcuserdata
 profile

--- a/Simplenote.xcworkspace/contents.xcworkspacedata
+++ b/Simplenote.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Simplenote.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Simplenote.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Simplenote.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
### Fix

This makes a few changes to fix CircleCI for the project:

- Updated the Orb so that `ios/test` defaults to latest iOS version (see https://github.com/wordpress-mobile/circleci-orbs/pull/23) and to allow it to run as a command (see https://github.com/wordpress-mobile/circleci-orbs/pull/24).
- Copy the demo `config.plist` to allow the build to pass.
- Don't ignore `Simplenote.xcworkspace` from git. Ignoring it means it is not present in cached CI builds. We could implement custom caching logic if there is an objection to this.

~**Note:** This is a draft because https://github.com/wordpress-mobile/circleci-orbs/pull/24 is awaiting review.~ Now merged, so this can be reviewed.

### Test

- The 'Test' CircleCI check is green and it ran the tests.