### PR TITLE
Updating WordPress-AppBot dependency

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ abstract_target 'Automattic' do
 		pod 'Automattic-Tracks-iOS', '~> 0.4'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
 		pod 'Simperium', '~> 0.8.23'
-		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '479d05f7d6b963c9b44040e6ea9f190e8bd9a47a'
+		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :tag => '1.0.7'
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 
 		# Testing Target

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,7 +30,7 @@ PODS:
   - Simperium/SSKeychain (0.8.23)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPress-AppbotX (1.0.6)
+  - WordPress-AppbotX (1.0.7)
   - WordPress-Ratings-iOS (0.0.2)
   - ZIPFoundation (0.9.9)
 
@@ -42,7 +42,7 @@ DEPENDENCIES:
   - SAMKeychain (= 1.5.2)
   - Simperium (~> 0.8.23)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
+  - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, tag `1.0.7`)
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -64,13 +64,13 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPress-AppbotX:
-    :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
+    :tag: 1.0.7
 
 CHECKOUT OPTIONS:
   WordPress-AppbotX:
-    :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
+    :tag: 1.0.7
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -84,10 +84,10 @@ SPEC CHECKSUMS:
   Simperium: 71a5028fde163d1efead45b8b45adf4bdcf02039
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
+  WordPress-AppbotX: 624387ac980fc0663cbb9425e22bf514329be96f
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 53dfd6a1d87457ffb2f82ee7be603a373c0b5240
+PODFILE CHECKSUM: ac1230dcc0ef3ec22b03ea22ca29b6005ad547a1
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
### Details:
This PR contains literally zero changes. We're not locking against a Appbot commit hash anymore.
Instead... now we've got a beautiful tag, which should silence further Peril warnings.

cc @frosty 
James, may I bug you with a VERY small PR?
Thank you!!

### Testing:
- [ ] Please verify the app builds correctly!
