### PR TITLE
SignUp >> Login String

### DIFF
--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -78,7 +78,7 @@ extension SPAuthError {
         case .signupBadCredentials:
             return NSLocalizedString("Could not create an account with the provided email address and password.", comment: "Error for bad email or password")
         case .signupUserAlreadyExists:
-            return NSLocalizedString("The email you've entered is already associated with a simplenote account.", comment: "Error when address is in use")
+            return NSLocalizedString("The email you've entered is already associated with a Simplenote account.", comment: "Error when address is in use")
         case .unknown:
             return NSLocalizedString("We're having problems. Please try again soon.", comment: "Generic error")
         default:


### PR DESCRIPTION
### Details:
In this PR we're shipping a tiny minor string-fix. Zero behavior is altered.

cc @frosty May i trouble you with a really quick review?
Thank you!

### Test
1. Fresh install the app
2. Press over **Create an Account**
3. Enter a username + password that already exists

Verify that an alert shows up, and Simplenote is in uppercase:

```
The email you've entered is already associated with a simplenote account.
```
