### PR TITLE
Peek + Pop: Preventing Pan

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		B58218A51FCC45330094ECA1 /* KeychainMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58218A41FCC45330094ECA1 /* KeychainMigratorTests.swift */; };
 		B59314D81A486B3800B651ED /* SPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = B59314D61A486B3800B651ED /* SPConstants.m */; };
 		B59484BF1D6CE2580006D427 /* config.plist in Resources */ = {isa = PBXBuildFile; fileRef = BE7F27BB1D5A47DE00A1A0A9 /* config.plist */; };
+		B59FFB43231851C700567627 /* UIGestureRecognizer+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59FFB42231851C700567627 /* UIGestureRecognizer+Simplenote.swift */; };
 		B5A6166F2150855300CBE47B /* Preferences.m in Sources */ = {isa = PBXBuildFile; fileRef = B594E61321508247001577EE /* Preferences.m */; };
 		B5AA4B5222F46A0F0072BF5D /* UIColorName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C57A4022E78F4D009166EA /* UIColorName.swift */; };
 		B5AA4B5322F46A200072BF5D /* VSTheme+Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513FB2522EF6A7300B178AC /* VSTheme+Keys.swift */; };
@@ -445,6 +446,7 @@
 		B594E60C21508170001577EE /* Simplenote 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 4.xcdatamodel"; sourceTree = "<group>"; };
 		B594E61321508247001577EE /* Preferences.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Preferences.m; sourceTree = "<group>"; };
 		B594E61421508247001577EE /* Preferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Preferences.h; sourceTree = "<group>"; };
+		B59FFB42231851C700567627 /* UIGestureRecognizer+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIGestureRecognizer+Simplenote.swift"; path = "Classes/UIGestureRecognizer+Simplenote.swift"; sourceTree = "<group>"; };
 		B5AA4B5922F46B300072BF5D /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Colors.xcassets; path = Simplenote/Colors.xcassets; sourceTree = SOURCE_ROOT; };
 		B5AB169722FA124F00B4EBA5 /* SPSheetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSheetController.swift; path = Classes/SPSheetController.swift; sourceTree = "<group>"; };
 		B5AB169922FA128000B4EBA5 /* SPSheetController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSheetController.xib; path = Classes/SPSheetController.xib; sourceTree = "<group>"; };
@@ -967,6 +969,7 @@
 				B5CDE61D2150834C00C3FED4 /* Simperium+Simplenote.h */,
 				B5CDE61E2150834C00C3FED4 /* Simperium+Simplenote.m */,
 				B50F479E1D1D77FC00822748 /* UIAlertController+Helpers.swift */,
+				B59FFB42231851C700567627 /* UIGestureRecognizer+Simplenote.swift */,
 				B56A695A22F9CD4E00B90398 /* UINavigationBar+Simplenote.swift */,
 				B56A696622F9D55F00B90398 /* UIView+Animations.swift */,
 				B56E763522BD565700C5AA47 /* UIView+Simplenote.swift */,
@@ -1789,6 +1792,7 @@
 				46A3C96C17DFA81A002865AE /* SPOptionsViewController.m in Sources */,
 				B52BB74A22CFC0670042C162 /* FileManager+Simplenote.swift in Sources */,
 				3762530620F54FFB00C1F239 /* SPAboutViewController.swift in Sources */,
+				B59FFB43231851C700567627 /* UIGestureRecognizer+Simplenote.swift in Sources */,
 				B550F93622BA7E9100091939 /* NSUserActivity+Simplenote.swift in Sources */,
 				B5BE054E1AB75902002417BF /* NSProcessInfo+Util.m in Sources */,
 				46A3C96D17DFA81A002865AE /* SPOutsideTouchView.m in Sources */,

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -22,8 +22,13 @@ extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
             return nil
         }
 
+        /// Prevent any Pan gesture from passing thru
+        panGestureRecognizer.fail()
+
+        /// Mark the source of the interaction
         previewingContext.sourceRect = tableView.rectForRow(at: indexPath)
 
+        /// Setup the Editor
         let note = fetchedResultsController.object(at: indexPath)
         let editorViewController = SPAppDelegate.shared().noteEditorViewController
         editorViewController.update(note)

--- a/Simplenote/Classes/SPSidebarContainerViewController.h
+++ b/Simplenote/Classes/SPSidebarContainerViewController.h
@@ -37,6 +37,7 @@
 }
 
 @property (nonatomic, assign) id<SPContainerSidePanelViewDelegate> sidePanelViewDelegate;
+@property (nonatomic, strong) UIPanGestureRecognizer *panGestureRecognizer;
 @property (nonatomic, strong) UIView *rootView;
 @property (nonatomic, strong) SPSidebarViewController *sidePanelViewController;
 

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -24,7 +24,7 @@ static CGFloat sidePanelWidth;
 
 @implementation SPSidebarContainerViewController
 
-- (id)initWithSidebarViewController:(SPSidebarViewController *)sidebarViewController {
+- (instancetype)initWithSidebarViewController:(SPSidebarViewController *)sidebarViewController {
     
     self = [super init];
     if (self) {
@@ -37,10 +37,9 @@ static CGFloat sidePanelWidth;
         [self.view addSubview:_rootView];
         
         // setup gesture recognizers
-        UIPanGestureRecognizer *panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self
-                                                                                     action:@selector(viewDidPan:)];
-        panGesture.delegate = self;
-        [self.rootView addGestureRecognizer:panGesture];
+        self.panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(viewDidPan:)];
+        self.panGestureRecognizer.delegate = self;
+        [self.rootView addGestureRecognizer:_panGestureRecognizer];
         
         _sidePanelViewController = sidebarViewController;
         _sidePanelViewController.containerViewController = self;

--- a/Simplenote/Classes/UIGestureRecognizer+Simplenote.swift
+++ b/Simplenote/Classes/UIGestureRecognizer+Simplenote.swift
@@ -1,0 +1,15 @@
+import Foundation
+import UIKit
+
+
+// MARK: - UIGestureRecognizer Simplenote Methods
+//
+extension UIGestureRecognizer {
+
+    /// Forgive me: this is the only known way (AFAIK) to force a recognizer to fail. Seen in WWDC 2014 (somewhere), and a better way is yet to be found.
+    ///
+    func fail() {
+        isEnabled = false
+        isEnabled = true
+    }
+}


### PR DESCRIPTION
### Fix
In this PR we're preventing the Pan gesture recognizer from kicking in, whenever the Peek and Pop flow kicks in.

cc @danielebogo 
Daniele, may i bug you with a hopefully fun PR?

Thanks in advance!


### Test
1. Log into your account
2. Force touch over any of the rows
3. Verify the Preview UI kicks in
4. While maintaining the same pressure level, move sideways
5. Release your finger
6. Verify that the left sidebar didn't show up
7. Perform "swipe" left to right
8. Verify the Tags List shows up
