### PR TITLE
Broken Settings Recovery

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		B5BE05541AB75C3B002417BF /* Settings.m in Sources */ = {isa = PBXBuildFile; fileRef = B5BE05521AB75C3B002417BF /* Settings.m */; };
 		B5BFAEBB21519DCA00918DC8 /* SPPrivacyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BFAEBA21519DCA00918DC8 /* SPPrivacyViewController.swift */; };
 		B5C9F71E193E75FE00FD2491 /* SPDebugViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5C9F71C193E75FE00FD2491 /* SPDebugViewController.m */; };
+		B5CBEF4022D3AD92009DBE67 /* MigrationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBEF3F22D3AD92009DBE67 /* MigrationsHandler.swift */; };
+		B5CBEF4222D3B419009DBE67 /* Bundle+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBEF4122D3B419009DBE67 /* Bundle+Simplenote.swift */; };
 		B5CDE61F2150834C00C3FED4 /* Simperium+Simplenote.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CDE61E2150834C00C3FED4 /* Simperium+Simplenote.m */; };
 		B5CFFFE222AA9AD100B968CD /* TextBundleWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CFFFE022AA9AD100B968CD /* TextBundleWrapper.m */; };
 		B5CFFFE722AA9DB100B968CD /* Uploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CFFFE622AA9DB100B968CD /* Uploader.swift */; };
@@ -382,6 +384,8 @@
 		B5C9F71B193E75FE00FD2491 /* SPDebugViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPDebugViewController.h; path = Classes/SPDebugViewController.h; sourceTree = "<group>"; };
 		B5C9F71C193E75FE00FD2491 /* SPDebugViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPDebugViewController.m; path = Classes/SPDebugViewController.m; sourceTree = "<group>"; };
 		B5CA3E0D22B1503700AC0D47 /* RELEASE-NOTES.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "RELEASE-NOTES.txt"; sourceTree = "<group>"; };
+		B5CBEF3F22D3AD92009DBE67 /* MigrationsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MigrationsHandler.swift; path = Classes/MigrationsHandler.swift; sourceTree = "<group>"; };
+		B5CBEF4122D3B419009DBE67 /* Bundle+Simplenote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Bundle+Simplenote.swift"; path = "Classes/Bundle+Simplenote.swift"; sourceTree = "<group>"; };
 		B5CDE61D2150834C00C3FED4 /* Simperium+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "Simperium+Simplenote.h"; path = "Classes/Simperium+Simplenote.h"; sourceTree = "<group>"; };
 		B5CDE61E2150834C00C3FED4 /* Simperium+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "Simperium+Simplenote.m"; path = "Classes/Simperium+Simplenote.m"; sourceTree = "<group>"; };
 		B5CFFFE022AA9AD100B968CD /* TextBundleWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TextBundleWrapper.m; sourceTree = "<group>"; };
@@ -811,6 +815,7 @@
 		B569DBFE1C03411500EC1FE8 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B5CBEF4122D3B419009DBE67 /* Bundle+Simplenote.swift */,
 				B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */,
 				DE7E545A214E34C8008D9928 /* NSString+Count.swift */,
 				B50F479E1D1D77FC00822748 /* UIAlertController+Helpers.swift */,
@@ -868,6 +873,7 @@
 		B5BE053E1AB751FD002417BF /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				B5CBEF3F22D3AD92009DBE67 /* MigrationsHandler.swift */,
 				B5BE053F1AB75225002417BF /* SPIntegrityHelper.h */,
 				B5BE05401AB75225002417BF /* SPIntegrityHelper.m */,
 				B5D3FCCF201F96AC00A813B7 /* StatusChecker.h */,
@@ -1567,6 +1573,7 @@
 				B5BE054E1AB75902002417BF /* NSProcessInfo+Util.m in Sources */,
 				46A3C96D17DFA81A002865AE /* SPOutsideTouchView.m in Sources */,
 				375D24B821E01131007AB25A /* hash.c in Sources */,
+				B5CBEF4022D3AD92009DBE67 /* MigrationsHandler.swift in Sources */,
 				B5CDE61F2150834C00C3FED4 /* Simperium+Simplenote.m in Sources */,
 				46A3C96E17DFA81A002865AE /* SPPopoverContainerViewController.m in Sources */,
 				46A3C96F17DFA81A002865AE /* SPButton.m in Sources */,
@@ -1660,6 +1667,7 @@
 				46A3C9A717DFA81A002865AE /* DTPinLockController.m in Sources */,
 				46A3C9A817DFA81A002865AE /* SPBorderedView.m in Sources */,
 				46A3C9A917DFA81A002865AE /* SPModalActivityIndicator.m in Sources */,
+				B5CBEF4222D3B419009DBE67 /* Bundle+Simplenote.swift in Sources */,
 				46A3C9AA17DFA81A002865AE /* UITableView+Styling.m in Sources */,
 				46A3C9AB17DFA81A002865AE /* UIImage+Extensions.m in Sources */,
 				37E55A6721BF2B1800F14241 /* SPTextAttachment.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		B51889A01E0D5F2200E71B83 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B518899F1E0D5F2200E71B83 /* Contacts.framework */; };
 		B51889A41E0DB01E00E71B83 /* ContactsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B51889A31E0DB01E00E71B83 /* ContactsUI.framework */; };
 		B521A1961BC8446900E1CF2A /* SPAutomatticTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B521A1941BC8446900E1CF2A /* SPAutomatticTracker.m */; };
+		B52646AA22D3E04C00EBF299 /* UIViewController+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52646A922D3E04C00EBF299 /* UIViewController+Simplenote.swift */; };
 		B52B8A231BAAF80B002CC55D /* UIViewController+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52B8A211BAAF80B002CC55D /* UIViewController+Extensions.m */; };
 		B52B8A271BAB0DF0002CC55D /* UIView+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B52B8A251BAB0DF0002CC55D /* UIView+Extensions.m */; };
 		B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B53971A11AB8DCDC00B1A582 /* SPTracker.m */; };
@@ -319,6 +320,7 @@
 		B521A1931BC8446900E1CF2A /* SPAutomatticTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPAutomatticTracker.h; path = Classes/SPAutomatticTracker.h; sourceTree = "<group>"; };
 		B521A1941BC8446900E1CF2A /* SPAutomatticTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPAutomatticTracker.m; path = Classes/SPAutomatticTracker.m; sourceTree = "<group>"; };
 		B5250A6B22B922F900AE7797 /* Simplenote-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "Simplenote-Internal.entitlements"; sourceTree = "<group>"; };
+		B52646A922D3E04C00EBF299 /* UIViewController+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIViewController+Simplenote.swift"; path = "Classes/UIViewController+Simplenote.swift"; sourceTree = "<group>"; };
 		B52B8A201BAAF80B002CC55D /* UIViewController+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIViewController+Extensions.h"; path = "Classes/UIViewController+Extensions.h"; sourceTree = "<group>"; };
 		B52B8A211BAAF80B002CC55D /* UIViewController+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+Extensions.m"; path = "Classes/UIViewController+Extensions.m"; sourceTree = "<group>"; };
 		B52B8A241BAB0DF0002CC55D /* UIView+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIView+Extensions.h"; path = "Classes/UIView+Extensions.h"; sourceTree = "<group>"; };
@@ -824,6 +826,7 @@
 				B5CDE61E2150834C00C3FED4 /* Simperium+Simplenote.m */,
 				B55E428D22A1C0B90018C0CE /* VSTheme+Keys.swift */,
 				B5DF734322A56E2800602CE7 /* UserDefaults+Simplenote.swift */,
+				B52646A922D3E04C00EBF299 /* UIViewController+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1650,6 +1653,7 @@
 				46A3C99D17DFA81A002865AE /* SPAddCollaboratorsViewController.m in Sources */,
 				46A3C99E17DFA81A002865AE /* SPTableViewCell.m in Sources */,
 				46A3C99F17DFA81A002865AE /* VSThemeManager.m in Sources */,
+				B52646AA22D3E04C00EBF299 /* UIViewController+Simplenote.swift in Sources */,
 				B55E428C22A1A4550018C0CE /* SPSortOrderViewController.swift in Sources */,
 				E2B0863618070045001ED52D /* SPTagPill.m in Sources */,
 				46A3C9A117DFA81A002865AE /* SPTagsListViewController.m in Sources */,

--- a/Simplenote/Classes/Bundle+Simplenote.swift
+++ b/Simplenote/Classes/Bundle+Simplenote.swift
@@ -1,0 +1,16 @@
+import Foundation
+import UIKit
+
+
+/// Bundle: Woo Methods
+///
+extension Bundle {
+
+    /// Returns the Bundle Short Version String.
+    ///
+    @objc
+    var shortVersionString: String {
+        let version = infoDictionary?["CFBundleShortVersionString"] as? String
+        return version ?? ""
+    }
+}

--- a/Simplenote/Classes/Bundle+Simplenote.swift
+++ b/Simplenote/Classes/Bundle+Simplenote.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 
-/// Bundle: Woo Methods
+/// Bundle: Simplenote Methods
 ///
 extension Bundle {
 

--- a/Simplenote/Classes/MigrationsHandler.swift
+++ b/Simplenote/Classes/MigrationsHandler.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+
+// MARK: - Simplenote's Upgrade handling flows
+//
+class MigrationsHandler: NSObject {
+
+    /// Returns the Runtime version
+    ///
+    private let runtimeVersion = Bundle.main.shortVersionString
+
+    /// Stores the last known version.
+    ///
+    /// - Note: When this property is empty, we'll tamper into the `WordPress-Ratings-iOS` framework's internal UserDefaults key.
+    ///   Why? Because we ... really need to. *Do NOT* attempt this at home.
+    ///
+    private var lastKnownVersion: String {
+        get {
+            return UserDefaults.standard.string(forKey: .lastKnownVersion)
+                ?? UserDefaults.standard.string(forKey: .lastKnownVersionByRatingsFramework)
+                ?? String()
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: .lastKnownVersion)
+        }
+    }
+
+    /// Processes any routines required to (safely) handle App Version Upgrades.
+    ///
+    @objc
+    func ensureUpdateIsHandled() {
+        guard runtimeVersion != lastKnownVersion else {
+            return
+        }
+
+        processMigrations(from: lastKnownVersion, to: runtimeVersion)
+        lastKnownVersion = runtimeVersion
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension MigrationsHandler {
+
+    /// Handles a migration *from* a given version, *towards* a given version
+    ///
+    func processMigrations(from: String, to: String) {
+        switch (from, to) {
+        case (SimplenoteVersion.mk4_8_0, _):
+            processMigrationFromMark4_8_0()
+        default:
+            break
+        }
+    }
+}
+
+
+// MARK: - Migration from 4.8.0
+//
+private extension MigrationsHandler {
+
+    func processMigrationFromMark4_8_0() {
+        guard Options.shared.listSortMode == .alphabeticallyDescending,
+            SPAppDelegate.shared()?.simperium.user.authenticated() == true
+            else {
+                    return
+        }
+
+        presentSortOptionsResetAlert()
+    }
+
+    func presentSortOptionsResetAlert() {
+        let title = String()
+        let message = NSLocalizedString("Our update may have changed the order in which your notes appear. Would you like to review sort settings?",
+                                     comment: "AlertController's Payload for the broken Sort Options Fix")
+
+        let controller = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
+        let cancelText = NSLocalizedString("No", comment: "Alert's Cancel Action")
+        let cancelAction = UIAlertAction(title: cancelText, style: .cancel, handler: nil)
+
+        let okText = NSLocalizedString("Yes", comment: "Alert's Accept Action")
+        let okAction = UIAlertAction(title: okText, style: .default) { _ in
+
+        }
+
+        controller.addAction(cancelAction)
+        controller.addAction(okAction)
+
+        controller.presentFromRootViewController()
+    }
+}
+
+
+// MARK: - Known App Versions
+//
+private enum SimplenoteVersion {
+    static let mk4_8_0 = "4.8.0"
+    static let mk4_8_1 = "4.8.1"
+}

--- a/Simplenote/Classes/MigrationsHandler.swift
+++ b/Simplenote/Classes/MigrationsHandler.swift
@@ -100,6 +100,7 @@ private extension MigrationsHandler {
     ///
     func presentSortOptionsViewController() {
         let sortingViewController = SPSortOrderViewController()
+        sortingViewController.displaysDismissButton = true
         sortingViewController.selectedMode = Options.shared.listSortMode
         sortingViewController.onChange = { newMode in
             Options.shared.listSortMode = newMode

--- a/Simplenote/Classes/MigrationsHandler.swift
+++ b/Simplenote/Classes/MigrationsHandler.swift
@@ -76,6 +76,8 @@ private extension MigrationsHandler {
         presentSortOptionsResetAlert()
     }
 
+    /// Presents the Sort Options Alert
+    ///
     func presentSortOptionsResetAlert() {
         let title = String()
         let message = NSLocalizedString("Our update may have changed the order in which your notes appear. Would you like to review sort settings?",
@@ -84,17 +86,28 @@ private extension MigrationsHandler {
         let controller = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
         let cancelText = NSLocalizedString("No", comment: "Alert's Cancel Action")
-        let cancelAction = UIAlertAction(title: cancelText, style: .cancel, handler: nil)
+        controller.addActionWithTitle(cancelText, style: .cancel)
 
         let okText = NSLocalizedString("Yes", comment: "Alert's Accept Action")
-        let okAction = UIAlertAction(title: okText, style: .default) { _ in
-
+        controller.addActionWithTitle(okText, style: .default) { _ in
+            self.presentSortOptionsViewController()
         }
 
-        controller.addAction(cancelAction)
-        controller.addAction(okAction)
-
         controller.presentFromRootViewController()
+    }
+
+    /// Presents (Modally) the SortOptions Interface
+    ///
+    func presentSortOptionsViewController() {
+        let sortingViewController = SPSortOrderViewController()
+        sortingViewController.selectedMode = Options.shared.listSortMode
+        sortingViewController.onChange = { newMode in
+            Options.shared.listSortMode = newMode
+        }
+
+        let navigationController = SPNavigationController(rootViewController: sortingViewController)
+        navigationController.modalPresentationStyle = .formSheet
+        navigationController.presentFromRootViewController()
     }
 }
 

--- a/Simplenote/Classes/MigrationsHandler.swift
+++ b/Simplenote/Classes/MigrationsHandler.swift
@@ -60,6 +60,12 @@ private extension MigrationsHandler {
 //
 private extension MigrationsHandler {
 
+    /// Display the Sort Options Reset Alert whenever:
+    ///
+    /// A.  The user comes from 4.8.0
+    /// B.  The user is actually logged
+    /// C.  The "bad Sort Mode" flag is detected
+    ///
     func processMigrationFromMark4_8_0() {
         guard Options.shared.listSortMode == .alphabeticallyDescending,
             SPAppDelegate.shared()?.simperium.user.authenticated() == true

--- a/Simplenote/Classes/SPSortOrderViewController.swift
+++ b/Simplenote/Classes/SPSortOrderViewController.swift
@@ -28,6 +28,10 @@ class SPSortOrderViewController: UITableViewController {
     @objc
     var onChange: ((SortMode) -> Void)?
 
+    /// Indicates if an Action button should be attached to the navigationBar
+    ///
+    var displaysDismissButton = false
+
     /// Designated Initializer
     ///
     init() {
@@ -81,6 +85,12 @@ private extension SPSortOrderViewController {
 
     func setupNavigationItem() {
         title = NSLocalizedString("Sort Order", comment: "Sort Order for the Notes List")
+
+        if displaysDismissButton {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
+                                                                target: self,
+                                                                action: #selector(dismissWasPressed))
+        }
     }
 
     func setupTableView() {
@@ -114,6 +124,14 @@ private extension SPSortOrderViewController {
     }
 }
 
+
+extension SPSortOrderViewController {
+
+    @objc
+    func dismissWasPressed() {
+        dismiss(animated: true, completion: nil)
+    }
+}
 
 // MARK: - Constants
 //

--- a/Simplenote/Classes/UIAlertController+Helpers.swift
+++ b/Simplenote/Classes/UIAlertController+Helpers.swift
@@ -4,44 +4,26 @@ import UIKit
 
 extension UIAlertController {
 
-    @discardableResult
-    @objc func addCancelActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @discardableResult @objc
+    func addCancelActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         return addActionWithTitle(title, style: .cancel, handler: handler)
     }
 
-    @discardableResult
-    @objc func addDestructiveActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @discardableResult @objc
+    func addDestructiveActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         return addActionWithTitle(title, style: .destructive, handler: handler)
     }
 
-    @discardableResult
-    @objc func addDefaultActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @discardableResult @objc
+    func addDefaultActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         return addActionWithTitle(title, style: .default, handler: handler)
     }
 
-    @discardableResult
-    @objc func addActionWithTitle(_ title: String?, style: UIAlertAction.Style, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @discardableResult @objc
+    func addActionWithTitle(_ title: String?, style: UIAlertAction.Style, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         let action = UIAlertAction(title: title, style: style, handler: handler)
         addAction(action)
 
         return action
-    }
-
-    @objc func presentFromRootViewController() {
-        // Note:
-        // This method is required because the presenter ViewController must be visible, and we've got several
-        // flows in which the VC that triggers the alert, might not be visible anymore.
-        //
-        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController else {
-            print("Error loading the rootViewController")
-            return
-        }
-
-        var leafViewController = rootViewController
-        while leafViewController.presentedViewController != nil {
-            leafViewController = leafViewController.presentedViewController!
-        }
-
-        leafViewController.present(self, animated: true, completion: nil)
     }
 }

--- a/Simplenote/Classes/UIViewController+Simplenote.swift
+++ b/Simplenote/Classes/UIViewController+Simplenote.swift
@@ -1,0 +1,29 @@
+import Foundation
+import UIKit
+
+
+// MARK: - UIAlertController's Simplenote Methods
+//
+extension UIViewController {
+
+    /// Presents the receiver from the RootViewController's leaf
+    ///
+    @objc
+    func presentFromRootViewController() {
+        // Note:
+        // This method is required because the presenter ViewController must be visible, and we've got several
+        // flows in which the VC that triggers the alert, might not be visible anymore.
+        //
+        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController else {
+            print("Error loading the rootViewController")
+            return
+        }
+
+        var leafViewController = rootViewController
+        while leafViewController.presentedViewController != nil {
+            leafViewController = leafViewController.presentedViewController!
+        }
+
+        leafViewController.present(self, animated: true, completion: nil)
+    }
+}

--- a/Simplenote/Classes/UserDefaults+Simplenote.swift
+++ b/Simplenote/Classes/UserDefaults+Simplenote.swift
@@ -5,6 +5,8 @@ import Foundation
 //
 extension UserDefaults {
     enum Key: String {
+        case lastKnownVersion
+        case lastKnownVersionByRatingsFramework = "WPRatingsCurrentVersion"
         case listSortMode
         case listSortModeLegacy = "SPAlphabeticalSortPref"
     }
@@ -31,6 +33,12 @@ extension UserDefaults {
     ///
     func object<T>(forKey key: Key) -> T? {
         return value(forKey: key.rawValue) as? T
+    }
+
+    /// Returns the String (if any) associated with the specified Key.
+    ///
+    func string(forKey key: Key) -> String? {
+        return value(forKey: key.rawValue) as? String
     }
 
     /// Stores the Key/Value Pair.

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -238,10 +238,14 @@
 	[self setupBitHockey];
     [self setupCrashLogging];
     [self setupDefaultWindow];
-    [self setupAppRatings];
-    
+
 	// Once the UI is wired, Auth Simperium
 	[self authenticateSimperium];
+
+    // Handle Simplenote Migrations: We *need* to initialize the Ratings framework after this step, for reasons be.
+    // TODO: Cleanup after 4.8.1 has been released!
+    [[MigrationsHandler new] ensureUpdateIsHandled];
+    [self setupAppRatings];
     
     // Initialize UI
     [self loadLastSelectedNote];
@@ -972,7 +976,7 @@
     [[ABXApiClient instance] setApiKey:[SPCredentials appbotKey]];
     
     // Initialize AppRatings Helper
-    NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    NSString *version = [[NSBundle mainBundle] shortVersionString];
     
     [[SPRatingsHelper sharedInstance] initializeForVersion:version];
     [[SPRatingsHelper sharedInstance] reloadSettings];

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -16,3 +16,4 @@
 #import "VSThemeManager.h"
 #import "SPEditorTextView.h"
 #import "SPNotifications.h"
+#import "SPNavigationController.h"

--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.8.0</string>
+	<string>4.8.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/SimplenoteShare/Info.plist
+++ b/SimplenoteShare/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.8.0</string>
+	<string>4.8.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### Details:
In this PR we're implementing a visual fallback for the users who upgraded to 4.8.0, and have the Sort Options setting in an irrecoverable state (in which we cannot determine if `.alphabeticallyDescending` was set by us, or them).  Ref #352

- New Migrations Handler, in charge of detecting whenever the App's Bundle was updated, and handling anything necessary.
- In this PR we're updating the version to Mark 4.8.1

---

### Scenario A: Explicit Modified Newest (4.7.0 > 4.8.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. **Settings** > Enable **Sort Alphabetically** > Disable **Sort Alphabetically**
5. Exit Xcode
6. `git checkout 4.8.0`
7. Relaunch Simplenote. 
8. `git checkout hotfix/broken-settings-recovery`
9. Relaunch Simplenote

- [x] Verify an Alert shows up onscreen, and tap over **YES**
- [x] Verify the Sort Options UI shows up. Select `modified newest`
- [x] Verify that after dismissing the Sort Options UI, the Notes List is back to its original state (2)
- [x] Verify that Step 9 looks like a Sheet on an iPad device

### Scenario B: Explicit Modified Newest (4.7.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. **Settings** > Enable **Sort Alphabetically** > Disable **Sort Alphabetically**
5. Exit Xcode
6. `git checkout hotfix/broken-settings-recovery`
7. Relaunch Simplenote

- [x] Verify **no Alert** shows up onscreen
- [x] Verify the sort mode remains the same as in (3)

### Scenario C: Legacy Default (4.7.0 > 4.8.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. Exit Xcode
5. `git checkout 4.8.0`
6. Relaunch Simplenote
7. Verify the Sort Order is broken
8. `git checkout hotfix/broken-settings-recovery`

- [x] Verify the Sort order is restored, and the notes look exactly as they did in (3)
- [x] Verify no Alert shows up

### Scenario D: Legacy Default (4.7.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. Exit Xcode
5. `git checkout hotfix/broken-settings-recovery`

- [x] Verify the Sort order looks exactly the same as in (3)
- [x] Verify no Alert shows up

### Scenario E: Legacy Alphabetically (4.7.0 > 4.8.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. **Settings** > Enable **Sort Alphabetically**
5. Exit Xcode
6. `git checkout release/4.8.0`
7. Relaunch Simplenote. 
8. Verify the Sort Order remains the same as in (3)
8. `git checkout hotfix/broken-settings-recovery`

- [x] Verify the Sort Order remains okay
- [x] Verify no Alert shows up

### Scenario F: Legacy Alphabetically (4.7.0 > 4.8.1)
1. Reset your simulator
2. `git checkout 4.7.0`
3. Log into your account
4. **Settings** > Enable **Sort Alphabetically**
5. Exit Xcode
6. `git checkout hotfix/broken-settings-recovery`

- [x] Verify the Sort Order remains okay
- [x] Verify no Alert shows up

### Scenario G: Fresh Install
1. Reset your simulator
2. `git checkout hotfix/broken-settings-recovery`
3. Log into your account

- [x] Verify the default sort order is set to `.modifiedNewest`
