### PR TITLE
Restoring First Responder Behavior

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -214,7 +214,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 - (void)ensureEditorIsFirstResponder
 {
-    if ((_noteEditorTextView.text.length == 0) && !bActionSheetVisible && !_isPreviewing) {
+    if ((_currentNote.content.length == 0) && !bActionSheetVisible && !_isPreviewing) {
         [_noteEditorTextView becomeFirstResponder];
     }
 }


### PR DESCRIPTION
### Details:
As a side effect of #395, i'm afraid, the First Reponder behavior has been altered. Simplenote is expected to automatically display the keyboard **only** when the note being edited is effectively empty.

Thanks in advance gentlemen!
cc @bummytime or @aerych 

### Testing
- [x] Verify that opening an **Empty Note** immeditely causes the Keyboard to show up
- [x] Verify that opening a **NON Empty Note** doesn't cause the keyboard to show up