### PR TITLE
Forgot Password: Escaping Emails

### DIFF
--- a/Simplenote/Classes/SPAuthHandler.swift
+++ b/Simplenote/Classes/SPAuthHandler.swift
@@ -135,7 +135,8 @@ class SPAuthHandler {
     /// Presents the Password Reset (Web) Interface
     ///
     func presentPasswordReset(from sourceViewController: UIViewController, username: String) {
-        guard let targetURL = URL(string: kSimperiumForgotPasswordURL + "?email=" + username) else {
+        let escapedUsername = username.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? username
+        guard let targetURL = URL(string: kSimperiumForgotPasswordURL + "?email=" + escapedUsername) else {
             return
         }
 


### PR DESCRIPTION
### Details:
In this PR we're fixing the Forgot Password pre-fill: email addresses that contain special characters (such as +) will now be properly escaped.

@aerych sir, may i trouble you yet again?
Thanks in advance!!


### Testing:
1. Fresh install the app
2. Press `Log In` > `Log In with Email`
3. Enter an email address with a + sign (ie. `test+9999@invalid.invalid`)
4. Press over `Forgotten Password`

Verify that the Forgot Password WebView shows up, and the `+` is properly displayed.

