### PR TITLE
Add codefreeze automation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 1cfb99dcb2d7284165a6ee4fa149f1c9374db312
-  tag: 0.1.8
+  revision: 074bac6f11ae07a293d73eed71eede716480ef6e
+  tag: 0.2.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.1.8)
+    fastlane-plugin-wpmreleasetoolkit (0.2.0)
       diffy
       git
       nokogiri

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,8 +7,9 @@ platform :ios do
 ########################################################################
 Dotenv.load('~/.simplenoteios-env.default')
 ENV[GHHELPER_REPO="Automattic/simplenote-ios"]
+ENV["PROJECT_NAME"]="Simplenote"
 ENV["PROJECT_ROOT_FOLDER"]="./"
-ENV["PUBLIC_CONFIG_FILE"]="../config/Version.Public.xcconfig"
+ENV["PUBLIC_CONFIG_FILE"]="./config/Version.Public.xcconfig"
 ENV["DOWNLOAD_METADATA"]="./fastlane/download_metadata.swift"
 ENV["PROJECT_ROOT_FOLDER"]="./"
 
@@ -37,9 +38,8 @@ ENV["PROJECT_ROOT_FOLDER"]="./"
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
 
-    ios_localize_project()
     ios_tag_build()
-    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wpios_prs_list_#{old_version}_#{new_version}.txt")
+    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/simplenoteios_prs_list_#{old_version}_#{new_version}.txt")
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,10 +8,39 @@ platform :ios do
 Dotenv.load('~/.simplenoteios-env.default')
 ENV[GHHELPER_REPO="Automattic/simplenote-ios"]
 ENV["PROJECT_ROOT_FOLDER"]="./"
+ENV["PUBLIC_CONFIG_FILE"]="../config/Version.Public.xcconfig"
+ENV["DOWNLOAD_METADATA"]="./fastlane/download_metadata.swift"
+ENV["PROJECT_ROOT_FOLDER"]="./"
 
 ########################################################################
 # Release Lanes
 ########################################################################
+  #####################################################################################
+  # code_freeze
+  # -----------------------------------------------------------------------------------
+  # This lane executes the steps planned on code freeze
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane code_freeze [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane code_freeze
+  # bundle exec fastlane code_freeze skip_confirm:true
+  #####################################################################################
+  desc "Creates a new release branch from the current develop"
+  lane :code_freeze do | options |
+    old_version = ios_codefreeze_prechecks(options)
+    
+    ios_bump_version_release()
+    new_version = ios_get_app_version()
+    ios_update_release_notes(new_version: new_version)
+    setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
+    setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
+
+    ios_localize_project()
+    ios_tag_build()
+    get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wpios_prs_list_#{old_version}_#{new_version}.txt")
+  end
 
   #####################################################################################
   # update_appstore_strings

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-sentry'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.1.8'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.2.0'


### PR DESCRIPTION
This PR adds a Fastlane function to automate some of the code freeze steps of the release process.

# To Test 
### Setup
1. Run `bundle install`. Make sure you setup the env file as described in https://github.com/Automattic/simplenote-ios/pull/332.
2. Tag a commit in the develop branch as the previous release (`4.8` currently). Please, make sure you don't tag the HEAD commit and that there's at least one PR merged between the tag and the current HEAD.

### Test
3. Run `bundle exec fastlane code_freeze`.
4. When prompted, verify that the system reads the correct version and propose the right one. Confirm.
5. Verify that the operation finishes without errors.
6. Verify that a new release/[next_release] (currently 4.9) has been created, the branch protection set and that the version has been updated correctly in the xcconfig file.
7. Verify that the proper tag has been added (should be 4.9.0.0).
8. Verify that the proper milestone (currently 4.9) has been marked with the snowflake tag.
9. Verify that the a `simplenoteios_prs_list_xx_xx.txt` file has been created in the home folder with the changelog.

### Clean up
10. Remove the 4.9.0.0 tag from your local repository and from GitHub.
11. Remove the 4.8 tag from your local repository.
12. Remove the snowflake tag from the milestone.
13. Delete the new release branch from your local repository and from GitHub.

