### PR TITLE
Notes List: iOS 13 clipsToBounds Bugfix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -   The Notes List now displays an icon, outlining notes that have been published.
 -   When sharing to the WordPress App, Notes will no longer be blockquoted.
 -   The iOS share extension UI has been completly updated.
+-   Fixed an iOS 13 bug that caused the Notes List to get clipped upon Swipe Actions.
 
 4.8.0
 =====

--- a/Simplenote/Classes/SPTableViewCell.m
+++ b/Simplenote/Classes/SPTableViewCell.m
@@ -42,7 +42,7 @@ static CGFloat const kAccessoryImagePaddingLeft = 16;
     if (self) {
         
         self.clipsToBounds = YES;
-        self.contentView.clipsToBounds = NO;
+        self.contentView.clipsToBounds = YES;
 
         // setup preview view
         CGRect frame = self.bounds;


### PR DESCRIPTION
### Details:
We've got a simple bug in iOS 13. Yet, quite annoying:

1. Launch Simplenote on an iOS 13 device
2. Log into your account
3. Swipe over any of the notes in the list

As a result, you should get something like the following screenshot.

In this PR we're introducing a **one liner** fix. (Yay!)

<img width="487" alt="Screen Shot 2019-07-23 at 5 16 26 PM" src="https://user-images.githubusercontent.com/1195260/61744842-9b98c900-ad6e-11e9-88d3-ca4997863f2b.png">

---

### Testing:
1. Launch Simplenote on an iOS 13 device
2. Log into your account
3. Swipe over any of the notes in the list
4. Verify the UI looks as expected
