### PR TITLE
Fix/download translations

### DIFF
--- a/Scripts/update-translations.rb
+++ b/Scripts/update-translations.rb
@@ -21,7 +21,7 @@
 # * Turkish
 # * Japanese
 # * Italian
-
+require 'json'
 
 if Dir.pwd =~ /Scripts/
   puts "Must run script from root folder"
@@ -49,6 +49,28 @@ ALL_LANGS={
   'zh-tw' => 'zh-Hant-TW', # Chinese (Taiwan)
 }
 
+def copy_header(target_file, trans_strings)
+  trans_strings.each_line do |line|
+    if (!line.start_with?("/*"))
+      target_file.write("\n")
+      return
+    end 
+
+    target_file.write(line)
+  end
+end
+
+def copy_comment(f, trans_strings, value)
+  prev_line=""
+  trans_strings.each_line do |line|
+    if line.include?(value)
+      f.write(prev_line)
+      return 
+    end
+    prev_line=line
+  end
+end
+
 langs = {}
 if ARGV.count > 0
   for key in ARGV
@@ -66,11 +88,32 @@ langs.each do |code,local|
   lang_dir = File.join('Simplenote', "#{local}.lproj")
   puts "Updating #{code}"
   system "mkdir -p #{lang_dir}"
+  
+  # Backup the current file
   system "if [ -e #{lang_dir}/Localizable.strings ]; then cp #{lang_dir}/Localizable.strings #{lang_dir}/Localizable.strings.bak; fi"
-  system "curl -sSfL --globoff -o #{lang_dir}/Localizable.strings https://translate.wordpress.com/projects/simplenote%2Fios/#{code}/default/export-translations?format=strings" or begin
+
+  # Download translations in JSON format in order to get the string keys
+  system "curl -sSfL --globoff -o #{lang_dir}/Localizable.json https://translate.wordpress.com/projects/simplenote%2Fios/#{code}/default/export-translations?format=json" or begin
     puts "Error downloading #{code}"
+  end
+  trans_json = JSON.parse(File.read("#{lang_dir}/Localizable.json"))
+
+  # Download translations in strings format in order to get the comments
+  system "curl -sSfL --globoff -o #{lang_dir}/Localizable.strings.tmp https://translate.wordpress.com/projects/simplenote%2Fios/#{code}/default/export-translations?format=strings" or begin
+    puts "Error downloading #{code}"
+  end
+  trans_strings = File.read("#{lang_dir}/Localizable.strings.tmp")
+  
+  File.open("#{lang_dir}/Localizable.strings", "w") do |f|
+    copy_header(f, trans_strings)
+    Hash[trans_json.to_a.reverse].each do | key, value |
+      copy_comment(f, trans_strings, value[0]) unless value[0].nil?
+      f.write("\"#{key.split("\u0004")[0]}\" = \"#{value[0]}\";\n\n") unless value[0].nil?
+    end
   end
   system "./Scripts/fix-translation #{lang_dir}/Localizable.strings"
   system "plutil -lint #{lang_dir}/Localizable.strings" and system "rm #{lang_dir}/Localizable.strings.bak"
+  system "rm #{lang_dir}/Localizable.strings.tmp"
+  system "rm #{lang_dir}/Localizable.json"
   system "grep -a '\\x00\\x20\\x00\\x22\\x00\\x22\\x00\\x3b$' #{lang_dir}/Localizable.strings"
 end

--- a/Simplenote/ar.lproj/Localizable.strings
+++ b/Simplenote/ar.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d من الكلمات";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i محاولات فاشلة لإدخال رمز المرور";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i محاولات فاشلة لإدخال رمز المرور";
-
 /* Label of accept button on alert dialog */
 "Accept" = "قبول";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "إضافة مشارك جديد...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "العلامة...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "إضافة وسم";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "هل لديك حساب بالفعل؟";
-
-/* No comment provided by engineer. */
-"Back" = "رجوع";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "يعني تسجيلك موافقتك على شروط الخدمة »";
 
 /* No comment provided by engineer. */
 "Cancel" = "إلغاء";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "تشارك";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "تمكين الآخرين للتعاون";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "المشاركون";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "تأكيد";
-
-/* Ratings View: Contact */
-"Contact" = "جهة الاتصال";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "قد يكون أفضل";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "تعذر إنشاء حساب بعنوان البريد الإلكتروني وكلمة المرور اللذين تم إدخالهما.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "تعذر تسجيل الدخول بعنوان البريد الإلكتروني وكلمة المرور اللذين تم إدخالهما.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "هل بإمكانك إبلاغنا بكيفية تحسين ذلك؟";
+"collaborators-description" = "أضف عنوان بريد إلكتروني لمشاركة هذه الملاحظة مع شخص ما. بعدها يمكنكما إجراء التغييرات عليها.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "إنشاء ملاحظة جديدة";
@@ -84,22 +48,13 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "المشاركون الحاليون";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "قالب داكن";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "إصلاح الخطأ";
-
-/* Permanent Delete */
-"Delete" = "حذف";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "تم حذف هذه الملاحظة من جهاز آخر.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "تجاهل لوحة المفاتيح";
 
-/* A short description to access the account creation screen */
-"Don't have an account?" = "ليس لديك حساب؟";
-
-/* No comment provided by engineer. */
+/* An error message */
 "Done" = "تم";
 
 /* Re-order or delete tags */
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "إفراغ سلة المهملات";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "إدخال رمز مرور";
-
-/* Pin Lock */
-"Enter your passcode" = "إدخال رمز المرور الخاص بك";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "هل فقدت الوصول إلى Simplenote؟ يمكنك الحصول على حق الوصول مرة أخرى عن طريق تثبيت التطبيق مجددًا وتسجيل الدخول إلى حسابك.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "ابحث عن الملاحظات بسرعة باستخدام ميزة البحث الفوري والوسوم البسيطة.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "البدء";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "";
-
 /* Noun - the version history of a note */
 "History" = "سجل الأحداث";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "استعادة ملاحظة إلى إصدار سابق";
 
 /* Action - view the version history of a note */
 "History..." = "سجل الأحداث...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "كيف نساعدك؟";
-
-/* No comment provided by engineer. */
-"I Like It" = "يعجبني هذا";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "اترك رأيًا";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d، h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "MMM d، yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "القائمة";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "عرض خيارات للملاحظة";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "لا توجد ملاحظات";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "لا توجد نتائج";
 
-/* No comment provided by engineer. */
-"No Thanks" = "لا شكرًا";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "تم نشر الملاحظة";
 
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
+/* Description of Simplenote shown in first launch view */
 "Notes" = "ملاحظات";
 
-/* No comment provided by engineer. */
-"OK" = "موافق";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "إغلاق الملاحظة الحالية";
 
 /* No comment provided by engineer. */
 "Off" = "إيقاف تشغيل";
+
+/* TOS */
+"OK" = "موافق";
 
 /* No comment provided by engineer. */
 "On" = "تشغيل";
@@ -196,17 +108,8 @@
 /* Select a note to view in the note editor */
 "Open note" = "فتح الملاحظة";
 
-/* A 4-digit code to lock the app when it is closed */
+/* Number of failed entries entering in passcode */
 "Passcode" = "رمز المرور";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "رموز المرور غير متطابقة. حاول مرة أخرى.";
-
-/* Hint displayed in the password field */
-"Password" = "كلمة المرور";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "يجب أن تحتوي كلمة المرور على 4 أحرف على الأقل.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "تثبيت الملاحظة";
@@ -223,16 +126,13 @@
 /* No comment provided by engineer. */
 "Preferences" = "التفضيلات";
 
-/* Markdown Preview */
-"Preview" = "معاينة";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+/* Confirmation shown when a note is published */
 "Publish" = "نشر";
 
 /* Failure message after attempting to publish a note */
 "Publish Failed" = "فشل النشر";
 
-/* Action which published a note to a web page */
+/* Confirmation shown when a note is published */
 "Publish note" = "نشر الملاحظة";
 
 /* Switch which marks a note as published or unpublished */
@@ -244,14 +144,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "جار النشر...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "إعادة إدخال رمز المرور";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "إزالة كل الملاحظات من سلة المهملات";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "إزالة الوسم";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "إزالة كل الملاحظات من سلة المهملات";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "هل تريد إزالة الوسم؟";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "استعادة الملاحظة";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "الأمان";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "إرسال";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "إرسال الملاحظات";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "تعيين رمز المرور";
 
 /* Title of options screen */
 "Settings" = "إعدادات";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "يمكنك مشاركة قائمة أو نشر بعض التعليقات أو نشر أفكارك.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "مشاركة محتوى الملاحظة الحالية";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "الشريط الجانبي";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "تسجيل الدخول";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "تسجيل الخروج";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "التسجيل";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "إضافة وسم إلى الملاحظة الحالية";
 
-/* A short link to access the account login screen */
-"Sign in" = "تسجيل الدخول";
-
-/* A short link to access the account creation screen */
-"Sign up" = "التسجيل";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "سيؤدي تسجيل الخروج إلى حذف أي ملحوظات غير متزامنة. يمكنك التحقق من ملحوظاتك المتزامنة عن طريق تسجيل الدخول إلى تطبيق الويب.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "فرز الملاحظات أبجديًا";
-
-/* Message shown in first launch view */
-"Stay organized" = "البقاء منظمًا";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "إزالة وسم من الملاحظة الحالية";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "الوسم: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "هناك مشكلة بالاتصال.  يُرجى المحاولة مرة أخرى لاحقاً.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "اليوم";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "تبديل الشريط الجانبي للوسوم";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "معرف اللمس";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "نقل الملاحظة الحالية إلى سلة المهملات";
 
-/* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "سلة المهملات";
+/* Remove all notes from the trash */
+"Trash-noun" = "سلة المهملات";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "سلة المهملات";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "إيقاف رمز المرور";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "إلغاء تأمين %@";
+/* Remove all notes from the trash */
+"Trash-verb" = "سلة المهملات";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "إلغاء تثبيت الملاحظة";
@@ -349,75 +210,203 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "جارٍ إلغاء النشر...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "تم الكشف عن ملحوظات غير متزامنة";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "استخدامها في كل مكان";
-
 /* Represents a snapshot in time for a note */
 "Version" = "النسخة";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "مرحبًا بك في Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "الاتصال بالإنترنت للوصول إلى الإصدارات السابقة";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "ما رأيك في Simplenote؟";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "التحول إلى هذا الإصدار";
 
-/* Message shown in first launch view */
-"Work together" = "العمل معًا";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "جلب الإصدار";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "أمس";
 
-/* No comment provided by engineer. */
-"Your Email:" = "بريدك الإلكتروني:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i محاولات فاشلة لإدخال رمز المرور";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "إدخال رمز مرور";
+
+/* Pin Lock */
+"Enter your passcode" = "إدخال رمز المرور الخاص بك";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "رموز المرور غير متطابقة. حاول مرة أخرى.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "إعادة إدخال رمز المرور";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "تعيين رمز المرور";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "إيقاف رمز المرور";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "إلغاء تأمين %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i محاولات فاشلة لإدخال رمز المرور";
+
+"welcomeNote-iOS" = "أهلاً بك في Simplenote لنظام التشغيل iOS!
+
+لإضافة ملاحظة، انقر فوق زر علامة الزائد.
+
+انقر على القائمة لتصفح ملاحظاتك. انقر فوق عنوان لعرض ملاحظة، ثم انقر فوق محتوياتها لتغييرها.
+
+يمكنك البحث في جميع ملاحظاتك بالكتابة في حقل البحث أعلى قائمة الملاحظات.
+
+انقر فوق زر السهم أعلى اليسار أو اسحب بإصبعك عبر قائمة الملاحظات لعرض الوسوم. يمكنك إضافة وسوم إلى ملاحظة بأسفل محرر الملاحظات، ثم استخدام الشريط الجانبي لمساعدتك في المحافظة على التنظيم.
+
+هناك المزيد من خيارات الملاحظات إذا كنت بحاجة إليها. حيث يمكنك إضافة أفراد آخرين كمساهمين إلى ملاحظة أو نشر ملاحظة كصفحة ويب.
+
+استخدم Simplenote على جهاز Mac أو جهاز Android الخاص بك أو في متصفح الويب على http://simplenote.com. تبقى ملاحظاتك مُحدَّثة في كل مكان تلقائيًا.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "فرز الملاحظات أبجديًا";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "هل لديك حساب بالفعل؟";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "تأكيد";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "تعذر إنشاء حساب بعنوان البريد الإلكتروني وكلمة المرور اللذين تم إدخالهما.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "تعذر تسجيل الدخول بعنوان البريد الإلكتروني وكلمة المرور اللذين تم إدخالهما.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "ليس لديك حساب؟";
+
+/* An error message */
+"Password" = "كلمة المرور";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "يجب أن تحتوي كلمة المرور على 4 أحرف على الأقل.";
+
+/* Message displayed when login fails */
+"Sign in" = "تسجيل الدخول";
+
+/* Message displayed when login fails */
+"Sign In" = "تسجيل الدخول";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "التسجيل";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "التسجيل";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "هناك مشكلة بالاتصال.  يُرجى المحاولة مرة أخرى لاحقاً.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "عنوان البريد الإلكتروني الخاص بك غير صالح.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "ابحث عن الملاحظات بسرعة باستخدام ميزة البحث الفوري والوسوم البسيطة.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "البدء";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "يمكنك مشاركة قائمة أو نشر بعض التعليقات أو نشر أفكارك.";
+
+/* Message shown in first launch view */
+"Stay organized" = "البقاء منظمًا";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "استخدامها في كل مكان";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "مرحبًا بك في Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "العمل معًا";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "تظل ملاحظاتك محدثة عبر أجهزتك كلها. لا توجد أزرار للضغط عليها. إنها تعمل بدقة.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "تمكين الآخرين للتعاون";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "قالب داكن";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "إصلاح الخطأ";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d، h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "MMM d، yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "معرف اللمس";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "الأمان";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "يعني تسجيلك موافقتك على شروط الخدمة »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "ما رأيك في Simplenote؟";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "أضف عنوان بريد إلكتروني لمشاركة هذه الملاحظة مع شخص ما. بعدها يمكنكما إجراء التغييرات عليها.";
+"I Like It" = "يعجبني هذا";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "تم حذف هذه الملاحظة من جهاز آخر.";
+/* No comment provided by engineer. */
+"Could Be Better" = "قد يكون أفضل";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "استعادة ملاحظة إلى إصدار سابق";
+/* No comment provided by engineer. */
+"Leave a Review" = "اترك رأيًا";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "عرض خيارات للملاحظة";
+/* No comment provided by engineer. */
+"No Thanks" = "لا شكرًا";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "إغلاق الملاحظة الحالية";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "هل بإمكانك إبلاغنا بكيفية تحسين ذلك؟";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "مشاركة محتوى الملاحظة الحالية";
+/* No comment provided by engineer. */
+"Send Feedback" = "إرسال الملاحظات";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "إضافة وسم إلى الملاحظة الحالية";
+/* Ratings View: Contact */
+"Contact" = "جهة الاتصال";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "إزالة وسم من الملاحظة الحالية";
+/* No comment provided by engineer. */
+"Your Email:" = "بريدك الإلكتروني:";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "نقل الملاحظة الحالية إلى سلة المهملات";
+/* No comment provided by engineer. */
+"How can we help?" = "كيف نساعدك؟";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "الاتصال بالإنترنت للوصول إلى الإصدارات السابقة";
+/* No comment provided by engineer. */
+"Back" = "رجوع";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "التحول إلى هذا الإصدار";
+/* Permanent Delete */
+"Delete" = "حذف";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "جلب الإصدار";
+/* Markdown Preview */
+"Preview" = "معاينة";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "أهلاً بك في Simplenote لنظام التشغيل iOS!\n\nلإضافة ملاحظة، انقر فوق زر علامة الزائد.\n\nانقر على القائمة لتصفح ملاحظاتك. انقر فوق عنوان لعرض ملاحظة، ثم انقر فوق محتوياتها لتغييرها.\n\nيمكنك البحث في جميع ملاحظاتك بالكتابة في حقل البحث أعلى قائمة الملاحظات.\n\nانقر فوق زر السهم أعلى اليسار أو اسحب بإصبعك عبر قائمة الملاحظات لعرض الوسوم. يمكنك إضافة وسوم إلى ملاحظة بأسفل محرر الملاحظات، ثم استخدام الشريط الجانبي لمساعدتك في المحافظة على التنظيم.\n\nهناك المزيد من خيارات الملاحظات إذا كنت بحاجة إليها. حيث يمكنك إضافة أفراد آخرين كمساهمين إلى ملاحظة أو نشر ملاحظة كصفحة ويب.\n\nاستخدم Simplenote على جهاز Mac أو جهاز Android الخاص بك أو في متصفح الويب على http:\/\/simplenote.com. تبقى ملاحظاتك مُحدَّثة في كل مكان تلقائيًا.";
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "سيؤدي تسجيل الخروج إلى حذف أي ملحوظات غير متزامنة. يمكنك التحقق من ملحوظاتك المتزامنة عن طريق تسجيل الدخول إلى تطبيق الويب.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "تم الكشف عن ملحوظات غير متزامنة";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "العلامة...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "هل فقدت الوصول إلى Simplenote؟ يمكنك الحصول على حق الوصول مرة أخرى عن طريق تثبيت التطبيق مجددًا وتسجيل الدخول إلى حسابك.";
 

--- a/Simplenote/cy.lproj/Localizable.strings
+++ b/Simplenote/cy.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d Gair";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i Ymgais Aflwyddiannus gyda'r Cod Cyfrin";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i Ymgais Aflwyddiannus gyda'r Cod Cyfrin";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Derbyn";
 
@@ -30,23 +24,11 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Ychwanegu cydweithredwr newydd...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Tag...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Ychwanegu tag";
 
 /* Title of option to display all notes */
 "All Notes" = "Pob Nodyn";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Eisoes â chyfrif?";
-
-/* No comment provided by engineer. */
-"Back" = "Nôl";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Drwy ymuno, rydych yn cytuno i'n Amodau Gwasanaeth »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Canslo";
@@ -54,29 +36,17 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Cydweithredu";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Galluogi i eraill gydweithredu";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Cydweithredwyr";
 
+/* No comment provided by engineer. */
+"collaborators-description" = "Ychwanegwch gyfeiriad e-bost i rannu'r nodyn hwn gyda rhywun. Yna byddwch chi'n dau yn gallu gwneud newidiadau iddo.";
+
 /* Option to make the note list show only 1 line of text. The default is 3. */
 "Condensed Note List" = "Rhestr Gryno o Nodiadau";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Cadarnhau";
-
-/* Ratings View: Contact */
-"Contact" = "Cysylltu";
-
-/* No comment provided by engineer. */
-"Could Be Better" = "Gallai Fod yn Well";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Nid oedd modd creu cyfrif gyda'r cyfeiriad e-bost a chyfrinair a ddarparwyd.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Nid oedd modd mewngofnodi gyda'r cyfeiriad e-bost a chyfrinair a ddarparwyd. ";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Dwedwch wrthym sut y gallwn ni ei wella?";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Creu nodyn newydd";
@@ -84,20 +54,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Cydweithredwyr Cyfredol";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Thema Tywyll";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Dadfygio";
-
-/* Permanent Delete */
-"Delete" = "Dileu";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Dilëwyd y nodyn hwn ar ddyfais arall.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Cau'r bysellfwrdd";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Heb greu cyfrif?";
 
 /* No comment provided by engineer. */
 "Done" = "Gorffen";
@@ -111,57 +72,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Clirio'r sbwriel";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Rhowch god cyfrin";
-
-/* Pin Lock */
-"Enter your passcode" = "Rhowch eich cod cyfrin";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Ydych chi wedi colli cysylltiad â Simplenote? Gallwch adennill mynediad drwy ailosod y rhaglen a mewngofnodi i'ch cyfrif.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Dewch o hyd i nodiadau'n gyflym gyda'r gallu i chwilio ar unwaith a thagiau syml.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Wedi anghofio eich cyfrinair? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Cychwyn Arni";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "Gwych! Hoffech chi adael adolygiad da?\n\n\nMae wir yn helpu.";
-
 /* Noun - the version history of a note */
 "History" = "Hanes";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Adfer y nodyn i'r fersiwn blaenorol";
 
 /* Action - view the version history of a note */
 "History..." = "Hanes...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Sut gallwn ni helpu?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Rydw i'n ei Hoffi";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Gadael Adolygiad";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "MMM d, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Dewislen";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Dangos y dewisiadau ar gyfer y nodyn";
 
 /* Label to create a new note */
 "New note" = "Nodyn newydd";
@@ -173,22 +97,22 @@
 "No Results" = "Dim Canlyniadau";
 
 /* No comment provided by engineer. */
-"No Thanks" = "Dim Diolch";
+"Note not published" = "Nodyn heb ei gyhoeddi";
 
 /* Confirmation shown when a note is published */
 "Note Published" = "Cyhoeddwyd y nodyn";
 
-/* No comment provided by engineer. */
-"Note not published" = "Nodyn heb ei gyhoeddi";
-
-/* Plural form of notes */
+/* Option to make the note list show only 1 line of text. The default is 3. */
 "Notes" = "Nodiadau";
 
-/* No comment provided by engineer. */
-"OK" = "IAWN";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Cau'r nodyn cyfredol";
 
 /* No comment provided by engineer. */
 "Off" = "I ffwrdd";
+
+/* No comment provided by engineer. */
+"OK" = "IAWN";
 
 /* No comment provided by engineer. */
 "On" = "Ymlaen";
@@ -198,15 +122,6 @@
 
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Cod cyfrin";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Nid oedd y codau cyfrin yn cyfateb. Rhowch gynnig arall arni.";
-
-/* Hint displayed in the password field */
-"Password" = "Cyfrinair";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Rhaid i'r cyfrinair gynnwys o leiaf 4 nod.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Pinio'r nodyn";
@@ -223,9 +138,6 @@
 /* No comment provided by engineer. */
 "Preferences" = "Dewisiadau";
 
-/* Markdown Preview */
-"Preview" = "Rhagolwg";
-
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Cyhoeddi";
 
@@ -238,20 +150,17 @@
 /* Switch which marks a note as published or unpublished */
 "Publish toggle" = "Cyhoeddi togl";
 
-/* No comment provided by engineer. */
+/* Confirmation shown when a note is published */
 "Published" = "Cyhoeddwyd";
 
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Wrthi'n cyhoeddi...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Nodwch eich cod cyfrin eto";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Cael gwared â'r holl nodiadau o'r sbwriel";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Tynnu'r tag";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Cael gwared â'r holl nodiadau o'r sbwriel";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Tynnu'r tag?";
@@ -265,59 +174,32 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Adfer Nodyn";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Diogelwch";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Anfon";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Anfon Adborth";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Gosodwch god cyfrin";
 
 /* Title of options screen */
 "Settings" = "Gosodiadau";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Rhannwch restr, postiwch rai cyfarwyddiadau, neu cyhoeddwch eich meddyliau.";
-
 /* No comment provided by engineer. */
 "Share note" = "Rhannu nodyn";
+
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Rhannu cynnwys y nodyn cyfredol";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Bar ochr";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Mewngofnodi";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Allgofnodi";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Cofrestru";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Ychwanegu tag i'r nodyn cyfredol";
 
-/* A short link to access the account login screen */
-"Sign in" = "Mewngofnodi";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Cofrestru";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Bydd all-gofnodi'n dileu unrhyw nodau heb eu cydweddu. Gallwch ddilysu eich nodau wedi eu cydweddu drwy fewngofnodi i'r Web App.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Trefnu Nodiadau yn Nhrefn yr Wyddor";
-
-/* Message shown in first launch view */
-"Stay organized" = "Cadw trefn ar bethau";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Tynnu'r tag o'r nodyn cyfredol";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Tag: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Mae problem gyda'r cysylltiad. Rhowch gynnig arall arni nes ymlaen.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Heddiw";
@@ -325,20 +207,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Bar ochr toglo tagiau";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Enw Cyffwrdd";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Symud y nodyn cyfredol i'r sbwriel";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Sbwriel";
+"Trash-noun" = "Sbwriel";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Sbwriel";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Diffodd y cod cyfrin";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Datgloi %@";
+/* Trash (noun) - the location where deleted notes are stored */
+"Trash-verb" = "Sbwriel";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Dadbinio'r nodyn";
@@ -349,75 +225,212 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Wrthi'n dad-gyhoeddi...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Wedi Canfod Nodau Heb eu Cydweddu";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Defnyddio'r ap ym mhob man";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Fersiwn";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Croeso i Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Cysylltwch â'r rhyngrwyd i gael mynediad at fersiynau blaenorol";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Beth ydych chi'n ei feddwl Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Newid i'r fersiwn hwn";
 
-/* Message shown in first launch view */
-"Work together" = "Gweithio gyda'ch gilydd";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Wrthi'n ôl y fersiwn";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Ddoe";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Eich Cyfeiriad E-bost:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i Ymgais Aflwyddiannus gyda'r Cod Cyfrin";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Rhowch god cyfrin";
+
+/* Pin Lock */
+"Enter your passcode" = "Rhowch eich cod cyfrin";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Nid oedd y codau cyfrin yn cyfateb. Rhowch gynnig arall arni.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Nodwch eich cod cyfrin eto";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Gosodwch god cyfrin";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Diffodd y cod cyfrin";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Datgloi %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i Ymgais Aflwyddiannus gyda'r Cod Cyfrin";
+
+"welcomeNote-iOS" = "Croeso i Simplenote ar gyfer iOS!
+
+I ychwanegu nodyn, tapiwch y botwm adio.
+
+Ffliciwch y rhestr i bori'ch nodiadau. Tapiwch deitl i weld nodyn, yna tapiwch y cynnwys i'w newid.
+
+Gallwch chwilio trwy bob un o'ch nodiadau trwy deipio yn y maes chwilio ar frig y rhestr o nodiadau.
+
+Tapiwch y botwm saeth ar y brig ar yr ochr chwith neu llusgwch ar draws eich rhestr o nodiadau i weld eich tagiau. Gallwch ychwanegu tagiau i nodyn ar waelod y golygydd nodiadau, ac yna defnyddio'r bar ochr i'ch helpu i gadw trefn ar bethau.
+
+Mae mwy o ddewisiadau nodiadau os ydych chi eu hangen. Gallwch ychwanegu rhai eraill fel cydweithredwyr i nodyn, neu gyhoeddi nodyn fel tudalen we.
+
+Defnyddiwch Simplenote ar eich Mac, dyfais Android, neu yn eich porwr gwe ar http://simplenote.com. Bydd eich nodiadau yn diweddaru ym mhob man yn awtomatig.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Trefnu Nodiadau yn Nhrefn yr Wyddor";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Eisoes â chyfrif?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Cadarnhau";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Nid oedd modd creu cyfrif gyda'r cyfeiriad e-bost a chyfrinair a ddarparwyd.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Nid oedd modd mewngofnodi gyda'r cyfeiriad e-bost a chyfrinair a ddarparwyd. ";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Heb greu cyfrif?";
+
+/* Hint displayed in the password field */
+"Password" = "Cyfrinair";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Rhaid i'r cyfrinair gynnwys o leiaf 4 nod.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Mewngofnodi";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Mewngofnodi";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Cofrestru";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Cofrestru";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Mae problem gyda'r cysylltiad. Rhowch gynnig arall arni nes ymlaen.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Nid yw eich cyfeiriad e-bost yn ddilys.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Dewch o hyd i nodiadau'n gyflym gyda'r gallu i chwilio ar unwaith a thagiau syml.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Cychwyn Arni";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Rhannwch restr, postiwch rai cyfarwyddiadau, neu cyhoeddwch eich meddyliau.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Cadw trefn ar bethau";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Defnyddio'r ap ym mhob man";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Croeso i Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Gweithio gyda'ch gilydd";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Mae'ch nodiadau yn cael eu diweddaru ar draws pob un o'ch dyfeisiau. Dim botymau i'w gwthio. Mae jyst yn gweithio.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Galluogi i eraill gydweithredu";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Thema Tywyll";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "Dadfygio";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "MMM d, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Enw Cyffwrdd";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Diogelwch";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Drwy ymuno, rydych yn cytuno i'n Amodau Gwasanaeth »";
+
+/* Forgot Password */
+"Forgot password? »" = "Wedi anghofio eich cyfrinair? »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Beth ydych chi'n ei feddwl Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Ychwanegwch gyfeiriad e-bost i rannu'r nodyn hwn gyda rhywun. Yna byddwch chi'n dau yn gallu gwneud newidiadau iddo.";
+"I Like It" = "Rydw i'n ei Hoffi";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Dilëwyd y nodyn hwn ar ddyfais arall.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Gallai Fod yn Well";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Adfer y nodyn i'r fersiwn blaenorol";
+"Great! Could you leave us a nice review?
+It really helps." = "Gwych! Hoffech chi adael adolygiad da?
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Dangos y dewisiadau ar gyfer y nodyn";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Cau'r nodyn cyfredol";
+Mae wir yn helpu.";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Rhannu cynnwys y nodyn cyfredol";
+/* No comment provided by engineer. */
+"Leave a Review" = "Gadael Adolygiad";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Ychwanegu tag i'r nodyn cyfredol";
+/* No comment provided by engineer. */
+"No Thanks" = "Dim Diolch";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Tynnu'r tag o'r nodyn cyfredol";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Dwedwch wrthym sut y gallwn ni ei wella?";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Symud y nodyn cyfredol i'r sbwriel";
+/* No comment provided by engineer. */
+"Send Feedback" = "Anfon Adborth";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Cysylltwch â'r rhyngrwyd i gael mynediad at fersiynau blaenorol";
+/* Ratings View: Contact */
+"Contact" = "Cysylltu";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Newid i'r fersiwn hwn";
+/* No comment provided by engineer. */
+"Your Email:" = "Eich Cyfeiriad E-bost:";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Wrthi'n ôl y fersiwn";
+/* No comment provided by engineer. */
+"How can we help?" = "Sut gallwn ni helpu?";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Croeso i Simplenote ar gyfer iOS!\n\nI ychwanegu nodyn, tapiwch y botwm adio.\n\nFfliciwch y rhestr i bori'ch nodiadau. Tapiwch deitl i weld nodyn, yna tapiwch y cynnwys i'w newid.\n\nGallwch chwilio trwy bob un o'ch nodiadau trwy deipio yn y maes chwilio ar frig y rhestr o nodiadau.\n\nTapiwch y botwm saeth ar y brig ar yr ochr chwith neu llusgwch ar draws eich rhestr o nodiadau i weld eich tagiau. Gallwch ychwanegu tagiau i nodyn ar waelod y golygydd nodiadau, ac yna defnyddio'r bar ochr i'ch helpu i gadw trefn ar bethau.\n\nMae mwy o ddewisiadau nodiadau os ydych chi eu hangen. Gallwch ychwanegu rhai eraill fel cydweithredwyr i nodyn, neu gyhoeddi nodyn fel tudalen we.\n\nDefnyddiwch Simplenote ar eich Mac, dyfais Android, neu yn eich porwr gwe ar http:\/\/simplenote.com. Bydd eich nodiadau yn diweddaru ym mhob man yn awtomatig.";
+/* No comment provided by engineer. */
+"Back" = "Nôl";
+
+/* Permanent Delete */
+"Delete" = "Dileu";
+
+/* Markdown Preview */
+"Preview" = "Rhagolwg";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Bydd all-gofnodi'n dileu unrhyw nodau heb eu cydweddu. Gallwch ddilysu eich nodau wedi eu cydweddu drwy fewngofnodi i'r Web App.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Wedi Canfod Nodau Heb eu Cydweddu";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Tag...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Ydych chi wedi colli cysylltiad â Simplenote? Gallwch adennill mynediad drwy ailosod y rhaglen a mewngofnodi i'ch cyfrif.";
 

--- a/Simplenote/de.lproj/Localizable.strings
+++ b/Simplenote/de.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d Wörter";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i fehlgeschlagener Passcode-Versuch";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i fehlgeschlagene Passcode-Versuche";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Akzeptieren";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Neuen Mitarbeiter hinzufügen…";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Tag...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Schlagwort hinzufügen";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Du hast bereits ein Konto?";
-
-/* No comment provided by engineer. */
-"Back" = "Zurück";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Indem du dich registrierst, stimmst du unseren Geschäftsbedingungen zu »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Abbrechen";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Zusammenarbeiten";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Mitarbeit durch andere Personen ermöglichen";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Mitarbeiter";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Bestätigen";
-
-/* Ratings View: Contact */
-"Contact" = "Kontakt";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "Könnte besser sein";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Mit der angegebenen E-Mail-Adresse und dem Passwort konnte kein Konto erstellt werden.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Mit der angegebenen E-Mail-Adresse und dem Passwort war keine Anmeldung möglich.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Könntest du uns Verbesserungsvorschläge machen?";
+"collaborators-description" = "Füge eine E-Mail-Adresse hinzu, um diese Notiz mit jemandem zu teilen. Dann könnt ihr beide Änderungen daran vornehmen.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Neue Notiz erstellen";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Aktuelle Mitarbeiter";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Dunkles Theme";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Debuggen";
-
-/* Permanent Delete */
-"Delete" = "Delete";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Diese Notiz wurde auf einem anderen Gerät gelöscht.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Tastatur ausblenden";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Du hast noch kein Konto?";
 
 /* No comment provided by engineer. */
 "Done" = "Fertig";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Papierkorb leeren";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Gib einen Passcode ein";
-
-/* Pin Lock */
-"Enter your passcode" = "Gib deinen Passcode ein";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Mit der Schnellsuche und einfachen Schlagwörtern findest du Notizen im Handumdrehen.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Jetzt loslegen";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "Toll! Kannst Du uns eine Referenz hinterlassen? \n\nDas hilft uns wirklich.";
-
 /* Noun - the version history of a note */
 "History" = "Verlauf";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Vorherige Version der Notiz wiederherstellen";
 
 /* Action - view the version history of a note */
 "History..." = "Verlauf…";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Wie können wir helfen?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Gefällt mir";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Rezension schreiben";
-
-/* Month and day date formatter */
-"MMM d" = "d. MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d. MMM H:mm";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d. MMM yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Menü";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Optionen für Notiz anzeigen";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Keine Notizen";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Keine Ergebnisse";
 
-/* No comment provided by engineer. */
-"No Thanks" = "Nein danke";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "Notiz veröffentlicht";
 
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
+/* Description of Simplenote shown in first launch view */
 "Notes" = "Notizen";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Aktuelle Notiz schließen";
 
 /* No comment provided by engineer. */
 "Off" = "Aus";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "Ein";
@@ -196,17 +108,8 @@
 /* Select a note to view in the note editor */
 "Open note" = "Notiz öffnen";
 
-/* A 4-digit code to lock the app when it is closed */
+/* Number of failed entries entering in passcode */
 "Passcode" = "Passcode";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Die Passcodes stimmten nicht überein. Versuch's nochmal.";
-
-/* Hint displayed in the password field */
-"Password" = "Passwort";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Das Passwort muss mindestens 4 Zeichen lang sein.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Notiz anheften";
@@ -222,9 +125,6 @@
 
 /* No comment provided by engineer. */
 "Preferences" = "Einstellungen";
-
-/* Markdown Preview */
-"Preview" = "Preview";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Veröffentlichen";
@@ -244,14 +144,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Veröffentlichung läuft…";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Passcode erneut eingeben";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Alle Notizen aus Papierkorb entfernen";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Tag entfernen";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Alle Notizen aus Papierkorb entfernen";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Tag entfernen?";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Notiz wiederherstellen";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Sicherheit";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Senden";
 
 /* No comment provided by engineer. */
-"Send Feedback" = "Feedback senden";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Passcode festlegen";
-
-/* Title of options screen */
 "Settings" = "Einstellungen";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Du kannst eine Liste teilen, Anweisungen posten oder deine Ideen veröffentlichen.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Inhalt der aktuellen Notiz teilen";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Seitenleiste";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Anmelden";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Abmelden";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Registrieren";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Tag zur aktuellen Notiz hinzufügen";
 
-/* A short link to access the account login screen */
-"Sign in" = "Anmelden";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Registrieren";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Bei der Abmeldung werden alle nicht synchronisierten Notizen gelöscht. Du kannst überprüfen, ob deine Notizen synchronisiert wurden, indem du dich in der Web-App anmeldest.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Notizen alphabetisch sortieren";
-
-/* Message shown in first launch view */
-"Stay organized" = "Übersichtlich";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Tag aus aktueller Notiz entfernen";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Tag: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Es gibt ein Problem mit der Verbindung.  Bitte versuche es später erneut.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Heute";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Schlagwort-Seitenleiste umschalten";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Aktuelle Notiz in den Papierkorb verschieben";
 
-/* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Papierkorb";
+/* Remove all notes from the trash */
+"Trash-noun" = "Papierkorb";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Papierkorb";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Passcode deaktivieren";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "%@ entsperren";
+/* Remove all notes from the trash */
+"Trash-verb" = "Papierkorb";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Notiz lösen";
@@ -349,75 +210,196 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Veröffentlichung wird aufgehoben…";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Nicht synchronisierte Notizen entdeckt";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Überall einsatzbereit";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Version";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Willkommen bei Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Stelle eine Verbindung mit dem Internet her, um auf frühere Versionen zuzugreifen";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Was hältst du von Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Zu dieser Version wechseln";
 
-/* Message shown in first launch view */
-"Work together" = "Zusammenarbeit";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Version wird abgerufen";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Gestern";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Deine E-Mail-Adresse:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i fehlgeschlagener Passcode-Versuch";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Gib einen Passcode ein";
+
+/* Pin Lock */
+"Enter your passcode" = "Gib deinen Passcode ein";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Die Passcodes stimmten nicht überein. Versuch's nochmal.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Passcode erneut eingeben";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Passcode festlegen";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Passcode deaktivieren";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "%@ entsperren";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i fehlgeschlagene Passcode-Versuche";
+
+"welcomeNote-iOS" = "Willkommen bei Simplenote für iOS!
+
+Tippe auf das Pluszeichen, um eine Notiz hinzuzufügen.
+
+Blättere die Liste durch, um deine Notizen zu durchsuchen. Tippe auf einen Titel, um eine Notiz anzuzeigen, und tippe dann auf den Inhalt, um sie zu bearbeiten.
+
+Du kannst alle Notizen durchsuchen, indem du im Suchfeld am oberen Rand der Notizliste Text eingibst.
+
+Tippe auf die Pfeilschaltfläche oben links oder wische über die Notizliste, um deine Tags anzuzeigen. Du kannst einer Notiz am unteren Rand des Notiz-Editors Tags hinzufügen und dann die Seitenleiste verwenden, um den Überblick zu behalten.
+
+Es gibt noch mehr Notizoptionen, falls du noch welche benötigst. Du kannst andere Personen als Mitwirkende zu einer Notiz hinzufügen oder eine Notiz als Webseite veröffentlichen.
+
+Verwende Simplenote auf deinem Mac, Android-Gerät oder in deinem Webbrowser unter http://simplenote.com. Deine Notizen werden überall automatisch aktualisiert.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Notizen alphabetisch sortieren";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Du hast bereits ein Konto?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Bestätigen";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Mit der angegebenen E-Mail-Adresse und dem Passwort konnte kein Konto erstellt werden.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Mit der angegebenen E-Mail-Adresse und dem Passwort war keine Anmeldung möglich.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Du hast noch kein Konto?";
+
+/* An error message */
+"Password" = "Passwort";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Das Passwort muss mindestens 4 Zeichen lang sein.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Anmelden";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Anmelden";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Registrieren";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Registrieren";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Es gibt ein Problem mit der Verbindung.  Bitte versuche es später erneut.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Deine E-Mail-Adresse ist ungültig.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Mit der Schnellsuche und einfachen Schlagwörtern findest du Notizen im Handumdrehen.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Jetzt loslegen";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Du kannst eine Liste teilen, Anweisungen posten oder deine Ideen veröffentlichen.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Übersichtlich";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Überall einsatzbereit";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Willkommen bei Simplenote";
+
+/* Verb - work with others on a note */
+"Work together" = "Zusammenarbeit";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Die Notizen sind auf allen Geräten stets auf dem neuesten Stand. Das funktioniert ganz ohne Tasten. Einfach so.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Mitarbeit durch andere Personen ermöglichen";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Dunkles Theme";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "Debuggen";
+
+/* Month and day date formatter */
+"MMM d" = "d. MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d. MMM H:mm";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d. MMM yyyy";
+
+/* Month, day, and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Sicherheit";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Indem du dich registrierst, stimmst du unseren Geschäftsbedingungen zu »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Was hältst du von Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Füge eine E-Mail-Adresse hinzu, um diese Notiz mit jemandem zu teilen. Dann könnt ihr beide Änderungen daran vornehmen.";
+"I Like It" = "Gefällt mir";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Diese Notiz wurde auf einem anderen Gerät gelöscht.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Könnte besser sein";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Vorherige Version der Notiz wiederherstellen";
+"Great! Could you leave us a nice review?
+It really helps." = "Toll! Kannst Du uns eine Referenz hinterlassen? 
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Optionen für Notiz anzeigen";
+Das hilft uns wirklich.";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Aktuelle Notiz schließen";
+/* No comment provided by engineer. */
+"Leave a Review" = "Rezension schreiben";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Inhalt der aktuellen Notiz teilen";
+/* No comment provided by engineer. */
+"No Thanks" = "Nein danke";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Tag zur aktuellen Notiz hinzufügen";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Könntest du uns Verbesserungsvorschläge machen?";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Tag aus aktueller Notiz entfernen";
+/* No comment provided by engineer. */
+"Send Feedback" = "Feedback senden";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Aktuelle Notiz in den Papierkorb verschieben";
+/* Ratings View: Contact */
+"Contact" = "Kontakt";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Stelle eine Verbindung mit dem Internet her, um auf frühere Versionen zuzugreifen";
+/* No comment provided by engineer. */
+"Your Email:" = "Deine E-Mail-Adresse:";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Zu dieser Version wechseln";
+/* No comment provided by engineer. */
+"How can we help?" = "Wie können wir helfen?";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Version wird abgerufen";
+/* No comment provided by engineer. */
+"Back" = "Zurück";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Willkommen bei Simplenote für iOS!\n\nTippe auf das Pluszeichen, um eine Notiz hinzuzufügen.\n\nBlättere die Liste durch, um deine Notizen zu durchsuchen. Tippe auf einen Titel, um eine Notiz anzuzeigen, und tippe dann auf den Inhalt, um sie zu bearbeiten.\n\nDu kannst alle Notizen durchsuchen, indem du im Suchfeld am oberen Rand der Notizliste Text eingibst.\n\nTippe auf die Pfeilschaltfläche oben links oder wische über die Notizliste, um deine Tags anzuzeigen. Du kannst einer Notiz am unteren Rand des Notiz-Editors Tags hinzufügen und dann die Seitenleiste verwenden, um den Überblick zu behalten.\n\nEs gibt noch mehr Notizoptionen, falls du noch welche benötigst. Du kannst andere Personen als Mitwirkende zu einer Notiz hinzufügen oder eine Notiz als Webseite veröffentlichen.\n\nVerwende Simplenote auf deinem Mac, Android-Gerät oder in deinem Webbrowser unter http:\/\/simplenote.com. Deine Notizen werden überall automatisch aktualisiert.";
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Bei der Abmeldung werden alle nicht synchronisierten Notizen gelöscht. Du kannst überprüfen, ob deine Notizen synchronisiert wurden, indem du dich in der Web-App anmeldest.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Nicht synchronisierte Notizen entdeckt";
 

--- a/Simplenote/el.lproj/Localizable.strings
+++ b/Simplenote/el.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d λέξεις";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i αποτυχημένη απόπειρα συνθηματικού";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i αποτυχημένες απόπειρες συνθηματικού";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Αποδοχή";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Προσθήκη συνεργάτη...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Tag...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Προσθήκη ετικέτας";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Έχετε ήδη λογαριασμό;";
-
-/* No comment provided by engineer. */
-"Back" = "Back";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "By signing up, you agree to our Terms of Service »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Ακύρωση";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Συνεργασία";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Ενεργοποίηση συνεργατών";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Συνεργάτες";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Επιβεβαίωση";
-
-/* Ratings View: Contact */
-"Contact" = "Contact";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "Could Be Better";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Δεν ήταν δυνατή η δημιουργία λογαριασμού με αυτό το email και κωδικό.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Δεν ήταν δυνατή η σύνδεση με αυτό το email και κωδικό.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Could you tell us how we could improve?";
+"collaborators-description" = "Εισάγετε το email του συνεργάτη σας ώστε να ενεργοποιηθεί η δυνατότητα συνεργασίας και ταυτόχρονων αλλαγών στην σημείωση.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Δημιουργία σημείωσης";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Συνεργατες";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Νυχτερινό θέμα";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Debug";
-
-/* Permanent Delete */
-"Delete" = "Delete";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Η σημείωση αυτή έχει διαγραφεί σε κάποια άλλη συσκευή";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Απόκρυψη";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Δεν έχετε λογαριασμό;";
 
 /* No comment provided by engineer. */
 "Done" = "OK";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Διαγραφή όλων";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Δημιουργία συνθηματικού";
-
-/* Pin Lock */
-"Enter your passcode" = "Εισάγετε το συνθηματικό σας";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Βρείτε σημειώσεις εύκολα και γρήγορα.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Ξεκινήστε";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "";
-
 /* Noun - the version history of a note */
 "History" = "Ιστορικό";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Ανάκτηση σημείωσης στην προηγούμενη έκδοση";
 
 /* Action - view the version history of a note */
 "History..." = "Ιστορικό...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "How can we help?";
-
-/* No comment provided by engineer. */
-"I Like It" = "I Like It";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Leave a Review";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "MMM d, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Μενού";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Επιλογές σημείωσης";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Καμία σημείωση";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Δεν βρέθηκε";
 
-/* No comment provided by engineer. */
-"No Thanks" = "No Thanks";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "Δημοσιευμένη σημείωση";
-
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
 
 /* Plural form of notes */
 "Notes" = "Σημειώσεις";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Κλείσιμο";
 
 /* No comment provided by engineer. */
 "Off" = "Απενεργοποίηση";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "Ενεργό";
@@ -199,32 +111,17 @@
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Συνθηματικό";
 
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Τα συνθηματικά δεν συμφωνούν. Δοκιμάστε ξανά.";
+"Pin note" = "Επισ/νση";
 
-/* Hint displayed in the password field */
-"Password" = "Κωδικός";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Ο κωδικός πρέπει να περιέχει τουλάχιστον 4 χαρακτήρες.";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Επισ\/νση";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "Επισ\/νση";
+"Pin to Top" = "Επισ/νση";
 
 /* Switch which marks a note as pinned or unpinned */
 "Pin toggle" = "Επισήμανση";
 
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Επ\/θηκε";
+"Pinned" = "Επ/θηκε";
 
 /* No comment provided by engineer. */
 "Preferences" = "Επιλογες";
-
-/* Markdown Preview */
-"Preview" = "Preview";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Αποστολή";
@@ -244,14 +141,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Δημοσίευση...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Εισάγετε ξανά το συνθηματικό σας";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Διαγραφή όλων των σημειώσεων";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Διαγραφή ετικέτας";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Διαγραφή όλων των σημειώσεων";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Διαγραφή ετικέτας;";
@@ -265,59 +159,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Ανάκτηση σημείωσης";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Security";
-
-/* Verb - send the content of the note by email, message, etc */
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Send" = "Αποστολή";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Send Feedback";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Δημιουργία συνθηματικού";
 
 /* Title of options screen */
 "Settings" = "Ρυθμίσεις";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Κοινοποιήστε λίστες, οδηγίες ή απλά τις σκέψεις σας.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Κοινοποίηση σημείωσης";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Στήλη";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Σύνδεση";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Αποσύνδεση";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Εγγραφή";
+/* Label on button to add a new tag to a note */
+"tag-add-accessibility-hint" = "Προσθήκη ετικέτας";
 
-/* A short link to access the account login screen */
-"Sign in" = "Σύνδεση";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Εγγραφή";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Προβολή αλφαβητικά";
-
-/* Message shown in first launch view */
-"Stay organized" = "Οργανωθείτε";
+/* Delete a tag and remove it from all associated notes */
+"tag-delete-accessibility-hint" = "Διαγραφή ετικέτας";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Ετικέτα: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Πρόβλημα με τη σύνδεση. Δοκιμάστε ξανά.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Σήμερα";
@@ -325,22 +189,16 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Εμφάνιση στήλης";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Διαγραφή σημείωσης";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Διαγεγραμμένα";
+"Trash-noun" = "Διαγεγραμμένα";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Διαγραφή";
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Trash-verb" = "Διαγραφή";
 
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Απενεργοποίηση συνθηματικού";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Ξεκλείδωμα %@";
-
-/* Action to mark a note as unpinned */
+/* No comment provided by engineer. */
 "Unpin note" = "Ακύρωση";
 
 /* Action which unpublishes a note */
@@ -349,75 +207,131 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Ακύρωση δημοσίευσης...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Unsynced Notes Detected";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Χρησιμοποιήστε το παντού";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Έκδοση";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Καλώς ήρθατε στο Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Συνδεθείτε στο internet για πρόσβαση στο ιστορικό";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "What do you think about Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Χρήση αυτής της έκδοσης";
 
-/* Message shown in first launch view */
-"Work together" = "Συνεργαστείτε";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Ανάγνωση έκδοσης";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Εχθές";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Your Email:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i αποτυχημένη απόπειρα συνθηματικού";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Δημιουργία συνθηματικού";
+
+/* Pin Lock */
+"Enter your passcode" = "Εισάγετε το συνθηματικό σας";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Τα συνθηματικά δεν συμφωνούν. Δοκιμάστε ξανά.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Εισάγετε ξανά το συνθηματικό σας";
+
+/* Message shown on passcode lock screen */
+"Set Passcode" = "Δημιουργία συνθηματικού";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Απενεργοποίηση συνθηματικού";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Ξεκλείδωμα %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i αποτυχημένες απόπειρες συνθηματικού";
+
+"welcomeNote-iOS" = "Καλώς ήρθατε στο Simplenote!
+
+Για νέα σημείωση πατήστε στο κουμπί συν.
+
+Πατήστε στον τίτλο της σημείωσης για άνοιγμα. Πατήστε στο περιεχόμενο για αλλαγές.
+
+Βρείτε σημειώσεις χρησιμοποιώντας το πεδίο αναζήτησης στο πάνω μέρος της οθόνης.
+
+Πατήστε στο κουμπί με το βέλος πάνω αριστερά ή σαρώστε προς τα δεξιά για να δείτε όλες τις ετικέτες. Προσθέστε ετικέτες σε κάθε σημειώση χρησιμοποιώντας το πεδίο Ετικέτες στο τέλος κάθε σημείωσης.
+
+Πατήστε στο κουμπί i για περισσότερες επιλογές. Προσθέστε συνεργάτες ή δημοσιεύστε την σημείωση ως ιστοσελίδα.
+
+Χρησιμοποιήστε το Simplenote σε Mac και Android ή στο http://simplenote.com. Όλες οι σημειώσεις συγχρονίζονται αυτόματα παντού.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Προβολή αλφαβητικά";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Έχετε ήδη λογαριασμό;";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Επιβεβαίωση";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Δεν ήταν δυνατή η δημιουργία λογαριασμού με αυτό το email και κωδικό.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Δεν ήταν δυνατή η σύνδεση με αυτό το email και κωδικό.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Δεν έχετε λογαριασμό;";
+
+/* Hint displayed in the password field */
+"Password" = "Κωδικός";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Ο κωδικός πρέπει να περιέχει τουλάχιστον 4 χαρακτήρες.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Σύνδεση";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Σύνδεση";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Εγγραφή";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Εγγραφή";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Πρόβλημα με τη σύνδεση. Δοκιμάστε ξανά.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Μη έγκυρη διεύθυνση email.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Βρείτε σημειώσεις εύκολα και γρήγορα.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Ξεκινήστε";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Κοινοποιήστε λίστες, οδηγίες ή απλά τις σκέψεις σας.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Οργανωθείτε";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Χρησιμοποιήστε το παντού";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Καλώς ήρθατε στο Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Συνεργαστείτε";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Οι σημειώσεις αποθηκεύονται και ενημερώνονται αυτόματα σε όλες τις συσκευές σας.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Ενεργοποίηση συνεργατών";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Νυχτερινό θέμα";
 
-/* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Εισάγετε το email του συνεργάτη σας ώστε να ενεργοποιηθεί η δυνατότητα συνεργασίας και ταυτόχρονων αλλαγών στην σημείωση.";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Η σημείωση αυτή έχει διαγραφεί σε κάποια άλλη συσκευή";
-
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Ανάκτηση σημείωσης στην προηγούμενη έκδοση";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Επιλογές σημείωσης";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Κλείσιμο";
-
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Κοινοποίηση σημείωσης";
-
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Προσθήκη ετικέτας";
-
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Διαγραφή ετικέτας";
-
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Διαγραφή σημείωσης";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Συνδεθείτε στο internet για πρόσβαση στο ιστορικό";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Χρήση αυτής της έκδοσης";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Ανάγνωση έκδοσης";
-
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Καλώς ήρθατε στο Simplenote!\n\nΓια νέα σημείωση πατήστε στο κουμπί συν.\n\nΠατήστε στον τίτλο της σημείωσης για άνοιγμα. Πατήστε στο περιεχόμενο για αλλαγές.\n\nΒρείτε σημειώσεις χρησιμοποιώντας το πεδίο αναζήτησης στο πάνω μέρος της οθόνης.\n\nΠατήστε στο κουμπί με το βέλος πάνω αριστερά ή σαρώστε προς τα δεξιά για να δείτε όλες τις ετικέτες. Προσθέστε ετικέτες σε κάθε σημειώση χρησιμοποιώντας το πεδίο Ετικέτες στο τέλος κάθε σημείωσης.\n\nΠατήστε στο κουμπί i για περισσότερες επιλογές. Προσθέστε συνεργάτες ή δημοσιεύστε την σημείωση ως ιστοσελίδα.\n\nΧρησιμοποιήστε το Simplenote σε Mac και Android ή στο http:\/\/simplenote.com. Όλες οι σημειώσεις συγχρονίζονται αυτόματα παντού.";
+"Touch ID" = "Touch ID";
 

--- a/Simplenote/es.lproj/Localizable.strings
+++ b/Simplenote/es.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d Palabras";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i Intento Fallido";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i Intentos Fallidos";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Aceptar";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Agregar Nuevo Colaborador";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Etiqueta...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Agregar Etiqueta";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Ya esta registrado?";
-
-/* No comment provided by engineer. */
-"Back" = "Volver";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Al registrarte, aceptas nuestros Términos de servicio »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Cancelar";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Colaborar";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Permitale a otros colaborar en esta nota";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Colaboradores";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Confirmar";
-
-/* Ratings View: Contact */
-"Contact" = "Contacto";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "Podría ser mejor";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "No se ha podido crear una cuenta con el correo y contraseña ingresados.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "No se ha podido iniciar sesion con el correo y contraseña ingresados.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "¿Por qué no nos dices cómo podríamos mejorar?";
+"collaborators-description" = "Agregue una direccion de correo electronico para compartir la nota con alguien. De esa forma ambos podran realizar cambios sobre la misma.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Crear Nueva Nota";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Colaboradores Actuales";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Modo Noche";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Debug";
-
-/* Permanent Delete */
-"Delete" = "Eliminar";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "La nota fue eliminada en otro dispositivo.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Ocultar Teclado";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Aun no tiene una cuenta?";
 
 /* No comment provided by engineer. */
 "Done" = "Listo";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Vaciar Papelera";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Ingrese una contraseña";
-
-/* Pin Lock */
-"Enter your passcode" = "Ingrese su contraseña";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "¿Has dejado de tener acceso a Simplenote? Puedes recuperar el acceso si vuelves a instalar la aplicación e inicias sesión en tu cuenta.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Ubique anotaciones rapidamente utilizando la busqueda instantanea y etiquetas.\n";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Comenzar";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?\\n\\nRealmente ayuda.";
-
 /* Noun - the version history of a note */
 "History" = "Historial";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Restaurar una version antigua";
 
 /* Action - view the version history of a note */
 "History..." = "Historial...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "¿Cómo podemos ayudarte?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Me gusta";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Escribir una reseña";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Menu";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Ver Opciones";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "No hay Notas";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "No hay resultados";
 
-/* No comment provided by engineer. */
-"No Thanks" = "No, gracias";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "Nota Publicada";
 
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
+/* Message shown in note list when no notes are in the current view */
 "Notes" = "Notas";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Cerrar la Nota Actual";
 
 /* No comment provided by engineer. */
 "Off" = "Apagado";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "Encendido";
@@ -198,15 +110,6 @@
 
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Codigo";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Contraseña incorrecta. Intente nuevamente.";
-
-/* Hint displayed in the password field */
-"Password" = "Contraseña";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Contraseña requiere tener al menos 4 caracteres.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Anclar nota";
@@ -222,9 +125,6 @@
 
 /* No comment provided by engineer. */
 "Preferences" = "Preferencias";
-
-/* Markdown Preview */
-"Preview" = "Vista previa";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Publicar";
@@ -244,14 +144,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Publicando...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Re-Ingrese la contraseña";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Eliminar todas las notas permanentemente";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Remover Etiqueta";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Eliminar todas las notas permanentemente";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Remover Etiqueta?";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Restaurar Nota";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Seguridad";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Enviar";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Enviar comentario";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Ingrese una contraseña";
 
 /* Title of options screen */
 "Settings" = "Configuracion";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Comparta una lista, instrucciones, o comparta lo que piensa.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Compartir el contenido de la nota actual";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Barra Lateral";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Iniciar Sesion";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Cerrar Sesion";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Crear Cuenta";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Agregar una etiqueta a la nota actual";
 
-/* A short link to access the account login screen */
-"Sign in" = "Iniciar Sesion";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Crear Cuenta";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Si cierras sesión, se eliminarán las notas no sincronizadas. Inicia sesión en la aplicación web para verificar tus notas sincronizadas.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Ordenar Alfabeticamente";
-
-/* Message shown in first launch view */
-"Stay organized" = "Mantengase Organizado";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Remover una etiqueta de la nota actual";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Etiqueta: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Lo sentimos, ha habido un error con la conexion a internet. Por favor, intente mas tarde.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Hoy";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Cambiar barra lateral de etiquetas";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Mover la nota actual a la papelera";
 
-/* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Papelera";
+/* Remove all notes from the trash */
+"Trash-noun" = "Papelera";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Eliminar";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Remover Contraseña";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Desbloquear %@";
+/* Permanent Delete */
+"Trash-verb" = "Eliminar";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Desanclar nota";
@@ -349,75 +210,208 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Despublicando...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Se han detectado notas sin sincronizar";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Utilizelo en todo lugar";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Version";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Bienvenido a Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Conectese a Internet para acceder a antiguas revisiones";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "¿Qué opinas de Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Restaurar esta version";
 
-/* Message shown in first launch view */
-"Work together" = "Trabaje en equipo";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Recuperando version";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Ayer";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Tu email:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i Intento Fallido";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Ingrese una contraseña";
+
+/* Pin Lock */
+"Enter your passcode" = "Ingrese su contraseña";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Contraseña incorrecta. Intente nuevamente.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Re-Ingrese la contraseña";
+
+/* Message shown on passcode lock screen */
+"Set Passcode" = "Ingrese una contraseña";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Remover Contraseña";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Desbloquear %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i Intentos Fallidos";
+
+"welcomeNote-iOS" = "Bienvenido a Simplenote para iOS!
+
+Para agregar una nota, presione el boton con el signo de suma.
+
+Deslize su dedo sobre la lista para visualizar sus notas. Para ver el contenido de una nota, simplemente presione sobre la misma. Si desea editarla, presione nuevamente en el area del editor.
+
+Usted puede buscar en todas sus notas simplemente tipeando en la barra de busqueda ubicada al extremo superior de la lista de notas.
+
+Para visualizar las etiquetas, presione la flecha en el extremo superior izquierdo, o dirijase hacia el final del contenido de la nota que se encuentre visualizando. Usted puede agregar etiquetas en cualquier nota en el extremo inferior del editor, y luego utilizar la barra lateral para un rapido acceso.
+
+Si usted asi lo necesitara, tambien es posible agregar colaboradores para edicion en simultaneo, o publicar una nota como una pagina web.
+
+Utilice Simplenote en su Mac, dispositivo Android, o en su navegador web en http://simplenote.com. Sus notas se mantendran actualizadas automaticamente, en todos lados.
+
+";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Ordenar Alfabeticamente";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Ya esta registrado?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Confirmar";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "No se ha podido crear una cuenta con el correo y contraseña ingresados.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "No se ha podido iniciar sesion con el correo y contraseña ingresados.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Aun no tiene una cuenta?";
+
+/* Pin Lock */
+"Password" = "Contraseña";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Contraseña requiere tener al menos 4 caracteres.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Iniciar Sesion";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Iniciar Sesion";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Crear Cuenta";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Crear Cuenta";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Lo sentimos, ha habido un error con la conexion a internet. Por favor, intente mas tarde.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Su dirección de correo electrónico no es valida.";
 
+"Find notes quickly with instant searching and simple tags." = "Ubique anotaciones rapidamente utilizando la busqueda instantanea y etiquetas.
+";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Comenzar";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Comparta una lista, instrucciones, o comparta lo que piensa.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Mantengase Organizado";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Utilizelo en todo lugar";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Bienvenido a Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Trabaje en equipo";
+
 /* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Sus notas se mantendran actualizadas en todos sus dispositivos, sin presionar ni un solo boton. Simplemente funciona.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Permitale a otros colaborar en esta nota";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Modo Noche";
+
+
+"Debug" = "Debug";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Seguridad";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Al registrarte, aceptas nuestros Términos de servicio »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "¿Qué opinas de Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Agregue una direccion de correo electronico para compartir la nota con alguien. De esa forma ambos podran realizar cambios sobre la misma.";
+"I Like It" = "Me gusta";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "La nota fue eliminada en otro dispositivo.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Podría ser mejor";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Restaurar una version antigua";
+"Great! Could you leave us a nice review?
+It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?\n\nRealmente ayuda.";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Ver Opciones";
+/* No comment provided by engineer. */
+"Leave a Review" = "Escribir una reseña";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Cerrar la Nota Actual";
+/* No comment provided by engineer. */
+"No Thanks" = "No, gracias";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Compartir el contenido de la nota actual";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "¿Por qué no nos dices cómo podríamos mejorar?";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Agregar una etiqueta a la nota actual";
+/* No comment provided by engineer. */
+"Send Feedback" = "Enviar comentario";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Remover una etiqueta de la nota actual";
+/* Ratings View: Contact */
+"Contact" = "Contacto";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Mover la nota actual a la papelera";
+/* No comment provided by engineer. */
+"Your Email:" = "Tu email:";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Conectese a Internet para acceder a antiguas revisiones";
+/* No comment provided by engineer. */
+"How can we help?" = "¿Cómo podemos ayudarte?";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Restaurar esta version";
+/* No comment provided by engineer. */
+"Back" = "Volver";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Recuperando version";
+/* Permanent Delete */
+"Delete" = "Eliminar";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Bienvenido a Simplenote para iOS!\n\nPara agregar una nota, presione el boton con el signo de suma.\n\nDeslize su dedo sobre la lista para visualizar sus notas. Para ver el contenido de una nota, simplemente presione sobre la misma. Si desea editarla, presione nuevamente en el area del editor.\n\nUsted puede buscar en todas sus notas simplemente tipeando en la barra de busqueda ubicada al extremo superior de la lista de notas.\n\nPara visualizar las etiquetas, presione la flecha en el extremo superior izquierdo, o dirijase hacia el final del contenido de la nota que se encuentre visualizando. Usted puede agregar etiquetas en cualquier nota en el extremo inferior del editor, y luego utilizar la barra lateral para un rapido acceso.\n\nSi usted asi lo necesitara, tambien es posible agregar colaboradores para edicion en simultaneo, o publicar una nota como una pagina web.\n\nUtilice Simplenote en su Mac, dispositivo Android, o en su navegador web en http:\/\/simplenote.com. Sus notas se mantendran actualizadas automaticamente, en todos lados.\n\n";
+/* Markdown Preview */
+"Preview" = "Vista previa";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Si cierras sesión, se eliminarán las notas no sincronizadas. Inicia sesión en la aplicación web para verificar tus notas sincronizadas.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Se han detectado notas sin sincronizar";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Etiqueta...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "¿Has dejado de tener acceso a Simplenote? Puedes recuperar el acceso si vuelves a instalar la aplicación e inicias sesión en tu cuenta.";
 

--- a/Simplenote/fr.lproj/Localizable.strings
+++ b/Simplenote/fr.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d mots";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i échec de code PIN";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i échecs de code PIN";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Accepter";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Ajouter un nouveau collaborateur...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Étiquette...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Ajouter un tag";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Déjà un compte ?";
-
-/* No comment provided by engineer. */
-"Back" = "Retour";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "En vous inscrivant, vous acceptez les conditions d'utilisation »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Annuler";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Collaborer";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Permettre aux autres de collaborer";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Collaborateurs";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Confirmer";
-
-/* Ratings View: Contact */
-"Contact" = "Contact";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "Pourrait être améliorée";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Impossible de créer un compte avec l'e-mail et le mot de passe fourni.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Impossible de se connecter avec l'e-mail et le mot de passe fourni.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Pouvez-vous nous signaler des pistes d’amélioration ?";
+"collaborators-description" = "Ajouter une adresse e-mail pour partager cette note avec quelqu'un. Vous pourrez ensuite  la modifier tous les deux.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Créer une nouvelle note";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Collaborateurs actuels";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Thème sombre";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Débogage";
-
-/* Permanent Delete */
-"Delete" = "Supprimer";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Cette note à été supprimée sur un autre appareil.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Cacher le clavier";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Vous n'avez pas encore de compte ?";
 
 /* No comment provided by engineer. */
 "Done" = "Terminé";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Vider la corbeille";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Entrez un code PIN";
-
-/* Pin Lock */
-"Enter your passcode" = "Entrez votre code PIN";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Vous n’avez plus accès à Simplenote ? Vous pouvez y accéder en réinstallant l’application et en vous connectant à votre compte.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Trouvez des notes rapidement avec la recherche instantanée ou par simples tags.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "C'est parti !";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "Super ! Pouvez-vous nous laisser un commentaire ?\n\nCela nous aide vraiment.";
-
 /* Noun - the version history of a note */
 "History" = "Historique";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Restaurer une version précédente de la note";
 
 /* Action - view the version history of a note */
 "History..." = "Historique...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Comment pouvons-nous vous aider ?";
-
-/* No comment provided by engineer. */
-"I Like It" = "J’aime";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Laisser un avis";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Menu";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Affiche toutes les options de la note";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Pas de note";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Aucun résultat";
 
-/* No comment provided by engineer. */
-"No Thanks" = "Non merci";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "Note publiée";
 
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
+/* Title of option to display all notes */
 "Notes" = "Notes";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Fermer cette note";
 
 /* No comment provided by engineer. */
 "Off" = "Désactivé";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "Activé";
@@ -199,32 +111,19 @@
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Code PIN";
 
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Codes PIN différents. Essayez de nouveau.";
-
-/* Hint displayed in the password field */
-"Password" = "Mot de passe";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Le mot de passe doit contenir au moins 4 caractères.";
-
 /* Action to mark a note as pinned */
 "Pin note" = "Épingler la note";
 
-/* Denotes when note is pinned to the top of the note list */
+/* Action to mark a note as pinned */
 "Pin to Top" = "Épingler";
 
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "Épingler\/Désépingler";
+"Pin toggle" = "Épingler/Désépingler";
 
 /* Pinned notes are stuck to the note of the note list */
 "Pinned" = "Épinglé";
 
 /* No comment provided by engineer. */
 "Preferences" = "Préférences";
-
-/* Markdown Preview */
-"Preview" = "Aperçu";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Publier";
@@ -235,7 +134,7 @@
 /* Action which published a note to a web page */
 "Publish note" = "Publier la note";
 
-/* Switch which marks a note as published or unpublished */
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish toggle" = "Publier";
 
 /* No comment provided by engineer. */
@@ -244,14 +143,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Publication...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Retapez votre code PIN";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Retirer les notes de la corbeille";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Supprimer le tag";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Retirer les notes de la corbeille";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Supprimer le tag ?";
@@ -265,80 +161,43 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Restaurer la note";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Sécurité";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Envoyer";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Envoyez votre avis";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Activez le code PIN";
 
 /* Title of options screen */
 "Settings" = "Paramètres";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Partagez une liste, postez quelques instructions ou publiez vos pensées.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Partager le contenu de cette note";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Barre latérale";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Se connecter";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Se déconnecter";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "S'inscrire";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Ajouter un tag à cette note";
 
-/* A short link to access the account login screen */
-"Sign in" = "Se connecter";
-
-/* A short link to access the account creation screen */
-"Sign up" = "S'inscrire";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "La déconnexion entraînera la suppression de l’ensemble des notes non synchronisées. Vous pouvez vérifier vos notes synchronisées en vous connectant à l’application Web. ";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Trier les notes alphabétiquement";
-
-/* Message shown in first launch view */
-"Stay organized" = "Restez organisé";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Retirer un tag de cette note";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Tag: %@";
 
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Problème de connexion. Réessayez plus tard.";
-
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Aujourd'hui";
 
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Activer\/désactiver la barre de tag";
+"Toggle tag sidebar" = "Activer/désactiver la barre de tag";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Déplacer cette note dans la corbeille";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Corbeille";
+"Trash-noun" = "Corbeille";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Supprimer";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Désactiver le code PIN";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Débloquer %@";
+/* Permanent Delete */
+"Trash-verb" = "Supprimer";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Désépingler la note";
@@ -349,75 +208,210 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Dépublication...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Notes non-synchronisées détectées";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Utilisez-le n'importe où";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Version";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Bienvenue sur Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Connectez-vous pour accéder aux versions précédentes";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Que pensez-vous de Simplenote ?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Passer à cette version";
 
-/* Message shown in first launch view */
-"Work together" = "Travaillez ensemble";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Récupération de version";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Hier";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Votre e-mail :";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i échec de code PIN";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Entrez un code PIN";
+
+/* Pin Lock */
+"Enter your passcode" = "Entrez votre code PIN";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Codes PIN différents. Essayez de nouveau.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Retapez votre code PIN";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Activez le code PIN";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Désactiver le code PIN";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Débloquer %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i échecs de code PIN";
+
+"welcomeNote-iOS" = "Bienvenue sur la version iOS de Simplenote !
+
+Pour créer une nouvelle note, touchez le bouton plus.
+
+Naviguez dans la liste de notes. Touchez un titre pour voir la totalité de la note et touchez ensuite le contenu de la note pour effectuer des changements.
+
+Cherchez parmi vos notes en touchant le champ de recherche en haut de la liste de notes.
+
+Touchez la flèche en haut ou faites glisser votre liste de notes pour voir vos tags. Vous pouvez ajouter des tags à une note en bas de l'éditeur, et ensuite utiliser le menu pour rester organisé.
+
+Vous avez une note vraiment importante ? Touchez le bouton favoris pendant la lecture d'une note pour la garder en tête de liste.
+
+D'autres options de notes existent si vous en avez besoin. Vous pouvez ajouter d'autres collaborateurs à une note, ou même publier une note comme une page web.
+
+Vous pouvez accéder à toutes vos notes sur le web ou sur vos autres appareils. Rendez-vous sur http://simplenote.com pour démarrer. Vos notes resteront à jour partout automatiquement.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Trier les notes alphabétiquement";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Déjà un compte ?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Confirmer";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Impossible de créer un compte avec l'e-mail et le mot de passe fourni.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Impossible de se connecter avec l'e-mail et le mot de passe fourni.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Vous n'avez pas encore de compte ?";
+
+/* Hint displayed in the password field */
+"Password" = "Mot de passe";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Le mot de passe doit contenir au moins 4 caractères.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Se connecter";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Se connecter";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "S'inscrire";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "S'inscrire";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Problème de connexion. Réessayez plus tard.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Votre adresse e-mail n'est pas valide.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Trouvez des notes rapidement avec la recherche instantanée ou par simples tags.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "C'est parti !";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Partagez une liste, postez quelques instructions ou publiez vos pensées.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Restez organisé";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Utilisez-le n'importe où";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Bienvenue sur Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Travaillez ensemble";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Vos notes restent à jour sur tous vos appareils. Pas besoin d'appuyer sur un bouton, ça marche tout seul !";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Permettre aux autres de collaborer";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Thème sombre";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "Débogage";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM yyyy";
+
+/* Month, day, and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Sécurité";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "En vous inscrivant, vous acceptez les conditions d'utilisation »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Que pensez-vous de Simplenote ?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Ajouter une adresse e-mail pour partager cette note avec quelqu'un. Vous pourrez ensuite  la modifier tous les deux.";
+"I Like It" = "J’aime";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Cette note à été supprimée sur un autre appareil.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Pourrait être améliorée";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Restaurer une version précédente de la note";
+"Great! Could you leave us a nice review?
+It really helps." = "Super ! Pouvez-vous nous laisser un commentaire ?
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Affiche toutes les options de la note";
+Cela nous aide vraiment.";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Fermer cette note";
+/* No comment provided by engineer. */
+"Leave a Review" = "Laisser un avis";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Partager le contenu de cette note";
+/* No comment provided by engineer. */
+"No Thanks" = "Non merci";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Ajouter un tag à cette note";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Pouvez-vous nous signaler des pistes d’amélioration ?";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Retirer un tag de cette note";
+/* No comment provided by engineer. */
+"Send Feedback" = "Envoyez votre avis";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Déplacer cette note dans la corbeille";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Connectez-vous pour accéder aux versions précédentes";
+"Contact" = "Contact";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Passer à cette version";
+/* No comment provided by engineer. */
+"Your Email:" = "Votre e-mail :";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Récupération de version";
+/* No comment provided by engineer. */
+"How can we help?" = "Comment pouvons-nous vous aider ?";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Bienvenue sur la version iOS de Simplenote !\n\nPour créer une nouvelle note, touchez le bouton plus.\n\nNaviguez dans la liste de notes. Touchez un titre pour voir la totalité de la note et touchez ensuite le contenu de la note pour effectuer des changements.\n\nCherchez parmi vos notes en touchant le champ de recherche en haut de la liste de notes.\n\nTouchez la flèche en haut ou faites glisser votre liste de notes pour voir vos tags. Vous pouvez ajouter des tags à une note en bas de l'éditeur, et ensuite utiliser le menu pour rester organisé.\n\nVous avez une note vraiment importante ? Touchez le bouton favoris pendant la lecture d'une note pour la garder en tête de liste.\n\nD'autres options de notes existent si vous en avez besoin. Vous pouvez ajouter d'autres collaborateurs à une note, ou même publier une note comme une page web.\n\nVous pouvez accéder à toutes vos notes sur le web ou sur vos autres appareils. Rendez-vous sur http:\/\/simplenote.com pour démarrer. Vos notes resteront à jour partout automatiquement.";
+/* No comment provided by engineer. */
+"Back" = "Retour";
+
+/* Permanent Delete */
+"Delete" = "Supprimer";
+
+/* Markdown Preview */
+"Preview" = "Aperçu";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "La déconnexion entraînera la suppression de l’ensemble des notes non synchronisées. Vous pouvez vérifier vos notes synchronisées en vous connectant à l’application Web. ";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Notes non-synchronisées détectées";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Étiquette...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Vous n’avez plus accès à Simplenote ? Vous pouvez y accéder en réinstallant l’application et en vous connectant à votre compte.";
 

--- a/Simplenote/he.lproj/Localizable.strings
+++ b/Simplenote/he.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d מילים";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i ניסיון קוד סיסמה שנכשל";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i ניסיונות קוד סיסמה שנכשלו";
-
 /* Label of accept button on alert dialog */
 "Accept" = "קבלה";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "הוספת שותף עריכה חדש...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "תגית...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "הוספת תגית";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "יש לך כבר חשבון?";
-
-/* No comment provided by engineer. */
-"Back" = "חזרה";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "הרשמתך מהווה הסכמה לתנאי השימוש שלנו »";
 
 /* No comment provided by engineer. */
 "Cancel" = "ביטול";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "שיתוף פעולה בעריכה";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "מאפשר לאחרים לשתף פעולה";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "שותפי עריכה";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "פעם נוספת";
-
-/* Ratings View: Contact */
-"Contact" = "איש קשר";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "יכול להיות יותר טוב";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "לא ניתן ליצור חשבון באמצעות כתובת האימייל והסיסמה שסופקו.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "לא ניתן להיכנס באמצעות כתובת האימייל והסיסמה שסופקו.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "באפשרותך לומר לנו כיצד נוכל להשתפר?";
+"collaborators-description" = "יש להוסיף כתובת אימייל כדי לשתף פתק זה עם מישהו. לאחר מכן תוכלו שניכם לערוך בו שינויים.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "יצירת פתק חדש";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "שותפי עריכה קיימים";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "ערכת עיצוב כהה";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "איתור באגים";
-
-/* Permanent Delete */
-"Delete" = "מחיקה";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "הפתק נמחק במכשיר אחר.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "ביטול מקלדת";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "אין לך חשבון עדיין?";
 
 /* No comment provided by engineer. */
 "Done" = "בוצע";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "לרוקן את הפח";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "הזנת קוד סיסמה";
-
-/* Pin Lock */
-"Enter your passcode" = "הזנת קוד סיסמה";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "האם אבדה לך הגישה ל-Simplenote? אפשר להשיב את הגישה באמצעות התקנה חוזרת של האפליקציה וכניסה לחשבון שלך.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "איתור פתקים במהירות באמצעות חיפוש מהיר ותגיות פשוטות.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "התחלה";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "נהדר! תוכל\/י אולי לדרג אותנו?\n\n\nזה ממש יעזור.";
-
 /* Noun - the version history of a note */
 "History" = "היסטוריה";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "החזרת פתק לגרסה הקודמת";
 
 /* Action - view the version history of a note */
 "History..." = "היסטוריה...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "כיצד נוכל לעזור?";
-
-/* No comment provided by engineer. */
-"I Like It" = "אהבתי את זה";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "השארת חוות דעת";
-
-/* Month and day date formatter */
-"MMM d" = "d ‏MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d ‏MMM, ‏hh:mm";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d ‏MMM, ‏yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM ‏yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "תפריט";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "הצגת אפשרויות לפתק";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "אין פתקים";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "אין תוצאות";
 
-/* No comment provided by engineer. */
-"No Thanks" = "לא תודה";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "הפתק פורסם";
 
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
+/* Description of Simplenote shown in first launch view */
 "Notes" = "פתקים";
 
-/* No comment provided by engineer. */
-"OK" = "אישור";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "סגירת פתק נוכחי";
 
 /* No comment provided by engineer. */
 "Off" = "כבוי";
+
+/* No comment provided by engineer. */
+"OK" = "אישור";
 
 /* No comment provided by engineer. */
 "On" = "מופעל";
@@ -196,17 +108,8 @@
 /* Select a note to view in the note editor */
 "Open note" = "פתיחת פתק";
 
-/* A 4-digit code to lock the app when it is closed */
+/* Number of failed entries entering in passcode */
 "Passcode" = "קוד סיסמה";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "קודי הסיסמה לא התאימו. יש לנסות שוב.";
-
-/* Hint displayed in the password field */
-"Password" = "סיסמה";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "הסיסמה חייבת להכיל לפחות ארבעה תווים.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "הצמדת פתק";
@@ -223,9 +126,6 @@
 /* No comment provided by engineer. */
 "Preferences" = "העדפות";
 
-/* Markdown Preview */
-"Preview" = "תצוגה מקדימה";
-
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "לפרסם";
 
@@ -238,20 +138,17 @@
 /* Switch which marks a note as published or unpublished */
 "Publish toggle" = "החלפת מצב תרגום";
 
-/* No comment provided by engineer. */
+/* Confirmation shown when a note is published */
 "Published" = "פורסם";
 
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "מפרסם...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "הזנה מחדש של קוד הסיסמה";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "הסרת כל הפתקים מהפח";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "הסרת תגית";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "הסרת כל הפתקים מהפח";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "להסיר תגית?";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "שחזור פתק";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "אבטחה";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "שליחה";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "שליחת משוב";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "הגדרת קוד סיסמה";
 
 /* Title of options screen */
 "Settings" = "הגדרות";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "שיתוף רשימה, פרסום הנחיות או פרסום מחשבות.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "שיתוף תוכן הפתק הנוכחי";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "סרגל צדדי";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "התחברות";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "לצאת מהמערכת";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "הרשמה";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "הוספת תגית לפתק הנוכחי";
 
-/* A short link to access the account login screen */
-"Sign in" = "כניסה למערכת";
-
-/* A short link to access the account creation screen */
-"Sign up" = "הרשמה";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "לאחר ההתנתקות, כל הפתקים שלא סוכרנו יימחקו. אפשר לאמת אילו פתקים סונכרנו באמצעות התחברות לאפליקציית הרשת.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "מיון פתקים בסדר אלפביתי";
-
-/* Message shown in first launch view */
-"Stay organized" = "שמירה על ארגון";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "הסרת תגית מהפתק הנוכחי";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "תגית: ‎%@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "יש בעיה בחיבור.  יש לנסות שוב מאוחר יותר.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "היום";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "החלפת מצב סרגל צדדי";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "מזהה מגע";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "העבר את הפתק הנוכחי לפח";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "העברה לפח";
+"Trash-noun" = "העברה לפח";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "העברה לפח";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "השבתת קוד סיסמה";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "ביטול נעילה %@";
+/* Trash (noun) - the location where deleted notes are stored */
+"Trash-verb" = "העברה לפח";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "ביטול הצמדת פתק";
@@ -349,75 +210,209 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "ביטול פרסום...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "אותרו הערות שלא סונכרנו";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "להשתמש בו בכל מקום";
-
 /* Represents a snapshot in time for a note */
 "Version" = "גרסה";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "ברוכים הבאים אל Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "התחברות לאינטרנט לצורך גישה לגרסאות קודמות";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "מה דעתך על Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "מעבר לגרסה זו";
 
-/* Message shown in first launch view */
-"Work together" = "עבודה שיתופית";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "הורדת גרסה";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "אתמול";
 
-/* No comment provided by engineer. */
-"Your Email:" = "כתובת האימייל שלך:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i ניסיון קוד סיסמה שנכשל";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "הזנת קוד סיסמה";
+
+/* Message shown on passcode lock screen */
+"Enter your passcode" = "הזנת קוד סיסמה";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "קודי הסיסמה לא התאימו. יש לנסות שוב.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "הזנה מחדש של קוד הסיסמה";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "הגדרת קוד סיסמה";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "השבתת קוד סיסמה";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "ביטול נעילה %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i ניסיונות קוד סיסמה שנכשלו";
+
+"welcomeNote-iOS" = "ברוכים הבאים אל Simplenote עבור iOS!
+
+כדי להוסיף פתק, יש להקיש על לחצן הפלוס.
+
+רפרוף ברשימה כדי לעיין בפתקים שלך. יש להקיש על כותרת כדי להציג פתק, ולאחר מכן להקיש על התוכן שלו כדי לשנות אותו.
+
+אפשר לחפש בכל הפתקים באמצעות הקלדה בשדה החיפוש בחלק העליון של רשימת הפתקים.
+
+יש להקיש על לחצן החץ בחלק הימני העליון, או להחליק על רשימת הפתקים כדי להציג את התגיות שלך. אפשר להוסיף תגיות לפתק בתחתית עורך הפתקים, ולאחר מכן להשתמש בסרגל הצדדי כדי לעזור לך לשמור על הסדר.
+
+קיימות אפשרויות נוספות לפתקים במקרה הצורך. אפשר להוסיף אחרים כמשתפי פעולה לפתק, או לפרסם פתק כדף אינטרנט.
+
+ניתן להשתמש ב-Simplenote במחשב Mac, מכשיר Android, או בדפדפן האינטרנט, בכתובת http://simplenote.com. הפתקים שלך יישארו מעודכנים בכל מקום, באופן אוטומטי.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "מיון פתקים בסדר אלפביתי";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "יש לך כבר חשבון?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "פעם נוספת";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "לא ניתן ליצור חשבון באמצעות כתובת האימייל והסיסמה שסופקו.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "לא ניתן להיכנס באמצעות כתובת האימייל והסיסמה שסופקו.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "אין לך חשבון עדיין?";
+
+/* Number of failed entries entering in passcode */
+"Password" = "סיסמה";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "הסיסמה חייבת להכיל לפחות ארבעה תווים.";
+
+/* A short link to access the account login screen */
+"Sign in" = "כניסה למערכת";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "התחברות";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "הרשמה";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "הרשמה";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "יש בעיה בחיבור.  יש לנסות שוב מאוחר יותר.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "כתובת האימייל שלך אינה חוקית.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "איתור פתקים במהירות באמצעות חיפוש מהיר ותגיות פשוטות.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "התחלה";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "שיתוף רשימה, פרסום הנחיות או פרסום מחשבות.";
+
+/* Message shown in first launch view */
+"Stay organized" = "שמירה על ארגון";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "להשתמש בו בכל מקום";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "ברוכים הבאים אל Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "עבודה שיתופית";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "הפתקים שלך תמיד מעודכנים, בכל המכשירים שלך. בלי לחיצות מיותרות. זה פשוט עובד.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "מאפשר לאחרים לשתף פעולה";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "ערכת עיצוב כהה";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "איתור באגים";
+
+/* Month and day date formatter */
+"MMM d" = "d ‏MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d ‏MMM, ‏hh:mm";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d ‏MMM, ‏yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM ‏yyyy";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "מזהה מגע";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "אבטחה";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "הרשמתך מהווה הסכמה לתנאי השימוש שלנו »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "מה דעתך על Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "יש להוסיף כתובת אימייל כדי לשתף פתק זה עם מישהו. לאחר מכן תוכלו שניכם לערוך בו שינויים.";
+"I Like It" = "אהבתי את זה";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "הפתק נמחק במכשיר אחר.";
+/* No comment provided by engineer. */
+"Could Be Better" = "יכול להיות יותר טוב";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "החזרת פתק לגרסה הקודמת";
+"Great! Could you leave us a nice review?
+It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "הצגת אפשרויות לפתק";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "סגירת פתק נוכחי";
+זה ממש יעזור.";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "שיתוף תוכן הפתק הנוכחי";
+/* No comment provided by engineer. */
+"Leave a Review" = "השארת חוות דעת";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "הוספת תגית לפתק הנוכחי";
+/* No comment provided by engineer. */
+"No Thanks" = "לא תודה";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "הסרת תגית מהפתק הנוכחי";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "באפשרותך לומר לנו כיצד נוכל להשתפר?";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "העבר את הפתק הנוכחי לפח";
+/* No comment provided by engineer. */
+"Send Feedback" = "שליחת משוב";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "התחברות לאינטרנט לצורך גישה לגרסאות קודמות";
+/* Ratings View: Contact */
+"Contact" = "איש קשר";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "מעבר לגרסה זו";
+/* No comment provided by engineer. */
+"Your Email:" = "כתובת האימייל שלך:";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "הורדת גרסה";
+/* No comment provided by engineer. */
+"How can we help?" = "כיצד נוכל לעזור?";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "ברוכים הבאים אל Simplenote עבור iOS!\n\nכדי להוסיף פתק, יש להקיש על לחצן הפלוס.\n\nרפרוף ברשימה כדי לעיין בפתקים שלך. יש להקיש על כותרת כדי להציג פתק, ולאחר מכן להקיש על התוכן שלו כדי לשנות אותו.\n\nאפשר לחפש בכל הפתקים באמצעות הקלדה בשדה החיפוש בחלק העליון של רשימת הפתקים.\n\nיש להקיש על לחצן החץ בחלק הימני העליון, או להחליק על רשימת הפתקים כדי להציג את התגיות שלך. אפשר להוסיף תגיות לפתק בתחתית עורך הפתקים, ולאחר מכן להשתמש בסרגל הצדדי כדי לעזור לך לשמור על הסדר.\n\nקיימות אפשרויות נוספות לפתקים במקרה הצורך. אפשר להוסיף אחרים כמשתפי פעולה לפתק, או לפרסם פתק כדף אינטרנט.\n\nניתן להשתמש ב-Simplenote במחשב Mac, מכשיר Android, או בדפדפן האינטרנט, בכתובת http:\/\/simplenote.com. הפתקים שלך יישארו מעודכנים בכל מקום, באופן אוטומטי.";
+/* No comment provided by engineer. */
+"Back" = "חזרה";
+
+/* Permanent Delete */
+"Delete" = "מחיקה";
+
+/* Markdown Preview */
+"Preview" = "תצוגה מקדימה";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "לאחר ההתנתקות, כל הפתקים שלא סוכרנו יימחקו. אפשר לאמת אילו פתקים סונכרנו באמצעות התחברות לאפליקציית הרשת.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "אותרו הערות שלא סונכרנו";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "תגית...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "האם אבדה לך הגישה ל-Simplenote? אפשר להשיב את הגישה באמצעות התקנה חוזרת של האפליקציה וכניסה לחשבון שלך.";
 

--- a/Simplenote/id.lproj/Localizable.strings
+++ b/Simplenote/id.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d Kata";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i Upaya Kode Sandi Gagal";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i Upaya Kode Sandi Gagal";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Terima";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Tambahkan kolaborator baru...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Tag...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Tambahkan label";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Sudah memiliki akun?";
-
-/* No comment provided by engineer. */
-"Back" = "Kembali";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Dengan mendaftar, berarti Anda menyetujui Ketentuan Layanan »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Cancel";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Kolaborasi";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Aktifkan yang lain untuk berkolaborasi";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Kolaborator";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Konfirmasi";
-
-/* Ratings View: Contact */
-"Contact" = "Hubungi";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "Bisa Lebih Baik";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Tidak dapat membuat akun dengan alamat email dan kata sandi yang diberikan.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Tidak dapat masuk dengan alamat email dan kata sandi yang diberikan.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Menurut Anda, penyempurnaan apa yang dapat kami lakukan?";
+"collaborators-description" = "Tambahkan alamat email untuk berbagi catatan ini dengan seseorang. Kemudian Anda dan orang yang Anda bagi catatan tersebut dapat melakukan perubahan.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Buat catatan baru";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Kolaborator Saat Ini";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Tema gelap";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Debug";
-
-/* Permanent Delete */
-"Delete" = "Hapus";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Catatan ini dihapus pada perangkat lain.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Abaikan keyboard";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Belum memiliki akun?";
 
 /* No comment provided by engineer. */
 "Done" = "Selesai";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Kosongkan sampah";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Masukkan kode sandi";
-
-/* Pin Lock */
-"Enter your passcode" = "Masukkan kode sandi Anda";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Apakah Anda tidak dapat mengakses Simplenote? Anda dapat mengaksesnya lagi dengan menginstal ulang aplikasi dan masuk ke akun Anda.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Temukan catatan dengan cepat menggunakan pencarian instan dan label sederhana.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Memulai";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\\n\\nIni benar-benar membantu.";
-
 /* Noun - the version history of a note */
 "History" = "Riwayat";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Pulihkan catatan ke versi sebelumnya";
 
 /* Action - view the version history of a note */
 "History..." = "Riwayat...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Apa yang dapat kami bantu?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Saya Menyukainya";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Berikan Tinjauan";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
+/* Ratings View: Don't Like */
 "Menu" = "Menu";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Tampilkan opsi untuk catatan";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Tidak ada Catatan";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Tidak ada Hasil";
 
-/* No comment provided by engineer. */
-"No Thanks" = "Tidak, Terima Kasih";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "Catatan Diterbitkan";
 
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
+/* Message shown in note list when no notes are in the current view */
 "Notes" = "Catatan";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Tutup catatan saat ini";
 
 /* No comment provided by engineer. */
 "Off" = "Matikan";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "Menyala";
@@ -198,15 +110,6 @@
 
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Kode sandi";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Kode sandi tidak cocok. Coba lagi.";
-
-/* Hint displayed in the password field */
-"Password" = "Kata sandi";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Kata sandi harus berisi sedikitnya 4 karakter.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Sematkan catatan";
@@ -223,9 +126,6 @@
 /* No comment provided by engineer. */
 "Preferences" = "Preferensi";
 
-/* Markdown Preview */
-"Preview" = "Pratinjau";
-
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Terbitkan";
 
@@ -238,20 +138,17 @@
 /* Switch which marks a note as published or unpublished */
 "Publish toggle" = "Terbitkan pilihan";
 
-/* No comment provided by engineer. */
+/* Confirmation shown when a note is published */
 "Published" = "Diterbitkan";
 
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Menerbitkan...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Masukkan ulang kode sandi";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Buang semua catatan dari sampah";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Buang Label";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Buang semua catatan dari sampah";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Buang label?";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Pulihkan Catatan";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Keamanan";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Kirim";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Kirim Masukan";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Atur Kode Sandi";
 
 /* Title of options screen */
 "Settings" = "Settings";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Bagikan daftar, kirimkan instruksi, atau terbitkan ide Anda.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Bagikan konten dari catatan saat ini";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Panel Sisi";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Masuk";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Keluar";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Mendaftar";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Tambahkan label pada catatan saat ini";
 
-/* A short link to access the account login screen */
-"Sign in" = "Masuk";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Mendaftar";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Catatan yang tidak disinkronkan akan dihapus saat Anda keluar. Anda dapat memverifikasi catatan Anda yang disinkronkan dengan masuk ke Aplikasi Web.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Urutkan Catatan sesuai Abjad";
-
-/* Message shown in first launch view */
-"Stay organized" = "Tetap tertata";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Buang label dari catatan saat ini";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Label: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Ada masalah dengan koneksi. Coba lagi nanti.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Hari ini";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Panel sisi label pilihan";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "ID Sentuhan";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Pindahkan catatan saat ini ke sampah";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Sampah";
+"Trash-noun" = "Sampah";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Sampah";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Matikan Kode Sandi";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Buka kunci %@";
+/* Trash (noun) - the location where deleted notes are stored */
+"Trash-verb" = "Sampah";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Lepas sematan catatan";
@@ -349,75 +210,206 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Batal menerbitkan...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Catatan yang Tidak Disinkronkan Terdeteksi";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Gunakan di mana saja";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Versi";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Selamat Datang di Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Hubungkan ke Internet untuk Mengakses Versi Sebelumnya";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Apa pendapat Anda tentang Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Beralih ke versi ini";
 
-/* Message shown in first launch view */
-"Work together" = "Bekerja sama";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Mengambil versi";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Kemarin";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Email Anda:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i Upaya Kode Sandi Gagal";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Masukkan kode sandi";
+
+/* Pin Lock */
+"Enter your passcode" = "Masukkan kode sandi Anda";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Kode sandi tidak cocok. Coba lagi.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Masukkan ulang kode sandi";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Atur Kode Sandi";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Matikan Kode Sandi";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Buka kunci %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i Upaya Kode Sandi Gagal";
+
+"welcomeNote-iOS" = "Selamat Datang di Simplenote untuk iOS!
+
+Untuk menambahkan catatan, ketuk tombol plus.
+
+Sentil daftar untuk menjelajahi catatan Anda. Ketuk judul untuk melihat catatan, kemudian ketuk isi untuk mengubahnya.
+
+Anda dapat mencari semua catatan Anda dengan mengetik di bidang pencarian pada bagian atas daftar catatan.
+
+Ketuk tombol panah di bagian kiri atas atau sapukan jari pada daftar catatan untuk melihat label. Anda dapat menambahkan label pada catatan di bagian bawah penyunting catatan, lalu gunakan panel sisi untuk menjaga tetap teratur.
+
+Ada opsi catatan lainnya jika Anda memerlukan. Anda dapat menambahkan lainnya sebagai kolaborator pada catatan, atau menerbitkan catatan sebagai sebuah halaman web.
+
+Gunakan Simplenote di perangkat Mac, Android, atau di browser web Anda di http://simplenote.com. Catatan Anda akan tetap diperbarui di mana saja secara otomatis.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Urutkan Catatan sesuai Abjad";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Sudah memiliki akun?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Konfirmasi";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Tidak dapat membuat akun dengan alamat email dan kata sandi yang diberikan.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Tidak dapat masuk dengan alamat email dan kata sandi yang diberikan.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Belum memiliki akun?";
+
+/* Hint displayed in the password field */
+"Password" = "Kata sandi";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Kata sandi harus berisi sedikitnya 4 karakter.";
+
+/* Message shown on passcode lock screen */
+"Sign in" = "Masuk";
+
+/* Message shown on passcode lock screen */
+"Sign In" = "Masuk";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Mendaftar";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Mendaftar";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Ada masalah dengan koneksi. Coba lagi nanti.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Alamat email Anda tidak valid.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Temukan catatan dengan cepat menggunakan pencarian instan dan label sederhana.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Memulai";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Bagikan daftar, kirimkan instruksi, atau terbitkan ide Anda.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Tetap tertata";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Gunakan di mana saja";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Selamat Datang di Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Bekerja sama";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Catatan Anda diperbarui lintas seluruh perangkat Anda. Tidak ada tombol untuk ditekan. Ini langsung bekerja.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Aktifkan yang lain untuk berkolaborasi";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Tema gelap";
+
+
+"Debug" = "Debug";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM yyyy";
+
+/* Month, day, and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "ID Sentuhan";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Keamanan";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Dengan mendaftar, berarti Anda menyetujui Ketentuan Layanan »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Apa pendapat Anda tentang Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Tambahkan alamat email untuk berbagi catatan ini dengan seseorang. Kemudian Anda dan orang yang Anda bagi catatan tersebut dapat melakukan perubahan.";
+"I Like It" = "Saya Menyukainya";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Catatan ini dihapus pada perangkat lain.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Bisa Lebih Baik";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Pulihkan catatan ke versi sebelumnya";
+"Great! Could you leave us a nice review?
+It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nIni benar-benar membantu.";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Tampilkan opsi untuk catatan";
+/* No comment provided by engineer. */
+"Leave a Review" = "Berikan Tinjauan";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Tutup catatan saat ini";
+/* No comment provided by engineer. */
+"No Thanks" = "Tidak, Terima Kasih";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Bagikan konten dari catatan saat ini";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Menurut Anda, penyempurnaan apa yang dapat kami lakukan?";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Tambahkan label pada catatan saat ini";
+/* No comment provided by engineer. */
+"Send Feedback" = "Kirim Masukan";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Buang label dari catatan saat ini";
+/* Ratings View: Contact */
+"Contact" = "Hubungi";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Pindahkan catatan saat ini ke sampah";
+/* No comment provided by engineer. */
+"Your Email:" = "Email Anda:";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Hubungkan ke Internet untuk Mengakses Versi Sebelumnya";
+/* No comment provided by engineer. */
+"How can we help?" = "Apa yang dapat kami bantu?";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Beralih ke versi ini";
+/* No comment provided by engineer. */
+"Back" = "Kembali";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Mengambil versi";
+/* Permanent Delete */
+"Delete" = "Hapus";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Selamat Datang di Simplenote untuk iOS!\n\nUntuk menambahkan catatan, ketuk tombol plus.\n\nSentil daftar untuk menjelajahi catatan Anda. Ketuk judul untuk melihat catatan, kemudian ketuk isi untuk mengubahnya.\n\nAnda dapat mencari semua catatan Anda dengan mengetik di bidang pencarian pada bagian atas daftar catatan.\n\nKetuk tombol panah di bagian kiri atas atau sapukan jari pada daftar catatan untuk melihat label. Anda dapat menambahkan label pada catatan di bagian bawah penyunting catatan, lalu gunakan panel sisi untuk menjaga tetap teratur.\n\nAda opsi catatan lainnya jika Anda memerlukan. Anda dapat menambahkan lainnya sebagai kolaborator pada catatan, atau menerbitkan catatan sebagai sebuah halaman web.\n\nGunakan Simplenote di perangkat Mac, Android, atau di browser web Anda di http:\/\/simplenote.com. Catatan Anda akan tetap diperbarui di mana saja secara otomatis.";
+/* Markdown Preview */
+"Preview" = "Pratinjau";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Catatan yang tidak disinkronkan akan dihapus saat Anda keluar. Anda dapat memverifikasi catatan Anda yang disinkronkan dengan masuk ke Aplikasi Web.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Catatan yang Tidak Disinkronkan Terdeteksi";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Tag...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Apakah Anda tidak dapat mengakses Simplenote? Anda dapat mengaksesnya lagi dengan menginstal ulang aplikasi dan masuk ke akun Anda.";
 

--- a/Simplenote/it.lproj/Localizable.strings
+++ b/Simplenote/it.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d Parole";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i tentativo di accesso fallito";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i tentativi di accesso falliti";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Ok";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Aggiungi un nuovo collaboratore...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Tag...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Aggiungi tag";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Hai già un account?";
-
-/* No comment provided by engineer. */
-"Back" = "Indietro";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Iscrivendoti, accetti i nostri Termini di servizio »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Annulla";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Collabora";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Aggiungi collaboratori";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Collaboratori";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Conferma";
-
-/* Ratings View: Contact */
-"Contact" = "Contatto";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "Potrebbe essere meglio";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Non è possibile creare un account con l'indirizzo email e la password forniti.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Nome utente o password errata.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Puoi dirci come possiamo migliorare?";
+"collaborators-description" = "Aggiungi un indirizzo email con cui condividere questa nota. Dopo la condivisione entrambi gli utenti potranno modificare la nota.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Crea una nuova nota";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Collaboratori attuali";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Tema scuro";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Debug";
-
-/* Permanent Delete */
-"Delete" = "Elimina";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Questa nota è stata cancellata da un altro dispositivo.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Nascondi la tastiera";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Non hai un account?";
 
 /* No comment provided by engineer. */
 "Done" = "Fatto";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Svuota cestino";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Inserisci il PIN";
-
-/* Pin Lock */
-"Enter your passcode" = "Inserisci il tuo PIN";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Hai perso l’accesso a Simplenote? Puoi ottenerlo nuovamente reinstallando l’app e accedendo al tuo account.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Trova le note facilmente con la ricerca in tempo reale e tramite i tag.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Inizia";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "Grande! Potresti lasciarci una recensione?\\n\\n\\nAiuterebbe molto.";
-
 /* Noun - the version history of a note */
 "History" = "Storia";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Ripristina da una versione precedente";
 
 /* Action - view the version history of a note */
 "History..." = "Storia...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Come possiamo aiutarti?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Mi piace";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Lascia una recensione";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Menu";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Mostra opzioni nota";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Nessuna nota presente";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Nessun risultato";
 
-/* No comment provided by engineer. */
-"No Thanks" = "No grazie";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "Nota pubblicata";
 
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
+/* Title of option to display all notes */
 "Notes" = "Note";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Chiudi la nota";
 
 /* No comment provided by engineer. */
 "Off" = "Off";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "On";
@@ -196,22 +108,13 @@
 /* Select a note to view in the note editor */
 "Open note" = "Apri nota";
 
-/* A 4-digit code to lock the app when it is closed */
+/* Message shown on passcode lock screen */
 "Passcode" = "PIN";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "PIN non coincidono. Prova ancora.";
-
-/* Hint displayed in the password field */
-"Password" = "Password";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "La password deve contenere almeno 4 caratteri.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Aggancia";
 
-/* Denotes when note is pinned to the top of the note list */
+/* Action to mark a note as pinned */
 "Pin to Top" = "Aggancia";
 
 /* Switch which marks a note as pinned or unpinned */
@@ -223,9 +126,6 @@
 /* No comment provided by engineer. */
 "Preferences" = "Preferenze";
 
-/* Markdown Preview */
-"Preview" = "Visualizzare in anteprima";
-
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Pubblica";
 
@@ -235,7 +135,7 @@
 /* Action which published a note to a web page */
 "Publish note" = "Pubblica nota";
 
-/* Switch which marks a note as published or unpublished */
+/* Confirmation shown when a note is published */
 "Publish toggle" = "Nota pubblicata";
 
 /* No comment provided by engineer. */
@@ -244,14 +144,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Pubblicazione in corso...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Inserisci nuovamente il PIN";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Elimina tutte le note dal cestino";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Rimuovi Tag";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Elimina tutte le note dal cestino";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Vuoi rimuovere il tag?";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Ripristina la nota";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Sicurezza";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Invia";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Invia un feedback";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Imposta il PIN";
 
 /* Title of options screen */
 "Settings" = "Impostazioni";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Condividere una lista di to-do, gli appunti, o pubblicarli sul web, è facile con Simplenote.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Condividi il contenuto della nota";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Barra laterale";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Accedi";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Esci";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Crea account";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Aggiungi un tag alla nota";
 
-/* A short link to access the account login screen */
-"Sign in" = "Accedi";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Registrati";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "La disconnessione causerà l’eliminazione di tutte le note non sincronizzate. È possibile verificare le note sincronizzate accedendo all’app web.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Ordina le note alfabeticamente";
-
-/* Message shown in first launch view */
-"Stay organized" = "Rimani organizzato";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Rimuovi il tag dalla nota";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Tag: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "C'è un problema con la connessione alla rete. Si prega di riprovare più tardi.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Oggi";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Mostra barra laterale";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Sposta la nota nel cestino";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Cestino";
+"Trash-noun" = "Cestino";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Elimina";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Disabilita il PIN";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Sblocca %@";
+/* Permanent Delete */
+"Trash-verb" = "Elimina";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Sgancia";
@@ -349,75 +210,206 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Rimuovendo dalla pubblicazione";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Note non sincronizzate rilevate";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Usa l'app su qualunque dispositivo";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Versione";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Benvenuto in Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Collegati ad internet per accedere alle versioni precedenti";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Che cosa pensi di Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Usa questa versione";
 
-/* Message shown in first launch view */
-"Work together" = "Condividi le note con altre persone";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Caricamento versioni";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Ieri";
 
-/* No comment provided by engineer. */
-"Your Email:" = "La tua Email:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i tentativo di accesso fallito";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Inserisci il PIN";
+
+/* Pin Lock */
+"Enter your passcode" = "Inserisci il tuo PIN";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "PIN non coincidono. Prova ancora.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Inserisci nuovamente il PIN";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Imposta il PIN";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Disabilita il PIN";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Sblocca %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i tentativi di accesso falliti";
+
+"welcomeNote-iOS" = "Benvenuto in Simplenote per iOS!
+
+Per creare una nuova nota, clicca sul bottone con il segno +.
+
+Scorri la lista per vedere tutte le tue note. Tocca il titolo della nota per aprire il dettaglio, e tocca il contenuto per modificarlo.
+
+Per effettuare una ricerca, scrivi nella barra di ricerca presente in alto nella schermata delle note.
+
+Clicca il pulsante in alto a sinistra della nota, oppure effettua uno swiping su di essa, per accedere ai tags. E' possibile aggiungere nuovi tags alla nota usando l'apposito campo presente in basso nella schermata di editing. Usa la barra laterale per accedere alle note filtrare per tag.
+
+Ci sono anche altre opzioni se le desideri. E' per esempio possibile aggiungere collaboratori ad una nota, oppure pubblicare una nota su una pagina web.
+
+Usa Simplenote per Mac, per Android, oppure visita http://simplenote.com per accedere alle tue note da qualunque posto e da qualunque dispositivo.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Ordina le note alfabeticamente";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Hai già un account?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Conferma";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Non è possibile creare un account con l'indirizzo email e la password forniti.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Nome utente o password errata.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Non hai un account?";
+
+
+"Password" = "Password";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "La password deve contenere almeno 4 caratteri.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Accedi";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Accedi";
+
+/* A short link to access the account creation screen */
+"Sign up" = "Registrati";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Crea account";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "C'è un problema con la connessione alla rete. Si prega di riprovare più tardi.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Il tuo indirizzo email non è valido.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Trova le note facilmente con la ricerca in tempo reale e tramite i tag.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Inizia";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Condividere una lista di to-do, gli appunti, o pubblicarli sul web, è facile con Simplenote.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Rimani organizzato";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Usa l'app su qualunque dispositivo";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Benvenuto in Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Condividi le note con altre persone";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Le tue note sono disponibili ed aggiornate in tempo reale su tutti i tuoi dispositivi, senza bisogno di alcuna configurazione. ";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Aggiungi collaboratori";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Tema scuro";
+
+
+"Debug" = "Debug";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM yyyy";
+
+/* Month, day, and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Sicurezza";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Iscrivendoti, accetti i nostri Termini di servizio »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Che cosa pensi di Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Aggiungi un indirizzo email con cui condividere questa nota. Dopo la condivisione entrambi gli utenti potranno modificare la nota.";
+"I Like It" = "Mi piace";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Questa nota è stata cancellata da un altro dispositivo.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Potrebbe essere meglio";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Ripristina da una versione precedente";
+"Great! Could you leave us a nice review?
+It really helps." = "Grande! Potresti lasciarci una recensione?\n\n\nAiuterebbe molto.";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Mostra opzioni nota";
+/* No comment provided by engineer. */
+"Leave a Review" = "Lascia una recensione";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Chiudi la nota";
+/* No comment provided by engineer. */
+"No Thanks" = "No grazie";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Condividi il contenuto della nota";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Puoi dirci come possiamo migliorare?";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Aggiungi un tag alla nota";
+/* No comment provided by engineer. */
+"Send Feedback" = "Invia un feedback";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Rimuovi il tag dalla nota";
+/* Ratings View: Contact */
+"Contact" = "Contatto";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Sposta la nota nel cestino";
+/* No comment provided by engineer. */
+"Your Email:" = "La tua Email:";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Collegati ad internet per accedere alle versioni precedenti";
+/* No comment provided by engineer. */
+"How can we help?" = "Come possiamo aiutarti?";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Usa questa versione";
+/* No comment provided by engineer. */
+"Back" = "Indietro";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Caricamento versioni";
+/* Permanent Delete */
+"Delete" = "Elimina";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Benvenuto in Simplenote per iOS!\n\nPer creare una nuova nota, clicca sul bottone con il segno +.\n\nScorri la lista per vedere tutte le tue note. Tocca il titolo della nota per aprire il dettaglio, e tocca il contenuto per modificarlo.\n\nPer effettuare una ricerca, scrivi nella barra di ricerca presente in alto nella schermata delle note.\n\nClicca il pulsante in alto a sinistra della nota, oppure effettua uno swiping su di essa, per accedere ai tags. E' possibile aggiungere nuovi tags alla nota usando l'apposito campo presente in basso nella schermata di editing. Usa la barra laterale per accedere alle note filtrare per tag.\n\nCi sono anche altre opzioni se le desideri. E' per esempio possibile aggiungere collaboratori ad una nota, oppure pubblicare una nota su una pagina web.\n\nUsa Simplenote per Mac, per Android, oppure visita http:\/\/simplenote.com per accedere alle tue note da qualunque posto e da qualunque dispositivo.";
+/* Markdown Preview */
+"Preview" = "Visualizzare in anteprima";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "La disconnessione causerà l’eliminazione di tutte le note non sincronizzate. È possibile verificare le note sincronizzate accedendo all’app web.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Note non sincronizzate rilevate";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Tag...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Hai perso l’accesso a Simplenote? Puoi ottenerlo nuovamente reinstallando l’app e accedendo al tuo account.";
 

--- a/Simplenote/ja.lproj/Localizable.strings
+++ b/Simplenote/ja.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d単語";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "パスコード試行に%i回失敗";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "パスコードを%i回誤入力しました";
-
 /* Label of accept button on alert dialog */
 "Accept" = "承認";
 
@@ -30,53 +24,23 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "共同編集者を追加";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "タグ ...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "タグを追加";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "すでにアカウントを持ちですか ?";
-
-/* No comment provided by engineer. */
-"Back" = "戻る";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "登録すると、利用規約に合意したものとみなされます。»";
 
 /* No comment provided by engineer. */
 "Cancel" = "キャンセル";
 
-/* Verb - work with others on a note */
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborate" = "共同編集";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "ノートの共同編集を有効化";
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "共同編集者";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "確認";
-
-/* Ratings View: Contact */
-"Contact" = "連絡";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "不満がある";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "入力されたメールアドレスとパスワードではアカウントを作成できませんでした。";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "入力されたメールアドレスとパスワードではログインできませんでした。";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "改善方法についてご意見いただけますか ?";
+"collaborators-description" = "ノートを共同編集したい人のメールアドレスを入力してください。その人も編集できるようになります。";
 
 /* No comment provided by engineer. */
 "Create a new note" = "新規ノートを作成";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "現在の共同編集者";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "ダークテーマ";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "デバッグ";
-
-/* Permanent Delete */
-"Delete" = "削除";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "このノートは他のデバイスから削除されました。";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "キーボードを閉じる";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "アカウントが無い場合";
 
 /* No comment provided by engineer. */
 "Done" = "完了";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "ゴミ箱を空にする";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "パスコードを入力";
-
-/* Pin Lock */
-"Enter your passcode" = "パスコードを入力してください";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Simplenote にアクセスできなくなりましたか ?再びアクセスできるようにするには、アプリを再インストールしてアカウントにログインします。";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "インスタントサーチとシンプルなタグで、ノートをすばやく見つけることができます。";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "スタート";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "ありがとうございます。レビューを書いてもらえると、とても助かります。";
-
 /* Noun - the version history of a note */
 "History" = "履歴";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "以前のバージョンにノートを復元";
 
 /* Action - view the version history of a note */
 "History..." = "履歴…";
 
-/* No comment provided by engineer. */
-"How can we help?" = "どのようなサポートをお求めですか ?";
-
-/* No comment provided by engineer. */
-"I Like It" = "満足している";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "レビューを書く";
-
-/* Month and day date formatter */
-"MMM d" = "M月d日";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "M月d日 h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "yyyy年M月d日";
-
-/* Month and year date formatter */
-"MMM yyyy" = "yyyy年M月";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "メニュー";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "ノートのオプションを表示";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "ノートがありません";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "一致する結果がありません";
 
-/* No comment provided by engineer. */
-"No Thanks" = "いいえ";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "ノートを公開しました";
-
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
 
 /* Plural form of notes */
 "Notes" = "メモ";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "現在のノートを閉じる";
 
 /* No comment provided by engineer. */
 "Off" = "オフ";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "オン";
@@ -196,17 +108,8 @@
 /* Select a note to view in the note editor */
 "Open note" = "ノートを開く";
 
-/* A 4-digit code to lock the app when it is closed */
+/* Number of failed entries entering in passcode */
 "Passcode" = "パスコード";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "パスコードが一致しませんでした。もう一度お試しください。";
-
-/* Hint displayed in the password field */
-"Password" = "パスワード";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "パスワードは4文字以上にしてください。";
 
 /* Action to mark a note as pinned */
 "Pin note" = "ノートを上部固定";
@@ -223,16 +126,13 @@
 /* No comment provided by engineer. */
 "Preferences" = "設定";
 
-/* Markdown Preview */
-"Preview" = "プレビュー";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+/* Confirmation shown when a note is published */
 "Publish" = "公開";
 
 /* Failure message after attempting to publish a note */
 "Publish Failed" = "公開に失敗しました";
 
-/* Action which published a note to a web page */
+/* Confirmation shown when a note is published */
 "Publish note" = "ノートを公開";
 
 /* Switch which marks a note as published or unpublished */
@@ -244,14 +144,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "公開中";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "パスコードを再入力";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "ゴミ箱からノートを完全消去";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "タグを削除";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "ゴミ箱からノートを完全消去";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "タグを削除しますか ?";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "ノートを復元";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "セキュリティ";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "送信";
 
 /* No comment provided by engineer. */
-"Send Feedback" = "意見を送る";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "パスコードを設定";
-
-/* Title of options screen */
 "Settings" = "設定";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "リストを共有したり、指示を投稿したり、考えを公開したりしましょう。";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "現在のノートのコンテンツを共有";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "サイドバー";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "ログイン";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "ログアウト";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "登録";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "現在のノートにタグを追加";
 
-/* A short link to access the account login screen */
-"Sign in" = "ログイン";
-
-/* A short link to access the account creation screen */
-"Sign up" = "登録";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "ログアウトすると、同期されていないメモはすべて削除されます。同期したメモを確認するには、Web アプリにログインします。";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "ABC 順にノートを並べる";
-
-/* Message shown in first launch view */
-"Stay organized" = "ノートを整理";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "現在のノートからタグを削除";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "タグ: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "接続の際に問題が発生しました。もう一度お試しください。";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "今日";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "タグサイドバーを切り替え";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "現在のノートをゴミ箱へ移動";
 
-/* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "ゴミ箱";
+/* Remove all notes from the trash */
+"Trash-noun" = "ゴミ箱";
 
 /* Trash (verb) - the action of deleting a note */
-"Trash" = "ゴミ箱に移動";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "パスコードを無効化";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "%@ のブロックを解除";
+"Trash-verb" = "ゴミ箱に移動";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "固定表示を解除";
@@ -349,75 +210,207 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "非公開設定中…";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "同期されていないメモが検出されました";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "どこでも利用可能";
-
 /* Represents a snapshot in time for a note */
 "Version" = "バージョン";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Simplenote へようこそ";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "以前のバージョンにアクセスするにはインターネットに接続してください。";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Simplenote アプリに満足していますか ?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "このバージョンにスイッチ";
 
-/* Message shown in first launch view */
-"Work together" = "複数デバイス対応";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "バージョンを取得中";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "昨日";
 
-/* No comment provided by engineer. */
-"Your Email:" = "メールアドレス:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "パスコード試行に%i回失敗";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "パスコードを入力";
+
+/* Pin Lock */
+"Enter your passcode" = "パスコードを入力してください";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "パスコードが一致しませんでした。もう一度お試しください。";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "パスコードを再入力";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "パスコードを設定";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "パスコードを無効化";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "%@ のブロックを解除";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "パスコードを%i回誤入力しました";
+
+"welcomeNote-iOS" = "Simplenote for iOS へようこそ !
+
+ノートを新規作成するには、「＋」ボタンをタップしてください。
+
+一覧を使ってノートをブラウズできます。ノートの内容を表示するにはタイトルをタップしてください。次の画面で本文をタップすると編集できます。
+
+ノートを検索するには、ノート一覧の上に検索キーワードを入力してください。
+
+左上の矢印ボタンをタップするか、ノート一覧画面で左から右にスワイプするとタグを表示できます。タグを追加するには、エディタの一番下をタップして入力してください。
+
+ノートには他にもオプションがあります。共同編集者を追加したり、ノートを Web ページとして公開したりできます。
+
+http://simplenote.com で Mac・Android アプリやブラウザからのアクセス方法をご覧いただけます。ノートはすべてのデバイスで自動的に更新されます。";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "ABC 順にノートを並べる";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "すでにアカウントを持ちですか ?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "確認";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "入力されたメールアドレスとパスワードではアカウントを作成できませんでした。";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "入力されたメールアドレスとパスワードではログインできませんでした。";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "アカウントが無い場合";
+
+/* An error message */
+"Password" = "パスワード";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "パスワードは4文字以上にしてください。";
+
+/* Message displayed when login fails */
+"Sign in" = "ログイン";
+
+/* Message displayed when login fails */
+"Sign In" = "ログイン";
+
+/* TOS */
+"Sign up" = "登録";
+
+/* TOS */
+"Sign Up" = "登録";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "接続の際に問題が発生しました。もう一度お試しください。";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "無効なメールアドレスです。";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "インスタントサーチとシンプルなタグで、ノートをすばやく見つけることができます。";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "スタート";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "リストを共有したり、指示を投稿したり、考えを公開したりしましょう。";
+
+/* Message shown in first launch view */
+"Stay organized" = "ノートを整理";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "どこでも利用可能";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Simplenote へようこそ";
+
+/* Message shown in first launch view */
+"Work together" = "複数デバイス対応";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "各種デバイスで常にノートが同期されます。ボタンをクリックする必要もなく、同期は自動的に完了します。";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "ノートの共同編集を有効化";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "ダークテーマ";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "デバッグ";
+
+/* Month and day date formatter */
+"MMM d" = "M月d日";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "M月d日 h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "yyyy年M月d日";
+
+/* Month, day, and year date formatter */
+"MMM yyyy" = "yyyy年M月";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "セキュリティ";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "登録すると、利用規約に合意したものとみなされます。»";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Simplenote アプリに満足していますか ?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "ノートを共同編集したい人のメールアドレスを入力してください。その人も編集できるようになります。";
+"I Like It" = "満足している";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "このノートは他のデバイスから削除されました。";
+/* No comment provided by engineer. */
+"Could Be Better" = "不満がある";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "以前のバージョンにノートを復元";
+/* Ratings View: Like */
+"Great! Could you leave us a nice review?
+It really helps." = "ありがとうございます。レビューを書いてもらえると、とても助かります。";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "ノートのオプションを表示";
+/* No comment provided by engineer. */
+"Leave a Review" = "レビューを書く";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "現在のノートを閉じる";
+/* No comment provided by engineer. */
+"No Thanks" = "いいえ";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "現在のノートのコンテンツを共有";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "改善方法についてご意見いただけますか ?";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "現在のノートにタグを追加";
+/* No comment provided by engineer. */
+"Send Feedback" = "意見を送る";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "現在のノートからタグを削除";
+/* Ratings View: Contact */
+"Contact" = "連絡";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "現在のノートをゴミ箱へ移動";
+/* No comment provided by engineer. */
+"Your Email:" = "メールアドレス:";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "以前のバージョンにアクセスするにはインターネットに接続してください。";
+/* No comment provided by engineer. */
+"How can we help?" = "どのようなサポートをお求めですか ?";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "このバージョンにスイッチ";
+/* No comment provided by engineer. */
+"Back" = "戻る";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "バージョンを取得中";
+/* Permanent Delete */
+"Delete" = "削除";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Simplenote for iOS へようこそ !\n\nノートを新規作成するには、「＋」ボタンをタップしてください。\n\n一覧を使ってノートをブラウズできます。ノートの内容を表示するにはタイトルをタップしてください。次の画面で本文をタップすると編集できます。\n\nノートを検索するには、ノート一覧の上に検索キーワードを入力してください。\n\n左上の矢印ボタンをタップするか、ノート一覧画面で左から右にスワイプするとタグを表示できます。タグを追加するには、エディタの一番下をタップして入力してください。\n\nノートには他にもオプションがあります。共同編集者を追加したり、ノートを Web ページとして公開したりできます。\n\nhttp:\/\/simplenote.com で Mac・Android アプリやブラウザからのアクセス方法をご覧いただけます。ノートはすべてのデバイスで自動的に更新されます。";
+/* Markdown Preview */
+"Preview" = "プレビュー";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "ログアウトすると、同期されていないメモはすべて削除されます。同期したメモを確認するには、Web アプリにログインします。";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "同期されていないメモが検出されました";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "タグ ...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Simplenote にアクセスできなくなりましたか ?再びアクセスできるようにするには、アプリを再インストールしてアカウントにログインします。";
 

--- a/Simplenote/ko.lproj/Localizable.strings
+++ b/Simplenote/ko.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "단어 %d개";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "실패한 패스코드 시도 %i번";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "실패한 패스코드 시도 %i번";
-
 /* Label of accept button on alert dialog */
 "Accept" = "수락";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "새 공동 작업자 추가...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "태그...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "태그 추가";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "이미 계정이 있으세요?";
-
-/* No comment provided by engineer. */
-"Back" = "뒤로";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "가입하려면 서비스 약관에 동의해야 합니다. »";
 
 /* No comment provided by engineer. */
 "Cancel" = "취소";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "협업";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "다른 사람과 협업할 수 있습니다.";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "공동 작업자";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "확인";
-
-/* Ratings View: Contact */
-"Contact" = "문의";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "별로";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "입력하신 이메일 주소와 비밀번호로 계정을 만들지 못했습니다.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "입력하신 이메일 주소와 비밀번호로 로그인하지 못했습니다.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "개선 방안을 말해 주시겠어요?";
+"collaborators-description" = "이 메모를 다른 사람과 공유하려면 이메일 주소를 추가하세요. 그러면 두 사람 모두 메모를 수정할 수 있습니다.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "새 메모 만들기";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "현재 공동 작업자";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "어두운 테마";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "디버그";
-
-/* Permanent Delete */
-"Delete" = "삭제";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "이 메모는 다른 장치에서 삭제됐습니다.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "키보드 비활성화";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "아직 계정이 없으세요?";
 
 /* No comment provided by engineer. */
 "Done" = "완료";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "휴지통 비우기";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "패스코드 입력";
-
-/* Pin Lock */
-"Enter your passcode" = "패스코드 입력";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Simplenote에 대한 액세스 권한을 잃어버리셨나요? 앱을 다시 설치하고 계정에 로그인하여 액세스 권한을 다시 얻을 수 있습니다.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "빠른 검색과 간편한 태그로 메모를 바로 찾을 수 있습니다.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "시작하기";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\\n\\n\\n많은 도움이 될 겁니다.";
-
 /* Noun - the version history of a note */
 "History" = "내역";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "이전 버전에 메모 복원";
 
 /* Action - view the version history of a note */
 "History..." = "내역...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "어떻게 도와드릴까요?";
-
-/* No comment provided by engineer. */
-"I Like It" = "좋아요";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "리뷰를 남겨주세요.";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "yyyy MMM d";
-
-/* Month and year date formatter */
-"MMM yyyy" = "yyyy MMM";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "메뉴";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "메모 옵션 표시";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "메모 없음";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "결과 없음";
 
-/* No comment provided by engineer. */
-"No Thanks" = "괜찮습니다.";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "메모 게시됨";
 
 /* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
 "Notes" = "메모";
 
-/* No comment provided by engineer. */
-"OK" = "확인";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "현재 메모 닫기";
 
 /* No comment provided by engineer. */
 "Off" = "끔";
+
+/* Hint displayed in the password confirmation field */
+"OK" = "확인";
 
 /* No comment provided by engineer. */
 "On" = "켬";
@@ -196,17 +108,8 @@
 /* Select a note to view in the note editor */
 "Open note" = "메모 열기";
 
-/* A 4-digit code to lock the app when it is closed */
+/* Number of failed entries entering in passcode */
 "Passcode" = "패스코드";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "패스코드가 일치하지 않습니다. 다시 시도해 주세요.";
-
-/* Hint displayed in the password field */
-"Password" = "비밀번호";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "비밀번호에는 최소 4개의 문자가 포함되어야 합니다.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "메모 고정";
@@ -223,35 +126,29 @@
 /* No comment provided by engineer. */
 "Preferences" = "기본 설정";
 
-/* Markdown Preview */
-"Preview" = "미리보기";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+/* Confirmation shown when a note is published */
 "Publish" = "게시";
 
 /* Failure message after attempting to publish a note */
 "Publish Failed" = "게시 실패";
 
-/* Action which published a note to a web page */
+/* Confirmation shown when a note is published */
 "Publish note" = "메모 게시";
 
 /* Switch which marks a note as published or unpublished */
 "Publish toggle" = "게시 상태 전환";
 
-/* No comment provided by engineer. */
+/* Confirmation shown when a note is published */
 "Published" = "게시됨";
 
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "게시 중...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "패스코드 다시 입력";
+/* Remove all notes from the trash */
+"Remove all notes from trash" = "휴지통 비우기";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "태그 제거";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "휴지통 비우기";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "태그를 제거할까요?";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "메모 복구";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "보안";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "보내기";
 
 /* No comment provided by engineer. */
-"Send Feedback" = "의견 보내기";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "패스코드 설정";
-
-/* Title of options screen */
 "Settings" = "설정";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "목록을 공유하거나 지침을 게시하거나 본인의 생각을 게시할 수 있습니다.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "현재 메모 내용 공유";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "사이드바";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "로그인";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "로그아웃";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "가입";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "현재 메모에 태그 추가";
 
-/* A short link to access the account login screen */
-"Sign in" = "로그인";
-
-/* A short link to access the account creation screen */
-"Sign up" = "가입";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "로그아웃하면 동기화되지 않은 모든 메모가 삭제됩니다. 웹 앱에 로그인하여 동기화된 메모를 확인할 수 있습니다.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "알파벳순으로 메모 정렬";
-
-/* Message shown in first launch view */
-"Stay organized" = "효율적으로 정리하기";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "현재 메모에서 태그 제거";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "태그: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "연결하는 데 문제가 있습니다. 나중에 다시 시도해 주세요.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "오늘";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "태그 사이드바 토글";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "휴지통으로 현재 메모 이동";
 
-/* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "휴지통";
+/* Remove all notes from the trash */
+"Trash-noun" = "휴지통";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "휴지통";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "패스코드 사용 끄기";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "%@ 잠금해제";
+/* Remove all notes from the trash */
+"Trash-verb" = "휴지통";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "메모 고정 취소";
@@ -349,75 +210,206 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "게시 취소 중...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "동기화되지 않은 메모 감지됨";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "어디서나 사용 가능";
-
 /* Represents a snapshot in time for a note */
 "Version" = "버전";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Simplenote 시작하기";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "이전 버전을 사용하려면 인터넷에 연결해야 합니다.";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Simplenote를 어떻게 생각하시나요?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "이 버전으로 전환";
 
-/* Message shown in first launch view */
-"Work together" = "협업 실현";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "버전 패치";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "어제";
 
-/* No comment provided by engineer. */
-"Your Email:" = "귀하의 이메일:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "실패한 패스코드 시도 %i번";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "패스코드 입력";
+
+/* Message shown on passcode lock screen */
+"Enter your passcode" = "패스코드 입력";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "패스코드가 일치하지 않습니다. 다시 시도해 주세요.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "패스코드 다시 입력";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "패스코드 설정";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "패스코드 사용 끄기";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "%@ 잠금해제";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "실패한 패스코드 시도 %i번";
+
+"welcomeNote-iOS" = "iOS용 Simplenote 시작하기
+
+메모를 추가하려면 더하기 버튼을 누르세요.
+
+메모를 탐색하려면 목록을 누르세요 메모를 보려면 제목을 누르고 메모를 수정하려면 메모 내용을 누르세요.
+
+메모 목록 상단의 검색 필드에 검색어를 입력해서 모든 메모를 검색할 수 있습니다.
+
+태그를 보려면 왼쪽 상단의 화살표 버튼을 누르거나 메모 목록을 옆으로 쓸어 넘기세요. 메모 에디터 하단에서 메모에 태그를 추가하고 사이드바를 사용해서 메모를 정리할 수 있습니다.
+
+필요한 경우 더욱 다양한 메모 옵션을 사용할 수 있습니다. 다른 사용자를 메모 공유자로 추가하거나 메모를 웹 페이지로 게시할 수 있습니다.
+
+Mac, Android 장치나 웹 브라우저(http://simplenote.com)에서 Simplenote를 사용할 수 있습니다. 어디에 있든 메모 내용이 자동으로 업데이트됩니다.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "알파벳순으로 메모 정렬";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "이미 계정이 있으세요?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "확인";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "입력하신 이메일 주소와 비밀번호로 계정을 만들지 못했습니다.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "입력하신 이메일 주소와 비밀번호로 로그인하지 못했습니다.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "아직 계정이 없으세요?";
+
+/* An error message */
+"Password" = "비밀번호";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "비밀번호에는 최소 4개의 문자가 포함되어야 합니다.";
+
+/* Message displayed when login fails */
+"Sign in" = "로그인";
+
+/* Message displayed when login fails */
+"Sign In" = "로그인";
+
+/* TOS */
+"Sign up" = "가입";
+
+/* TOS */
+"Sign Up" = "가입";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "연결하는 데 문제가 있습니다. 나중에 다시 시도해 주세요.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "이메일 주소가 올바르지 않습니다.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "빠른 검색과 간편한 태그로 메모를 바로 찾을 수 있습니다.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "시작하기";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "목록을 공유하거나 지침을 게시하거나 본인의 생각을 게시할 수 있습니다.";
+
+/* Message shown in first launch view */
+"Stay organized" = "효율적으로 정리하기";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "어디서나 사용 가능";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Simplenote 시작하기";
+
+/* Message shown in first launch view */
+"Work together" = "협업 실현";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "모든 장치에서 메모 내용을 최신으로 유지할 수 있습니다. 버튼을 누를 필요도 없습니다. 자동으로 업데이트됩니다.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "다른 사람과 협업할 수 있습니다.";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "어두운 테마";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "디버그";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "yyyy MMM d";
+
+/* Month, day, and year date formatter */
+"MMM yyyy" = "yyyy MMM";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "보안";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "가입하려면 서비스 약관에 동의해야 합니다. »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Simplenote를 어떻게 생각하시나요?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "이 메모를 다른 사람과 공유하려면 이메일 주소를 추가하세요. 그러면 두 사람 모두 메모를 수정할 수 있습니다.";
+"I Like It" = "좋아요";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "이 메모는 다른 장치에서 삭제됐습니다.";
+/* No comment provided by engineer. */
+"Could Be Better" = "별로";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "이전 버전에 메모 복원";
+"Great! Could you leave us a nice review?
+It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\n\n많은 도움이 될 겁니다.";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "메모 옵션 표시";
+/* No comment provided by engineer. */
+"Leave a Review" = "리뷰를 남겨주세요.";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "현재 메모 닫기";
+/* No comment provided by engineer. */
+"No Thanks" = "괜찮습니다.";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "현재 메모 내용 공유";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "개선 방안을 말해 주시겠어요?";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "현재 메모에 태그 추가";
+/* No comment provided by engineer. */
+"Send Feedback" = "의견 보내기";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "현재 메모에서 태그 제거";
+/* Ratings View: Contact */
+"Contact" = "문의";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "휴지통으로 현재 메모 이동";
+/* No comment provided by engineer. */
+"Your Email:" = "귀하의 이메일:";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "이전 버전을 사용하려면 인터넷에 연결해야 합니다.";
+/* No comment provided by engineer. */
+"How can we help?" = "어떻게 도와드릴까요?";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "이 버전으로 전환";
+/* No comment provided by engineer. */
+"Back" = "뒤로";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "버전 패치";
+/* Permanent Delete */
+"Delete" = "삭제";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "iOS용 Simplenote 시작하기\n\n메모를 추가하려면 더하기 버튼을 누르세요.\n\n메모를 탐색하려면 목록을 누르세요 메모를 보려면 제목을 누르고 메모를 수정하려면 메모 내용을 누르세요.\n\n메모 목록 상단의 검색 필드에 검색어를 입력해서 모든 메모를 검색할 수 있습니다.\n\n태그를 보려면 왼쪽 상단의 화살표 버튼을 누르거나 메모 목록을 옆으로 쓸어 넘기세요. 메모 에디터 하단에서 메모에 태그를 추가하고 사이드바를 사용해서 메모를 정리할 수 있습니다.\n\n필요한 경우 더욱 다양한 메모 옵션을 사용할 수 있습니다. 다른 사용자를 메모 공유자로 추가하거나 메모를 웹 페이지로 게시할 수 있습니다.\n\nMac, Android 장치나 웹 브라우저(http:\/\/simplenote.com)에서 Simplenote를 사용할 수 있습니다. 어디에 있든 메모 내용이 자동으로 업데이트됩니다.";
+/* Markdown Preview */
+"Preview" = "미리보기";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "로그아웃하면 동기화되지 않은 모든 메모가 삭제됩니다. 웹 앱에 로그인하여 동기화된 메모를 확인할 수 있습니다.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "동기화되지 않은 메모 감지됨";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "태그...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Simplenote에 대한 액세스 권한을 잃어버리셨나요? 앱을 다시 설치하고 계정에 로그인하여 액세스 권한을 다시 얻을 수 있습니다.";
 

--- a/Simplenote/nl.lproj/Localizable.strings
+++ b/Simplenote/nl.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d woorden";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i mislukte wachtwoordcodepoging";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i mislukte wachtwoordcodepogingen";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Accepteren";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Een nieuwe samenwerker toevoegen...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Tag...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Tag toevoegen";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Heb je al een account?";
-
-/* No comment provided by engineer. */
-"Back" = "Terug";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Als je je registreert, ga je akkoord met onze Terms of Service »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Annuleren";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Samenwerken";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Samenwerking met anderen inschakelen";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Samenwerkers";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Bevestigen";
-
-/* Ratings View: Contact */
-"Contact" = "Contact";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "Kan beter";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Kan geen account maken met het opgegeven e-mailadres en wachtwoord.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Kan niet inloggen met het opgegeven e-mailadres en wachtwoord.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Kun je ons vertellen wat we kunnen verbeteren?";
+"collaborators-description" = "Voeg een e-mailadres toe om deze notitie met iemand te delen. Dan kunnen jullie hem beide wijzigen.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Een nieuwe notitie maken";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Huidige samenwerkers";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Donker thema";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Debug";
-
-/* Permanent Delete */
-"Delete" = "Verwijderen";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Deze notitie is verwijderd op een ander apparaat.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Toetsenbord sluiten";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Heb je nog geen account?";
 
 /* No comment provided by engineer. */
 "Done" = "Klaar";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Prullenbak leegmaken";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Voer een wachtwoordcode in";
-
-/* Pin Lock */
-"Enter your passcode" = "Voer je wachtwoordcode in";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Heb je geen toegang meer tot Simplenote? Je kunt weer toegang krijgen door de app opnieuw te installeren en in te loggen op je account.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Vind notities snel terug met instant search en simple tags.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Aan de slag";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "";
-
 /* Noun - the version history of a note */
 "History" = "Geschiedenis";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Notitie herstellen naar eerdere versie";
 
 /* Action - view the version history of a note */
 "History..." = "Geschiedenis...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Hoe kunnen we helpen?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Ik vind het leuk";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Laat een beoordeling achter";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, u:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM jjjj";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM jjjj";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Menu";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Opties tonen voor notitie";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Geen notities";
@@ -172,25 +87,22 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Geen resultaten";
 
-/* No comment provided by engineer. */
-"No Thanks" = "Nee, liever niet";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "Notitie gepubliceerd";
-
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
 
 /* Plural form of notes */
 "Notes" = "Notities";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Huidige notitie sluiten";
 
 /* No comment provided by engineer. */
 "Off" = "Uit";
 
 /* No comment provided by engineer. */
+"OK" = "OK";
+
+/* Button label shown on first launch screen to start the log in process */
 "On" = "Aan";
 
 /* Select a note to view in the note editor */
@@ -198,15 +110,6 @@
 
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Wachtwoordcode";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Wachtwoordcodes komen niet overeen. Probeer het opnieuw.";
-
-/* Hint displayed in the password field */
-"Password" = "Wachtwoord";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Wachtwoord moet ten minste 4 tekens bevatten.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Notitie vastmaken";
@@ -222,9 +125,6 @@
 
 /* No comment provided by engineer. */
 "Preferences" = "Voorkeuren";
-
-/* Markdown Preview */
-"Preview" = "Voorbeeld bekijken";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Publiceren";
@@ -244,14 +144,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Publiceren...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Voer een wachtwoordpasscode opnieuw in";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Alle notities verwijderen uit prullenbak";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Tag verwijderen";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Alle notities verwijderen uit prullenbak";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Tag verwijderen?";
@@ -265,80 +162,43 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Notitie herstellen";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Beveiliging";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Verzenden";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Stuur feedback";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Wachtwoordcode instellen";
 
 /* Title of options screen */
 "Settings" = "Instellingen";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Deel een lijst, plaats instructies of publiceer je gedachten.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "De inhoud van de huidige notitie delen";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Sidebar";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Aanmelden";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Afmelden";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Registreren";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Een tag toevoegen aan de huidige notitie";
 
-/* A short link to access the account login screen */
-"Sign in" = "Aanmelden";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Registreren";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Door je af te melden worden gesynchroniseerde notities verwijderd. Je kunt je gesynchroniseerde notities verifiëren door je aan te melden via de web-app.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Notities alfabetisch sorteren";
-
-/* Message shown in first launch view */
-"Stay organized" = "Houd het overzicht";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Tag verwijderen uit de huidige notitie";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Tag: %@";
 
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Er is een probleem met de verbinding.  Probeer het later opnieuw.";
-
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Vandaag";
 
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Tag-sidebar tonen\/verbergen";
+"Toggle tag sidebar" = "Tag-sidebar tonen/verbergen";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "De huidige notitie verplaatsen naar de prullenbak";
 
-/* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Prullenbak";
+/* Remove all notes from the trash */
+"Trash-noun" = "Prullenbak";
 
 /* Trash (verb) - the action of deleting a note */
-"Trash" = "Naar prullenbak";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Wachtwoordcode uitschakelen";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "%@ ontgrendelen";
+"Trash-verb" = "Naar prullenbak";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Notitie losmaken";
@@ -349,75 +209,203 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Verwijderen ...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Ongesynchroniseerde notities gedetecteerd";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Gebruik het overal";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Versie";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Welkom bij Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Maak verbinding met internet voor toegang tot eerdere versies";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Wat vind je van Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Overschakelen naar deze versie";
 
-/* Message shown in first launch view */
-"Work together" = "Werk samen";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Versie ophalen";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Gisteren";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Je e-mailadres:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i mislukte wachtwoordcodepoging";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Voer een wachtwoordcode in";
+
+/* Pin Lock */
+"Enter your passcode" = "Voer je wachtwoordcode in";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Wachtwoordcodes komen niet overeen. Probeer het opnieuw.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Voer een wachtwoordpasscode opnieuw in";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Wachtwoordcode instellen";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Wachtwoordcode uitschakelen";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "%@ ontgrendelen";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i mislukte wachtwoordcodepogingen";
+
+"welcomeNote-iOS" = "Welkom bij Simplenote voor iOS!
+
+Om een notitie toe te voegen, tik je op de plusknop.
+
+Veeg door de lijst om te bladeren in je notities. Tik op een titel om een notitie te bekijken en tik dan op de inhoud om hem te wijzigen.
+
+Je kunt in al je notities zoeken door te typen in het zoekveld boven aan de notitielijst.
+
+Tik op de pijlknop linksboven of veeg over je notitielijst om je tags te bekijken. Je kunt tags toevoegen aan een notitie onder aan de notitie-editor en vervolgens de sidebar gebruiken om overzicht te houden.
+
+Desgewenst zijn er nog meer notitie-opties. Je kunt anderen toevoegen aan een notitie als samenwerker of een notitie publiceren als webpagina.
+
+Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://simplenote.com. Je notities worden overal automatisch bijgewerkt.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Notities alfabetisch sorteren";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Heb je al een account?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Bevestigen";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Kan geen account maken met het opgegeven e-mailadres en wachtwoord.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Kan niet inloggen met het opgegeven e-mailadres en wachtwoord.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Heb je nog geen account?";
+
+/* A 4-digit code to lock the app when it is closed */
+"Password" = "Wachtwoord";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Wachtwoord moet ten minste 4 tekens bevatten.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Aanmelden";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Aanmelden";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Registreren";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Registreren";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Er is een probleem met de verbinding.  Probeer het later opnieuw.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Je e-mailadres is niet geldig.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Vind notities snel terug met instant search en simple tags.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Aan de slag";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Deel een lijst, plaats instructies of publiceer je gedachten.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Houd het overzicht";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Gebruik het overal";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Welkom bij Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Werk samen";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Je notities blijven bijgewerkt op al je apparaten. Je hoeft geen knoppen in te drukken. Het gaat allemaal vanzelf.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Samenwerking met anderen inschakelen";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Donker thema";
+
+
+"Debug" = "Debug";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, u:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM jjjj";
+
+/* Month, day, and year date formatter */
+"MMM yyyy" = "MMM jjjj";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Beveiliging";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Als je je registreert, ga je akkoord met onze Terms of Service »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Wat vind je van Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Voeg een e-mailadres toe om deze notitie met iemand te delen. Dan kunnen jullie hem beide wijzigen.";
+"I Like It" = "Ik vind het leuk";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Deze notitie is verwijderd op een ander apparaat.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Kan beter";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Notitie herstellen naar eerdere versie";
+/* No comment provided by engineer. */
+"Leave a Review" = "Laat een beoordeling achter";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Opties tonen voor notitie";
+/* No comment provided by engineer. */
+"No Thanks" = "Nee, liever niet";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Huidige notitie sluiten";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Kun je ons vertellen wat we kunnen verbeteren?";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "De inhoud van de huidige notitie delen";
+/* No comment provided by engineer. */
+"Send Feedback" = "Stuur feedback";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Een tag toevoegen aan de huidige notitie";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Tag verwijderen uit de huidige notitie";
+"Contact" = "Contact";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "De huidige notitie verplaatsen naar de prullenbak";
+/* No comment provided by engineer. */
+"Your Email:" = "Je e-mailadres:";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Maak verbinding met internet voor toegang tot eerdere versies";
+/* No comment provided by engineer. */
+"How can we help?" = "Hoe kunnen we helpen?";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Overschakelen naar deze versie";
+/* No comment provided by engineer. */
+"Back" = "Terug";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Versie ophalen";
+/* Permanent Delete */
+"Delete" = "Verwijderen";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Welkom bij Simplenote voor iOS!\n\nOm een notitie toe te voegen, tik je op de plusknop.\n\nVeeg door de lijst om te bladeren in je notities. Tik op een titel om een notitie te bekijken en tik dan op de inhoud om hem te wijzigen.\n\nJe kunt in al je notities zoeken door te typen in het zoekveld boven aan de notitielijst.\n\nTik op de pijlknop linksboven of veeg over je notitielijst om je tags te bekijken. Je kunt tags toevoegen aan een notitie onder aan de notitie-editor en vervolgens de sidebar gebruiken om overzicht te houden.\n\nDesgewenst zijn er nog meer notitie-opties. Je kunt anderen toevoegen aan een notitie als samenwerker of een notitie publiceren als webpagina.\n\nGebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http:\/\/simplenote.com. Je notities worden overal automatisch bijgewerkt.";
+/* Markdown Preview */
+"Preview" = "Voorbeeld bekijken";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Door je af te melden worden gesynchroniseerde notities verwijderd. Je kunt je gesynchroniseerde notities verifiëren door je aan te melden via de web-app.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Ongesynchroniseerde notities gedetecteerd";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Tag...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Heb je geen toegang meer tot Simplenote? Je kunt weer toegang krijgen door de app opnieuw te installeren en in te loggen op je account.";
 

--- a/Simplenote/pt-BR.lproj/Localizable.strings
+++ b/Simplenote/pt-BR.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d palavras";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i tentativa de senha com falha";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i tentativas de senha com falha";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Aceitar";
 
@@ -30,23 +24,11 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Adicionar novo colaborador";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "tag...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Adicionar tag";
 
 /* Title of option to display all notes */
 "All Notes" = "Todas as anotações";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Já tem uma conta?";
-
-/* No comment provided by engineer. */
-"Back" = "Voltar";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Ao se registrar, você concorda com os nossos Termos de Serviço »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Cancelar";
@@ -54,29 +36,17 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Colaborar";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Habilitar outros a colaborar";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Colaboradores";
 
+/* No comment provided by engineer. */
+"collaborators-description" = "Adicione um endereço de email para compartilhar esta anotação com alguém. Em seguida, ambos poderão fazer alterações.";
+
 /* Option to make the note list show only 1 line of text. The default is 3. */
 "Condensed Note List" = "Lista condensada de anotações";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Confirmar";
-
-/* Ratings View: Contact */
-"Contact" = "Contato";
-
-/* No comment provided by engineer. */
-"Could Be Better" = "Poderia ser melhor";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Não foi possível criar uma conta com o endereço de email e senha fornecidos.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Não foi possível fazer login com o endereço de email e senha fornecidos.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Poderia nos dizer o que podemos fazer para melhorar?";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Criar uma nova anotação";
@@ -84,20 +54,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Colaboradores atuais";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Tema Escuro";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Depurar";
-
-/* Permanent Delete */
-"Delete" = "Excluir";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Esta anotação foi excluída em outro dispositivo.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Dispensar teclado";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Não tem uma conta?";
 
 /* No comment provided by engineer. */
 "Done" = "Concluído";
@@ -111,57 +72,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Esvaziar a lixeira";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Insira uma senha";
-
-/* Pin Lock */
-"Enter your passcode" = "Insira sua senha";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Perdeu o acesso ao Simplenote? Você pode recuperá-lo ao reinstalar o aplicativo e entrar na sua conta.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Localize rapidamente suas anotações com busca instantânea e tags simplificadas.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Esqueceu sua senha? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Começar";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "Legal! Que tal deixar suas impressoes sobre o aplicativo?\n\nIsso realmente ajudará!";
-
 /* Noun - the version history of a note */
 "History" = "Histórico";
 
-/* Action - view the version history of a note */
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Restaurar anotação para versão anterior";
+
+/* Noun - the version history of a note */
 "History..." = "Histórico";
-
-/* No comment provided by engineer. */
-"How can we help?" = "Como podemos ajudar?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Curti";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Faça uma avaliação";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
 
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Menu";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Mostrar opções para anotação";
 
 /* Label to create a new note */
 "New note" = "Nova anotação";
@@ -173,22 +97,22 @@
 "No Results" = "Nenhum resultado";
 
 /* No comment provided by engineer. */
-"No Thanks" = "Não, obrigado!";
+"Note not published" = "Anotação não publicada";
 
 /* Confirmation shown when a note is published */
 "Note Published" = "Anotação publicada";
 
-/* No comment provided by engineer. */
-"Note not published" = "Anotação não publicada";
-
 /* Plural form of notes */
 "Notes" = "Anotações";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Fechar anotação atual";
 
 /* No comment provided by engineer. */
 "Off" = "Desativado";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "Ativado";
@@ -198,15 +122,6 @@
 
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Senha";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "As senhas não corresponderam. Tente novamente.";
-
-/* Hint displayed in the password field */
-"Password" = "Senha";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "A senha deve ter 4 caracteres no mínimo.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Marcar anotação";
@@ -222,9 +137,6 @@
 
 /* No comment provided by engineer. */
 "Preferences" = "Preferências";
-
-/* Markdown Preview */
-"Preview" = "Visualizar";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Publicar";
@@ -244,14 +156,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Publicando...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Insira novamente uma senha";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Remover todas as anotações da lixeira";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Remover tag";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Remover todas as anotações da lixeira";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Remover tag?";
@@ -265,59 +174,32 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Restaurar anotação";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Segurança";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Enviar";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Enviar feedback";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Definir senha";
 
 /* Title of options screen */
 "Settings" = "Configurações";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Compartilhe listas, descreva instruções ou publique seus pensamentos.";
-
 /* No comment provided by engineer. */
 "Share note" = "Compartilhar anotação";
+
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Compartilhar o conteúdo da anotação atual";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Barra lateral";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Fazer login";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Sair";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Registrar-se";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Adicionar uma tag à anotação atual";
 
-/* A short link to access the account login screen */
-"Sign in" = "Fazer login";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Registrar-se";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Sair resultará na exclusão de quaisquer anotações não sincronizadas. Para verificar suas anotações sincronizadas, entre no Aplicativo para Web.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Exibir em ordem alfabética";
-
-/* Message shown in first launch view */
-"Stay organized" = "Organize-se";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Remover tag da anotação atual";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Tag: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Há um problema com a conexão.  Tente novamente mais tarde.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Hoje";
@@ -325,20 +207,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Exibir a barra lateral de tags";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Identificação por toque";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Mover a anotação atual para a lixeira";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Lixeira";
+"Trash-noun" = "Lixeira";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Lixeira";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Desativar senha";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Desbloquear %@";
+/* Trash (noun) - the location where deleted notes are stored */
+"Trash-verb" = "Lixeira";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Desmarcar anotação";
@@ -349,75 +225,211 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Cancelando publicação...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Anotações não sincronizadas detectadas";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Use em qualquer lugar";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Versão";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Bem-vindo ao Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Conecte-se à Internet para acessar as versões anteriores";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "O que você acha do Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Alternar para essa versão";
 
-/* Message shown in first launch view */
-"Work together" = "Trabalhe de forma integrada";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Obtendo a versão";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Ontem";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Seu email:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i tentativa de senha com falha";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Insira uma senha";
+
+/* Pin Lock */
+"Enter your passcode" = "Insira sua senha";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "As senhas não corresponderam. Tente novamente.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Insira novamente uma senha";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Definir senha";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Desativar senha";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Desbloquear %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i tentativas de senha com falha";
+
+"welcomeNote-iOS" = "Bem-vindo ao Simplenote para iOS!
+
+Para adicionar uma anotação, toque no botão de adição.
+
+Mexa na lista para procurar suas anotações. Toque em um título para visualizar uma anotação e no conteúdo para alterá-lo.
+
+Você pode pesquisar todas as suas anotações tocando no campo de pesquisa no topo da lista de anotações.
+
+Toque no botão de seta na parte superior à esquerda ou deslize os dedos pela lista de anotações para visualizar suas tags. Você pode adicionar tags a uma anotação na parte inferior do editor de anotações e usar a barra lateral para ajudá-lo com a organização.
+
+Há mais opções de anotação, se necessário. Você pode adicionar outras pessoas como colaboradores a uma anotação ou publicá-la como uma página na web.
+
+Use o Simplenote no seu dispositivo Mac, Android ou no navegador em http://simplenote.com. Suas anotações serão atualizadas automaticamente em qualquer lugar.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Exibir em ordem alfabética";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Já tem uma conta?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Confirmar";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Não foi possível criar uma conta com o endereço de email e senha fornecidos.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Não foi possível fazer login com o endereço de email e senha fornecidos.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Não tem uma conta?";
+
+/* A 4-digit code to lock the app when it is closed */
+"Password" = "Senha";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "A senha deve ter 4 caracteres no mínimo.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Fazer login";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Fazer login";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Registrar-se";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Registrar-se";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Há um problema com a conexão.  Tente novamente mais tarde.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Seu endereço de email é inválido.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Localize rapidamente suas anotações com busca instantânea e tags simplificadas.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Começar";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Compartilhe listas, descreva instruções ou publique seus pensamentos.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Organize-se";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Use em qualquer lugar";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Bem-vindo ao Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Trabalhe de forma integrada";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Suas anotações são atualizadas automaticamente em todos os dispositivos. Sem apertar nenhum botão. Simples assim.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Habilitar outros a colaborar";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Tema Escuro";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "Depurar";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Identificação por toque";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Segurança";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Ao se registrar, você concorda com os nossos Termos de Serviço »";
+
+/* Forgot Password */
+"Forgot password? »" = "Esqueceu sua senha? »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "O que você acha do Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Adicione um endereço de email para compartilhar esta anotação com alguém. Em seguida, ambos poderão fazer alterações.";
+"I Like It" = "Curti";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Esta anotação foi excluída em outro dispositivo.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Poderia ser melhor";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Restaurar anotação para versão anterior";
+"Great! Could you leave us a nice review?
+It really helps." = "Legal! Que tal deixar suas impressoes sobre o aplicativo?
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Mostrar opções para anotação";
+Isso realmente ajudará!";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Fechar anotação atual";
+/* No comment provided by engineer. */
+"Leave a Review" = "Faça uma avaliação";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Compartilhar o conteúdo da anotação atual";
+/* No comment provided by engineer. */
+"No Thanks" = "Não, obrigado!";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Adicionar uma tag à anotação atual";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Poderia nos dizer o que podemos fazer para melhorar?";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Remover tag da anotação atual";
+/* No comment provided by engineer. */
+"Send Feedback" = "Enviar feedback";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Mover a anotação atual para a lixeira";
+/* Ratings View: Contact */
+"Contact" = "Contato";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Conecte-se à Internet para acessar as versões anteriores";
+/* No comment provided by engineer. */
+"Your Email:" = "Seu email:";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Alternar para essa versão";
+/* No comment provided by engineer. */
+"How can we help?" = "Como podemos ajudar?";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Obtendo a versão";
+/* No comment provided by engineer. */
+"Back" = "Voltar";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Bem-vindo ao Simplenote para iOS!\n\nPara adicionar uma anotação, toque no botão de adição.\n\nMexa na lista para procurar suas anotações. Toque em um título para visualizar uma anotação e no conteúdo para alterá-lo.\n\nVocê pode pesquisar todas as suas anotações tocando no campo de pesquisa no topo da lista de anotações.\n\nToque no botão de seta na parte superior à esquerda ou deslize os dedos pela lista de anotações para visualizar suas tags. Você pode adicionar tags a uma anotação na parte inferior do editor de anotações e usar a barra lateral para ajudá-lo com a organização.\n\nHá mais opções de anotação, se necessário. Você pode adicionar outras pessoas como colaboradores a uma anotação ou publicá-la como uma página na web.\n\nUse o Simplenote no seu dispositivo Mac, Android ou no navegador em http:\/\/simplenote.com. Suas anotações serão atualizadas automaticamente em qualquer lugar.";
+/* Permanent Delete */
+"Delete" = "Excluir";
+
+/* Markdown Preview */
+"Preview" = "Visualizar";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Sair resultará na exclusão de quaisquer anotações não sincronizadas. Para verificar suas anotações sincronizadas, entre no Aplicativo para Web.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Anotações não sincronizadas detectadas";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "tag...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Perdeu o acesso ao Simplenote? Você pode recuperá-lo ao reinstalar o aplicativo e entrar na sua conta.";
 

--- a/Simplenote/ru.lproj/Localizable.strings
+++ b/Simplenote/ru.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d слов";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i неудачная попытка ввода кода доступа";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "Неудачные попытки ввода кода доступа: %i";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Согласен";
 
@@ -30,23 +24,11 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Добавить нового партнера";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Метка...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Добавить тег";
 
 /* Title of option to display all notes */
 "All Notes" = "Все заметки";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Уже есть учетная запись?";
-
-/* No comment provided by engineer. */
-"Back" = "Назад";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Регистрируясь, вы подтверждаете свое согласие с нашими Условиями предоставления услуг »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Отмена";
@@ -54,29 +36,17 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Партнер";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Разрешить другим сотрудничать";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Партнеры";
 
+"collaborators-description" = "Добавьте адрес электронной почто, чтобы делиться этой заметкой с кем-нибудь.
+Позже вы сможете изменить его. ";
+
 /* Option to make the note list show only 1 line of text. The default is 3. */
 "Condensed Note List" = "Сократить список заметок";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Подтвердить";
-
-/* Ratings View: Contact */
-"Contact" = "Обратная связь";
-
-/* No comment provided by engineer. */
-"Could Be Better" = "Нужно доработать";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Невозможно создать учетную запись с указанными адресом email и паролем.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Невозможно авторизоваться с указанными адресом email и паролем.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Посоветуйте, как нам стать лучше.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Создать новую заметку";
@@ -84,20 +54,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Текущие партнеры";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Темная тема";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Отладка";
-
-/* Permanent Delete */
-"Delete" = "Удалить";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Эта заметка была удалена на другом устройстве";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Скрыть клавиатуру";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Нет учетной записи?";
 
 /* No comment provided by engineer. */
 "Done" = "Готово";
@@ -111,57 +72,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Очистить корзину";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Ввести пароль";
-
-/* Pin Lock */
-"Enter your passcode" = "Введите ваш пароль";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Потеряли доступ к Simplenote? Чтобы восстановить доступ, переустановите приложение и войдите в учётную запись.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Быстро найти заметки через мгновенный поиск и теги. ";
-
-/* Forgot Password */
-"Forgot your password? »" = "Забыли пароль? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Начало работы";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "Замечательно! Не могли бы вы оставить нам хороший отзыв?\n\nЗаранее благодарим.";
-
 /* Noun - the version history of a note */
 "History" = "История";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Восстановить предыдущую версию заметки";
 
 /* Action - view the version history of a note */
 "History..." = "История…";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Чем вам помочь?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Мне нравится";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Оставить отзыв";
-
-/* Month and day date formatter */
-"MMM d" = "Д ммм";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "Д ммм, чч:мм";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "Д ммм гггг";
-
-/* Month and year date formatter */
-"MMM yyyy" = "МММ гггг";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Меню";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Показать опции заметки";
 
 /* Label to create a new note */
 "New note" = "Новая заметка";
@@ -173,22 +97,22 @@
 "No Results" = "Нет результатов";
 
 /* No comment provided by engineer. */
-"No Thanks" = "Нет, спасибо";
+"Note not published" = "Заметка не опубликована";
 
 /* Confirmation shown when a note is published */
 "Note Published" = "Заметка опубликована ";
 
-/* No comment provided by engineer. */
-"Note not published" = "Заметка не опубликована";
-
 /* Plural form of notes */
 "Notes" = "Заметки";
 
-/* No comment provided by engineer. */
-"OK" = "Хорошо";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Закрыть текущую заметку";
 
 /* No comment provided by engineer. */
 "Off" = "Выключить";
+
+/* No comment provided by engineer. */
+"OK" = "Хорошо";
 
 /* No comment provided by engineer. */
 "On" = "Включить";
@@ -198,15 +122,6 @@
 
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Пароль";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Пароль не подходит. Попробуйте снова. ";
-
-/* Hint displayed in the password field */
-"Password" = "Пароль";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Пароль должен содержать не менее 4 символов.";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Закрепить заметку";
@@ -222,9 +137,6 @@
 
 /* No comment provided by engineer. */
 "Preferences" = "Параметры";
-
-/* Markdown Preview */
-"Preview" = "Предварительный просмотр";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Публикация";
@@ -244,14 +156,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Публикация…";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Повторно ввести пароль";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Удалить все заметки из корзины";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Удалить тег";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Удалить все заметки из корзины";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Удалить тег?";
@@ -265,59 +174,32 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Восстановить заметку";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Безопасность";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Отправить";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Отправить отзыв";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Набрать пароль";
 
 /* Title of options screen */
 "Settings" = "Настройки";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Делитесь списком, отправляйте разные инструкции, или публикуйте ваши мысли. ";
-
 /* No comment provided by engineer. */
 "Share note" = "Поделиться заметкой";
+
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Поделится содержанием данной заметки";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Боковая панель";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Войти";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Выйти";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Зарегистрироваться";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Добавить тег к текущей заметке";
 
-/* A short link to access the account login screen */
-"Sign in" = "Войти";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Зарегистрироваться";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "При выходе из учётной записи все несинхронизированные заметки будут удалены. Чтобы убедиться, что заметки синхронизированы, войдите в веб-приложение.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Сортировать заметки по алфавиту";
-
-/* Message shown in first launch view */
-"Stay organized" = "Оставайтесь организованным";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Удалить тег в текущей заметке";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Тег: %@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Возникли проблемы с подключением. Попробуйте позже. ";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Сегодня";
@@ -325,20 +207,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Боковая панель переключения меток";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Идентификатор прикосновения";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Отправить текущую заметку в корзину";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Корзина";
+"Trash-noun" = "Корзина";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Удалить";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Отключить пароль";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Разблокировать %@";
+/* Permanent Delete */
+"Trash-verb" = "Удалить";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Открепить заметку";
@@ -349,75 +225,211 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Отмена публикации…";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Обнаружены несинхронизированные заметки";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Пользуйтесь им везде";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Версия";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Добро пожаловать в Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Подключитесь к интернету доя доступа к предыдущим вариантам";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Каково ваше мнение о Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Оставить этот вариант";
 
-/* Message shown in first launch view */
-"Work together" = "Работайте вместе";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Извлечение версии";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Вчера";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Ваш электронный адрес:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i неудачная попытка ввода кода доступа";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Ввести пароль";
+
+/* Pin Lock */
+"Enter your passcode" = "Введите ваш пароль";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Пароль не подходит. Попробуйте снова. ";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Повторно ввести пароль";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Набрать пароль";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Отключить пароль";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Разблокировать %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "Неудачные попытки ввода кода доступа: %i";
+
+"welcomeNote-iOS" = "Добро пожаловать в Simplenote для iOS!
+
+Добавьте заметку, тапнув на кнопку с плюсом. 
+
+Пролистайте список, чтобы просмотреть ваши заметки. Нажмите на название для просмотра заметки, затем нажмите на его содержание, чтобы изменить его.
+
+Вы можете искать ваши заметки: для этого пролестните вверх ваш список с заметки и нажмите на строку поиска. 
+
+Нажмите на кнопку в левом верхнем углу или смахните слева на право, чтобы посмотреть ваши теги. Вы можете добавить тег к заметке, нажав на кнопку при изменении заметки, и используйте боковую панель - она поможет оставаться Вам быть организованным. 
+
+Но у заметок есть больше опций, если они вам нужны. Например, вы можете пригласить партнеры или соавтора для общего ведения заметки, либо опубликовать запись в виде веб-страницы. 
+
+Пользуйтесь Simplenote на вашем компьютере Mac, Android устройствах или в вашем веб-браузере на сайте http://simplenote.com. Ваши заметки всегда останутся обновленными везде. ";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Сортировать заметки по алфавиту";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Уже есть учетная запись?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Подтвердить";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Невозможно создать учетную запись с указанными адресом email и паролем.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Невозможно авторизоваться с указанными адресом email и паролем.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Нет учетной записи?";
+
+/* A 4-digit code to lock the app when it is closed */
+"Password" = "Пароль";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Пароль должен содержать не менее 4 символов.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Войти";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Войти";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Зарегистрироваться";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Зарегистрироваться";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Возникли проблемы с подключением. Попробуйте позже. ";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Ваш адрес электронной почты не действителен.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Быстро найти заметки через мгновенный поиск и теги. ";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Начало работы";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Делитесь списком, отправляйте разные инструкции, или публикуйте ваши мысли. ";
+
+/* Message shown in first launch view */
+"Stay organized" = "Оставайтесь организованным";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Пользуйтесь им везде";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Добро пожаловать в Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Работайте вместе";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Ваши заметки обновляются на всех ваших устройствах. Ничего нажимать не нужно. Это просто работает. ";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Разрешить другим сотрудничать";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Темная тема";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "Отладка";
+
+/* Month and day date formatter */
+"MMM d" = "Д ммм";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "Д ммм, чч:мм";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "Д ммм гггг";
+
+/* Month and year date formatter */
+"MMM yyyy" = "МММ гггг";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Идентификатор прикосновения";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Безопасность";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Регистрируясь, вы подтверждаете свое согласие с нашими Условиями предоставления услуг »";
+
+/* Forgot Password */
+"Forgot password? »" = "Забыли пароль? »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Каково ваше мнение о Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Добавьте адрес электронной почто, чтобы делиться этой заметкой с кем-нибудь.\nПозже вы сможете изменить его. ";
+"I Like It" = "Мне нравится";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Эта заметка была удалена на другом устройстве";
+/* No comment provided by engineer. */
+"Could Be Better" = "Нужно доработать";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Восстановить предыдущую версию заметки";
+"Great! Could you leave us a nice review?
+It really helps." = "Замечательно! Не могли бы вы оставить нам хороший отзыв?
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Показать опции заметки";
+Заранее благодарим.";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Закрыть текущую заметку";
+/* No comment provided by engineer. */
+"Leave a Review" = "Оставить отзыв";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Поделится содержанием данной заметки";
+/* No comment provided by engineer. */
+"No Thanks" = "Нет, спасибо";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Добавить тег к текущей заметке";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Посоветуйте, как нам стать лучше.";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Удалить тег в текущей заметке";
+/* No comment provided by engineer. */
+"Send Feedback" = "Отправить отзыв";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Отправить текущую заметку в корзину";
+/* Ratings View: Contact */
+"Contact" = "Обратная связь";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Подключитесь к интернету доя доступа к предыдущим вариантам";
+/* No comment provided by engineer. */
+"Your Email:" = "Ваш электронный адрес:";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Оставить этот вариант";
+/* No comment provided by engineer. */
+"How can we help?" = "Чем вам помочь?";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Извлечение версии";
+/* No comment provided by engineer. */
+"Back" = "Назад";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Добро пожаловать в Simplenote для iOS!\n\nДобавьте заметку, тапнув на кнопку с плюсом. \n\nПролистайте список, чтобы просмотреть ваши заметки. Нажмите на название для просмотра заметки, затем нажмите на его содержание, чтобы изменить его.\n\nВы можете искать ваши заметки: для этого пролестните вверх ваш список с заметки и нажмите на строку поиска. \n\nНажмите на кнопку в левом верхнем углу или смахните слева на право, чтобы посмотреть ваши теги. Вы можете добавить тег к заметке, нажав на кнопку при изменении заметки, и используйте боковую панель - она поможет оставаться Вам быть организованным. \n\nНо у заметок есть больше опций, если они вам нужны. Например, вы можете пригласить партнеры или соавтора для общего ведения заметки, либо опубликовать запись в виде веб-страницы. \n\nПользуйтесь Simplenote на вашем компьютере Mac, Android устройствах или в вашем веб-браузере на сайте http:\/\/simplenote.com. Ваши заметки всегда останутся обновленными везде. ";
+/* Permanent Delete */
+"Delete" = "Удалить";
+
+/* Markdown Preview */
+"Preview" = "Предварительный просмотр";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "При выходе из учётной записи все несинхронизированные заметки будут удалены. Чтобы убедиться, что заметки синхронизированы, войдите в веб-приложение.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Обнаружены несинхронизированные заметки";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Метка...";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Потеряли доступ к Simplenote? Чтобы восстановить доступ, переустановите приложение и войдите в учётную запись.";
 

--- a/Simplenote/sv.lproj/Localizable.strings
+++ b/Simplenote/sv.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d ord";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i felaktig inmatning";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i felaktiga inmatningar";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Godkänn";
 
@@ -30,23 +24,11 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Lägg till ny redigerare...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Etikett…";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Lägg till etikett";
 
 /* Title of option to display all notes */
 "All Notes" = "Alla anteckningar";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Har du redan ett konto?";
-
-/* No comment provided by engineer. */
-"Back" = "Tillbaka";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Genom att skapa ett konto godkänner du användaravtalet »";
 
 /* No comment provided by engineer. */
 "Cancel" = "Avbryt";
@@ -54,29 +36,17 @@
 /* Verb - work with others on a note */
 "Collaborate" = "Samarbeta";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Gör så att andra kan hjälpa till och redigera";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Redigerare";
 
+/* No comment provided by engineer. */
+"collaborators-description" = "Lägg till en e-postadress för att dela denna anteckning med någon, då kan ni båda göra ändringar.";
+
 /* Option to make the note list show only 1 line of text. The default is 3. */
 "Condensed Note List" = "Komprimerad anteckningslista";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Bekräfta";
-
-/* Ratings View: Contact */
-"Contact" = "Kontakt";
-
-/* No comment provided by engineer. */
-"Could Be Better" = "Kunde vara bättre";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Kunde inte skapa ett konto med den e-postadressen och det lösenordet.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Kunde inte logga in med den e-postadressen och det lösenordet.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Kan du berätta för oss vad vi kan förbättra?";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Skapa ny anteckning";
@@ -84,20 +54,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Nuvarande redigerare";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Mörkt tema";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Felsök";
-
-/* Permanent Delete */
-"Delete" = "Ta bort";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Denna anteckning har blivit borttagen på en annan enhet.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Göm tangentbord";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Har du inget konto?";
 
 /* No comment provided by engineer. */
 "Done" = "Klar";
@@ -111,57 +72,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Töm papperskorgen";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Ange en lösenkod";
-
-/* Pin Lock */
-"Enter your passcode" = "Ange lösenkod";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Har du förlorat åtkomsten till Simplenote? Du kan få åtkomst igen genom att installera om appen och logga in på ditt konto.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Hitta anteckningar snabbt genom att söka i realtid och använda etiketter.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Glömt ditt lösenord? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Kom igång";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\\n\\nDet skulle verkligen uppskattas.";
-
 /* Noun - the version history of a note */
 "History" = "Historik";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Återställ anteckning till tidigare version";
 
 /* Action - view the version history of a note */
 "History..." = "Historik...";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Hur kan vi hjälpa till?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Jag gillar den";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Skriv en recension";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Meny";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Visa alternativ för anteckning";
 
 /* Label to create a new note */
 "New note" = "Ny anteckning";
@@ -173,22 +97,22 @@
 "No Results" = "Inga sökresultat";
 
 /* No comment provided by engineer. */
-"No Thanks" = "Nej, tack";
+"Note not published" = "Anteckning inte publicerad";
 
 /* Confirmation shown when a note is published */
 "Note Published" = "Anteckning publicerad";
 
-/* No comment provided by engineer. */
-"Note not published" = "Anteckning inte publicerad";
-
 /* Plural form of notes */
 "Notes" = "Anteckningar";
 
-/* No comment provided by engineer. */
-"OK" = "OK";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Stäng nuvarande anteckning";
 
 /* No comment provided by engineer. */
 "Off" = "Av";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
 
 /* No comment provided by engineer. */
 "On" = "På";
@@ -199,32 +123,19 @@
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Lösenkod";
 
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Lösenkoderna matchar inte varandra. Försök igen.";
-
-/* Hint displayed in the password field */
-"Password" = "Lösenord";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Lösenord måste innehålla minst 4 tecken.";
-
 /* Action to mark a note as pinned */
 "Pin note" = "Nåla fast anteckning";
 
 /* Denotes when note is pinned to the top of the note list */
 "Pin to Top" = "Nåla fast högst upp";
 
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "Slå på\/av fastnålning";
+"Pin toggle" = "Slå på/av fastnålning";
 
 /* Pinned notes are stuck to the note of the note list */
 "Pinned" = "Fastnålad";
 
 /* No comment provided by engineer. */
 "Preferences" = "Alternativ";
-
-/* Markdown Preview */
-"Preview" = "Förhandsgranska";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Publicera";
@@ -235,8 +146,7 @@
 /* Action which published a note to a web page */
 "Publish note" = "Publicera anteckning";
 
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "Publicera på\/av";
+"Publish toggle" = "Publicera på/av";
 
 /* No comment provided by engineer. */
 "Published" = "Publicerad";
@@ -244,14 +154,11 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Publicerar...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Ange lösenkoden en gång till";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Ta bort alla anteckningar från papperskorgen";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Ta bort etikett";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Ta bort alla anteckningar från papperskorgen";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Ta bort etikett?";
@@ -265,80 +172,46 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Återställ anteckning";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Säkerhet";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Skicka";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Skicka feedback";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Ställ in lösenkod";
 
 /* Title of options screen */
 "Settings" = "Inställningar";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Dela en lista, skriv ner instruktioner, eller publicera dina tankar.";
-
 /* No comment provided by engineer. */
 "Share note" = "Dela anteckning";
+
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Dela innehåll i nuvarande anteckning";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Sidopanel";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Logga in";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Logga ut";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Skapa konto";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Lägg till en etikett för anteckningen";
 
-/* A short link to access the account login screen */
-"Sign in" = "Logga in";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Skapa konto";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Utloggning kommer att radera alla osynkroniserade anteckningar. Du kan verifiera dina synkroniserade anteckningar genom att logga in på webbappen.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Sortera anteckningar alfabetiskt";
-
-/* Message shown in first launch view */
-"Stay organized" = "Håll ordning";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Ta bort etikett från den nuvarande anteckningen";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Etikett: %@";
 
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Det var ett problem med anslutningen. Försök igen senare.";
-
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Idag";
 
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Slå på\/av etiketter i sidopanelen";
+"Toggle tag sidebar" = "Slå på/av etiketter i sidopanelen";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Kasta anteckningen i papperskorgen";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Papperskorgen";
+"Trash-noun" = "Papperskorgen";
 
 /* Trash (verb) - the action of deleting a note */
-"Trash" = "Kasta bort";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Stäng av lösenkod";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "Lås upp %@";
+"Trash-verb" = "Kasta bort";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Ta bort nål";
@@ -349,75 +222,209 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Slutar publicera...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Osynkroniserade anteckningar upptäckta";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "Använd var som helst";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Version";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Välkommen till Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Anslut till ett nätverk för att se tidigare versioner";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Vad tycker du om Simplenote?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Välj denna version";
 
-/* Message shown in first launch view */
-"Work together" = "Arbeta tillsammans";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Hämtar version";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Igår";
 
-/* No comment provided by engineer. */
-"Your Email:" = "Din e-post:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i felaktig inmatning";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Ange en lösenkod";
+
+/* Pin Lock */
+"Enter your passcode" = "Ange lösenkod";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Lösenkoderna matchar inte varandra. Försök igen.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Ange lösenkoden en gång till";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Ställ in lösenkod";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Stäng av lösenkod";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "Lås upp %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i felaktiga inmatningar";
+
+"welcomeNote-iOS" = "Välkommen till Simplenote för iOS!
+
+För att skapa en anteckning, tryck på plus-knappen.
+
+Scrolla i listan för att se dina anteckningar. Tryck på en rubrik för att visa en anteckning, sedan på dess innehåll för att ändra det.
+
+Du kan söka bland dina anteckningar genom att skriva i sökfältet högst upp i anteckningslistan.
+
+Tryck på pilen eller dra från vänster för att visa sidopanelen och dina etiketter. Du kan lägga till etiketter för en anteckning längst ner i redigeraren och sedan använda sidopanelen för att filtrera anteckningar.
+
+Det finns fler inställningar för dina anteckningar om du behöver dem. Du kan bjuda in andra att redigera en anteckning, publicera en anteckning som en webbsida, med mera.
+
+Använd Simplenote på din Mac, din Android-platta eller -telefon och direkt i din webbläsare på http://simplenote.com. Dina anteckningar synkroniseras automatiskt mellan alla dina enheter.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Sortera anteckningar alfabetiskt";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Har du redan ett konto?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Bekräfta";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Kunde inte skapa ett konto med den e-postadressen och det lösenordet.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Kunde inte logga in med den e-postadressen och det lösenordet.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Har du inget konto?";
+
+/* Hint displayed in the password field */
+"Password" = "Lösenord";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Lösenord måste innehålla minst 4 tecken.";
+
+/* Title of button for logging in (must be short) */
+"Sign in" = "Logga in";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Logga in";
+
+/* Title of button to create a new account (must be short) */
+"Sign up" = "Skapa konto";
+
+/* Title of button to create a new account (must be short) */
+"Sign Up" = "Skapa konto";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Det var ett problem med anslutningen. Försök igen senare.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "Din e-postadress är inte giltig.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Hitta anteckningar snabbt genom att söka i realtid och använda etiketter.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Kom igång";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Dela en lista, skriv ner instruktioner, eller publicera dina tankar.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Håll ordning";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "Använd var som helst";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Välkommen till Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "Arbeta tillsammans";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Dina anteckningar synkroniseras till alla dina enheter. Du behöver inte ställa in någonting. Det bara fungerar.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Gör så att andra kan hjälpa till och redigera";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Mörkt tema";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "Felsök";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Säkerhet";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Genom att skapa ett konto godkänner du användaravtalet »";
+
+/* Forgot Password */
+"Forgot password? »" = "Glömt ditt lösenord? »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Vad tycker du om Simplenote?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Lägg till en e-postadress för att dela denna anteckning med någon, då kan ni båda göra ändringar.";
+"I Like It" = "Jag gillar den";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Denna anteckning har blivit borttagen på en annan enhet.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Kunde vara bättre";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Återställ anteckning till tidigare version";
+"Great! Could you leave us a nice review?
+It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\nDet skulle verkligen uppskattas.";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Visa alternativ för anteckning";
+/* No comment provided by engineer. */
+"Leave a Review" = "Skriv en recension";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Stäng nuvarande anteckning";
+/* No comment provided by engineer. */
+"No Thanks" = "Nej, tack";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Dela innehåll i nuvarande anteckning";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Kan du berätta för oss vad vi kan förbättra?";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Lägg till en etikett för anteckningen";
+/* No comment provided by engineer. */
+"Send Feedback" = "Skicka feedback";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Ta bort etikett från den nuvarande anteckningen";
+/* Ratings View: Contact */
+"Contact" = "Kontakt";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Kasta anteckningen i papperskorgen";
+/* No comment provided by engineer. */
+"Your Email:" = "Din e-post:";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Anslut till ett nätverk för att se tidigare versioner";
+/* No comment provided by engineer. */
+"How can we help?" = "Hur kan vi hjälpa till?";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Välj denna version";
+/* No comment provided by engineer. */
+"Back" = "Tillbaka";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Hämtar version";
+/* Permanent Delete */
+"Delete" = "Ta bort";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Välkommen till Simplenote för iOS!\n\nFör att skapa en anteckning, tryck på plus-knappen.\n\nScrolla i listan för att se dina anteckningar. Tryck på en rubrik för att visa en anteckning, sedan på dess innehåll för att ändra det.\n\nDu kan söka bland dina anteckningar genom att skriva i sökfältet högst upp i anteckningslistan.\n\nTryck på pilen eller dra från vänster för att visa sidopanelen och dina etiketter. Du kan lägga till etiketter för en anteckning längst ner i redigeraren och sedan använda sidopanelen för att filtrera anteckningar.\n\nDet finns fler inställningar för dina anteckningar om du behöver dem. Du kan bjuda in andra att redigera en anteckning, publicera en anteckning som en webbsida, med mera.\n\nAnvänd Simplenote på din Mac, din Android-platta eller -telefon och direkt i din webbläsare på http:\/\/simplenote.com. Dina anteckningar synkroniseras automatiskt mellan alla dina enheter.";
+/* Markdown Preview */
+"Preview" = "Förhandsgranska";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Utloggning kommer att radera alla osynkroniserade anteckningar. Du kan verifiera dina synkroniserade anteckningar genom att logga in på webbappen.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Osynkroniserade anteckningar upptäckta";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Etikett…";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Har du förlorat åtkomsten till Simplenote? Du kan få åtkomst igen genom att installera om appen och logga in på ditt konto.";
 

--- a/Simplenote/tr.lproj/Localizable.strings
+++ b/Simplenote/tr.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d Sözcük";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "%i Başarısız Parola Denemesi";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "%i Başarısız Parola Denemesi";
-
 /* Label of accept button on alert dialog */
 "Accept" = "Kabul";
 
@@ -30,23 +24,8 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Yeni çalışma arkadaşı ekle...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Etiketle…";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "Etiket ekle";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "Hesabınız zaten var mı?";
-
-/* No comment provided by engineer. */
-"Back" = "Geri";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "Kaydolmakla Hizmet Koşulları'nı kabul etmiş olursunuz »";
 
 /* No comment provided by engineer. */
 "Cancel" = "İptal";
@@ -54,29 +33,14 @@
 /* Verb - work with others on a note */
 "Collaborate" = "İşbirliği Yap";
 
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "Diğer kişilerin iş birliği kurmasını sağlayın";
+
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Çalışma Arkadaşları";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "Onayla";
-
-/* Ratings View: Contact */
-"Contact" = "İletişim";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "Daha İyi Olabilir";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "Verilen e-posta adresi ve parolayla hesap oluşturulamadı.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Verilen e-posta adresi ve parolayla oturum açılamadı.";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "Bize nasıl daha iyi olabileceğimizi belirtir misiniz?";
+"collaborators-description" = "Bu notu bir başka kişinin görebilmesi için o kişinin e-posta adresini ekleyin. Bunun ardından her ikiniz de not üzerinde değişiklik yapabilirsiniz.";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Yeni not oluştur";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "Şu Anki Çalışma Arkadaşları";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "Koyu Tema";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "Hata ayıklama";
-
-/* Permanent Delete */
-"Delete" = "Sil";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "Bu not bir başka aygıtta silindi.";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Klavyeyi kapat";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "Hesabınız yok mu?";
 
 /* No comment provided by engineer. */
 "Done" = "Bitti";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Çöpü boşalt";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "Parola girin";
-
-/* Pin Lock */
-"Enter your passcode" = "Parolanızı girin";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Simplenote'a erişim sağlayamıyor musunuz? Uygulamayı yeniden yükleyip hesabınızda oturum açarak tekrar erişim elde edebilirsiniz.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "Anında arama ve basit etiketlerle notları hızlı bir şekilde bulabilirsiniz.";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "Başlayın";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "";
-
 /* Noun - the version history of a note */
 "History" = "Geçmiş";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "Notu önceki sürüme geri yükle";
 
 /* Action - view the version history of a note */
 "History..." = "Geçmiş…";
 
-/* No comment provided by engineer. */
-"How can we help?" = "Nasıl yardımcı olabiliriz?";
-
-/* No comment provided by engineer. */
-"I Like It" = "Beğendim";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "Görüşünüzü Paylaşın";
-
-/* Month and day date formatter */
-"MMM d" = "AAA g";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "g, AAA, sa:dkdk sn";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "g, AAA, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "AAA yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Menü";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "Not seçeneklerini göster";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Not Yok";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Sonuç Yok";
 
-/* No comment provided by engineer. */
-"No Thanks" = "Hayır, teşekkürler";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "Not Yayınlandı";
-
-/* No comment provided by engineer. */
-"Note not published" = "Note not published";
 
 /* Plural form of notes */
 "Notes" = "Notlar";
 
-/* No comment provided by engineer. */
-"OK" = "Tamam";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "Geçerli notu kapat";
 
 /* No comment provided by engineer. */
 "Off" = "Kapalı";
+
+/* No comment provided by engineer. */
+"OK" = "Tamam";
 
 /* No comment provided by engineer. */
 "On" = "Açık";
@@ -199,23 +111,13 @@
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Geçiş kodu";
 
-/* Pin Lock */
-"Passcodes did not match. Try again." = "Parolalar eşleşmiyor. Tekrar deneyin.";
-
-/* Hint displayed in the password field */
-"Password" = "Parola";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "Parola en az 4 karakter olmalıdır.";
-
 /* Action to mark a note as pinned */
 "Pin note" = "Notu iğnele";
 
 /* Denotes when note is pinned to the top of the note list */
 "Pin to Top" = "Üste İğnele";
 
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "İğneyi aç\/kapat";
+"Pin toggle" = "İğneyi aç/kapat";
 
 /* Pinned notes are stuck to the note of the note list */
 "Pinned" = "İğnelendi";
@@ -223,10 +125,7 @@
 /* No comment provided by engineer. */
 "Preferences" = "Tercihler";
 
-/* Markdown Preview */
-"Preview" = "Önizleme";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+/* Confirmation shown when a note is published */
 "Publish" = "Yayınla";
 
 /* Failure message after attempting to publish a note */
@@ -235,23 +134,19 @@
 /* Action which published a note to a web page */
 "Publish note" = "Notu yayınla";
 
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "Yayınlamayı aç\/kapat";
+"Publish toggle" = "Yayınlamayı aç/kapat";
 
-/* No comment provided by engineer. */
+/* Confirmation shown when a note is published */
 "Published" = "Yayınlandı";
 
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Yayınlanıyor…";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "Yeniden bir parola girin";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Çöp kutusundaki tüm notları kaldır";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "Etiketi Kaldır";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Çöp kutusundaki tüm notları kaldır";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "Etiket kaldırılsın mı?";
@@ -265,80 +160,43 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Notu Geri Yükle";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "Güvenlik";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Gönder";
-
-/* No comment provided by engineer. */
-"Send Feedback" = "Geri Bildirim Gönder";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "Parolayı Ayarla";
 
 /* Title of options screen */
 "Settings" = "Ayarlar";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "Liste paylaşın, yönergeler gönderin veya düşüncelerinizi yayınlayın.";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "Geçerli notun içeriğini paylaş";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Kenar çubuğu";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "Oturum Aç";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "Çıkış Yap";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "Kaydol";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "Geçerli nota etiket ekle";
 
-/* A short link to access the account login screen */
-"Sign in" = "Oturum aç";
-
-/* A short link to access the account creation screen */
-"Sign up" = "Kaydol";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Oturumu kapattığınızda, senkronize edilmemiş tüm notlar silinir. Senkronize edilmiş notlarınızı Web Uygulamasında oturum açarak doğrulayabilirsiniz.";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "Notları Alfabetik Olarak Sırala";
-
-/* Message shown in first launch view */
-"Stay organized" = "Düzenli olun";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "Geçerli nottan etiket kaldır";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "Etiket: %@";
 
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "Bağlantıyla ilgili bir sorun oluştu.  Lütfen daha sonra tekrar deneyin.";
-
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Bugün";
 
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Etiket kenar çubuğunu aç\/kapat";
+"Toggle tag sidebar" = "Etiket kenar çubuğunu aç/kapat";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "Geçerli notu çöp kutusuna taşı";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "Çöpe At";
+"Trash-noun" = "Çöpe At";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "Çöpe At";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "Parolayı Kapat";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "%@ öğesinin kilidini aç";
+/* Trash (noun) - the location where deleted notes are stored */
+"Trash-verb" = "Çöpe At";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Notu kaldır";
@@ -349,75 +207,203 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "Yayından kaldırılıyor...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Senkronize Edilmemiş Notlar Tespit Edildi";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "İstediğiniz yerde kullanın";
-
 /* Represents a snapshot in time for a note */
 "Version" = "Sürüm";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "Simplenote'a Hoş Geldiniz";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "Önceki Sürümlere Erişmek için İnternet'e bağlanın";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "Simplenote hakkında ne düşünüyorsunuz?";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "Bu sürümü değiştir";
 
-/* Message shown in first launch view */
-"Work together" = "Birlikte çalışın";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "Sürüm alınıyor";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Dün";
 
-/* No comment provided by engineer. */
-"Your Email:" = "E-posta adresiniz:";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "%i Başarısız Parola Denemesi";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "Parola girin";
+
+/* Pin Lock */
+"Enter your passcode" = "Parolanızı girin";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "Parolalar eşleşmiyor. Tekrar deneyin.";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "Yeniden bir parola girin";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "Parolayı Ayarla";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "Parolayı Kapat";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "%@ öğesinin kilidini aç";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "%i Başarısız Parola Denemesi";
+
+"welcomeNote-iOS" = "iOS için Simplenote’a hoş geldiniz!
+
+Yeni bir not eklemek için artı düğmesine dokunun.
+
+Notlarınıza göz atmak için listeye hafifçe vurun. Bir notu görmek için başlığa dokunun; ardından değiştirmek için notun içeriklerine dokunun.
+
+Not listesinin üst kısmında bulunan arama alanına yazarak tüm notlarınızda arama yapabilirsiniz.
+
+Sol üst kısımdaki ok düğmesine dokunarak veya not listenizi kaydırarak etiketlerinizi görebilirsiniz. Not düzenleyicinin alt kısmında bir nota etiket ekleyebilir, ardından kenar çubuğunu kullanarak notları düzenli şekilde saklayabilirsiniz.
+
+Gerek duyduğunuzda diğer not seçeneklerini de kullanabilirsiniz. Bir nota iş birliği kurduğunuz kişiler olarak başka insanlar ekleyebilir veya notu web sayfası olarak yayınlayabilirsiniz.
+
+Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com adresini yazarak internet tarayıcınızda kullanabilirsiniz. Notlarınız her yerde otomatik olarak güncellenecek.";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "Notları Alfabetik Olarak Sırala";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "Hesabınız zaten var mı?";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "Onayla";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "Verilen e-posta adresi ve parolayla hesap oluşturulamadı.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Verilen e-posta adresi ve parolayla oturum açılamadı.";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "Hesabınız yok mu?";
+
+/* Number of failed entries entering in passcode */
+"Password" = "Parola";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "Parola en az 4 karakter olmalıdır.";
+
+/* A short link to access the account login screen */
+"Sign in" = "Oturum aç";
+
+/* Title of button for logging in (must be short) */
+"Sign In" = "Oturum Aç";
+
+/* TOS */
+"Sign up" = "Kaydol";
+
+/* TOS */
+"Sign Up" = "Kaydol";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "Bağlantıyla ilgili bir sorun oluştu.  Lütfen daha sonra tekrar deneyin.";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "E-posta adresiniz geçerli değil.";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "Anında arama ve basit etiketlerle notları hızlı bir şekilde bulabilirsiniz.";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "Başlayın";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "Liste paylaşın, yönergeler gönderin veya düşüncelerinizi yayınlayın.";
+
+/* Message shown in first launch view */
+"Stay organized" = "Düzenli olun";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "İstediğiniz yerde kullanın";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "Simplenote'a Hoş Geldiniz";
+
+/* Message shown in first launch view */
+"Work together" = "Birlikte çalışın";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "Notlarınız tüm cihazlarınızda güncel kalır. Basılacak düğme yok. Kendiliğinden çalışır.";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "Diğer kişilerin iş birliği kurmasını sağlayın";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "Koyu Tema";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "Hata ayıklama";
+
+/* Month and day date formatter */
+"MMM d" = "AAA g";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "g, AAA, sa:dkdk sn";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "g, AAA, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "AAA yyyy";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "Güvenlik";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "Kaydolmakla Hizmet Koşulları'nı kabul etmiş olursunuz »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "Simplenote hakkında ne düşünüyorsunuz?";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "Bu notu bir başka kişinin görebilmesi için o kişinin e-posta adresini ekleyin. Bunun ardından her ikiniz de not üzerinde değişiklik yapabilirsiniz.";
+"I Like It" = "Beğendim";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "Bu not bir başka aygıtta silindi.";
+/* No comment provided by engineer. */
+"Could Be Better" = "Daha İyi Olabilir";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "Notu önceki sürüme geri yükle";
+/* No comment provided by engineer. */
+"Leave a Review" = "Görüşünüzü Paylaşın";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "Not seçeneklerini göster";
+/* No comment provided by engineer. */
+"No Thanks" = "Hayır, teşekkürler";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "Geçerli notu kapat";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "Bize nasıl daha iyi olabileceğimizi belirtir misiniz?";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "Geçerli notun içeriğini paylaş";
+/* No comment provided by engineer. */
+"Send Feedback" = "Geri Bildirim Gönder";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "Geçerli nota etiket ekle";
+/* Ratings View: Contact */
+"Contact" = "İletişim";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "Geçerli nottan etiket kaldır";
+/* No comment provided by engineer. */
+"Your Email:" = "E-posta adresiniz:";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "Geçerli notu çöp kutusuna taşı";
+/* No comment provided by engineer. */
+"How can we help?" = "Nasıl yardımcı olabiliriz?";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "Önceki Sürümlere Erişmek için İnternet'e bağlanın";
+/* No comment provided by engineer. */
+"Back" = "Geri";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "Bu sürümü değiştir";
+/* Permanent Delete */
+"Delete" = "Sil";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "Sürüm alınıyor";
+/* Markdown Preview */
+"Preview" = "Önizleme";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "iOS için Simplenote’a hoş geldiniz!\n\nYeni bir not eklemek için artı düğmesine dokunun.\n\nNotlarınıza göz atmak için listeye hafifçe vurun. Bir notu görmek için başlığa dokunun; ardından değiştirmek için notun içeriklerine dokunun.\n\nNot listesinin üst kısmında bulunan arama alanına yazarak tüm notlarınızda arama yapabilirsiniz.\n\nSol üst kısımdaki ok düğmesine dokunarak veya not listenizi kaydırarak etiketlerinizi görebilirsiniz. Not düzenleyicinin alt kısmında bir nota etiket ekleyebilir, ardından kenar çubuğunu kullanarak notları düzenli şekilde saklayabilirsiniz.\n\nGerek duyduğunuzda diğer not seçeneklerini de kullanabilirsiniz. Bir nota iş birliği kurduğunuz kişiler olarak başka insanlar ekleyebilir veya notu web sayfası olarak yayınlayabilirsiniz.\n\nSimplenote’u Mac’inizde, Android aygıtınızda veya http:\/\/simplenote.com adresini yazarak internet tarayıcınızda kullanabilirsiniz. Notlarınız her yerde otomatik olarak güncellenecek.";
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Oturumu kapattığınızda, senkronize edilmemiş tüm notlar silinir. Senkronize edilmiş notlarınızı Web Uygulamasında oturum açarak doğrulayabilirsiniz.";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Senkronize Edilmemiş Notlar Tespit Edildi";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "Etiketle…";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "Simplenote'a erişim sağlayamıyor musunuz? Uygulamayı yeniden yükleyip hesabınızda oturum açarak tekrar erişim elde edebilirsiniz.";
 

--- a/Simplenote/zh-Hans-CN.lproj/Localizable.strings
+++ b/Simplenote/zh-Hans-CN.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d 个字";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "密码尝试失败 %i 次";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "密码尝试失败 %i 次";
-
 /* Label of accept button on alert dialog */
 "Accept" = "接受";
 
@@ -30,53 +24,23 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "添加新协作者...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "Tag...";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "添加标签";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "已有帐户？";
-
-/* No comment provided by engineer. */
-"Back" = "返回";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "注册即表示您同意我们的服务条款 »";
 
 /* No comment provided by engineer. */
 "Cancel" = "取消";
 
-/* Verb - work with others on a note */
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborate" = "协作";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "同意他人进行协作";
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "协作者";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "确认";
-
-/* Ratings View: Contact */
-"Contact" = "联系";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "还可以更好";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "无法使用所提供的电子邮件地址和密码创建帐户。";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "无法使用所提供的电子邮件地址和密码登录。";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "您可以告诉我们如何改进吗？";
+"collaborators-description" = "添加电子邮件地址即可与他人分享此笔记。而且，您与协作者均可对笔记作出更改。";
 
 /* No comment provided by engineer. */
 "Create a new note" = "创建新笔记";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "当前协作者";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "深色主题";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "调试";
-
-/* Permanent Delete */
-"Delete" = "Delete";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "此笔记已从其他设备上删除。";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "关闭键盘";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "还没有帐户？";
 
 /* No comment provided by engineer. */
 "Done" = "完成";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "清空回收站";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "输入密码";
-
-/* Pin Lock */
-"Enter your passcode" = "输入您的密码";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account.";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "使用快速搜索以及简单的标签来迅速查找笔记。";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "开始";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "";
-
 /* Noun - the version history of a note */
 "History" = "历史";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "将笔记恢复至之前版本";
 
 /* Action - view the version history of a note */
 "History..." = "历史…";
 
-/* No comment provided by engineer. */
-"How can we help?" = "您希望我们如何为您提供帮助？";
-
-/* No comment provided by engineer. */
-"I Like It" = "我喜欢";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "留下评价";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "yyyy MMM d";
-
-/* Month and year date formatter */
-"MMM yyyy" = "yyyy MMM";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "菜单";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "显示笔记选项";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "无笔记";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "无结果";
 
-/* No comment provided by engineer. */
-"No Thanks" = "不用了，谢谢";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "笔记已发布";
 
 /* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
 "Notes" = "笔记";
 
-/* No comment provided by engineer. */
-"OK" = "确定";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "关闭当前笔记";
 
 /* No comment provided by engineer. */
 "Off" = "关闭";
+
+/* No comment provided by engineer. */
+"OK" = "确定";
 
 /* No comment provided by engineer. */
 "On" = "打开";
@@ -196,17 +108,8 @@
 /* Select a note to view in the note editor */
 "Open note" = "打开笔记";
 
-/* A 4-digit code to lock the app when it is closed */
+/* Number of failed entries entering in passcode */
 "Passcode" = "密码";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "密码不匹配。重试。";
-
-/* Hint displayed in the password field */
-"Password" = "密码";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "密码中必须至少包含 4 个字符。";
 
 /* Action to mark a note as pinned */
 "Pin note" = "固定笔记";
@@ -223,10 +126,7 @@
 /* No comment provided by engineer. */
 "Preferences" = "偏好设置";
 
-/* Markdown Preview */
-"Preview" = "Preview";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+/* Confirmation shown when a note is published */
 "Publish" = "发布";
 
 /* Failure message after attempting to publish a note */
@@ -238,20 +138,17 @@
 /* Switch which marks a note as published or unpublished */
 "Publish toggle" = "发布切换";
 
-/* No comment provided by engineer. */
+/* Confirmation shown when a note is published */
 "Published" = "已发布";
 
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "正在发布...";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "再次输入密码";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "从回收站中移除所有笔记";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "删除标签";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "从回收站中移除所有笔记";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "要删除标签吗？";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "恢复笔记";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "安全";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "发送";
 
 /* No comment provided by engineer. */
-"Send Feedback" = "发送反馈";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "设置密码";
-
-/* Title of options screen */
 "Settings" = "设置";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "分享列表、发布一些说明或发表自己的想法。";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "分享当前笔记的内容";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "侧边栏";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "登录";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "注销";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "注册";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "向当前笔记中添加标签";
 
-/* A short link to access the account login screen */
-"Sign in" = "登录";
-
-/* A short link to access the account creation screen */
-"Sign up" = "注册";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "注销会删除所有未同步的备注。您可以通过登录 Web 应用程序以确认您已同步的备注。";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "按字母顺序对笔记进行排序";
-
-/* Message shown in first launch view */
-"Stay organized" = "井井有条";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "将标签从当前笔记中删除";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "标签：%@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "连接出错。请稍后重试。";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "今天";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "切换标签侧边栏";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "触摸 ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "将当前笔记移至回收站";
 
 /* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "移到回收站";
+"Trash-noun" = "移到回收站";
 
-/* Trash (verb) - the action of deleting a note */
-"Trash" = "移到回收站";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "关闭密码";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "解锁 %@";
+/* Trash (noun) - the location where deleted notes are stored */
+"Trash-verb" = "移到回收站";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "取消固定笔记";
@@ -349,75 +210,191 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "正在取消发布...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "检测到未同步的备注";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "随时随地使用";
-
 /* Represents a snapshot in time for a note */
 "Version" = "版本";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "欢迎使用 Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "连接至互联网，访问之前版本";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "您觉得 Simplenote 怎么样？";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "切换至此版本";
 
-/* Message shown in first launch view */
-"Work together" = "协同运作";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "正在获取版本";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "昨天";
 
-/* No comment provided by engineer. */
-"Your Email:" = "您的电子邮件：";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "密码尝试失败 %i 次";
+
+/* Message shown on passcode lock screen */
+"Enter a passcode" = "输入密码";
+
+/* Pin Lock */
+"Enter your passcode" = "输入您的密码";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "密码不匹配。重试。";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "再次输入密码";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "设置密码";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "关闭密码";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "解锁 %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "密码尝试失败 %i 次";
+
+"welcomeNote-iOS" = "欢迎使用 iOS 版 Simplenote！
+
+要添加笔记，请轻点“加号”按钮。
+
+弹出列表即可浏览笔记。轻点标题即可查看笔记；轻点笔记内容即可对其进行更改。
+
+您可以通过在笔记列表顶部的搜索字段中输入相关内容来搜索笔记。
+
+要查看标签，请轻点左上方的“箭头”按钮或滑动笔记列表。您可以在笔记编辑器底部向笔记添加标签，并借助侧边栏来整理笔记。
+
+您可以根据需要选择其他笔记选项。您可以将其他人添加为笔记的协作者，或将笔记作为网页发布。
+
+您可以通过 Mac、Android 设备或网络浏览器 (http://simplenote.com) 使用 Simplenote。您的笔记可随时随地自动更新。";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "按字母顺序对笔记进行排序";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "已有帐户？";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "确认";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "无法使用所提供的电子邮件地址和密码创建帐户。";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "无法使用所提供的电子邮件地址和密码登录。";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "还没有帐户？";
+
+/* Number of failed entries entering in passcode */
+"Password" = "密码";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "密码中必须至少包含 4 个字符。";
+
+/* Message displayed when login fails */
+"Sign in" = "登录";
+
+/* Message displayed when login fails */
+"Sign In" = "登录";
+
+/* TOS */
+"Sign up" = "注册";
+
+/* TOS */
+"Sign Up" = "注册";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "连接出错。请稍后重试。";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "您输入的电子邮件地址无效。";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "使用快速搜索以及简单的标签来迅速查找笔记。";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "开始";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "分享列表、发布一些说明或发表自己的想法。";
+
+/* Message shown in first launch view */
+"Stay organized" = "井井有条";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "随时随地使用";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "欢迎使用 Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "协同运作";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "您所有设备上的笔记会同步更新。无需按任何按钮。就是这么方便。";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "同意他人进行协作";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "深色主题";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "调试";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "yyyy MMM d";
+
+/* Month, day, and year date formatter */
+"MMM yyyy" = "yyyy MMM";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "触摸 ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "安全";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "注册即表示您同意我们的服务条款 »";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "您觉得 Simplenote 怎么样？";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "添加电子邮件地址即可与他人分享此笔记。而且，您与协作者均可对笔记作出更改。";
+"I Like It" = "我喜欢";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "此笔记已从其他设备上删除。";
+/* No comment provided by engineer. */
+"Could Be Better" = "还可以更好";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "将笔记恢复至之前版本";
+/* No comment provided by engineer. */
+"Leave a Review" = "留下评价";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "显示笔记选项";
+/* No comment provided by engineer. */
+"No Thanks" = "不用了，谢谢";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "关闭当前笔记";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "您可以告诉我们如何改进吗？";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "分享当前笔记的内容";
+/* No comment provided by engineer. */
+"Send Feedback" = "发送反馈";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "向当前笔记中添加标签";
+/* Ratings View: Contact */
+"Contact" = "联系";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "将标签从当前笔记中删除";
+/* No comment provided by engineer. */
+"Your Email:" = "您的电子邮件：";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "将当前笔记移至回收站";
+/* No comment provided by engineer. */
+"How can we help?" = "您希望我们如何为您提供帮助？";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "连接至互联网，访问之前版本";
+/* No comment provided by engineer. */
+"Back" = "返回";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "切换至此版本";
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "注销会删除所有未同步的备注。您可以通过登录 Web 应用程序以确认您已同步的备注。";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "正在获取版本";
-
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "欢迎使用 iOS 版 Simplenote！\n\n要添加笔记，请轻点“加号”按钮。\n\n弹出列表即可浏览笔记。轻点标题即可查看笔记；轻点笔记内容即可对其进行更改。\n\n您可以通过在笔记列表顶部的搜索字段中输入相关内容来搜索笔记。\n\n要查看标签，请轻点左上方的“箭头”按钮或滑动笔记列表。您可以在笔记编辑器底部向笔记添加标签，并借助侧边栏来整理笔记。\n\n您可以根据需要选择其他笔记选项。您可以将其他人添加为笔记的协作者，或将笔记作为网页发布。\n\n您可以通过 Mac、Android 设备或网络浏览器 (http:\/\/simplenote.com) 使用 Simplenote。您的笔记可随时随地自动更新。";
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "检测到未同步的备注";
 

--- a/Simplenote/zh-Hant-TW.lproj/Localizable.strings
+++ b/Simplenote/zh-Hant-TW.lproj/Localizable.strings
@@ -15,12 +15,6 @@
 /* Number of words in a note */
 "%d Words" = "%d 字";
 
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempt" = "嘗試輸入密碼失敗 %i 次";
-
-/* Number of failed entries entering in passcode */
-"%i Failed Passcode Attempts" = "嘗試輸入密碼失敗 %i 次";
-
 /* Label of accept button on alert dialog */
 "Accept" = "接受";
 
@@ -30,53 +24,23 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "新增協作者…";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tag..." = "標籤…";
-
 /* Label on button to add a new tag to a note */
 "Add tag" = "新增標籤";
-
-/* Title of option to display all notes */
-"All Notes" = "All Notes";
-
-/* A short description to access the account login screen */
-"Already have an account?" = "已經有帳號了？";
-
-/* No comment provided by engineer. */
-"Back" = "上一步";
-
-/* TOS */
-"By signing up, you agree to our Terms of Service »" = "註冊即代表你同意我們的「服務條款」»";
 
 /* No comment provided by engineer. */
 "Cancel" = "取消";
 
-/* Verb - work with others on a note */
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborate" = "協作";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"collaborate-accessibility-hint" = "將其他人加入協作";
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "協作者";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Condensed Note List";
-
-/* Hint displayed in the password confirmation field */
-"Confirm" = "確認";
-
-/* Ratings View: Contact */
-"Contact" = "聯絡";
-
 /* No comment provided by engineer. */
-"Could Be Better" = "可以再好一點";
-
-/* An error message */
-"Could not create an account with the provided email address and password." = "無法使用提供的電子郵件地址和密碼建立帳號。";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "無法使用提供的電子郵件地址和密碼登入。";
-
-/* Ratings View: Don't Like */
-"Could you tell us how we could improve?" = "你可以告訴我們哪裡該改進嗎？";
+"collaborators-description" = "新增電子郵件地址，將此筆記與他人分享。這樣雙方都能變更筆記內容。";
 
 /* No comment provided by engineer. */
 "Create a new note" = "建立新筆記";
@@ -84,20 +48,11 @@
 /* No comment provided by engineer. */
 "Current Collaborators" = "目前協作者";
 
-/* Option to enable the dark app theme. */
-"Dark Theme" = "深色系佈景主題";
-
-/* Debug Screen Title Display internal debug status */
-"Debug" = "偵錯";
-
-/* Permanent Delete */
-"Delete" = "刪除";
+/* Warning message shown when current note is deleted on another device */
+"deleted-note-warning" = "此筆記已在另一部裝置上刪除。";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "收起鍵盤";
-
-/* A short description to access the account creation screen */
-"Don't have an account?" = "還沒有帳號？";
 
 /* No comment provided by engineer. */
 "Done" = "完成";
@@ -111,60 +66,20 @@
 /* Remove all notes from the trash */
 "Empty trash" = "清空垃圾桶";
 
-/* Message shown on passcode lock screen */
-"Enter a passcode" = "輸入密碼";
-
-/* Pin Lock */
-"Enter your passcode" = "輸入你的密碼";
-
-/* Passcode Failed Attempts */
-"Have you lost access to Simplenote? You can regain access by re-installing the app and logging into your account." = "是否無法存取 Simplenote？重新安裝應用程式並登入帳號即可再次存取 Simplenote。";
-
-/* Description of Simplenote shown in first launch view */
-"Find notes quickly with instant searching and simple tags." = "利用即時搜尋和簡單的標籤，快速找到筆記。";
-
-/* Forgot Password */
-"Forgot your password? »" = "Forgot your password? »";
-
-/* Button label shown on first launch screen to start the log in process */
-"Get Started" = "開始使用";
-
-/* Ratings View: Like */
-"Great! Could you leave us a nice review?
-\nIt really helps." = "太棒了！你可以給我們一些回饋嗎？\n\n\n您的回饋會使我們更好";
-
 /* Noun - the version history of a note */
 "History" = "歷史紀錄";
+
+/* Accessibility hint on button which shows the history of a note */
+"history-accessibility-hint" = "將筆記還原至先前版本";
 
 /* Action - view the version history of a note */
 "History..." = "歷史紀錄…";
 
-/* No comment provided by engineer. */
-"How can we help?" = "需要什麼協助？";
-
-/* No comment provided by engineer. */
-"I Like It" = "我喜歡";
-
-/* No comment provided by engineer. */
-"Leave a Review" = "留下評語";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "MMM d, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "選單";
 
-/* Label to create a new note */
-"New note" = "New note";
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"menu-accessibility-hint" = "顯示筆記選項";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "沒有筆記";
@@ -172,23 +87,20 @@
 /* Message shown when no notes match a search string */
 "No Results" = "沒有任何搜尋結果";
 
-/* No comment provided by engineer. */
-"No Thanks" = "不用了，謝謝";
-
 /* Confirmation shown when a note is published */
 "Note Published" = "筆記已發表";
 
 /* No comment provided by engineer. */
-"Note not published" = "Note not published";
-
-/* Plural form of notes */
 "Notes" = "筆記";
 
-/* No comment provided by engineer. */
-"OK" = "確定";
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"notes-accessibility-hint" = "關閉目前筆記";
 
 /* No comment provided by engineer. */
 "Off" = "關閉";
+
+/* No comment provided by engineer. */
+"OK" = "確定";
 
 /* No comment provided by engineer. */
 "On" = "開啟";
@@ -196,17 +108,8 @@
 /* Select a note to view in the note editor */
 "Open note" = "開啟筆記";
 
-/* A 4-digit code to lock the app when it is closed */
+/* Number of failed entries entering in passcode */
 "Passcode" = "密碼";
-
-/* Pin Lock */
-"Passcodes did not match. Try again." = "密碼不相符。請再試一次。";
-
-/* Hint displayed in the password field */
-"Password" = "密碼";
-
-/* Message displayed when password is invalid */
-"Password must contain at least 4 characters." = "密碼必須包含至少 4 個字元。";
 
 /* Action to mark a note as pinned */
 "Pin note" = "釘選筆記";
@@ -223,10 +126,7 @@
 /* No comment provided by engineer. */
 "Preferences" = "喜好設定";
 
-/* Markdown Preview */
-"Preview" = "預覽";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+/* Confirmation shown when a note is published */
 "Publish" = "發表";
 
 /* Failure message after attempting to publish a note */
@@ -238,20 +138,17 @@
 /* Switch which marks a note as published or unpublished */
 "Publish toggle" = "發表開關";
 
-/* No comment provided by engineer. */
+/* Confirmation shown when a note is published */
 "Published" = "已發表";
 
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "正在發表…";
 
-/* Prompt when setting up a passcode */
-"Re-enter a passcode" = "重新輸入密碼";
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "移除垃圾桶的所有筆記";
 
 /* Delete a tag and remove it from all associated notes */
 "Remove Tag" = "移除標籤";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "移除垃圾桶的所有筆記";
 
 /* Prompt asking user to confirm the removal of a tag from a note */
 "Remove tag?" = "移除標籤？";
@@ -265,59 +162,29 @@
 /* Restore a note to a previous version */
 "Restore Note" = "還原筆記";
 
-/* Title displayed in the Option's Security section. */
-"Security" = "安全性";
-
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "傳送";
 
 /* No comment provided by engineer. */
-"Send Feedback" = "傳送回饋意見";
-
-/* Prompt when setting up a passcode */
-"Set Passcode" = "設定密碼";
-
-/* Title of options screen */
 "Settings" = "設定";
 
-/* Description of Simplenote shown in first launch view */
-"Share a list, post some instructions, or publish your thoughts." = "分享清單、張貼說明，或是發表你的想法，都沒問題。";
-
-/* No comment provided by engineer. */
-"Share note" = "Share note";
+/* Accessibility hint on button to share note */
+"share-accessibility-hint" = "分享目前筆記的內容";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "側選單";
 
-/* Title of button for logging in (must be short) */
-"Sign In" = "登入";
-
 /* Sign out of the active account in the app */
 "Sign Out" = "登出";
 
-/* Title of button to create a new account (must be short) */
-"Sign Up" = "註冊";
+/* Accessibility hint for adding a tag to a note */
+"tag-add-accessibility-hint" = "將標籤新增至目前筆記";
 
-/* A short link to access the account login screen */
-"Sign in" = "登入";
-
-/* A short link to access the account creation screen */
-"Sign up" = "註冊";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "登出將會刪除任何尚未同步的備註。登入網頁應用程式即可驗證已同步的備註。";
-
-/* Option to sort notes in the note list alphabetically. The default is by modification date */
-"Sort Notes Alphabetically" = "以字母排序筆記";
-
-/* Message shown in first launch view */
-"Stay organized" = "有條不紊";
+/* Accessibility hint on button to remove a tag from a current note */
+"tag-delete-accessibility-hint" = "移除目前筆記的標籤";
 
 /* Text used to display the name of a tag */
 "Tag: %@" = "標籤：%@";
-
-/* Details for a dialog that is displayed when there's a connection problem */
-"There's a problem with the connection.  Please try again later." = "連線發生問題。請稍後再試一次。";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "今天";
@@ -325,20 +192,14 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "切換標籤側選單";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Touch ID";
+/* Accessibility hint on button which moves a note to the trash */
+"trash-accessibility-hint" = "將目前筆記移至垃圾桶";
 
-/* Trash (noun) - the location where deleted notes are stored */
-"Trash" = "垃圾桶";
+/* Remove all notes from the trash */
+"Trash-noun" = "垃圾桶";
 
 /* Trash (verb) - the action of deleting a note */
-"Trash" = "移至垃圾桶";
-
-/* Prompt when disabling passcode */
-"Turn off Passcode" = "關閉密碼";
-
-/* Message shown when gaining entry to app via a passcode */
-"Unlock %@" = "解除鎖定 %@";
+"Trash-verb" = "移至垃圾桶";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "取消釘選筆記";
@@ -349,75 +210,209 @@
 /* Message shown when unpublishing a note */
 "Unpublishing..." = "正在取消發表...";
 
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "偵測到尚未同步的備註";
-
-/* Message shown in first launch view */
-"Use it everywhere" = "隨時隨地都可使用";
-
 /* Represents a snapshot in time for a note */
 "Version" = "版本";
 
-/* Message shown in first launch view */
-"Welcome to Simplenote" = "歡迎使用 Simplenote";
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"version-alert-message" = "連線至網際網路以存取先前版本";
 
-/* Ratings View */
-"What do you think about Simplenote?" = "你覺得 Simplenote 如何？";
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"version-cell-accessibility-hint" = "切換至此版本";
 
-/* Message shown in first launch view */
-"Work together" = "一同協作";
+/* Accessibility hint used when previous versions of a note are being fetched */
+"version-cell-fetching-accessibility-hint" = "正在擷取此版本";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "昨天";
 
-/* No comment provided by engineer. */
-"Your Email:" = "你的電子郵件：";
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempt" = "嘗試輸入密碼失敗 %i 次";
+
+/* Number of failed entries entering in passcode */
+"Enter a passcode" = "輸入密碼";
+
+/* Pin Lock */
+"Enter your passcode" = "輸入你的密碼";
+
+/* Pin Lock */
+"Passcodes did not match. Try again." = "密碼不相符。請再試一次。";
+
+/* Prompt when setting up a passcode */
+"Re-enter a passcode" = "重新輸入密碼";
+
+/* Prompt when setting up a passcode */
+"Set Passcode" = "設定密碼";
+
+/* Prompt when disabling passcode */
+"Turn off Passcode" = "關閉密碼";
+
+/* Message shown when gaining entry to app via a passcode */
+"Unlock %@" = "解除鎖定 %@";
+
+/* Number of failed entries entering in passcode */
+"%i Failed Passcode Attempts" = "嘗試輸入密碼失敗 %i 次";
+
+"welcomeNote-iOS" = "歡迎使用 Simplenote iOS 版！
+
+若要新增筆記，請點選加號按鈕。
+
+撥動清單即可瀏覽你的筆記。點選標題可瀏覽筆記，然後點選內容則可進行變更。
+
+你可以在筆記清單頂端的搜尋欄位內輸入關鍵字搜尋你全部的筆記。
+
+點選左上方的箭號按鈕或撥動筆記清單可檢視標籤。在筆記編輯器底部可將標籤新增至筆記，然後使用側選單可協助你妥善整理筆記。
+
+若有需要，還有更多筆記選項可供使用。你可以將其他人新增為筆記的協作者，或是將筆記發表至網頁。
+
+前往 http://simplenote.com 將 Simplenote 下載至你的 Mac、Android 裝置或在網頁瀏覽器中使用。你的筆記將會隨時隨地保持更新。";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date */
+"Sort Notes Alphabetically" = "以字母排序筆記";
+
+/* A short description to access the account login screen */
+"Already have an account?" = "已經有帳號了？";
+
+/* Hint displayed in the password confirmation field */
+"Confirm" = "確認";
+
+/* An error message */
+"Could not create an account with the provided email address and password." = "無法使用提供的電子郵件地址和密碼建立帳號。";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "無法使用提供的電子郵件地址和密碼登入。";
+
+/* A short description to access the account creation screen */
+"Don't have an account?" = "還沒有帳號？";
+
+/* Number of failed entries entering in passcode */
+"Password" = "密碼";
+
+/* Message displayed when password is invalid */
+"Password must contain at least 4 characters." = "密碼必須包含至少 4 個字元。";
+
+/* Message displayed when login fails */
+"Sign in" = "登入";
+
+/* Message displayed when login fails */
+"Sign In" = "登入";
+
+/* TOS */
+"Sign up" = "註冊";
+
+/* TOS */
+"Sign Up" = "註冊";
+
+/* Details for a dialog that is displayed when there's a connection problem */
+"There's a problem with the connection.  Please try again later." = "連線發生問題。請稍後再試一次。";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid." = "你的電子郵件地址無效。";
 
 /* Description of Simplenote shown in first launch view */
+"Find notes quickly with instant searching and simple tags." = "利用即時搜尋和簡單的標籤，快速找到筆記。";
+
+/* Button label shown on first launch screen to start the log in process */
+"Get Started" = "開始使用";
+
+/* Description of Simplenote shown in first launch view */
+"Share a list, post some instructions, or publish your thoughts." = "分享清單、張貼說明，或是發表你的想法，都沒問題。";
+
+/* Message shown in first launch view */
+"Stay organized" = "有條不紊";
+
+/* Message shown in first launch view */
+"Use it everywhere" = "隨時隨地都可使用";
+
+/* Message shown in first launch view */
+"Welcome to Simplenote" = "歡迎使用 Simplenote";
+
+/* Message shown in first launch view */
+"Work together" = "一同協作";
+
+/* Description of Simplenote shown in first launch view */
 "Your notes stay updated across all your devices. No buttons to press. It just works." = "你的筆記會在你所有的裝置上更新。不用按按鈕。就是這麼簡單好用。";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"Enable others to collaborate" = "將其他人加入協作";
+/* Option to enable the dark app theme. */
+"Dark Theme" = "深色系佈景主題";
+
+/* Debug Screen Title Display internal debug status */
+"Debug" = "偵錯";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "MMM d, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+
+"Touch ID" = "Touch ID";
+
+/* Title displayed in the Option's Security section. */
+"Security" = "安全性";
+
+/* TOS */
+"By signing up, you agree to our Terms of Service »" = "註冊即代表你同意我們的「服務條款」»";
+
+/* Ratings View */
+"What do you think about Simplenote?" = "你覺得 Simplenote 如何？";
 
 /* No comment provided by engineer. */
-"Add an email address to share this note with someone. Then you can both make changes to it." = "新增電子郵件地址，將此筆記與他人分享。這樣雙方都能變更筆記內容。";
+"I Like It" = "我喜歡";
 
-/* Warning message shown when current note is deleted on another device */
-"This note was deleted on another device." = "此筆記已在另一部裝置上刪除。";
+/* No comment provided by engineer. */
+"Could Be Better" = "可以再好一點";
 
-/* Accessibility hint on button which shows the history of a note */
-"Restore note to previous version" = "將筆記還原至先前版本";
+"Great! Could you leave us a nice review?
+It really helps." = "太棒了！你可以給我們一些回饋嗎？
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"Show options for note" = "顯示筆記選項";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"Close current note" = "關閉目前筆記";
+您的回饋會使我們更好";
 
-/* Accessibility hint on button to share note */
-"Share the content of the current note" = "分享目前筆記的內容";
+/* No comment provided by engineer. */
+"Leave a Review" = "留下評語";
 
-/* Accessibility hint for adding a tag to a note */
-"Add a tag to the current note" = "將標籤新增至目前筆記";
+/* No comment provided by engineer. */
+"No Thanks" = "不用了，謝謝";
 
-/* Accessibility hint on button to remove a tag from a current note */
-"Remove tag from the current note" = "移除目前筆記的標籤";
+/* Ratings View: Don't Like */
+"Could you tell us how we could improve?" = "你可以告訴我們哪裡該改進嗎？";
 
-/* Accessibility hint on button which moves a note to the trash */
-"Move the current note to trash" = "將目前筆記移至垃圾桶";
+/* No comment provided by engineer. */
+"Send Feedback" = "傳送回饋意見";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"Connect to the Internet to Access Previous Versions" = "連線至網際網路以存取先前版本";
+/* Ratings View: Contact */
+"Contact" = "聯絡";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"Switch to this version" = "切換至此版本";
+/* No comment provided by engineer. */
+"Your Email:" = "你的電子郵件：";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"Fetching version" = "正在擷取此版本";
+/* No comment provided by engineer. */
+"How can we help?" = "需要什麼協助？";
 
-/* A welcome note for new iOS users */
-"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "歡迎使用 Simplenote iOS 版！\n\n若要新增筆記，請點選加號按鈕。\n\n撥動清單即可瀏覽你的筆記。點選標題可瀏覽筆記，然後點選內容則可進行變更。\n\n你可以在筆記清單頂端的搜尋欄位內輸入關鍵字搜尋你全部的筆記。\n\n點選左上方的箭號按鈕或撥動筆記清單可檢視標籤。在筆記編輯器底部可將標籤新增至筆記，然後使用側選單可協助你妥善整理筆記。\n\n若有需要，還有更多筆記選項可供使用。你可以將其他人新增為筆記的協作者，或是將筆記發表至網頁。\n\n前往 http:\/\/simplenote.com 將 Simplenote 下載至你的 Mac、Android 裝置或在網頁瀏覽器中使用。你的筆記將會隨時隨地保持更新。";
+/* No comment provided by engineer. */
+"Back" = "上一步";
+
+/* Permanent Delete */
+"Delete" = "刪除";
+
+/* Markdown Preview */
+"Preview" = "預覽";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "登出將會刪除任何尚未同步的備註。登入網頁應用程式即可驗證已同步的備註。";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "偵測到尚未同步的備註";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Add a tag..." = "標籤…";
+
+/* Passcode Failed Attempts */
+"FailedAttempts" = "是否無法存取 Simplenote？重新安裝應用程式並登入帳號即可再次存取 Simplenote。";
 


### PR DESCRIPTION
### Fix
This PR fixes an issue where some entries in `Localizable.strings` for languages other than English were  not in the correct format. 
Simplenote expects the strings to be referenced by a `key`, but GlotPress uses the `original` value as key when exporting in the `strings` format (https://github.com/GlotPress/GlotPress-WP/blob/2272ba7232f2e75ad1f3f0617ed09749990acc85/gp-includes/formats/format-strings.php#L77).
This results in missing translations in the app.

To fix it, we can export the translations using the `JSON` [format](https://github.com/GlotPress/GlotPress-WP/blob/2272ba7232f2e75ad1f3f0617ed09749990acc85/gp-includes/formats/format-json.php) that exports the proper keys. 

Since the comments are not exported in JSON, the script now downloads both the versions and merges them in order to create the final `Localizable.strings`.


### Test
1. Modify some translated strings.
2. Run `./Scripts/update-translations.rb` and verify that the translations are downloaded correctly.
3. Build the app and verify that the translations are recognized correctly (As an example, `trash-noun` and `trash-verb` are not correctly recognized before this fix).