### PR TITLE
Hotfix: System theme Issue

### DIFF
--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -85,6 +85,14 @@ extension Options {
     var themeDescription: String {
         return theme.description
     }
+
+    /// Nukes all of the Options. Useful for *logout* scenarios
+    ///
+    @objc
+    func reset() {
+        defaults.removeObject(forKey: .theme)
+        defaults.removeObject(forKey: .listSortMode)
+    }
 }
 
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -550,8 +550,8 @@
 			
             [[CSSearchableIndex defaultSearchableIndex] deleteAllSearchableItemsWithCompletionHandler:nil];
             
-            // Always fall back to the default theme
-            [[Options shared] setTheme:ThemeSystem];
+            // Nuke all of the User Preferences
+            [[Options shared] reset];
             
 			// remove the pin lock
 			[self removePin];


### PR DESCRIPTION
### Details:
@loremattei spotted a bad bug in which the **System Theme** would end up being preselected, on iOS 12 devices.

This was causing a crash in the theme selection UI.

cc @loremattei @aerych 
**Thank you Lorenzo!!!**

### Testing:
1. Fresn install on an iOS 12 device
2. Log into your account
3. Logout
4. Login again
5. Open **Settings** >> **Theme**

Verify the Light Theme is preselected.
