### PR TITLE
Enhanced Sort Options

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,0 +1,4 @@
+4.7.1
+=====
+
+-   The Notes List can now be sorted by creation and modification dates.

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -152,6 +152,9 @@
 		B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D3FCCE201F96AC00A813B7 /* StatusChecker.m */; };
 		B5D43FED1BA8CBBE00EF5104 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5D43FEB1BA8CBBE00EF5104 /* LaunchScreen.xib */; };
 		B5DF734022A54EE800602CE7 /* SPDefaultTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DF733F22A54EE800602CE7 /* SPDefaultTableViewCell.swift */; };
+		B5DF734222A565DA00602CE7 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DF734122A565DA00602CE7 /* Options.swift */; };
+		B5DF734422A56E2800602CE7 /* UserDefaults+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DF734322A56E2800602CE7 /* UserDefaults+Simplenote.swift */; };
+		B5DF734622A5713600602CE7 /* SortMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DF734522A5713600602CE7 /* SortMode.swift */; };
 		B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 174838281BBDCAA400E834AF /* SPMarkdownParser.m */; };
 		B5EB1EEF1C204EBD0080A1B3 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EB1EEE1C204EBD0080A1B3 /* ShareViewController.swift */; };
 		B5EB1EF21C204EBD0080A1B3 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EF01C204EBD0080A1B3 /* MainInterface.storyboard */; };
@@ -370,6 +373,9 @@
 		B5D3FCCF201F96AC00A813B7 /* StatusChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StatusChecker.h; path = Classes/StatusChecker.h; sourceTree = "<group>"; };
 		B5D43FEB1BA8CBBE00EF5104 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LaunchScreen.xib; path = ../LaunchScreen.xib; sourceTree = "<group>"; };
 		B5DF733F22A54EE800602CE7 /* SPDefaultTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPDefaultTableViewCell.swift; path = Classes/SPDefaultTableViewCell.swift; sourceTree = "<group>"; };
+		B5DF734122A565DA00602CE7 /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
+		B5DF734322A56E2800602CE7 /* UserDefaults+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UserDefaults+Simplenote.swift"; path = "Classes/UserDefaults+Simplenote.swift"; sourceTree = "<group>"; };
+		B5DF734522A5713600602CE7 /* SortMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SortMode.swift; path = Classes/SortMode.swift; sourceTree = "<group>"; };
 		B5EB1EEC1C204EBD0080A1B3 /* SimplenoteShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SimplenoteShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5EB1EEE1C204EBD0080A1B3 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		B5EB1EF11C204EBD0080A1B3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
@@ -697,7 +703,6 @@
 				B52B8A251BAB0DF0002CC55D /* UIView+Extensions.m */,
 				B5ADF2221BAB14DD00F864DB /* VSTheme+Extensions.h */,
 				B5ADF2231BAB14DD00F864DB /* VSTheme+Extensions.m */,
-				B55E428D22A1C0B90018C0CE /* VSTheme+Keys.swift */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -742,6 +747,8 @@
 				B59314D61A486B3800B651ED /* SPConstants.m */,
 				B512AF951C20B14200FE76D8 /* SPAnimations.h */,
 				B512AF961C20B14200FE76D8 /* SPAnimations.m */,
+				B5DF734122A565DA00602CE7 /* Options.swift */,
+				B5DF734522A5713600602CE7 /* SortMode.swift */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -766,6 +773,8 @@
 				F52A2FD01DE8B1FB002DEB0E /* CSSearchable+Helpers.swift */,
 				B5CDE61D2150834C00C3FED4 /* Simperium+Simplenote.h */,
 				B5CDE61E2150834C00C3FED4 /* Simperium+Simplenote.m */,
+				B55E428D22A1C0B90018C0CE /* VSTheme+Keys.swift */,
+				B5DF734322A56E2800602CE7 /* UserDefaults+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1447,6 +1456,7 @@
 			files = (
 				B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */,
 				E215C793180B115C00AD36B5 /* SPNavigationController.m in Sources */,
+				B5DF734422A56E2800602CE7 /* UserDefaults+Simplenote.swift in Sources */,
 				46A3C96217DFA81A002865AE /* SPTagListViewCell.m in Sources */,
 				B52B8A231BAAF80B002CC55D /* UIViewController+Extensions.m in Sources */,
 				B55738211AB8950A006043E4 /* NSDate+Helper.m in Sources */,
@@ -1473,6 +1483,7 @@
 				46A3C97117DFA81A002865AE /* UIButton+Images.m in Sources */,
 				46A3C97417DFA81A002865AE /* SPTransitionSnapshot.m in Sources */,
 				46A3C97717DFA81A002865AE /* SPTagView.m in Sources */,
+				B5DF734222A565DA00602CE7 /* Options.swift in Sources */,
 				46A3C97817DFA81A002865AE /* PersonTag.m in Sources */,
 				B5BFAEBB21519DCA00918DC8 /* SPPrivacyViewController.swift in Sources */,
 				375D24B921E01131007AB25A /* version.c in Sources */,
@@ -1537,6 +1548,7 @@
 				46A3C99C17DFA81A002865AE /* NSString+Bullets.m in Sources */,
 				B59314DF1A486C0100B651ED /* VSTheme+Simplenote.m in Sources */,
 				E215C79A180B130B00AD36B5 /* SPTableViewController.m in Sources */,
+				B5DF734622A5713600602CE7 /* SortMode.swift in Sources */,
 				46A3C99D17DFA81A002865AE /* SPAddCollaboratorsViewController.m in Sources */,
 				46A3C99E17DFA81A002865AE /* SPTableViewCell.m in Sources */,
 				46A3C99F17DFA81A002865AE /* VSThemeManager.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		B5CDE61F2150834C00C3FED4 /* Simperium+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CDE61E2150834C00C3FED4 /* Simperium+Simplenote.m */; };
 		B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D3FCCE201F96AC00A813B7 /* StatusChecker.m */; };
 		B5D43FED1BA8CBBE00EF5104 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5D43FEB1BA8CBBE00EF5104 /* LaunchScreen.xib */; };
+		B5DF734022A54EE800602CE7 /* SPDefaultTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DF733F22A54EE800602CE7 /* SPDefaultTableViewCell.swift */; };
 		B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 174838281BBDCAA400E834AF /* SPMarkdownParser.m */; };
 		B5EB1EEF1C204EBD0080A1B3 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EB1EEE1C204EBD0080A1B3 /* ShareViewController.swift */; };
 		B5EB1EF21C204EBD0080A1B3 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EF01C204EBD0080A1B3 /* MainInterface.storyboard */; };
@@ -368,6 +369,7 @@
 		B5D3FCCE201F96AC00A813B7 /* StatusChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = StatusChecker.m; path = Classes/StatusChecker.m; sourceTree = "<group>"; };
 		B5D3FCCF201F96AC00A813B7 /* StatusChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StatusChecker.h; path = Classes/StatusChecker.h; sourceTree = "<group>"; };
 		B5D43FEB1BA8CBBE00EF5104 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = LaunchScreen.xib; path = ../LaunchScreen.xib; sourceTree = "<group>"; };
+		B5DF733F22A54EE800602CE7 /* SPDefaultTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPDefaultTableViewCell.swift; path = Classes/SPDefaultTableViewCell.swift; sourceTree = "<group>"; };
 		B5EB1EEC1C204EBD0080A1B3 /* SimplenoteShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SimplenoteShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5EB1EEE1C204EBD0080A1B3 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		B5EB1EF11C204EBD0080A1B3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
@@ -847,6 +849,7 @@
 				E201864B17A57A7C00217E0B /* SPBorderedView.m */,
 				E22BCE0017960CBC00A17ED2 /* SPButton.h */,
 				E22BCE0117960CBC00A17ED2 /* SPButton.m */,
+				B5DF733F22A54EE800602CE7 /* SPDefaultTableViewCell.swift */,
 				E21F57B717C1244E001F02D3 /* SPEditorTextView.h */,
 				E21F57B817C1244E001F02D3 /* SPEditorTextView.m */,
 				E2C63C9617B00D1900CB7772 /* SPEmptyListView.h */,
@@ -1458,6 +1461,7 @@
 				46A3C96A17DFA81A002865AE /* SPTagStub.m in Sources */,
 				B50F47A61D1D791B00822748 /* NSURL+Extensions.swift in Sources */,
 				46A3C96B17DFA81A002865AE /* NSAttributedString+Styling.m in Sources */,
+				B5DF734022A54EE800602CE7 /* SPDefaultTableViewCell.swift in Sources */,
 				46A3C96C17DFA81A002865AE /* SPOptionsViewController.m in Sources */,
 				3762530620F54FFB00C1F239 /* SPAboutViewController.swift in Sources */,
 				B5BE054E1AB75902002417BF /* NSProcessInfo+Util.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B53971A11AB8DCDC00B1A582 /* SPTracker.m */; };
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B55738211AB8950A006043E4 /* NSDate+Helper.m in Sources */ = {isa = PBXBuildFile; fileRef = B557381F1AB8950A006043E4 /* NSDate+Helper.m */; };
+		B55E428C22A1A4550018C0CE /* SPSortOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55E428B22A1A4550018C0CE /* SPSortOrderViewController.swift */; };
 		B5686178195B9E93005F1245 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E2F149471799F5A500DC9690 /* libsqlite3.dylib */; };
 		B56B357F1AC3565600B9F365 /* UITextView+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B56B357D1AC3565600B9F365 /* UITextView+Simplenote.m */; };
 		B58218A51FCC45330094ECA1 /* KeychainMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58218A41FCC45330094ECA1 /* KeychainMigratorTests.swift */; };
@@ -319,6 +320,7 @@
 		B5536B8F1B8E4B8A00FF190A /* zh-Hans-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans-CN"; path = "zh-Hans-CN.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		B557381E1AB8950A006043E4 /* NSDate+Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSDate+Helper.h"; path = "Classes/NSDate+Helper.h"; sourceTree = "<group>"; };
 		B557381F1AB8950A006043E4 /* NSDate+Helper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDate+Helper.m"; path = "Classes/NSDate+Helper.m"; sourceTree = "<group>"; };
+		B55E428B22A1A4550018C0CE /* SPSortOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortOrderViewController.swift; path = Classes/SPSortOrderViewController.swift; sourceTree = "<group>"; };
 		B566A1DD189AA74600DC3F2D /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		B56B357C1AC3565600B9F365 /* UITextView+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UITextView+Simplenote.h"; path = "Classes/UITextView+Simplenote.h"; sourceTree = "<group>"; };
 		B56B357D1AC3565600B9F365 /* UITextView+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UITextView+Simplenote.m"; path = "Classes/UITextView+Simplenote.m"; sourceTree = "<group>"; };
@@ -1064,10 +1066,11 @@
 			children = (
 				E26AC90E179DA25F00C4BFB6 /* SPOptionsViewController.h */,
 				E26AC90F179DA25F00C4BFB6 /* SPOptionsViewController.m */,
-				B5BFAEBA21519DCA00918DC8 /* SPPrivacyViewController.swift */,
+				3762530520F54FFB00C1F239 /* SPAboutViewController.swift */,
 				B5C9F71B193E75FE00FD2491 /* SPDebugViewController.h */,
 				B5C9F71C193E75FE00FD2491 /* SPDebugViewController.m */,
-				3762530520F54FFB00C1F239 /* SPAboutViewController.swift */,
+				B5BFAEBA21519DCA00918DC8 /* SPPrivacyViewController.swift */,
+				B55E428B22A1A4550018C0CE /* SPSortOrderViewController.swift */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -1529,6 +1532,7 @@
 				46A3C99D17DFA81A002865AE /* SPAddCollaboratorsViewController.m in Sources */,
 				46A3C99E17DFA81A002865AE /* SPTableViewCell.m in Sources */,
 				46A3C99F17DFA81A002865AE /* VSThemeManager.m in Sources */,
+				B55E428C22A1A4550018C0CE /* SPSortOrderViewController.swift in Sources */,
 				E2B0863618070045001ED52D /* SPTagPill.m in Sources */,
 				46A3C9A117DFA81A002865AE /* SPTagsListViewController.m in Sources */,
 				E215C79E180B228800AD36B5 /* SPTextField.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B55738211AB8950A006043E4 /* NSDate+Helper.m in Sources */ = {isa = PBXBuildFile; fileRef = B557381F1AB8950A006043E4 /* NSDate+Helper.m */; };
 		B55E428C22A1A4550018C0CE /* SPSortOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55E428B22A1A4550018C0CE /* SPSortOrderViewController.swift */; };
+		B55E428E22A1C0B90018C0CE /* VSTheme+Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55E428D22A1C0B90018C0CE /* VSTheme+Keys.swift */; };
 		B5686178195B9E93005F1245 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E2F149471799F5A500DC9690 /* libsqlite3.dylib */; };
 		B56B357F1AC3565600B9F365 /* UITextView+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B56B357D1AC3565600B9F365 /* UITextView+Simplenote.m */; };
 		B58218A51FCC45330094ECA1 /* KeychainMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58218A41FCC45330094ECA1 /* KeychainMigratorTests.swift */; };
@@ -321,6 +322,7 @@
 		B557381E1AB8950A006043E4 /* NSDate+Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSDate+Helper.h"; path = "Classes/NSDate+Helper.h"; sourceTree = "<group>"; };
 		B557381F1AB8950A006043E4 /* NSDate+Helper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDate+Helper.m"; path = "Classes/NSDate+Helper.m"; sourceTree = "<group>"; };
 		B55E428B22A1A4550018C0CE /* SPSortOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortOrderViewController.swift; path = Classes/SPSortOrderViewController.swift; sourceTree = "<group>"; };
+		B55E428D22A1C0B90018C0CE /* VSTheme+Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VSTheme+Keys.swift"; sourceTree = "<group>"; };
 		B566A1DD189AA74600DC3F2D /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		B56B357C1AC3565600B9F365 /* UITextView+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UITextView+Simplenote.h"; path = "Classes/UITextView+Simplenote.h"; sourceTree = "<group>"; };
 		B56B357D1AC3565600B9F365 /* UITextView+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UITextView+Simplenote.m"; path = "Classes/UITextView+Simplenote.m"; sourceTree = "<group>"; };
@@ -693,6 +695,7 @@
 				B52B8A251BAB0DF0002CC55D /* UIView+Extensions.m */,
 				B5ADF2221BAB14DD00F864DB /* VSTheme+Extensions.h */,
 				B5ADF2231BAB14DD00F864DB /* VSTheme+Extensions.m */,
+				B55E428D22A1C0B90018C0CE /* VSTheme+Keys.swift */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -1519,6 +1522,7 @@
 				46A3C99317DFA81A002865AE /* SPActionButton.m in Sources */,
 				B5ADF2251BAB14DD00F864DB /* VSTheme+Extensions.m in Sources */,
 				46A3C99417DFA81A002865AE /* Note.m in Sources */,
+				B55E428E22A1C0B90018C0CE /* VSTheme+Keys.swift in Sources */,
 				46A3C99517DFA81A002865AE /* SPHorizontalPickerGradientView.m in Sources */,
 				46A3C99617DFA81A002865AE /* SPEntryListAutoCompleteCell.m in Sources */,
 				46A3C99717DFA81A002865AE /* SPEmptyListView.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		B5DF734222A565DA00602CE7 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DF734122A565DA00602CE7 /* Options.swift */; };
 		B5DF734422A56E2800602CE7 /* UserDefaults+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DF734322A56E2800602CE7 /* UserDefaults+Simplenote.swift */; };
 		B5DF734622A5713600602CE7 /* SortMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DF734522A5713600602CE7 /* SortMode.swift */; };
+		B5DF734F22A599D100602CE7 /* SPNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B5DF734E22A599D100602CE7 /* SPNotifications.m */; };
 		B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 174838281BBDCAA400E834AF /* SPMarkdownParser.m */; };
 		B5EB1EEF1C204EBD0080A1B3 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EB1EEE1C204EBD0080A1B3 /* ShareViewController.swift */; };
 		B5EB1EF21C204EBD0080A1B3 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EF01C204EBD0080A1B3 /* MainInterface.storyboard */; };
@@ -376,6 +377,8 @@
 		B5DF734122A565DA00602CE7 /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		B5DF734322A56E2800602CE7 /* UserDefaults+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UserDefaults+Simplenote.swift"; path = "Classes/UserDefaults+Simplenote.swift"; sourceTree = "<group>"; };
 		B5DF734522A5713600602CE7 /* SortMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SortMode.swift; path = Classes/SortMode.swift; sourceTree = "<group>"; };
+		B5DF734D22A599D100602CE7 /* SPNotifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SPNotifications.h; path = Classes/SPNotifications.h; sourceTree = "<group>"; };
+		B5DF734E22A599D100602CE7 /* SPNotifications.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SPNotifications.m; path = Classes/SPNotifications.m; sourceTree = "<group>"; };
 		B5EB1EEC1C204EBD0080A1B3 /* SimplenoteShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SimplenoteShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5EB1EEE1C204EBD0080A1B3 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		B5EB1EF11C204EBD0080A1B3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
@@ -749,6 +752,8 @@
 				B512AF961C20B14200FE76D8 /* SPAnimations.m */,
 				B5DF734122A565DA00602CE7 /* Options.swift */,
 				B5DF734522A5713600602CE7 /* SortMode.swift */,
+				B5DF734D22A599D100602CE7 /* SPNotifications.h */,
+				B5DF734E22A599D100602CE7 /* SPNotifications.m */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -1528,6 +1533,7 @@
 				B5A6166F2150855300CBE47B /* Preferences.m in Sources */,
 				46A3C98B17DFA81A002865AE /* SPHorizontalPickerViewCell.m in Sources */,
 				46A3C98E17DFA81A002865AE /* SPObjectManager.m in Sources */,
+				B5DF734F22A599D100602CE7 /* SPNotifications.m in Sources */,
 				46A3C98F17DFA81A002865AE /* SPNoteListViewController.m in Sources */,
 				B5BD6AF51BF66093004ECE33 /* SPMarkdownPreviewViewController.m in Sources */,
 				46A3C99117DFA81A002865AE /* NSString+Search.m in Sources */,

--- a/Simplenote.xcworkspace/contents.xcworkspacedata
+++ b/Simplenote.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,9 @@
       location = "group:Simplenote.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:RELEASE-NOTES.txt">
+   </FileRef>
+   <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Simplenote/Classes/SPDefaultTableViewCell.swift
+++ b/Simplenote/Classes/SPDefaultTableViewCell.swift
@@ -1,0 +1,52 @@
+//
+//  SPDefaultTableViewCell.swift
+//  Simplenote
+//
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - UITableViewCell with the `.default` Style
+//
+class SPDefaultTableViewCell: UITableViewCell {
+
+    /// UITableView's Reusable Identifier
+    ///
+    static let reusableIdentifier = "SPDefaultTableViewCell"
+
+    /// Designated Initializer
+    ///
+    init() {
+        super.init(style: .default, reuseIdentifier: SPDefaultTableViewCell.reusableIdentifier)
+        applySimplenoteStyle()
+    }
+
+    /// Required Initializer
+    ///
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        applySimplenoteStyle()
+    }
+}
+
+
+// MARK: - Private
+//
+private extension SPDefaultTableViewCell {
+
+    func applySimplenoteStyle() {
+        guard let theme = VSThemeManager.shared()?.theme() else {
+            fatalError()
+        }
+
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = theme.color(forKey: .noteCellBackgroundSelectionColor)
+
+        backgroundColor = theme.color(forKey: .backgroundColor)
+        selectedBackgroundView = backgroundView
+        detailTextLabel?.textColor = theme.color(forKey: .tableViewDetailTextLabelColor)
+        textLabel?.textColor = theme.color(forKey: .tableViewTextLabelColor)
+    }
+}

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -38,6 +38,7 @@
 
 #import <Simperium/Simperium.h>
 @import WordPress_AppbotX;
+#import "Simplenote-Swift.h"
 
 #import "VSThemeManager.h"
 #import "VSTheme+Simplenote.h"
@@ -85,11 +86,12 @@
                                                  selector:@selector(updateRowHeight:)
                                                      name:SPCondensedNoteListPreferenceChangedNotification
                                                    object:nil];
+
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(updateSortOrder:)
-                                                     name:SPAlphabeticalSortPreferenceChangedNotification
+                                                     name:SPNotesListSortModeChangedNotification
                                                    object:nil];
-        
+
         // voiceover status is tracked because the custom animated transition
         // is not used when enabled
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -646,40 +648,38 @@
     NSString *sortKey = nil;
     BOOL ascending = NO;
     SEL sortSelector = nil;
-    
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:SPAlphabeticalSortPref]) {
-        
-        sortKey = @"content";
-        ascending = YES;
-        sortSelector = @selector(caseInsensitiveCompare:);
-    } else
-        sortKey = @"modificationDate";
-    
-    //    switch (appDelegate.sortMode) {
-    //		case kSortModify:
-    //            sortKey = @"modificationDate";
-    //			break;
-    //		case kSortCreation:
-    //            sortKey = @"creationDate";
-    //			break;
-    //		case kSortAlpha:
-    //            sortKey = @"content";
-    //			//[self.notes sortUsingSelector:@selector(compareAlpha:)];
-    //            sortSelector = @selector(caseInsensitiveCompare:);
-    //            ascending = YES;
-    //			break;
-    //		case kSortModifyReverse:
-    //            sortKey = @"modificationDate";
-    //            ascending = YES;
-    //			break;
-    //		case kSortCreationReverse:
-    //            sortKey = @"creationDate";
-    //            ascending = YES;
-    //			break;
-    //		case kSortAlphaReverse:
-    //            sortKey = @"content";
-    //			break;
-    //    }
+
+    SortMode mode = [[Options shared] listSortMode];
+
+    switch (mode) {
+        case SortModeAlphabeticallyAscending:
+            sortKey = @"content";
+            ascending = YES;
+            sortSelector = @selector(caseInsensitiveCompare:);
+            break;
+        case SortModeAlphabeticallyDescending:
+            sortKey = @"content";
+            ascending = NO;
+            sortSelector = @selector(caseInsensitiveCompare:);
+            break;
+        case SortModeCreatedNewest:
+            sortKey = @"creationDate";
+            ascending = NO;
+            break;
+        case SortModeCreatedOldest:
+            sortKey = @"creationDate";
+            ascending = YES;
+            break;
+        case SortModeModifiedNewest:
+            sortKey = @"modificationDate";
+            ascending = NO;
+            break;
+        case SortModeModifiedOldest:
+            sortKey = @"modificationDate";
+            ascending = YES;
+            break;
+    }
+
     NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortKey ascending:ascending selector:sortSelector];
     NSSortDescriptor *pinnedSortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"pinned" ascending:NO];
     NSArray *sortDescriptors = [[NSArray alloc] initWithObjects:pinnedSortDescriptor, sortDescriptor, nil];

--- a/Simplenote/Classes/SPNotifications.h
+++ b/Simplenote/Classes/SPNotifications.h
@@ -1,0 +1,17 @@
+//
+//  SPNotifications.h
+//  Simplenote
+//
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+#pragma mark ================================================================================
+#pragma mark Notifications
+#pragma mark ================================================================================
+
+extern NSString *const SPAlphabeticalTagSortPreferenceChangedNotification;
+extern NSString *const SPCondensedNoteListPreferenceChangedNotification;
+extern NSString *const SPNotesListSortModeChangedNotification;

--- a/Simplenote/Classes/SPNotifications.m
+++ b/Simplenote/Classes/SPNotifications.m
@@ -1,0 +1,17 @@
+//
+//  SPNotifications.m
+//  Simplenote
+//
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+#import "SPNotifications.h"
+
+
+#pragma mark ================================================================================
+#pragma mark Notifications
+#pragma mark ================================================================================
+
+NSString *const SPAlphabeticalTagSortPreferenceChangedNotification  = @"SPAlphabeticalTagSortPreferenceChangedNotification";
+NSString *const SPCondensedNoteListPreferenceChangedNotification    = @"SPCondensedNoteListPreferenceChangedNotification";
+NSString *const SPNotesListSortModeChangedNotification              = @"SPNotesListSortModeChangedNotification";

--- a/Simplenote/Classes/SPOptionsViewController.h
+++ b/Simplenote/Classes/SPOptionsViewController.h
@@ -23,8 +23,4 @@
 @end
 
 extern NSString *const SPCondensedNoteListPref;
-extern NSString *const SPCondensedNoteListPreferenceChangedNotification;
-extern NSString *const SPAlphabeticalSortPref;
-extern NSString *const SPAlphabeticalSortPreferenceChangedNotification;
 extern NSString *const SPAlphabeticalTagSortPref;
-extern NSString *const SPAlphabeticalTagSortPreferenceChangedNotification;

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -22,11 +22,7 @@
 #import "Simperium+Simplenote.h"
 
 NSString *const SPCondensedNoteListPref                             = @"SPCondensedNoteListPref";
-NSString *const SPCondensedNoteListPreferenceChangedNotification    = @"SPCondensedNoteListPreferenceChangedNotification";
-NSString *const SPAlphabeticalSortPref                              = @"SPAlphabeticalSortPref";
-NSString *const SPAlphabeticalSortPreferenceChangedNotification     = @"SPAlphabeticalSortPreferenceChangedNotification";
 NSString *const SPAlphabeticalTagSortPref                           = @"SPAlphabeticalTagSortPref";
-NSString *const SPAlphabeticalTagSortPreferenceChangedNotification  = @"SPAlphabeticalTagSortPreferenceChangedNotification";
 NSString *const SPThemePref                                         = @"SPThemePref";
 
 @interface SPOptionsViewController ()

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -27,7 +27,6 @@ NSString *const SPThemePref                                         = @"SPThemeP
 
 @interface SPOptionsViewController ()
 @property (nonatomic, strong) UISwitch      *condensedNoteListSwitch;
-@property (nonatomic, strong) UISwitch      *alphabeticalNoteSortSwitch;
 @property (nonatomic, strong) UISwitch      *alphabeticalTagSortSwitch;
 @property (nonatomic, strong) UISwitch      *themeListSwitch;
 @property (nonatomic, strong) UISwitch      *biometrySwitch;
@@ -42,8 +41,8 @@ NSString *const SPThemePref                                         = @"SPThemeP
     NSArray *timeoutPickerOptions;
 }
 
-#define kTagAlphabeticalSort    1
-#define kTagAlphabeticalTagSort 2
+#define kTagNoteListSort        1
+#define kTagTagsListSort        2
 #define kTagCondensedNoteList   3
 #define kTagTheme               4
 #define kTagPasscode            5
@@ -106,7 +105,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (id)initWithStyle:(UITableViewStyle)style
+- (instancetype)initWithStyle:(UITableViewStyle)style
 {
     if (self = [super initWithStyle:UITableViewStyleGrouped])
     {
@@ -135,11 +134,6 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                                                                            action:@selector(doneAction:)];
     
     // Setup the Switches
-    self.alphabeticalNoteSortSwitch = [UISwitch new];
-    [self.alphabeticalNoteSortSwitch addTarget:self
-                                    action:@selector(sortSwitchDidChangeValue:)
-                          forControlEvents:UIControlEventValueChanged];
-    
     self.alphabeticalTagSortSwitch = [UISwitch new];
     [self.alphabeticalTagSortSwitch addTarget:self
                                         action:@selector(tagSortSwitchDidChangeValue:)
@@ -329,13 +323,11 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             
             switch (indexPath.row) {
                 case SPOptionsPreferencesRowSort: {
-                    cell.textLabel.text = NSLocalizedString(@"Sort Alphabetically", @"Option to sort notes in the note list alphabetically. The default is by modification date");
-                    
-                    [self.alphabeticalNoteSortSwitch setOn:[self alphabeticalSortPref]];
-                    
-                    cell.accessoryView = self.alphabeticalNoteSortSwitch;
-                    cell.selectionStyle = UITableViewCellSelectionStyleNone;
-                    cell.tag = kTagAlphabeticalSort;
+                    cell.textLabel.text = NSLocalizedString(@"Sort Order", @"Option to sort notes in the note list alphabetically. The default is by modification date");
+                    cell.detailTextLabel.text = [[Options shared] listSortModeDescription];
+                    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+                    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                    cell.tag = kTagNoteListSort;
                     break;
                 }
                 case SPOptionsPreferencesRowCondensed: {
@@ -364,7 +356,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     
                     cell.accessoryView = self.alphabeticalTagSortSwitch;
                     cell.selectionStyle = UITableViewCellSelectionStyleNone;
-                    cell.tag = kTagAlphabeticalSort;
+                    cell.tag = kTagTagsListSort;
                     break;
                 }
                 
@@ -510,6 +502,22 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
 
     switch (indexPath.section) {
+
+        case SPOptionsViewSectionsNotes: {
+            switch (cell.tag) {
+                case kTagNoteListSort: {
+                    SPSortOrderViewController *controller = [SPSortOrderViewController new];
+                    controller.selectedMode = [[Options shared] listSortMode];
+                    controller.onChange = ^(SortMode newMode) {
+                        [[Options shared] setListSortMode:newMode];
+                    };
+
+                    [self.navigationController pushViewController:controller animated:true];
+                    break;
+                }
+            }
+            break;
+        }
 
         case SPOptionsViewSectionsSecurity: {
             
@@ -707,20 +715,6 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                                         object:notificationObject];
 }
 
-
-- (void)sortSwitchDidChangeValue:(UISwitch *)sender
-{
-    BOOL isOn = [(UISwitch *)sender isOn];
-    NSNumber *notificationObject = [NSNumber numberWithBool:isOn];
-    
-    [[NSUserDefaults standardUserDefaults] setBool:isOn forKey:SPAlphabeticalSortPref];
-    
-    [SPTracker trackSettingsAlphabeticalSortEnabled:isOn];
-    
-    [[NSNotificationCenter defaultCenter] postNotificationName:SPAlphabeticalSortPreferenceChangedNotification
-                                                        object:notificationObject];
-}
-
 - (void)tagSortSwitchDidChangeValue:(UISwitch *)sender
 {
     BOOL isOn = [(UISwitch *)sender isOn];
@@ -763,7 +757,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 {
     // Reload Switch Styles
     VSTheme *theme          = [[VSThemeManager sharedManager] theme];
-    NSArray *switches       = @[ _condensedNoteListSwitch, _alphabeticalNoteSortSwitch, _alphabeticalTagSortSwitch,  _themeListSwitch, _biometrySwitch ];
+    NSArray *switches       = @[ _condensedNoteListSwitch, _alphabeticalTagSortSwitch,  _themeListSwitch, _biometrySwitch ];
     
     for (UISwitch *theSwitch in switches) {
         theSwitch.onTintColor   = [theme colorForKey:@"switchOnTintColor"];
@@ -794,11 +788,6 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 
 
 #pragma mark - Preferences
-
-- (BOOL)alphabeticalSortPref
-{
-    return [[NSUserDefaults standardUserDefaults] boolForKey:SPAlphabeticalSortPref];
-}
 
 - (BOOL)alphabeticalTagSortPref
 {

--- a/Simplenote/Classes/SPSortOrderViewController.swift
+++ b/Simplenote/Classes/SPSortOrderViewController.swift
@@ -2,7 +2,6 @@
 //  SPSortOrderViewController.swift
 //  Simplenote
 //
-//  Created by Lantean on 5/31/19.
 //  Copyright © 2019 Automattic. All rights reserved.
 //
 
@@ -10,7 +9,7 @@ import Foundation
 import UIKit
 
 
-// MARK: -
+// MARK: - Settings: Sort Order
 //
 class SPSortOrderViewController: UITableViewController {
 
@@ -25,17 +24,17 @@ class SPSortOrderViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationItem()
-        refreshStyle()
+        setupTableView()
     }
 }
 
 
-// MARK: -
+// MARK: - UITableViewDelegate Conformance
 //
 extension SPSortOrderViewController {
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return Settings.numberOfSections
+        return Constants.numberOfSections
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -43,7 +42,7 @@ extension SPSortOrderViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = dequeueCell(from: tableView)
+        let cell = tableView.dequeueReusableCell(withIdentifier: SPDefaultTableViewCell.reusableIdentifier) ?? SPDefaultTableViewCell()
         let row = Row.allCases[indexPath.row]
 
         setupCell(cell, with: row)
@@ -57,7 +56,7 @@ extension SPSortOrderViewController {
 }
 
 
-// MARK: -
+// MARK: - Private
 //
 private extension SPSortOrderViewController {
 
@@ -65,49 +64,24 @@ private extension SPSortOrderViewController {
         title = NSLocalizedString("Sort Order", comment: "Sort Order for the Notes List")
     }
 
+    func setupTableView() {
+        tableView.applyDefaultGroupedStyling()
+    }
+    
     func setupCell(_ cell: UITableViewCell, with row: Row) {
         cell.textLabel?.text = row.description
     }
-
-    func applyStyle(to cell: UITableViewCell) {
-        guard let theme = VSThemeManager.shared()?.theme() else {
-            fatalError()
-        }
-
-        let backgroundView = UIView()
-        backgroundView.backgroundColor = theme.color(forKey: .noteCellBackgroundSelectionColor)
-
-        cell.backgroundColor = theme.color(forKey: .backgroundColor)
-        cell.selectedBackgroundView = backgroundView
-        cell.detailTextLabel?.textColor = theme.color(forKey: .tableViewDetailTextLabelColor)
-        cell.textLabel?.textColor = theme.color(forKey: .tableViewTextLabelColor)
-    }
-
-    func refreshStyle() {
-        tableView.applyDefaultGroupedStyling()
-    }
-
-    func dequeueCell(from tableView: UITableView) -> UITableViewCell {
-        if let cell = tableView.dequeueReusableCell(withIdentifier: Settings.reusableIdentifier) {
-            return cell
-        }
-
-        let cell = UITableViewCell(style: .default, reuseIdentifier: Settings.reusableIdentifier)
-        applyStyle(to: cell)
-        return cell
-    }
 }
 
 
+// MARK: - Constants
 //
-//
-enum Settings {
+private enum Constants {
     static let numberOfSections = 1
-    static let reusableIdentifier = "reusableIdentifier"
 }
 
 
-//
+// MARK: - SortOrder Rows
 //
 private enum Row: CaseIterable {
     case modifiedNewest

--- a/Simplenote/Classes/SPSortOrderViewController.swift
+++ b/Simplenote/Classes/SPSortOrderViewController.swift
@@ -134,22 +134,3 @@ private enum Row: CaseIterable {
         }
     }
 }
-
-
-//
-//
-enum ThemeKey: String {
-    case backgroundColor
-    case noteCellBackgroundSelectionColor
-    case tableViewTextLabelColor
-    case tableViewDetailTextLabelColor
-}
-
-
-//
-//
-extension VSTheme {
-    func color(forKey key: ThemeKey) -> UIColor? {
-        return color(forKey: key.rawValue)
-    }
-}

--- a/Simplenote/Classes/SPSortOrderViewController.swift
+++ b/Simplenote/Classes/SPSortOrderViewController.swift
@@ -1,0 +1,155 @@
+//
+//  SPSortOrderViewController.swift
+//  Simplenote
+//
+//  Created by Lantean on 5/31/19.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+
+// MARK: -
+//
+class SPSortOrderViewController: UITableViewController {
+
+    init() {
+        super.init(style: .grouped)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupNavigationItem()
+        refreshStyle()
+    }
+}
+
+
+// MARK: -
+//
+extension SPSortOrderViewController {
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return Settings.numberOfSections
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return Row.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = dequeueCell(from: tableView)
+        let row = Row.allCases[indexPath.row]
+
+        setupCell(cell, with: row)
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+
+// MARK: -
+//
+private extension SPSortOrderViewController {
+
+    func setupNavigationItem() {
+        title = NSLocalizedString("Sort Order", comment: "Sort Order for the Notes List")
+    }
+
+    func setupCell(_ cell: UITableViewCell, with row: Row) {
+        cell.textLabel?.text = row.description
+    }
+
+    func applyStyle(to cell: UITableViewCell) {
+        guard let theme = VSThemeManager.shared()?.theme() else {
+            fatalError()
+        }
+
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = theme.color(forKey: .noteCellBackgroundSelectionColor)
+
+        cell.backgroundColor = theme.color(forKey: .backgroundColor)
+        cell.selectedBackgroundView = backgroundView
+        cell.detailTextLabel?.textColor = theme.color(forKey: .tableViewDetailTextLabelColor)
+        cell.textLabel?.textColor = theme.color(forKey: .tableViewTextLabelColor)
+    }
+
+    func refreshStyle() {
+        tableView.applyDefaultGroupedStyling()
+    }
+
+    func dequeueCell(from tableView: UITableView) -> UITableViewCell {
+        if let cell = tableView.dequeueReusableCell(withIdentifier: Settings.reusableIdentifier) {
+            return cell
+        }
+
+        let cell = UITableViewCell(style: .default, reuseIdentifier: Settings.reusableIdentifier)
+        applyStyle(to: cell)
+        return cell
+    }
+}
+
+
+//
+//
+enum Settings {
+    static let numberOfSections = 1
+    static let reusableIdentifier = "reusableIdentifier"
+}
+
+
+//
+//
+private enum Row: CaseIterable {
+    case modifiedNewest
+    case modifiedOldest
+    case createdNewest
+    case createdOldest
+    case alphabeticallyAscending
+    case alphabeticallyDescending
+
+    var description: String {
+        switch self {
+        case .modifiedNewest:
+            return NSLocalizedString("Newest modified date", comment: "")
+        case .modifiedOldest:
+            return NSLocalizedString("Oldest modified date", comment: "")
+        case .createdNewest:
+            return NSLocalizedString("Newest created date", comment: "")
+        case .createdOldest:
+            return NSLocalizedString("Oldest created date", comment: "")
+        case .alphabeticallyAscending:
+            return NSLocalizedString("Alphabetically, A-Z", comment: "")
+        case .alphabeticallyDescending:
+            return NSLocalizedString("Alphabetically, Z-A", comment: "")
+        }
+    }
+}
+
+
+//
+//
+enum ThemeKey: String {
+    case backgroundColor
+    case noteCellBackgroundSelectionColor
+    case tableViewTextLabelColor
+    case tableViewDetailTextLabelColor
+}
+
+
+//
+//
+extension VSTheme {
+    func color(forKey key: ThemeKey) -> UIColor? {
+        return color(forKey: key.rawValue)
+    }
+}

--- a/Simplenote/Classes/SPSortOrderViewController.swift
+++ b/Simplenote/Classes/SPSortOrderViewController.swift
@@ -86,7 +86,7 @@ private extension SPSortOrderViewController {
     func setupTableView() {
         tableView.applyDefaultGroupedStyling()
     }
-    
+
     func setupCell(_ cell: UITableViewCell, with mode: SortMode) {
         let selected = mode == selectedMode
 

--- a/Simplenote/Classes/SPTableViewCell.m
+++ b/Simplenote/Classes/SPTableViewCell.m
@@ -18,6 +18,8 @@
 #import "UIDevice+Extensions.h"
 #import "UIView+Extensions.h"
 #import "VSTheme+Extensions.h"
+#import "SPNotifications.h"
+
 
 @implementation SPTableViewCell
 

--- a/Simplenote/Classes/SPTracker.h
+++ b/Simplenote/Classes/SPTracker.h
@@ -47,7 +47,7 @@
 #pragma mark - Preferences
 + (void)trackSettingsPinlockEnabled:(BOOL)isOn;
 + (void)trackSettingsListCondensedEnabled:(BOOL)isOn;
-+ (void)trackSettingsAlphabeticalSortEnabled:(BOOL)isOn;
++ (void)trackSettingsNoteListSortMode:(NSString *)description;
 + (void)trackSettingsThemeUpdated:(NSString *)themeName;
 
 #pragma mark - Sidebar

--- a/Simplenote/Classes/SPTracker.m
+++ b/Simplenote/Classes/SPTracker.m
@@ -175,9 +175,9 @@
     [self trackAutomatticEventWithName:@"settings_list_condensed_enabled" properties:@{ @"enabled" : @(isOn) }];
 }
 
-+ (void)trackSettingsAlphabeticalSortEnabled:(BOOL)isOn
++ (void)trackSettingsNoteListSortMode:(NSString *)description
 {
-    [self trackAutomatticEventWithName:@"settings_alphabetical_sort_enabled" properties:@{ @"enabled" : @(isOn) }];
+    [self trackAutomatticEventWithName:@"settings_note_list_sort_mode" properties:@{ @"description" : description }];
 }
 
 + (void)trackSettingsThemeUpdated:(NSString *)themeName

--- a/Simplenote/Classes/SortMode.swift
+++ b/Simplenote/Classes/SortMode.swift
@@ -46,13 +46,13 @@ enum SortMode: Int, CaseIterable {
         case .alphabeticallyDescending:
             return NSLocalizedString("Alphabetically, Z-A", comment: "")
         case .createdNewest:
-            return NSLocalizedString("Newest created date", comment: "")
+            return NSLocalizedString("Created: Newest", comment: "")
         case .createdOldest:
-            return NSLocalizedString("Oldest created date", comment: "")
+            return NSLocalizedString("Created: Oldest", comment: "")
         case .modifiedNewest:
-            return NSLocalizedString("Newest modified date", comment: "")
+            return NSLocalizedString("Modified: Newest", comment: "")
         case .modifiedOldest:
-            return NSLocalizedString("Oldest modified date", comment: "")
+            return NSLocalizedString("Modified: Oldest", comment: "")
         }
     }
 }

--- a/Simplenote/Classes/SortMode.swift
+++ b/Simplenote/Classes/SortMode.swift
@@ -1,0 +1,58 @@
+//
+//  SortMode.swift
+//  Simplenote
+//
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - Represents all of the possible Sort Modes
+//
+@objc
+enum SortMode: Int, CaseIterable {
+
+    /// Order: A-Z
+    ///
+    case alphabeticallyAscending
+
+    /// Order: Z-A
+    ///
+    case alphabeticallyDescending
+
+    /// Order: Newest on Top
+    ///
+    case createdNewest
+
+    /// Order: Oldest on Top
+    ///
+    case createdOldest
+
+    /// Order: Newest on Top
+    ///
+    case modifiedNewest
+
+    /// Order: Oldest on Top
+    ///
+    case modifiedOldest
+
+    /// Returns a localized Description, matching the current rawValue
+    ///
+    var description: String {
+        switch self {
+        case .alphabeticallyAscending:
+            return NSLocalizedString("Alphabetically, A-Z", comment: "")
+        case .alphabeticallyDescending:
+            return NSLocalizedString("Alphabetically, Z-A", comment: "")
+        case .createdNewest:
+            return NSLocalizedString("Newest created date", comment: "")
+        case .createdOldest:
+            return NSLocalizedString("Oldest created date", comment: "")
+        case .modifiedNewest:
+            return NSLocalizedString("Newest modified date", comment: "")
+        case .modifiedOldest:
+            return NSLocalizedString("Oldest modified date", comment: "")
+        }
+    }
+}

--- a/Simplenote/Classes/SortMode.swift
+++ b/Simplenote/Classes/SortMode.swift
@@ -42,17 +42,17 @@ enum SortMode: Int, CaseIterable {
     var description: String {
         switch self {
         case .alphabeticallyAscending:
-            return NSLocalizedString("Alphabetically: A-Z", comment: "")
+            return NSLocalizedString("Alphabetically: A-Z", comment: "Sort Mode: Alphabetically, ascending")
         case .alphabeticallyDescending:
-            return NSLocalizedString("Alphabetically: Z-A", comment: "")
+            return NSLocalizedString("Alphabetically: Z-A", comment: "Sort Mode: Alphabetically, descending")
         case .createdNewest:
-            return NSLocalizedString("Created: Newest", comment: "")
+            return NSLocalizedString("Created: Newest", comment: "Sort Mode: Creation Date, descending")
         case .createdOldest:
-            return NSLocalizedString("Created: Oldest", comment: "")
+            return NSLocalizedString("Created: Oldest", comment: "Sort Mode: Creation Date, ascending")
         case .modifiedNewest:
-            return NSLocalizedString("Modified: Newest", comment: "")
+            return NSLocalizedString("Modified: Newest", comment: "Sort Mode: Modified Date, descending")
         case .modifiedOldest:
-            return NSLocalizedString("Modified: Oldest", comment: "")
+            return NSLocalizedString("Modified: Oldest", comment: "Sort Mode: Creation Date, ascending")
         }
     }
 }

--- a/Simplenote/Classes/SortMode.swift
+++ b/Simplenote/Classes/SortMode.swift
@@ -42,9 +42,9 @@ enum SortMode: Int, CaseIterable {
     var description: String {
         switch self {
         case .alphabeticallyAscending:
-            return NSLocalizedString("Alphabetically, A-Z", comment: "")
+            return NSLocalizedString("Alphabetically: A-Z", comment: "")
         case .alphabeticallyDescending:
-            return NSLocalizedString("Alphabetically, Z-A", comment: "")
+            return NSLocalizedString("Alphabetically: Z-A", comment: "")
         case .createdNewest:
             return NSLocalizedString("Created: Newest", comment: "")
         case .createdOldest:

--- a/Simplenote/Classes/UserDefaults+Simplenote.swift
+++ b/Simplenote/Classes/UserDefaults+Simplenote.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+
+// MARK: - WooCommerce UserDefaults Keys
+//
+extension UserDefaults {
+    enum Key: String {
+        case listSortMode
+        case listSortModeLegacy = "SPAlphabeticalSortPref"
+    }
+}
+
+
+// MARK: - Convenience Methods
+//
+extension UserDefaults {
+
+    /// Returns the Object (if any) associated with the specified Key.
+    ///
+    func integer(forKey key: Key) -> Int {
+        return integer(forKey: key.rawValue)
+    }
+
+    /// Returns the Object (if any) associated with the specified Key.
+    ///
+    func object<T>(forKey key: Key) -> T? {
+        return value(forKey: key.rawValue) as? T
+    }
+
+    /// Stores the Key/Value Pair.
+    ///
+    func set<T>(_ value: T?, forKey key: Key) {
+        set(value, forKey: key.rawValue)
+    }
+
+    /// Nukes any object associated with the specified Key.
+    ///
+    func removeObject(forKey key: Key) {
+        removeObject(forKey: key.rawValue)
+    }
+
+    /// Indicates if there's an entry for the specified Key.
+    ///
+    func containsObject(forKey key: Key) -> Bool {
+        return value(forKey: key.rawValue) != nil
+    }
+
+    /// Subscript Accessible via our new Key type!
+    ///
+    subscript<T>(key: Key) -> T? {
+        get {
+            return value(forKey: key.rawValue) as? T
+        }
+        set {
+            set(newValue, forKey: key.rawValue)
+        }
+    }
+
+    /// Subscript: "Type Inference Fallback". To be used whenever the type cannot be automatically inferred!
+    ///
+    subscript(key: Key) -> Any? {
+        get {
+            return value(forKey: key.rawValue)
+        }
+        set {
+            set(newValue, forKey: key.rawValue)
+        }
+    }
+}

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -47,6 +47,7 @@ extension Options {
         set {
             defaults.set(newValue.rawValue, forKey: .listSortMode)
             SPTracker.trackSettingsNoteListSortMode(newValue.description)
+            NotificationCenter.default.post(name: .SPNotesListSortModeChanged, object: nil)
         }
     }
 }

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -1,0 +1,67 @@
+//
+//  Options.swift
+//  Simplenote
+//
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - Wraps access to all of the UserDefault Values
+//
+class Options: NSObject {
+
+    /// Shared Instance
+    ///
+    @objc
+    static let shared = Options()
+
+    /// User Defaults: Convenience
+    ///
+    private var defaults: UserDefaults {
+        return UserDefaults.standard
+    }
+
+    /// Designated Initializer
+    ///
+    override private init() {
+        super.init()
+        migrateLegacyOptions()
+    }
+}
+
+
+// MARK: - Actual Options!
+//
+extension Options {
+
+    /// Returns the target Sort Mode for the Notes List
+    ///
+    @objc
+    var listSortMode: SortMode {
+        get {
+            let payload = defaults.integer(forKey: .listSortMode)
+            return SortMode(rawValue: payload) ?? .alphabeticallyAscending
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: .listSortMode)
+        }
+    }
+}
+
+
+// MARK: - Private
+//
+private extension Options {
+
+    func migrateLegacyOptions() {
+        guard let legacySortAscending: Bool = defaults[.listSortModeLegacy] else {
+            return
+        }
+
+        let newMode: SortMode = legacySortAscending ? .alphabeticallyAscending : .alphabeticallyDescending
+        defaults.set(newMode, forKey: .listSortMode)
+        defaults.removeObject(forKey: .listSortModeLegacy)
+    }
+}

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -51,6 +51,19 @@ extension Options {
 }
 
 
+// MARK: - ObjC Convenience Methods
+//
+extension Options {
+
+    /// Returns the *Description* for the current List's Sort Mode
+    ///
+    @objc
+    var listSortModeDescription: String {
+        return listSortMode.description
+    }
+}
+
+
 // MARK: - Private
 //
 private extension Options {

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -76,7 +76,7 @@ private extension Options {
         }
 
         let newMode: SortMode = legacySortAscending ? .alphabeticallyAscending : .alphabeticallyDescending
-        defaults.set(newMode, forKey: .listSortMode)
+        defaults.set(newMode.rawValue, forKey: .listSortMode)
         defaults.removeObject(forKey: .listSortModeLegacy)
     }
 }

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -46,6 +46,7 @@ extension Options {
         }
         set {
             defaults.set(newValue.rawValue, forKey: .listSortMode)
+            SPTracker.trackSettingsNoteListSortMode(newValue.description)
         }
     }
 }

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -115,20 +115,6 @@
         CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
     }
 }
-    
-- (void)importLegacyPreferences
-{
-    NSNumber *legacySortPref = (__bridge_transfer NSNumber *)CFPreferencesCopyAppValue(CFSTR("sortMode"), kCFPreferencesCurrentApplication);
-    if (legacySortPref != nil) {
-        
-        if ([legacySortPref integerValue] == 2) {
-            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:SPAlphabeticalSortPref];
-        }
-        
-        CFPreferencesSetAppValue(CFSTR("sortMode"), NULL, kCFPreferencesCurrentApplication);
-        CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
-    }
-}
 
 
 #pragma mark ================================================================================
@@ -240,9 +226,6 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-	// Old School!
-    [self importLegacyPreferences];
-    
     // Migrate keychain items
     KeychainMigrator *keychainMigrator = [[KeychainMigrator alloc] init];
 // Keychain Migration Testing: Should only run in *release* targets. Uncomment / use at will

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -15,3 +15,4 @@
 #import "UIImage+Colorization.h"
 #import "VSThemeManager.h"
 #import "SPEditorTextView.h"
+#import "SPNotifications.h"

--- a/Simplenote/VSTheme+Keys.swift
+++ b/Simplenote/VSTheme+Keys.swift
@@ -2,7 +2,6 @@
 //  VSTheme+Keys.swift
 //  Simplenote
 //
-//  Created by Lantean on 5/31/19.
 //  Copyright © 2019 Automattic. All rights reserved.
 //
 

--- a/Simplenote/VSTheme+Keys.swift
+++ b/Simplenote/VSTheme+Keys.swift
@@ -1,0 +1,31 @@
+//
+//  VSTheme+Keys.swift
+//  Simplenote
+//
+//  Created by Lantean on 5/31/19.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - ThemeKey represents all of the available Keys for the current theme.
+//
+enum ThemeKey: String {
+    case backgroundColor
+    case noteCellBackgroundSelectionColor
+    case tableViewTextLabelColor
+    case tableViewDetailTextLabelColor
+}
+
+
+// MARK: - Public Methods
+//
+extension VSTheme {
+
+    /// Returns the color associated to a given Key
+    ///
+    func color(forKey key: ThemeKey) -> UIColor? {
+        return color(forKey: key.rawValue)
+    }
+}


### PR DESCRIPTION
### Details:
In this PR we're matching Android's and Simplenote.com's Sort Options for the notes list.

Closes #204

### Testing:
1. Launch Simplenote on your iOS device
 1.1. Press over the top left icon
 1.2. Press over **Settings**
 1.3. Press over the first row: `Sort Order`
2. Log into Simplenote.com (same account as in step 1)
 2.1. Press over your account's email in the top right corner
 2.2. Press over **Settings**  
 2.3. Press over the **Edit** button in Display > Sorting
3. Modify the Sort Order in both iOS and Web
4. Compare both apps, and verify the notes are displayed in the same order

cc @bummytime
Thanks in advance sir!
