### PR TITLE
Hotfix: Sort Order Migration

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B53971A11AB8DCDC00B1A582 /* SPTracker.m */; };
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B55738211AB8950A006043E4 /* NSDate+Helper.m in Sources */ = {isa = PBXBuildFile; fileRef = B557381F1AB8950A006043E4 /* NSDate+Helper.m */; };
+		B55AC57A22D27B9100D8CEB2 /* OptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55AC57922D27B9100D8CEB2 /* OptionsTests.swift */; };
 		B55E428C22A1A4550018C0CE /* SPSortOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55E428B22A1A4550018C0CE /* SPSortOrderViewController.swift */; };
 		B55E428E22A1C0B90018C0CE /* VSTheme+Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55E428D22A1C0B90018C0CE /* VSTheme+Keys.swift */; };
 		B5686178195B9E93005F1245 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E2F149471799F5A500DC9690 /* libsqlite3.dylib */; };
@@ -335,6 +336,7 @@
 		B5536B8F1B8E4B8A00FF190A /* zh-Hans-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans-CN"; path = "zh-Hans-CN.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		B557381E1AB8950A006043E4 /* NSDate+Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSDate+Helper.h"; path = "Classes/NSDate+Helper.h"; sourceTree = "<group>"; };
 		B557381F1AB8950A006043E4 /* NSDate+Helper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDate+Helper.m"; path = "Classes/NSDate+Helper.m"; sourceTree = "<group>"; };
+		B55AC57922D27B9100D8CEB2 /* OptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsTests.swift; sourceTree = "<group>"; };
 		B55E428B22A1A4550018C0CE /* SPSortOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortOrderViewController.swift; path = Classes/SPSortOrderViewController.swift; sourceTree = "<group>"; };
 		B55E428D22A1C0B90018C0CE /* VSTheme+Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VSTheme+Keys.swift"; sourceTree = "<group>"; };
 		B566A1DD189AA74600DC3F2D /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
@@ -789,6 +791,23 @@
 			name = Trackers;
 			sourceTree = "<group>";
 		};
+		B55AC57822D27B7F00D8CEB2 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				B55AC57922D27B9100D8CEB2 /* OptionsTests.swift */,
+			);
+			name = Settings;
+			sourceTree = "<group>";
+		};
+		B55AC57B22D27BA300D8CEB2 /* Tools */ = {
+			isa = PBXGroup;
+			children = (
+				B58218A41FCC45330094ECA1 /* KeychainMigratorTests.swift */,
+				374F5EF421BF057E00B57E8B /* SPChecklistTest.swift */,
+			);
+			name = Tools;
+			sourceTree = "<group>";
+		};
 		B569DBFE1C03411500EC1FE8 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -827,10 +846,10 @@
 		B58218981FCC45170094ECA1 /* SimplenoteTests */ = {
 			isa = PBXGroup;
 			children = (
+				B55AC57822D27B7F00D8CEB2 /* Settings */,
+				B55AC57B22D27BA300D8CEB2 /* Tools */,
 				B58218A31FCC45320094ECA1 /* SimplenoteTests-Bridging-Header.h */,
 				B582189B1FCC45170094ECA1 /* Info.plist */,
-				B58218A41FCC45330094ECA1 /* KeychainMigratorTests.swift */,
-				374F5EF421BF057E00B57E8B /* SPChecklistTest.swift */,
 			);
 			path = SimplenoteTests;
 			sourceTree = "<group>";
@@ -1667,6 +1686,7 @@
 			files = (
 				B58218A51FCC45330094ECA1 /* KeychainMigratorTests.swift in Sources */,
 				374F5EF521BF057E00B57E8B /* SPChecklistTest.swift in Sources */,
+				B55AC57A22D27B9100D8CEB2 /* OptionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simplenote/Classes/UserDefaults+Simplenote.swift
+++ b/Simplenote/Classes/UserDefaults+Simplenote.swift
@@ -15,7 +15,13 @@ extension UserDefaults {
 //
 extension UserDefaults {
 
-    /// Returns the Object (if any) associated with the specified Key.
+    /// Returns the Booolean associated with the specified Key.
+    ///
+    func bool(forKey key: Key) -> Bool {
+        return bool(forKey: key.rawValue)
+    }
+
+    /// Returns the Integer (if any) associated with the specified Key.
     ///
     func integer(forKey key: Key) -> Int {
         return integer(forKey: key.rawValue)

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -25,7 +25,9 @@ class Options: NSObject {
 
     /// Designated Initializer
     ///
-    override private init() {
+    /// - Note: Should be *private*, but for unit testing purposes, we're opening this up.
+    ///
+    override init() {
         super.init()
         migrateLegacyOptions()
     }
@@ -71,11 +73,13 @@ extension Options {
 private extension Options {
 
     func migrateLegacyOptions() {
-        guard let legacySortAscending: Bool = defaults[.listSortModeLegacy] else {
+        guard defaults.containsObject(forKey: .listSortMode) == false else {
             return
         }
 
-        let newMode: SortMode = legacySortAscending ? .alphabeticallyAscending : .alphabeticallyDescending
+        let legacySortAlphabetically = defaults.bool(forKey: .listSortModeLegacy)
+        let newMode: SortMode = legacySortAlphabetically ? .alphabeticallyAscending : .modifiedNewest
+
         defaults.set(newMode.rawValue, forKey: .listSortMode)
         defaults.removeObject(forKey: .listSortModeLegacy)
     }

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -44,7 +44,7 @@ extension Options {
     var listSortMode: SortMode {
         get {
             let payload = defaults.integer(forKey: .listSortMode)
-            return SortMode(rawValue: payload) ?? .alphabeticallyAscending
+            return SortMode(rawValue: payload) ?? .modifiedNewest
         }
         set {
             defaults.set(newValue.rawValue, forKey: .listSortMode)

--- a/SimplenoteTests/OptionsTests.swift
+++ b/SimplenoteTests/OptionsTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+@testable import Simplenote
+
+
+// MARK: - Options Unit Tests
+//
+class OptionsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        resetUserDefaults()
+    }
+
+    func testEmptyLegacySortSettingsYieldModifiedNewest() {
+        let options = Options()
+        XCTAssert(options.listSortMode == .modifiedNewest)
+    }
+
+    func testLegacyAlphabeticalSortIsProperlyMigrated() {
+        UserDefaults.standard.set(true, forKey: .listSortModeLegacy)
+        let options = Options()
+        XCTAssert(options.listSortMode == .alphabeticallyAscending)
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension OptionsTests {
+
+    func resetUserDefaults() {
+        guard let identifier = Bundle.main.bundleIdentifier else {
+            return
+        }
+
+        UserDefaults.standard.removePersistentDomain(forName: identifier)
+    }
+}


### PR DESCRIPTION
### Details:
This PR fixes the Sort Order setting migration from Simplenote 4.7.0.

**Plus** the default sort order has been set to *Modified Newest*, matching the pre-new-sort-order PR's default setting.

cc @bummytime 

---

### Known Issues:
There's a known scenario in which the legacy sort order cannot be restored:

1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. **Settings** > Enable **Sort Alphabetically** > Disable **Sort Alphabetically**
5. Exit Xcode
6. `git checkout release/4.8.0`
7. Relaunch Simplenote. 
8. `git checkout hotfix/sort-order-migration`

This particular flow **can not** be fixed without user interaction.

**WHY**
[The migrateLegacyOptions routine](https://github.com/Automattic/simplenote-ios/pull/320/files#diff-6a6f50e71927cab953056ff1460f4712R78) was a destructive OP. The legacy setting was being removed, and the mapping from Legacy > New was off:

```
let newMode: SortMode = legacySortAscending ? .alphabeticallyAscending : .alphabeticallyDescending
```

Instead of using `.alphabeticallyDescending` when `legacySortAscending` was false, we should have picked `.modifiedNewest`.

We'll be checking out potential UI alternatives (such as presenting an alert, just once, offering users a shortcut to the Sort Order UI).


---

### Scenario A: Legacy Default (4.7.0 > 4.8.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. Exit Xcode
5. `git checkout release/4.8.0`
6. Relaunch Simplenote
7. Verify the Sort Order is broken
8. `git checkout hotfix/sort-order-migration`

- [x] Verify the Sort order is restored, and the notes look exactly as they did in (3)

### Scenario B: Legacy Default (4.7.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. Exit Xcode
5. `git checkout hotfix/sort-order-migration`

- [x] Verify the Sort order looks exactly the same as in (3)

### Scenario C: Legacy Alphabetically (4.7.0 > 4.8.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. **Settings** > Enable **Sort Alphabetically**
5. Exit Xcode
6. `git checkout release/4.8.0`
7. Relaunch Simplenote. 
8. Verify the Sort Order remains the same as in (3)
8. `git checkout hotfix/sort-order-migration`

- [x] Verify the Sort Order remains okay

### Scenario D: Legacy Alphabetically (4.7.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. **Settings** > Enable **Sort Alphabetically**
5. Exit Xcode
6. `git checkout hotfix/sort-order-migration`

- [x] Verify the Sort Order remains okay
