### PR TITLE
Share Extension: Fixing Keychain Access Groups

### DIFF
--- a/SimplenoteShare/SimplenoteShare-Development.entitlements
+++ b/SimplenoteShare/SimplenoteShare-Development.entitlements
@@ -12,7 +12,7 @@
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)group.com.codality.NotationalFlow.Development</string>
+		<string>$(AppIdentifierPrefix)com.codality.NotationalFlow.Development</string>
 		<string>4ESDVWK654.com.codality.NotationalFlow</string>
 	</array>
 </dict>

--- a/SimplenoteShare/SimplenoteShare-Internal.entitlements
+++ b/SimplenoteShare/SimplenoteShare-Internal.entitlements
@@ -12,7 +12,7 @@
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)group.com.codality.NotationalFlow.Internal</string>
+		<string>$(AppIdentifierPrefix)com.codality.NotationalFlow.Internal</string>
 		<string>4ESDVWK654.com.codality.NotationalFlow</string>
 	</array>
 </dict>


### PR DESCRIPTION
### Details:
In this PR we're fixing the Keychain's AccessGroups for the Share Extension: Development and Internal Builds.

cc @aerych or @frosty 
Thanks in advance gentlemen!!

### Testing:

1. Launch the Simplenote App in your device
2. Log into your account
3. Switch over to Safari
4. Open `www.wordpress.com`
5. Open the share sheet
6. Tap over the Simplenote icon (make sure you're picking up the development build)
7. Verify the Share Sheet shows up correctly
8. Tap over the top right *Post* button
9. Verify the note gets effectively uploaded
