### PR TITLE
SPEditorTextView: fix 294 by setting the insertion point

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -519,6 +519,12 @@ NSInteger const ChecklistCursorAdjustment = 2;
                 SPTextAttachment *attachment = (SPTextAttachment *)value;
                 BOOL wasChecked = attachment.isChecked;
                 [attachment setIsChecked:!wasChecked];
+
+                if (self.selectedRange.location == self.text.length) {
+                    // If the current selection is the end of the note, the keyboard has never shown,
+                    // so set the selected location to the checkbox. Must happen before `textViewDidChange`.
+                    self.selectedRange = NSMakeRange(characterIndex, self.selectedRange.length);
+                }
                 [self.delegate textViewDidChange:self];
                 [self.layoutManager invalidateDisplayForCharacterRange:range];
                 recognizer.cancelsTouchesInView = YES;


### PR DESCRIPTION
Changing the state of a checkbox is a change event that leaves the
insertion point at the end of the note, which triggers a scrolling bug.

### Fix
https://github.com/Automattic/simplenote-ios/issues/294

### Test
Open note with more than one list, where the length of the note exceeds the size of the screen.
Without bringing up the keyboard, simply press a checkbox to toggle the state, and watch the note scroll to the end.

### Review
Very small change.

### Release
