### PR TITLE
Share Extension: First Responder Handling

### DIFF
--- a/SimplenoteShare/ViewControllers/ShareViewController.swift
+++ b/SimplenoteShare/ViewControllers/ShareViewController.swift
@@ -80,6 +80,11 @@ class ShareViewController: UIViewController {
         loadContent()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        textView.becomeFirstResponder()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         ensureSimperiumTokenIsValid()
@@ -126,6 +131,7 @@ private extension ShareViewController {
     /// from the original `NSExtensionContext`
     ///
     func dismissExtension() {
+        view.endEditing(true)
         dismiss(animated: true, completion: self.dismissalCompletionBlock)
     }
 }


### PR DESCRIPTION
### Details:
In this PR we're doing a super minor enhancement:

1. The keyboard is now expected to animate along with the Share Extension animation
2. And whenever the Share Extension is dismissed, the keyboard should animate along!

### Testing:
1. Launch Simplenote (**easy steps**
2. Switch over to Safari
3. Trigger Simplenote's Share Extension

- [x] Verify that the keyboard animates along, and the TextView is the first responder
- [x] Verify that dismissing the Share Extension causes the keyboard to animate along
