### PR TITLE
Exporting Notes: WPiOS Customized Activity Item!

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 -   Simplenote now works with Siri shortcuts allowing you to open the app, open existing notes, and create new notes directly from Siri
 -   New Swipe Actions available in the Notes List: Pin and Share!
 -   The Notes List now displays an icon, outlining notes that have been published.
+-   When sharing to the WordPress App, Notes will no longer be blockquoted.
 
 4.8.0
 =====

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -122,6 +122,10 @@
 		B51889A41E0DB01E00E71B83 /* ContactsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B51889A31E0DB01E00E71B83 /* ContactsUI.framework */; };
 		B521A1961BC8446900E1CF2A /* SPAutomatticTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B521A1941BC8446900E1CF2A /* SPAutomatticTracker.m */; };
 		B52B8A231BAAF80B002CC55D /* UIViewController+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52B8A211BAAF80B002CC55D /* UIViewController+Extensions.m */; };
+		B52BB74822CFBD540042C162 /* UIActivityViewController+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52BB74722CFBD540042C162 /* UIActivityViewController+Simplenote.swift */; };
+		B52BB74A22CFC0670042C162 /* FileManager+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52BB74922CFC0670042C162 /* FileManager+Simplenote.swift */; };
+		B52BB74E22CFD1660042C162 /* SimplenoteActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52BB74D22CFD1660042C162 /* SimplenoteActivityItemSource.swift */; };
+		B52BB75022CFD18F0042C162 /* UIActivity+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52BB74F22CFD18F0042C162 /* UIActivity+Simplenote.swift */; };
 		B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B53971A11AB8DCDC00B1A582 /* SPTracker.m */; };
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B550F93122BA65CD00091939 /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93022BA65CD00091939 /* ActivityType.swift */; };
@@ -329,6 +333,10 @@
 		B5250A6B22B922F900AE7797 /* Simplenote-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "Simplenote-Internal.entitlements"; sourceTree = "<group>"; };
 		B52B8A201BAAF80B002CC55D /* UIViewController+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIViewController+Extensions.h"; path = "Classes/UIViewController+Extensions.h"; sourceTree = "<group>"; };
 		B52B8A211BAAF80B002CC55D /* UIViewController+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+Extensions.m"; path = "Classes/UIViewController+Extensions.m"; sourceTree = "<group>"; };
+		B52BB74722CFBD540042C162 /* UIActivityViewController+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIActivityViewController+Simplenote.swift"; sourceTree = "<group>"; };
+		B52BB74922CFC0670042C162 /* FileManager+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "FileManager+Simplenote.swift"; path = "Classes/FileManager+Simplenote.swift"; sourceTree = "<group>"; };
+		B52BB74D22CFD1660042C162 /* SimplenoteActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SimplenoteActivityItemSource.swift; path = Classes/SimplenoteActivityItemSource.swift; sourceTree = "<group>"; };
+		B52BB74F22CFD18F0042C162 /* UIActivity+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIActivity+Simplenote.swift"; path = "Classes/UIActivity+Simplenote.swift"; sourceTree = "<group>"; };
 		B53971A01AB8DCDC00B1A582 /* SPTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = SPTracker.h; path = Classes/SPTracker.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		B53971A11AB8DCDC00B1A582 /* SPTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = SPTracker.m; path = Classes/SPTracker.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		B55051811A4328B9002A1093 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
@@ -814,6 +822,16 @@
 			name = Trackers;
 			sourceTree = "<group>";
 		};
+		B52BB74C22CFD14C0042C162 /* Exporter */ = {
+			isa = PBXGroup;
+			children = (
+				B52BB74722CFBD540042C162 /* UIActivityViewController+Simplenote.swift */,
+				B52BB74F22CFD18F0042C162 /* UIActivity+Simplenote.swift */,
+				B52BB74D22CFD1660042C162 /* SimplenoteActivityItemSource.swift */,
+			);
+			name = Exporter;
+			sourceTree = "<group>";
+		};
 		B550F92F22BA643800091939 /* Siri */ = {
 			isa = PBXGroup;
 			children = (
@@ -829,6 +847,7 @@
 			isa = PBXGroup;
 			children = (
 				F52A2FD01DE8B1FB002DEB0E /* CSSearchable+Helpers.swift */,
+				B52BB74922CFC0670042C162 /* FileManager+Simplenote.swift */,
 				DE7E545A214E34C8008D9928 /* NSString+Count.swift */,
 				B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */,
 				B5CDE61D2150834C00C3FED4 /* Simperium+Simplenote.h */,
@@ -1091,6 +1110,7 @@
 			children = (
 				467D9C7A1788D10400785EF3 /* Categories */,
 				B569DBFE1C03411500EC1FE8 /* Extensions */,
+				B52BB74C22CFD14C0042C162 /* Exporter */,
 				467D9C601788A53700785EF3 /* Models */,
 				B5B8AE7B1AB9ECF80082775D /* Ratings */,
 				B512AF981C20B1A200FE76D8 /* Settings */,
@@ -1574,6 +1594,7 @@
 				46A3C96217DFA81A002865AE /* SPTagListViewCell.m in Sources */,
 				B52B8A231BAAF80B002CC55D /* UIViewController+Extensions.m in Sources */,
 				B55738211AB8950A006043E4 /* NSDate+Helper.m in Sources */,
+				B52BB74822CFBD540042C162 /* UIActivityViewController+Simplenote.swift in Sources */,
 				46A3C96317DFA81A002865AE /* NSString+Metadata.m in Sources */,
 				46A3C96417DFA81A002865AE /* SPVersionPickerViewCell.m in Sources */,
 				46A3C96517DFA81A002865AE /* SPActivityView.m in Sources */,
@@ -1586,8 +1607,10 @@
 				46A3C96A17DFA81A002865AE /* SPTagStub.m in Sources */,
 				B50F47A61D1D791B00822748 /* NSURL+Extensions.swift in Sources */,
 				46A3C96B17DFA81A002865AE /* NSAttributedString+Styling.m in Sources */,
+				B52BB74E22CFD1660042C162 /* SimplenoteActivityItemSource.swift in Sources */,
 				B5DF734022A54EE800602CE7 /* SPDefaultTableViewCell.swift in Sources */,
 				46A3C96C17DFA81A002865AE /* SPOptionsViewController.m in Sources */,
+				B52BB74A22CFC0670042C162 /* FileManager+Simplenote.swift in Sources */,
 				3762530620F54FFB00C1F239 /* SPAboutViewController.swift in Sources */,
 				B550F93622BA7E9100091939 /* NSUserActivity+Simplenote.swift in Sources */,
 				B5BE054E1AB75902002417BF /* NSProcessInfo+Util.m in Sources */,
@@ -1641,6 +1664,7 @@
 				46A3C98817DFA81A002865AE /* Simplenote.xcdatamodeld in Sources */,
 				B518899E1E0D5EF800E71B83 /* SPContactsManager.swift in Sources */,
 				46A3C98917DFA81A002865AE /* SPAppDelegate.m in Sources */,
+				B52BB75022CFD18F0042C162 /* UIActivity+Simplenote.swift in Sources */,
 				F9E197D42283D05C0092B3E1 /* CrashLogging.swift in Sources */,
 				DE7E545B214E34C8008D9928 /* NSString+Count.swift in Sources */,
 				B56B357F1AC3565600B9F365 /* UITextView+Simplenote.m in Sources */,

--- a/Simplenote/Classes/FileManager+Simplenote.swift
+++ b/Simplenote/Classes/FileManager+Simplenote.swift
@@ -25,11 +25,13 @@ extension FileManager {
         let filename = String(format: "%@.txt", note.simperiumKey)
         let targetURL = FileManager.documentsURL.appendingPathComponent(filename)
 
-        guard let error = try? payload.write(to: targetURL, atomically: true, encoding: .utf8) else {
-            return targetURL
+        do {
+            try payload.write(to: targetURL, atomically: true, encoding: .utf8)
+        } catch {
+            NSLog("Note Exporter Failure: \(error)")
+            return nil
         }
 
-        NSLog("Note Exporter Failure: \(error)")
-        return nil
+        return targetURL
     }
 }

--- a/Simplenote/Classes/FileManager+Simplenote.swift
+++ b/Simplenote/Classes/FileManager+Simplenote.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+
+// MARK: - Paths
+//
+extension FileManager {
+
+    /// User's Document Directory
+    ///
+    class var documentsURL: URL {
+        guard let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            fatalError("Cannot Access User Documents Directory")
+        }
+
+        return url
+    }
+
+    /// Writes a given Note to the Documents folder
+    ///
+    class func writeToDocuments(note: Note) -> URL? {
+        guard let payload = note.content else {
+            return nil
+        }
+
+        let filename = String(format: "%@.txt", note.simperiumKey)
+        let targetURL = FileManager.documentsURL.appendingPathComponent(filename)
+
+        guard let error = try? payload.write(to: targetURL, atomically: true, encoding: .utf8) else {
+            return targetURL
+        }
+
+        NSLog("Note Exporter Failure: \(error)")
+        return nil
+    }
+}

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1705,22 +1705,17 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     [self save];
     
     [SPTracker trackEditorNoteContentShared];
-	   
-    UISimpleTextPrintFormatter *print = [[UISimpleTextPrintFormatter alloc] initWithText:_currentNote.content];
 
-    UIActivityViewController *acv = [[UIActivityViewController alloc] initWithActivityItems:@[_currentNote.content, print]
-                                                                      applicationActivities:nil];
-    
+    UIActivityViewController *acv = [[UIActivityViewController alloc] initWithNote:_currentNote];
+
     if ([UIDevice isPad]) {
         acv.modalPresentationStyle = UIModalPresentationPopover;
         acv.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
         acv.popoverPresentationController.sourceRect = [self presentationRectForActionButton];
         acv.popoverPresentationController.sourceView = self.view;
-        [self presentViewController:acv animated:YES completion:nil];
-    } else {
-        [self.navigationController presentViewController:acv animated:YES completion:nil];
     }
-    
+
+    [self presentViewController:acv animated:YES completion:nil];
 }
 
 - (void)shareNoteURLAction:(id)sender {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -604,10 +604,7 @@
 
     [SPTracker trackEditorNoteContentShared];
 
-    UISimpleTextPrintFormatter *print = [[UISimpleTextPrintFormatter alloc] initWithText:note.content];
-
-    UIActivityViewController *acv = [[UIActivityViewController alloc] initWithActivityItems:@[note.content, print]
-                                                                      applicationActivities:nil];
+    UIActivityViewController *acv = [[UIActivityViewController alloc] initWithNote:note];
 
     if ([UIDevice isPad]) {
         acv.modalPresentationStyle = UIModalPresentationPopover;

--- a/Simplenote/Classes/SimplenoteActivityItemSource.swift
+++ b/Simplenote/Classes/SimplenoteActivityItemSource.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+
+// MARK: - UIActivityItem With Special Treatment for WordPress iOS
+//
+class SimplenoteActivityItemSource: NSObject, UIActivityItemSource {
+
+    /// The Note that's about to be exported
+    ///
+    private let note: Note
+
+    /// Designated Initializer
+    ///
+    init(note: Note) {
+        self.note = note
+        super.init()
+    }
+
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        return note.content ?? String()
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        guard activityType?.isWordPressActivity == true else {
+            return note.content
+        }
+
+        return FileManager.writeToDocuments(note: note) ?? note.content
+    }
+}

--- a/Simplenote/Classes/UIActivity+Simplenote.swift
+++ b/Simplenote/Classes/UIActivity+Simplenote.swift
@@ -5,6 +5,18 @@ import Foundation
 //
 extension UIActivity.ActivityType {
 
+    /// WordPress Draft Extension (AppStore)
+    ///
+    static var wordPressDraftAppStore: UIActivity.ActivityType {
+        return UIActivity.ActivityType("org.wordpress.WordPressDraftAction")
+    }
+
+    /// WordPress Draft Extension (Internal Beta)
+    ///
+    static var wordPressDraftInternal: UIActivity.ActivityType {
+        return UIActivity.ActivityType("org.wordpress.internal.WordPressDraftAction")
+    }
+
     /// WordPress Share Extension (AppStore)
     ///
     static var wordPressShareAppStore: UIActivity.ActivityType {
@@ -21,6 +33,8 @@ extension UIActivity.ActivityType {
     ///
     var isWordPressActivity: Bool {
         let wordpressActivities: [UIActivity.ActivityType] = [
+            .wordPressDraftAppStore,
+            .wordPressDraftInternal,
             .wordPressShareAppStore,
             .wordPressShareInternal
         ]

--- a/Simplenote/Classes/UIActivity+Simplenote.swift
+++ b/Simplenote/Classes/UIActivity+Simplenote.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+
+// MARK: - UIActivity <> WordPress iOS!
+//
+extension UIActivity.ActivityType {
+
+    /// WordPress Share Extension (AppStore)
+    ///
+    static var wordPressShareAppStore: UIActivity.ActivityType {
+        return UIActivity.ActivityType("org.wordpress.WordPressShare")
+    }
+
+    /// WordPress Share Extension (Internal Beta)
+    ///
+    static var wordPressShareInternal: UIActivity.ActivityType {
+        return UIActivity.ActivityType("org.wordpress.internal.WordPressShare")
+    }
+
+    /// Indicates if a given UIActivity belongs to the WordPress iOS App
+    ///
+    var isWordPressActivity: Bool {
+        let wordpressActivities: [UIActivity.ActivityType] = [
+            .wordPressShareAppStore,
+            .wordPressShareInternal
+        ]
+
+        return wordpressActivities.contains(self)
+    }
+}

--- a/Simplenote/UIActivityViewController+Simplenote.swift
+++ b/Simplenote/UIActivityViewController+Simplenote.swift
@@ -1,0 +1,22 @@
+import Foundation
+import UIKit
+
+
+// MARK: - ActivityViewController Simplenote Methods
+//
+extension UIActivityViewController {
+
+    /// Initializes a UIActivityViewController instance that will be able to export a given Note
+    ///
+    @objc
+    convenience init?(note: Note) {
+        guard let content = note.content else {
+            return nil
+        }
+
+        let print = UISimpleTextPrintFormatter(text: content)
+        let source = SimplenoteActivityItemSource(note: note)
+
+        self.init(activityItems: [print, source], applicationActivities: nil)
+    }
+}


### PR DESCRIPTION
### Details:
- WPiOS is blockquoting notes shared from Simplenote.
- As discussed over Slack, this is a desired behavior, and patching WPiOS is off the table
- In this PR we're implementing a workaround. The Share Sheet will now detect the Activity Type, and prepare a custom ActivityItem that will force WPiOS not to blockquote incoming text.

cc @bummytime 
Thank you @nheagy for helping us out!!


---

### Secenario: Source = Note Editor
0. Make sure you've got WPiOS installed in your device
1. Log into Simplenote and open your favorite note
2. Press the top right `( i )` icon, and press `Send`
3. In the Activity Sheet, press the WordPress Icon

- [x] Verify that the Note doesn't show up blockquoted.
- [x] Verify this also works from the Note List (swipe to reveal the Share Action)
- [x] Verify this works well on iPad Devices
