### PR TITLE
Reduce number of conflicts in RELEASE-NOTES.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+RELEASE-NOTES.txt merge=union


### PR DESCRIPTION
This PR changes the merging method for `RELEASE-NOTES.txt` to `union`, with the intention of making merge conflicts in that file rare. After this change, any conflict in that file will be automatically resolved by taking both of the new lines. Order is unpredictable. For release notes, this should be fine.

Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/10842 and https://github.com/woocommerce/woocommerce-ios/pull/651