### PR TITLE
Share extension: Absolute URL fallback for URLExtractor.buildExternalLinkNote

### DIFF
--- a/SimplenoteShare/Extractors/URLExtractor.swift
+++ b/SimplenoteShare/Extractors/URLExtractor.swift
@@ -116,11 +116,16 @@ private extension URLExtractor {
     /// Builds a Note for an external link
     ///
     func buildExternalLinkNote(with url: URL, context: NSExtensionContext) -> Note? {
-        guard url.isFileURL == false, let payload = context.attributedContentText?.string else {
+        guard url.isFileURL == false else {
             return nil
         }
 
-        let content = payload + "\n\n[" + url.absoluteString + "]"
+        var content = ""
+        if let payload = context.attributedContentText?.string {
+            content += payload + "\n\n"
+        }
+
+        content += "[" + url.absoluteString + "]"
         return Note(content: content)
     }
 }


### PR DESCRIPTION
**Hotfix for v4.9**

This PR fixes `URLExtractor.buildExternalLinkNote` such that if content cannot be extracted from `context.attributedContentText` we at least insert the absolute URL into a new note.

![fix_for_url_share](https://user-images.githubusercontent.com/154014/62159875-54638880-b2d8-11e9-922e-c8cb00a149b3.gif)

Fixes #377 

## Testing

1. Install and run the [News360 app](https://news360.com/)
2. Attempt to share an article to Simplenote
3. Verify the article link appears in the note.

@jleandroperez Would you mind giving this PR a 👀 ?

/cc @jtreanor 