### PR TITLE
Add metadata translations

### DIFF
--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -1,0 +1,43 @@
+# Translation of Release Notes & Apple Store Description in English (US)
+# This file is distributed under the same license as the Release Notes & Apple Store Description package.
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2019-06-18 17:30-0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 2.0.1\n"
+"Project-Id-Version: Release Notes & Apple Store Description\n"
+"POT-Creation-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+
+#. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
+msgctxt "app_store_subtitle"
+msgid "The simplest way to keep notes."
+msgstr ""
+
+#. translators: Multi-paragraph text used to display in the Apple App Store.
+msgctxt "app_store_desc"
+msgid ""
+"Simplenote is an easy way to keep notes, lists, ideas and more. Your notes stay in sync with all your devices for free.\n"
+"\n"
+"The Simplenote experience is all about speed and efficiency. Open it, write some thoughts, and you're done. As your collection of notes grows, you can search them instantly and keep them organized with tags and pins. You can also share notes and publish them for other people.\n"
+"\n"
+"The best way to learn about Simplenote is to try it. You'll be asked to create an account. This allows your notes to be backed up online and synchronized automatically.\n"
+"\n"
+"After you sign up, try creating some notes! Then go to simplenote.com to download Simplenote for your other devices.\n"
+msgstr ""
+
+#. translators: Keywords used in the App Store search engine to find the app.
+#. Delimit with a comma between each keyword. Limit to 100 characters including spaces and commas.
+msgctxt "app_store_keywords"
+msgid "notes,note,sync,simplenote,simple,todo,list"
+msgstr ""
+
+msgctxt "v4.8-whats-new"
+msgid ""
+"* The Notes List can now be sorted by creation and modification dates.\n"
+msgstr ""
+

--- a/Simplenote/Resources/release_notes.txt
+++ b/Simplenote/Resources/release_notes.txt
@@ -1,0 +1,1 @@
+* The Notes List can now be sorted by creation and modification dates.

--- a/Simplenote/en.lproj/Localizable.strings
+++ b/Simplenote/en.lproj/Localizable.strings
@@ -370,12 +370,6 @@
 /* A welcome note for new iOS users */
 "welcomeNote-iOS" = "Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically.";
 
-/* iTunes app description */
-"iTunes-description" = "Simplenote is an easy way to keep notes, lists, ideas and more. Your notes stay in sync with all your devices for free.\n\nThe Simplenote experience is all about speed and efficiency. Open it, write some thoughts, and you're done. As your collection of notes grows, you can search them instantly and keep them organized with tags and pins. You can also share notes and publish them for other people.\n\nThe best way to learn about Simplenote is to try it. You'll be asked to create an account. This allows your notes to be backed up online and synchronized automatically.\n\nAfter you sign up, try creating some notes! Then go to simplenote.com to download Simplenote for your other devices.";
-
-/* iTunes keywords used to discover app in the App Store */
-"iTunes-keywords" = "notes,note,sync,simplenote,simple,todo,list";
-
 /* Ratings View */
 "What do you think about Simplenote?" = "What do you think about Simplenote?";
 "I Like It" = "I Like It";

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,6 +13,35 @@ ENV["PROJECT_ROOT_FOLDER"]="./"
 # Release Lanes
 ########################################################################
 
+  #####################################################################################
+  # update_appstore_strings
+  # -----------------------------------------------------------------------------------
+  # This lane updates the AppStoreStrings.pot files with the latest content from
+  # the release_notes.txt file and the other text sources
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane update_appstore_strings version:<release note version>
+  #
+  # Example:
+  # bundle exec fastlane update_appstore_strings version:1.1
+  #####################################################################################
+  desc "Updates the AppStoreStrings.pot file with the latest data"
+  lane :update_appstore_strings do | options |
+    prj_folder = Pathname.new(File.join(Dir.pwd, "..")).expand_path.to_s
+    source_metadata_folder = File.join(prj_folder, "fastlane/appstoreres/metadata/source")
+
+    files = {
+      whats_new: File.join(prj_folder,  "/Simplenote/Resources/release_notes.txt"),
+      app_store_subtitle: File.join(source_metadata_folder, "subtitle.txt"),
+      app_store_desc: File.join(source_metadata_folder, "description.txt"),
+      app_store_keywords: File.join(source_metadata_folder, "keywords.txt")
+    }
+
+    ios_update_metadata_source(po_file_path: prj_folder + "/Simplenote/Resources/AppStoreStrings.pot", 
+      source_files: files, 
+      release_version: options[:version])
+  end
+
   desc "Push a new beta build to TestFlight"
   lane :beta do
     build_app(workspace: "Simplenote.xcworkspace", scheme: "Simplenote")

--- a/fastlane/actions/ios_update_metadata_source.rb
+++ b/fastlane/actions/ios_update_metadata_source.rb
@@ -1,0 +1,83 @@
+module Fastlane
+  module Actions
+    class IosUpdateMetadataSourceAction < Action
+      def self.run(params)
+        # Check local repo status
+        #other_action.ensure_git_status_clean()
+
+        other_action.gp_update_metadata_source(po_file_path: params[:po_file_path],
+          source_files: params[:source_files], 
+          release_version: params[:release_version])
+
+        Action.sh("git add #{params[:po_file_path]}")
+        params[:source_files].each do | key, file |
+          Action.sh("git add #{file}")
+        end
+
+        repo_status = Actions.sh("git status --porcelain")
+        repo_clean = repo_status.empty?
+        if (!repo_clean) then
+          #Action.sh("git commit -m \"Update metadata strings\"")
+          #Action.sh("git push")
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Updates the AppStoreStrings.po file with the data from text source files"
+      end
+
+      def self.details
+        "Updates the AppStoreStrings.po file with the data from text source files"
+      end
+
+      def self.available_options
+        # Define all options your action supports. 
+        
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :po_file_path,
+                                        env_name: "FL_IOS_UPDATE_METADATA_SOURCE_PO_FILE_PATH", 
+                                        description: "The path of the .po file to update", 
+                                        is_string: true,
+                                        verify_block: proc do |value|
+                                          UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value and not value.empty?)
+                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                        end),
+          FastlaneCore::ConfigItem.new(key: :release_version,
+                                        env_name: "FL_IOS_UPDATE_METADATA_SOURCE_RELEASE_VERSION",
+                                        description: "The release version of the app (to use to mark the release notes)",
+                                        verify_block: proc do |value|
+                                          UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value and not value.empty?) 
+                                        end),
+          FastlaneCore::ConfigItem.new(key: :source_files,
+                                        env_name: "FL_IOS_UPDATE_METADATA_SOURCE_SOURCE_FILES",
+                                        description: "The hash with the path to the source files and the key to use to include their content",
+                                        is_string: false,
+                                        verify_block: proc do |value|
+                                          UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value and not value.empty?)
+                                        end)
+        ]
+      end
+
+      def self.output
+
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/fastlane/appstoreres/metadata/source/description.txt
+++ b/fastlane/appstoreres/metadata/source/description.txt
@@ -1,0 +1,7 @@
+Simplenote is an easy way to keep notes, lists, ideas and more. Your notes stay in sync with all your devices for free.
+
+The Simplenote experience is all about speed and efficiency. Open it, write some thoughts, and you're done. As your collection of notes grows, you can search them instantly and keep them organized with tags and pins. You can also share notes and publish them for other people.
+
+The best way to learn about Simplenote is to try it. You'll be asked to create an account. This allows your notes to be backed up online and synchronized automatically.
+
+After you sign up, try creating some notes! Then go to simplenote.com to download Simplenote for your other devices.

--- a/fastlane/appstoreres/metadata/source/keywords.txt
+++ b/fastlane/appstoreres/metadata/source/keywords.txt
@@ -1,0 +1,1 @@
+notes,note,sync,simplenote,simple,todo,list

--- a/fastlane/appstoreres/metadata/source/subtitle.txt
+++ b/fastlane/appstoreres/metadata/source/subtitle.txt
@@ -1,0 +1,1 @@
+The simplest way to keep notes.


### PR DESCRIPTION
This PR adds `AppStoreStrings.pot` which contains all the strings used in the App Store listing. The file is meant to be uploaded to GlotPress for translations.

The PR also adds a new Fastlane lane that helps update the .pot file getting the data from standard text files.

To Test:
1. Create a new test branch out of this one and push it to GitHub setting it as upstream.
2. In the new test branch, make a change in `Simplenote/Resources/release_notes.txt`.
3. Commit the changes.
4. Run `bundle exec fastlane update_appstore_strings version:4.8`.
5. Verify that `AppStoreStrings.pot` has been updated and the changes committed and pushed. 