### PR TITLE
Fixing Search Race Condition

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -767,6 +767,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     if (string.length > 0) {
         bSearching = YES;
         _searchString = string;
+        searchResultRanges = nil;
         [self.navigationController setToolbarHidden:NO animated:YES];
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -616,12 +616,14 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     }
     
     _currentNote = note;
-    [_noteEditorTextView scrollToTop];
-    
-    // push off updating note text in order to speed up animated transition
+    [self.noteEditorTextView scrollToTop];
+
+    // Synchronously set the TextView's contents. Otherwise we risk race conditions with `highlightSearchResults`
+    self.noteEditorTextView.attributedText = [note.content attributedString];
+
+    // Push off Checklist Processing to smoothen out push animation
     dispatch_async(dispatch_get_main_queue(), ^{
-        self->_noteEditorTextView.attributedText = [note.content attributedString];
-        [self->_noteEditorTextView processChecklists];
+        [self.noteEditorTextView processChecklists];
     });
     
     [self resetNavigationBarToIdentityWithAnimation:NO completion:nil];

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -28,6 +28,7 @@ extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
         let editorViewController = SPAppDelegate.shared().noteEditorViewController
         editorViewController.update(note)
         editorViewController.isPreviewing = true
+        editorViewController.searchString = searchText
 
         return editorViewController
     }


### PR DESCRIPTION
### Fix
In this PR we're fixing a race condition, which is preventing the Search feature from highlighting the matches.

@aerych May I trouble you with a quick review?

Thanks in advance!!

### Test
1. Log into your account
2. Search for any note's contents
3. Press over any of the matches
4. Verify you get the bottom bar to iterate over the matches
5. Repeat 1-2, but instead of pressing, perform the Force Press gesture
6. Verify the bottom bar allows you to iterate over matches
