### PR TITLE
Splitting Notes List Initializer

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17C421CE1BE0BAB100752B56 /* SPInteractivePushPopAnimationController.m */; };
 		B50789FF1C1F5592009F097A /* markdown-default.css in Resources */ = {isa = PBXBuildFile; fileRef = 1748382E1BC1CC2D00E834AF /* markdown-default.css */; };
 		B5078A001C1F5595009F097A /* markdown-dark.css in Resources */ = {isa = PBXBuildFile; fileRef = 17BC3D461BC46BA800535DF3 /* markdown-dark.css */; };
+		B50E99F4234242130092F274 /* UISearchBar+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50E99F3234242130092F274 /* UISearchBar+Simplenote.swift */; };
 		B50F479F1D1D77FC00822748 /* UIAlertController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50F479E1D1D77FC00822748 /* UIAlertController+Helpers.swift */; };
 		B50F47A41D1D78EA00822748 /* SPRatingsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B50F47A31D1D78EA00822748 /* SPRatingsHelper.m */; };
 		B50F47A61D1D791B00822748 /* NSURL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */; };
@@ -398,6 +399,7 @@
 		A774E3E4F5041D36FBE400BD /* Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig"; sourceTree = "<group>"; };
 		AE066B9C23C9166D41F1A732 /* Pods-SimplenoteTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B303123B163A5C7805D10DC7 /* Pods-Automattic-Simplenote.distribution adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution adhoc.xcconfig"; sourceTree = "<group>"; };
+		B50E99F3234242130092F274 /* UISearchBar+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UISearchBar+Simplenote.swift"; path = "Classes/UISearchBar+Simplenote.swift"; sourceTree = "<group>"; };
 		B50F479E1D1D77FC00822748 /* UIAlertController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIAlertController+Helpers.swift"; path = "Classes/UIAlertController+Helpers.swift"; sourceTree = "<group>"; };
 		B50F47A21D1D78EA00822748 /* SPRatingsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPRatingsHelper.h; path = Classes/SPRatingsHelper.h; sourceTree = "<group>"; };
 		B50F47A31D1D78EA00822748 /* SPRatingsHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPRatingsHelper.m; path = Classes/SPRatingsHelper.m; sourceTree = "<group>"; };
@@ -1003,6 +1005,7 @@
 				B513F2B72319A9A40021CFA4 /* UITableViewCell+Simplenote.swift */,
 				B52AC185233587F8007B2E75 /* UITraitCollection+Simplenote.swift */,
 				B58039852322D4F90083C916 /* UIView+ImageRepresentation.swift */,
+				B50E99F3234242130092F274 /* UISearchBar+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1967,6 +1970,7 @@
 				46A3C9A617DFA81A002865AE /* SPActionSheet.m in Sources */,
 				E2922AC7180CAC62003AF914 /* SPSidebarViewController.m in Sources */,
 				375D24B221E01131007AB25A /* buffer.c in Sources */,
+				B50E99F4234242130092F274 /* UISearchBar+Simplenote.swift in Sources */,
 				46A3C9A717DFA81A002865AE /* DTPinLockController.m in Sources */,
 				B56A696522F9D54600B90398 /* SPLabel.swift in Sources */,
 				46A3C9A817DFA81A002865AE /* SPBorderedView.m in Sources */,

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -16,11 +16,15 @@ extension SPNoteListViewController {
     /// Refreshes the SearchBar Style.
     ///
     @objc
-    func styleSearchBar() {
+    func styleSearchBar(_ searchBar: UISearchBar) {
+        let backgroundImage = UIImage()
+        let backgroundColor = UIColor.color(name: .backgroundColor)?.withAlphaComponent(Constants.searchBarBackgroundAlpha)
         let searchIconColor = UIColor.color(name: .simplenoteSlateGrey)
         let searchIconImage = UIImage.image(name: .searchIconImage)?.withOverlayColor(searchIconColor)
 
+        searchBar.backgroundColor = backgroundColor
         searchBar.setImage(searchIconImage, for: .search, state: .normal)
+        searchBar.setBackgroundImage(backgroundImage, for: .any, barMetrics: .default)
         searchBar.setSearchFieldBackgroundImage(.searchBarBackgroundImage, for: .normal)
         searchBarContainer.backgroundColor = .clear
 
@@ -67,4 +71,14 @@ extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
         editorViewController.isPreviewing = false
         navigationController?.pushViewController(editorViewController, animated: true)
     }
+}
+
+
+// MARK: - Constants
+//
+private enum Constants {
+
+    /// SearchBar's Background Alpha, so that it matches with the navigationBar!
+    ///
+    static let searchBarBackgroundAlpha = CGFloat(0.9)
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -13,26 +13,17 @@ extension SPNoteListViewController {
         registerForPreviewing(with: self, sourceView: tableView)
     }
 
-    /// Refreshes the SearchBar Style.
+    /// Refreshes the ListViewController's Title
     ///
     @objc
-    func styleSearchBar(_ searchBar: UISearchBar) {
-        let backgroundImage = UIImage()
-        let backgroundColor = UIColor.color(name: .backgroundColor)?.withAlphaComponent(Constants.searchBarBackgroundAlpha)
-        let searchIconColor = UIColor.color(name: .simplenoteSlateGrey)
-        let searchIconImage = UIImage.image(name: .searchIconImage)?.withOverlayColor(searchIconColor)
+    func refreshTitle() {
+        let selectedTag = SPAppDelegate.shared().selectedTag ?? NSLocalizedString("All Notes", comment: "Title: No filters applied")
 
-        searchBar.backgroundColor = backgroundColor
-        searchBar.setImage(searchIconImage, for: .search, state: .normal)
-        searchBar.setBackgroundImage(backgroundImage, for: .any, barMetrics: .default)
-        searchBar.setSearchFieldBackgroundImage(.searchBarBackgroundImage, for: .normal)
-        searchBarContainer.backgroundColor = .clear
-
-        // Apply font to search field by traversing subviews
-        for textField in searchBar.subviewsOfType(UITextField.self) {
-            textField.font = .preferredFont(forTextStyle: .body)
-            textField.textColor = .color(name: .textColor)
-            textField.keyboardAppearance = SPUserInterface.isDark ? .dark : .default
+        switch selectedTag {
+        case kSimplenoteTagTrashKey:
+            title = NSLocalizedString("Trash-noun", comment: "Title: Trash Tag is selected")
+        default:
+            title = selectedTag
         }
     }
 }
@@ -71,14 +62,4 @@ extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
         editorViewController.isPreviewing = false
         navigationController?.pushViewController(editorViewController, animated: true)
     }
-}
-
-
-// MARK: - Constants
-//
-private enum Constants {
-
-    /// SearchBar's Background Alpha, so that it matches with the navigationBar!
-    ///
-    static let searchBarBackgroundAlpha = CGFloat(0.9)
 }

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -23,8 +23,6 @@ typedef enum {
     BOOL bSearching;
     BOOL bDisableUserInteraction;
     BOOL bListViewIsEmpty;
-    BOOL bTitleViewAnimating;
-    BOOL bResetTitleView;
     BOOL bIndexingNotes;
     BOOL bShouldShowSidePanel;
         

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -16,13 +16,6 @@ typedef enum {
 } SPTagFilterType;
 
 @interface SPNoteListViewController : SPSidebarContainerViewController {
-     
-    // Navigation Bar
-    UIBarButtonItem *addButton;
-    UIBarButtonItem *sidebarButton;
-    UIBarButtonItem *iPadCancelButton;
-
-    UIBarButtonItem *emptyTrashButton;
             
     NSTimer *searchTimer;
     

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -31,9 +31,7 @@ typedef enum {
     UIBarButtonItem *iPadCancelButton;
 
     UIBarButtonItem *emptyTrashButton;
-        
-    UIActivityIndicatorView *activityIndicator;
-    
+            
     NSTimer *searchTimer;
     
     // Bools

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -1,11 +1,3 @@
-//
-//  SPNoteListViewController.h
-//  Simplenote
-//
-//  Created by Tom Witkin on 7/3/13.
-//  Copyright (c) 2013 Automattic. All rights reserved.
-//
-
 #import <UIKit/UIKit.h>
 #import "SPBorderedTableView.h"
 #import "SPTransitionController.h"

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -988,7 +988,7 @@
     
     self.addButton.customView.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
     self.addButton.enabled = YES;
-    self.emptyTrashButton.enabled = (tagFilterType == SPTagFilterTypeDeleted && [self numNotes] > 0) || tagFilterType != SPTagFilterTypeDeleted ? YES : NO;
+    self.emptyTrashButton.enabled = (tagFilterType == SPTagFilterTypeDeleted && [self numNotes] > 0) || tagFilterType != SPTagFilterTypeDeleted;
     
     [UIView animateWithDuration:UIKitConstants.animationQuickDuration animations:^{
         self.searchBar.alpha = UIKitConstants.alphaFull;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -756,7 +756,7 @@
 {
     SPAppDelegate *appDelegate = [SPAppDelegate sharedDelegate];
     if (appDelegate.selectedTag != nil &&
-        [appDelegate.selectedTag compare:@"trash"] == NSOrderedSame) {
+        [appDelegate.selectedTag compare:kSimplenoteTagTrashKey] == NSOrderedSame) {
         
         tagFilterType = SPTagFilterTypeDeleted;
         _searchBar.placeholder = NSLocalizedString(@"Trash-noun", nil).lowercaseString;
@@ -781,7 +781,6 @@
     
     [self.tableView reloadData];
 }
-
 
 - (NSPredicate *)fetchPredicate {
     

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -191,7 +191,7 @@
     [self.tableView reloadData];
 
     // Restyle the search bar
-    [self styleSearchBar];
+    [self.searchBar applySimplenoteStyle];
 }
 
 - (void)updateNavigationBar {
@@ -218,7 +218,7 @@
         _searchBar.searchTextPositionAdjustment = UIOffsetMake(5, 1);
         _searchBar.searchBarStyle = UISearchBarStyleMinimal;
 
-        [self styleSearchBar];
+        [_searchBar applySimplenoteStyle];
 
         _searchBar.delegate = self;
         [_searchBarContainer addSubview:_searchBar];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -50,6 +50,9 @@
                                         UITextFieldDelegate,
                                         SPTransitionControllerDelegate>
 
+@property (nonatomic, strong) UISearchBar               *searchBar;
+@property (nonatomic, strong) UIActivityIndicatorView   *activityIndicator;
+
 @property (nonatomic, strong) SPTransitionController    *transitionController;
 @property (nonatomic, assign) CGFloat                   keyboardHeight;
 
@@ -1008,6 +1011,7 @@
     bDisableUserInteraction = NO;
     [(SPNavigationController *)self.navigationController setDisableRotation:NO];
 }
+
 
 #pragma mark - Index progress
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -75,43 +75,7 @@
 
         [self.tableView registerNib:[SPNoteTableViewCell loadNib] forCellReuseIdentifier:[SPNoteTableViewCell reuseIdentifier]];
 
-        // Dynamic Fonts!
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(contentSizeWasUpdated:)
-                                                     name:UIContentSizeCategoryDidChangeNotification
-                                                   object:nil];
-
-        // Condensed Notes
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(condensedPreferenceWasUpdated:)
-                                                     name:SPCondensedNoteListPreferenceChangedNotification
-                                                   object:nil];
-
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(sortOrderPreferenceWasUpdated:)
-                                                     name:SPNotesListSortModeChangedNotification
-                                                   object:nil];
-
-        // Voiceover status is tracked because the custom animated transition is not used when enabled
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(didReceiveVoiceoverNotification:)
-                                                     name:UIAccessibilityVoiceOverStatusDidChangeNotification
-                                                   object:nil];
-        
-        // Register for keyboard notifications
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(keyboardWillShow:)
-                                                     name:UIKeyboardWillShowNotification
-                                                   object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(keyboardWillHide:)
-                                                     name:UIKeyboardWillHideNotification
-                                                   object:nil];
-        // Themes
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(themeDidChange)
-                                                     name:VSThemeManagerThemeDidChangeNotification
-                                                   object:nil];
+        [self startListeningToNotifications];
         [self updateRowHeight];
         [self configureNavigationButtons];
         [self updateNavigationBar];
@@ -180,7 +144,7 @@
     }
 }
 
- - (void)updateRowHeight {
+- (void)updateRowHeight {
         
     CGFloat verticalPadding = [self.theme floatForKey:@"noteVerticalPadding"];
     CGFloat topTextViewPadding = verticalPadding;
@@ -191,6 +155,31 @@
     self.tableView.rowHeight = ceilf(2.5 * verticalPadding + 2 * topTextViewPadding + lineHeight * numberLines);
     
     [self.tableView reloadData];
+}
+
+
+#pragma mark - Notifications
+
+- (void)startListeningToNotifications {
+
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+
+    // Dynamic Fonts!
+    [nc addObserver:self selector:@selector(contentSizeWasUpdated:) name:UIContentSizeCategoryDidChangeNotification object:nil];
+
+    // Condensed Notes
+    [nc addObserver:self selector:@selector(condensedPreferenceWasUpdated:) name:SPCondensedNoteListPreferenceChangedNotification object:nil];
+    [nc addObserver:self selector:@selector(sortOrderPreferenceWasUpdated:) name:SPNotesListSortModeChangedNotification object:nil];
+
+    // Voiceover status is tracked because the custom animated transition is not used when enabled
+    [nc addObserver:self selector:@selector(didReceiveVoiceoverNotification:) name:UIAccessibilityVoiceOverStatusDidChangeNotification object:nil];
+
+    // Register for keyboard notifications
+    [nc addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
+    [nc addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+
+    // Themes
+    [nc addObserver:self selector:@selector(themeDidChange) name:VSThemeManagerThemeDidChangeNotification object:nil];
 }
 
 - (void)condensedPreferenceWasUpdated:(id)sender {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -1,11 +1,3 @@
-//
-//  SPNoteListViewController.m
-//  Simplenote
-//
-//  Created by Tom Witkin on 7/3/13.
-//  Copyright (c) 2013 Automattic. All rights reserved.
-//
-
 #import "SPNoteListViewController.h"
 #import "SPOptionsViewController.h"
 #import "SPNavigationController.h"

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -98,6 +98,9 @@
     return self;
 }
 
+
+#pragma mark - View Lifecycle
+
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
@@ -111,24 +114,6 @@
     if (![SPAppDelegate sharedDelegate].simperium.user) {
         [self setWaitingForIndex:YES];
     }
-}
-
-
-- (VSTheme *)theme {
-    
-    return [[VSThemeManager sharedManager] theme];
-}
-
-- (void)themeDidChange {
-    // Refresh the containerView's backgroundColor
-    self.view.backgroundColor = [UIColor colorWithName:UIColorNameBackgroundColor];
-
-    // Refresh the Table's UI
-    [self.tableView applyTheme];
-    [self.tableView reloadData];
-
-    // Restyle the search bar
-    [self styleSearchBar];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
@@ -146,7 +131,7 @@
 
 - (void)updateRowHeight {
         
-    CGFloat verticalPadding = [self.theme floatForKey:@"noteVerticalPadding"];
+    CGFloat verticalPadding = [[[VSThemeManager sharedManager] theme] floatForKey:@"noteVerticalPadding"];
     CGFloat topTextViewPadding = verticalPadding;
 
     CGFloat numberLines = [[Options shared] numberOfPreviewLines];
@@ -195,6 +180,18 @@
 - (void)sortOrderPreferenceWasUpdated:(id)sender {
 
     [self update];
+}
+
+- (void)themeDidChange {
+    // Refresh the containerView's backgroundColor
+    self.view.backgroundColor = [UIColor colorWithName:UIColorNameBackgroundColor];
+
+    // Refresh the Table's UI
+    [self.tableView applyTheme];
+    [self.tableView reloadData];
+
+    // Restyle the search bar
+    [self styleSearchBar];
 }
 
 - (void)updateNavigationBar {
@@ -334,6 +331,7 @@
     [self.searchBar setShowsCancelButton:NO animated:YES];
 }
 
+
 #pragma mark - SearchBar Delegate methods
 
 - (BOOL)searchBarShouldBeginEditing:(UISearchBar *)s {
@@ -373,12 +371,11 @@
 }
 
 - (void)searchBarCancelButtonClicked:(UISearchBar *)s {
-    
     [self cancelSearchButtonAction:self.searchBar];
 }
 
-- (void)performSearch
-{
+- (void)performSearch {
+
     if (!self.searchText) {
         return;
     }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -24,12 +24,12 @@
 #import "UIBarButtonItem+Images.h"
 #import "UIDevice+Extensions.h"
 #import "UIImage+Colorization.h"
+#import "VSThemeManager.h"
 
 #import <Simperium/Simperium.h>
-@import WordPress_AppbotX;
 #import "Simplenote-Swift.h"
 
-#import "VSThemeManager.h"
+@import WordPress_AppbotX;
 
 
 @interface SPNoteListViewController () <ABXPromptViewDelegate,
@@ -41,6 +41,11 @@
                                         UISearchBarDelegate,
                                         UITextFieldDelegate,
                                         SPTransitionControllerDelegate>
+
+@property (nonatomic, strong) UIBarButtonItem           *addButton;
+@property (nonatomic, strong) UIBarButtonItem           *sidebarButton;
+@property (nonatomic, strong) UIBarButtonItem           *iPadCancelButton;
+@property (nonatomic, strong) UIBarButtonItem           *emptyTrashButton;
 
 @property (nonatomic, strong) UISearchBar               *searchBar;
 @property (nonatomic, strong) UIActivityIndicatorView   *activityIndicator;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -145,6 +145,18 @@
 }
 
 
+#pragma mark - Properties
+
+- (UIActivityIndicatorView *)activityIndicator {
+    if (_activityIndicator == nil) {
+        UIActivityIndicatorViewStyle style = SPUserInterface.isDark ? UIActivityIndicatorViewStyleWhite : UIActivityIndicatorViewStyleGray;
+        _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:style];
+    }
+
+    return _activityIndicator;
+}
+
+
 #pragma mark - Notifications
 
 - (void)startListeningToNotifications {
@@ -744,8 +756,7 @@
 - (void)updateFetchPredicate
 {
     SPAppDelegate *appDelegate = [SPAppDelegate sharedDelegate];
-    if (appDelegate.selectedTag != nil &&
-        [appDelegate.selectedTag compare:kSimplenoteTagTrashKey] == NSOrderedSame) {
+    if (appDelegate.selectedTag != nil && [appDelegate.selectedTag isEqualToString:kSimplenoteTagTrashKey]) {
         
         tagFilterType = SPTagFilterTypeDeleted;
         _searchBar.placeholder = NSLocalizedString(@"Trash-noun", nil).lowercaseString;
@@ -1007,15 +1018,11 @@
     if (tagFilterType == SPTagFilterTypeDeleted && waiting)
         return;
     
-    if (waiting && self.navigationItem.titleView != _activityIndicator && (self.fetchedResultsController.fetchedObjects.count == 0 || _firstLaunch)){
-        
-        if (!_activityIndicator)
-            _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:(SPUserInterface.isDark ? UIActivityIndicatorViewStyleWhite : UIActivityIndicatorViewStyleGray)];
-        
-        [_activityIndicator startAnimating];
+    if (waiting && self.navigationItem.titleView != self.activityIndicator && (self.fetchedResultsController.fetchedObjects.count == 0 || _firstLaunch)){
+
+        [self.activityIndicator startAnimating];
         self.bResetTitleView = NO;
-        [self animateTitleViewSwapWithNewView:_activityIndicator
-                                   completion:nil];
+        [self animateTitleViewSwapWithNewView:self.activityIndicator completion:nil];
         
     } else if (!waiting && self.navigationItem.titleView != _searchBarContainer && !self.bTitleViewAnimating) {
         

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -284,9 +284,6 @@
     _emptyTrashButton.accessibilityLabel = NSLocalizedString(@"Empty trash", @"Remove all notes from the trash");
     _emptyTrashButton.accessibilityHint = NSLocalizedString(@"Remove all notes from trash", nil);
 
-    UIOffset titleOffset = [UIDevice isPad] ? UIOffsetMake(7, 0) : UIOffsetZero;
-    [self.emptyTrashButton setTitlePositionAdjustment:titleOffset forBarMetrics:UIBarMetricsDefault];
-
     /// Button: Cancel Search (iPad)
     ///
     self.iPadCancelButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", @"Verb - dismiss the notes search view")

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -55,6 +55,9 @@
 @property (nonatomic, strong) UIImage                   *panImageDelete;
 @property (nonatomic, strong) UIImage                   *panImageRestore;
 
+@property (nonatomic, assign) BOOL                      bTitleViewAnimating;
+@property (nonatomic, assign) BOOL                      bResetTitleView;
+
 @end
 
 @implementation SPNoteListViewController
@@ -1010,16 +1013,16 @@
             _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:(SPUserInterface.isDark ? UIActivityIndicatorViewStyleWhite : UIActivityIndicatorViewStyleGray)];
         
         [_activityIndicator startAnimating];
-        bResetTitleView = NO;
+        self.bResetTitleView = NO;
         [self animateTitleViewSwapWithNewView:_activityIndicator
                                    completion:nil];
         
-    } else if (!waiting && self.navigationItem.titleView != _searchBarContainer && !bTitleViewAnimating) {
+    } else if (!waiting && self.navigationItem.titleView != _searchBarContainer && !self.bTitleViewAnimating) {
         
         [self resetTitleView];
         
     } else if (!waiting) {
-        bResetTitleView = YES;
+        self.bResetTitleView = YES;
     }
     
     bIndexingNotes = waiting;
@@ -1029,7 +1032,7 @@
 
 - (void)animateTitleViewSwapWithNewView:(UIView *)newView completion:(void (^)())completion {
     
-    bTitleViewAnimating = YES;
+    self.bTitleViewAnimating = YES;
     [UIView animateWithDuration:0.25
                      animations:^{
                          self.navigationItem.titleView.alpha = 0.0;
@@ -1045,11 +1048,11 @@
                                               if (completion)
                                                   completion();
                                               
-                                              self->bTitleViewAnimating = NO;
+                                              self.bTitleViewAnimating = NO;
                                               
-                                              if (self->bResetTitleView)
+                                              if (self.bResetTitleView) {
                                                   [self resetTitleView];
-                                              
+                                              }
                                           }];
                      }];
     
@@ -1057,13 +1060,12 @@
 
 - (void)resetTitleView {
     
-    [self animateTitleViewSwapWithNewView:_searchBarContainer
-                               completion:^{
-                                   self->bResetTitleView = NO;
-                                   [self->_activityIndicator stopAnimating];
-                               }];
-    
+    [self animateTitleViewSwapWithNewView:_searchBarContainer completion:^{
+        self.bResetTitleView = NO;
+        [self.activityIndicator stopAnimating];
+    }];
 }
+
 
 #pragma mark - VoiceOver
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -114,6 +114,7 @@
                                                      name:VSThemeManagerThemeDidChangeNotification
                                                    object:nil];
         [self updateRowHeight];
+        [self configureNavigationButtons];
         [self updateNavigationBar];
         
         _panImageDelete = [[UIImage imageNamed:@"icon_cell_pan_trash"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -209,38 +210,6 @@
 }
 
 - (void)updateNavigationBar {
-    
-    if (!addButton) {
-        addButton = [UIBarButtonItem barButtonWithImage:[UIImage imageNamed:@"icon_new_note"]
-                     imageAlignment:UIBarButtonImageAlignmentRight
-                                                 target:self
-                                               selector:@selector(addButtonAction:)];
-        addButton.accessibilityLabel = NSLocalizedString(@"New note", nil);
-        addButton.accessibilityHint =NSLocalizedString(@"Create a new note", nil);
-    }
-    
-    
-    if (!sidebarButton) {
-        sidebarButton = [UIBarButtonItem barButtonContainingCustomViewWithImage:[UIImage imageNamed:@"icon_tags"]
-                                              imageAlignment:UIBarButtonImageAlignmentLeft
-                                                 target:self
-                                               selector:@selector(sidebarButtonAction:)];
-        sidebarButton.isAccessibilityElement = YES;
-        sidebarButton.accessibilityLabel = NSLocalizedString(@"Sidebar", @"UI region to the left of the note list which shows all of a users tags");
-        sidebarButton.accessibilityHint = NSLocalizedString(@"Toggle tag sidebar", @"Accessibility hint used to show or hide the sidebar");
-    }
-    
-    if (!emptyTrashButton) {
-        emptyTrashButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Empty", @"Verb - empty causes all notes to be removed permenently from the trash")
-                                                            style:UIBarButtonItemStylePlain
-                                                           target:self
-                                                           action:@selector(emptyAction:)];
-        emptyTrashButton.accessibilityLabel = NSLocalizedString(@"Empty trash", @"Remove all notes from the trash");
-        emptyTrashButton.accessibilityHint = NSLocalizedString(@"Remove all notes from trash", nil);
-        
-        UIOffset titleOffset = [UIDevice isPad] ? UIOffsetMake(7, 0) : UIOffsetZero;
-        [emptyTrashButton setTitlePositionAdjustment:titleOffset forBarMetrics:UIBarMetricsDefault];
-    }
         
     if (!_searchBar) {
         // titleView was changed to use autolayout in iOS 11
@@ -273,14 +242,7 @@
     if (bSearching) {
         // Add a Cancel button to the toolbar, only needed for iPads
         if ([UIDevice isPad]) {
-            if (!iPadCancelButton) {
-                iPadCancelButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", @"Verb - dismiss the notes search view")
-                                                 style:UIBarButtonItemStylePlain
-                                                target:self
-                                                action:@selector(cancelSearchButtonAction:)];
-            }
-            
-            [self.navigationItem setRightBarButtonItem:iPadCancelButton animated:YES];
+            [self.navigationItem setRightBarButtonItem:_iPadCancelButton animated:YES];
         } else {
            [self.navigationItem setRightBarButtonItem:nil animated:YES];
         }
@@ -289,6 +251,52 @@
     } else if (tagFilterType == SPTagFilterTypeDeleted) {
         [self.navigationItem setRightBarButtonItem:emptyTrashButton animated:YES];
         [self.navigationItem setLeftBarButtonItem:sidebarButton animated:YES];
+
+- (void)configureNavigationButtons {
+
+    /// Button: New Note
+    ///
+    self.addButton = [UIBarButtonItem barButtonWithImage:[UIImage imageNamed:@"icon_new_note"]
+                                          imageAlignment:UIBarButtonImageAlignmentRight
+                                                  target:self
+                                                selector:@selector(addButtonAction:)];
+    _addButton.isAccessibilityElement = YES;
+    _addButton.accessibilityLabel = NSLocalizedString(@"New note", nil);
+    _addButton.accessibilityHint = NSLocalizedString(@"Create a new note", nil);
+
+    /// Button: Display Tags
+    ///
+    self.sidebarButton = [UIBarButtonItem barButtonContainingCustomViewWithImage:[UIImage imageNamed:@"icon_tags"]
+                                                                  imageAlignment:UIBarButtonImageAlignmentLeft
+                                                                          target:self
+                                                                        selector:@selector(sidebarButtonAction:)];
+    _sidebarButton.isAccessibilityElement = YES;
+    _sidebarButton.accessibilityLabel = NSLocalizedString(@"Sidebar", @"UI region to the left of the note list which shows all of a users tags");
+    _sidebarButton.accessibilityHint = NSLocalizedString(@"Toggle tag sidebar", @"Accessibility hint used to show or hide the sidebar");
+
+    /// Button: Empty Trash
+    ///
+    self.emptyTrashButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Empty", @"Verb - empty causes all notes to be removed permenently from the trash")
+                                                             style:UIBarButtonItemStylePlain
+                                                            target:self
+                                                            action:@selector(emptyAction:)];
+    _emptyTrashButton.isAccessibilityElement = YES;
+    _emptyTrashButton.accessibilityLabel = NSLocalizedString(@"Empty trash", @"Remove all notes from the trash");
+    _emptyTrashButton.accessibilityHint = NSLocalizedString(@"Remove all notes from trash", nil);
+
+    UIOffset titleOffset = [UIDevice isPad] ? UIOffsetMake(7, 0) : UIOffsetZero;
+    [self.emptyTrashButton setTitlePositionAdjustment:titleOffset forBarMetrics:UIBarMetricsDefault];
+
+    /// Button: Cancel Search (iPad)
+    ///
+    self.iPadCancelButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Cancel", @"Verb - dismiss the notes search view")
+                                                             style:UIBarButtonItemStylePlain
+                                                            target:self
+                                                            action:@selector(cancelSearchButtonAction:)];
+    _iPadCancelButton.isAccessibilityElement = YES;
+    _iPadCancelButton.accessibilityLabel = NSLocalizedString(@"Cancel Search", @"Verb - dismiss the search UI on iPad Devices");
+    _iPadCancelButton.accessibilityHint = NSLocalizedString(@"Stop searching", @"Accessibility hint for the iPad Cancel Search button");
+}
     } else {
         [self.navigationItem setRightBarButtonItem:addButton animated:YES];
         [self.navigationItem setLeftBarButtonItem:sidebarButton animated:YES];
@@ -651,7 +659,7 @@
 {
     [SPTracker trackListTrashEmptied];
 	[[SPObjectManager sharedManager] emptyTrash];
-	[emptyTrashButton setEnabled:NO];
+	[self.emptyTrashButton setEnabled:NO];
     [self updateViewIfEmpty];
 }
 
@@ -739,7 +747,7 @@
     [self updateFetchPredicate];
     
     if (tagFilterType == SPTagFilterTypeDeleted) {
-		[emptyTrashButton setEnabled: [self numNotes] > 0];
+		[self.emptyTrashButton setEnabled: [self numNotes] > 0];
     }
     
     self.tableView.allowsSelection = !(tagFilterType == SPTagFilterTypeDeleted);
@@ -975,9 +983,9 @@
     self.tableView.allowsSelection = NO;
     [self.tableView setBorderVisibile:YES];
     
-    addButton.customView.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
-    addButton.enabled = NO;
-    emptyTrashButton.enabled = NO;
+    self.addButton.customView.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
+    self.addButton.enabled = NO;
+    self.emptyTrashButton.enabled = NO;
     
     [UIView animateWithDuration:UIKitConstants.animationQuickDuration animations:^{
         self.searchBar.alpha = UIKitConstants.alphaMid;
@@ -994,9 +1002,9 @@
     self.tableView.allowsSelection = !(tagFilterType == SPTagFilterTypeDeleted);
     [self.tableView setBorderVisibile:NO];
     
-    addButton.customView.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
-    addButton.enabled = YES;
-    emptyTrashButton.enabled = (tagFilterType == SPTagFilterTypeDeleted && [self numNotes] > 0) || tagFilterType != SPTagFilterTypeDeleted ? YES : NO;
+    self.addButton.customView.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
+    self.addButton.enabled = YES;
+    self.emptyTrashButton.enabled = (tagFilterType == SPTagFilterTypeDeleted && [self numNotes] > 0) || tagFilterType != SPTagFilterTypeDeleted ? YES : NO;
     
     [UIView animateWithDuration:UIKitConstants.animationQuickDuration animations:^{
         self.searchBar.alpha = UIKitConstants.alphaFull;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -70,11 +70,11 @@
         self.tableView.delegate = self;
         self.tableView.dataSource = self;
         self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-
+        self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+        self.tableView.alwaysBounceVertical = YES;
         [self.rootView addSubview:_tableView];
 
         [self.tableView registerNib:[SPNoteTableViewCell loadNib] forCellReuseIdentifier:[SPNoteTableViewCell reuseIdentifier]];
-        self.tableView.alwaysBounceVertical = YES;
 
         // Dynamic Fonts!
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -113,10 +113,7 @@
                                                  selector:@selector(themeDidChange)
                                                      name:VSThemeManagerThemeDidChangeNotification
                                                    object:nil];
-
-        self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
         [self updateRowHeight];
-        
         [self updateNavigationBar];
         
         _panImageDelete = [[UIImage imageNamed:@"icon_cell_pan_trash"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -260,9 +260,9 @@
                                           imageAlignment:UIBarButtonImageAlignmentRight
                                                   target:self
                                                 selector:@selector(addButtonAction:)];
-    _addButton.isAccessibilityElement = YES;
-    _addButton.accessibilityLabel = NSLocalizedString(@"New note", nil);
-    _addButton.accessibilityHint = NSLocalizedString(@"Create a new note", nil);
+    self.addButton.isAccessibilityElement = YES;
+    self.addButton.accessibilityLabel = NSLocalizedString(@"New note", nil);
+    self.addButton.accessibilityHint = NSLocalizedString(@"Create a new note", nil);
 
     /// Button: Display Tags
     ///
@@ -270,9 +270,9 @@
                                                                   imageAlignment:UIBarButtonImageAlignmentLeft
                                                                           target:self
                                                                         selector:@selector(sidebarButtonAction:)];
-    _sidebarButton.isAccessibilityElement = YES;
-    _sidebarButton.accessibilityLabel = NSLocalizedString(@"Sidebar", @"UI region to the left of the note list which shows all of a users tags");
-    _sidebarButton.accessibilityHint = NSLocalizedString(@"Toggle tag sidebar", @"Accessibility hint used to show or hide the sidebar");
+    self.sidebarButton.isAccessibilityElement = YES;
+    self.sidebarButton.accessibilityLabel = NSLocalizedString(@"Sidebar", @"UI region to the left of the note list which shows all of a users tags");
+    self.sidebarButton.accessibilityHint = NSLocalizedString(@"Toggle tag sidebar", @"Accessibility hint used to show or hide the sidebar");
 
     /// Button: Empty Trash
     ///
@@ -280,9 +280,9 @@
                                                              style:UIBarButtonItemStylePlain
                                                             target:self
                                                             action:@selector(emptyAction:)];
-    _emptyTrashButton.isAccessibilityElement = YES;
-    _emptyTrashButton.accessibilityLabel = NSLocalizedString(@"Empty trash", @"Remove all notes from the trash");
-    _emptyTrashButton.accessibilityHint = NSLocalizedString(@"Remove all notes from trash", nil);
+    self.emptyTrashButton.isAccessibilityElement = YES;
+    self.emptyTrashButton.accessibilityLabel = NSLocalizedString(@"Empty trash", @"Remove all notes from the trash");
+    self.emptyTrashButton.accessibilityHint = NSLocalizedString(@"Remove all notes from trash", nil);
 
     /// Button: Cancel Search (iPad)
     ///
@@ -290,9 +290,9 @@
                                                              style:UIBarButtonItemStylePlain
                                                             target:self
                                                             action:@selector(cancelSearchButtonAction:)];
-    _iPadCancelButton.isAccessibilityElement = YES;
-    _iPadCancelButton.accessibilityLabel = NSLocalizedString(@"Cancel Search", @"Verb - dismiss the search UI on iPad Devices");
-    _iPadCancelButton.accessibilityHint = NSLocalizedString(@"Stop searching", @"Accessibility hint for the iPad Cancel Search button");
+    self.iPadCancelButton.isAccessibilityElement = YES;
+    self.iPadCancelButton.accessibilityLabel = NSLocalizedString(@"Cancel Search", @"Verb - dismiss the search UI on iPad Devices");
+    self.iPadCancelButton.accessibilityHint = NSLocalizedString(@"Stop searching", @"Accessibility hint for the iPad Cancel Search button");
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -47,7 +47,6 @@
 @property (nonatomic, strong) UIBarButtonItem           *iPadCancelButton;
 @property (nonatomic, strong) UIBarButtonItem           *emptyTrashButton;
 
-@property (nonatomic, strong) UISearchBar               *searchBar;
 @property (nonatomic, strong) UIActivityIndicatorView   *activityIndicator;
 
 @property (nonatomic, strong) SPTransitionController    *transitionController;
@@ -249,8 +248,21 @@
         
         [self.navigationItem setLeftBarButtonItem:nil animated:YES];
     } else if (tagFilterType == SPTagFilterTypeDeleted) {
-        [self.navigationItem setRightBarButtonItem:emptyTrashButton animated:YES];
-        [self.navigationItem setLeftBarButtonItem:sidebarButton animated:YES];
+        [self.navigationItem setRightBarButtonItem:_emptyTrashButton animated:YES];
+        [self.navigationItem setLeftBarButtonItem:_sidebarButton animated:YES];
+    } else {
+        [self.navigationItem setRightBarButtonItem:_addButton animated:YES];
+        [self.navigationItem setLeftBarButtonItem:_sidebarButton animated:YES];
+    }
+
+    self.navigationItem.titleView = _searchBarContainer;
+    self.navigationItem.titleView.hidden = NO;
+
+    // Title must be set to an empty string because we're using a custom titleView,
+    // and otherwise we get odd navigation bar behaviour when pushing view controllers
+    // onto the navigation controller after the notes editor.
+    self.navigationItem.title = @"";
+}
 
 - (void)configureNavigationButtons {
 
@@ -293,19 +305,6 @@
     _iPadCancelButton.isAccessibilityElement = YES;
     _iPadCancelButton.accessibilityLabel = NSLocalizedString(@"Cancel Search", @"Verb - dismiss the search UI on iPad Devices");
     _iPadCancelButton.accessibilityHint = NSLocalizedString(@"Stop searching", @"Accessibility hint for the iPad Cancel Search button");
-}
-    } else {
-        [self.navigationItem setRightBarButtonItem:addButton animated:YES];
-        [self.navigationItem setLeftBarButtonItem:sidebarButton animated:YES];
-    }
-    
-    self.navigationItem.titleView = _searchBarContainer;
-    self.navigationItem.titleView.hidden = NO;
-    
-    // Title must be set to an empty string because we're using a custom titleView,
-    // and otherwise we get odd navigation bar behaviour when pushing view controllers
-    // onto the navigation controller after the notes editor.
-    self.navigationItem.title = @"";
 }
 
 
@@ -1020,14 +1019,14 @@
     if (tagFilterType == SPTagFilterTypeDeleted && waiting)
         return;
     
-    if (waiting && self.navigationItem.titleView != activityIndicator && (self.fetchedResultsController.fetchedObjects.count == 0 || _firstLaunch)){
+    if (waiting && self.navigationItem.titleView != _activityIndicator && (self.fetchedResultsController.fetchedObjects.count == 0 || _firstLaunch)){
         
-        if (!activityIndicator)
-            activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:(SPUserInterface.isDark ? UIActivityIndicatorViewStyleWhite : UIActivityIndicatorViewStyleGray)];
+        if (!_activityIndicator)
+            _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:(SPUserInterface.isDark ? UIActivityIndicatorViewStyleWhite : UIActivityIndicatorViewStyleGray)];
         
-        [activityIndicator startAnimating];
+        [_activityIndicator startAnimating];
         bResetTitleView = NO;
-        [self animateTitleViewSwapWithNewView:activityIndicator
+        [self animateTitleViewSwapWithNewView:_activityIndicator
                                    completion:nil];
         
     } else if (!waiting && self.navigationItem.titleView != _searchBarContainer && !bTitleViewAnimating) {
@@ -1076,7 +1075,7 @@
     [self animateTitleViewSwapWithNewView:_searchBarContainer
                                completion:^{
                                    self->bResetTitleView = NO;
-                                   [self->activityIndicator stopAnimating];
+                                   [self->_activityIndicator stopAnimating];
                                }];
     
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -101,8 +101,7 @@
 
 #pragma mark - View Lifecycle
 
-- (void)viewDidAppear:(BOOL)animated
-{
+- (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     [self showRatingViewIfNeeded];
 }

--- a/Simplenote/Classes/SPSidebarContainerViewController.h
+++ b/Simplenote/Classes/SPSidebarContainerViewController.h
@@ -55,6 +55,7 @@
 - (BOOL)shouldShowSidebar;
 - (void)sidebarWillShow;
 - (void)sidebarDidShow;
+- (void)sidebarWillHide;
 - (void)sidebarDidHide;
 - (void)sidebarDidSlideToPercentVisible:(CGFloat)percentVisible;
 - (void)resetNavigationBar;

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -326,7 +326,8 @@ static CGFloat sidePanelWidth;
 - (void)hideSidePanelAnimated:(BOOL)animated completion:(void (^)())completion {
     
     [self resetNavigationBar];
-    
+    [self sidebarWillHide];
+
     CGRect newRootFrame = _rootView.frame;
     newRootFrame.origin.x = 0;
     
@@ -398,6 +399,10 @@ static CGFloat sidePanelWidth;
 
 - (void)sidebarDidShow {
     
+}
+
+- (void)sidebarWillHide {
+
 }
 
 - (void)sidebarDidHide {

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -29,7 +29,6 @@
 #define kActionSheetRenameIndex 1
 #define kActionSheetCancelIndex 2
 
-static NSString * const SPTagTrashKey = @"trash";
 static CGFloat const SPSettingsButtonHeight = 40;
 static UIEdgeInsets SPButtonContentInsets = {0, 25, 0, 0};
 static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
@@ -227,7 +226,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 -(void)trashTap:(UIButton *)sender
 {
     [SPTracker trackTrashViewed];
-    [self openNoteListForTagName:SPTagTrashKey];
+    [self openNoteListForTagName:kSimplenoteTagTrashKey];
 }
 
 -(void)settingsTap:(UIButton *)sender

--- a/Simplenote/Classes/UISearchBar+Simplenote.swift
+++ b/Simplenote/Classes/UISearchBar+Simplenote.swift
@@ -1,0 +1,37 @@
+import Foundation
+import UIKit
+
+
+// MARK: - UISearchBar Simplenote Methods
+//
+extension UISearchBar {
+
+    /// Yes. This is a hack. A quite violent one.
+    ///
+    /// Why do we need this?: UISearchController is attaching the SearchBar below the NavigationBar, and a 1pt line is being rendered.
+    /// There is just no way to remove such line using a clean API. This workaround is to be applied on `iOS <13` devices, since, thanks god,
+    /// iOS 13's behavior is what we expect.
+    ///
+    /// Important: This method should be called whenever`viewWillLayoutSubviews` is executed, otherwise the searchBar instance won't
+    /// have its superview setup.
+    ///
+    @objc
+    func removeBottomSeparatorOnIOS12AndBelow() {
+        if #available(iOS 13, *) {
+            return
+        }
+
+        guard let containerView = superview else {
+            return
+        }
+
+        let targetClassName = "_UIBarBackground"
+        for backgroundView in containerView.subviews {
+            guard String(describing: type(of: backgroundView)) == targetClassName else {
+                continue
+            }
+
+            backgroundView.isHidden = true
+        }
+    }
+}

--- a/Simplenote/Classes/UISearchBar+Simplenote.swift
+++ b/Simplenote/Classes/UISearchBar+Simplenote.swift
@@ -6,35 +6,6 @@ import UIKit
 //
 extension UISearchBar {
 
-    /// Yes. This is a hack. A quite violent one.
-    ///
-    /// Why do we need this?: UISearchController is attaching the SearchBar below the NavigationBar, and a 1pt line is being rendered.
-    /// There is just no way to remove such line using a clean API. This workaround is to be applied on `iOS <13` devices, since, thanks god,
-    /// iOS 13's behavior is what we expect.
-    ///
-    /// Important: This method should be called whenever`viewWillLayoutSubviews` is executed, otherwise the searchBar instance won't
-    /// have its superview setup.
-    ///
-    @objc
-    func removeBottomSeparatorOnIOS12AndBelow() {
-        if #available(iOS 13, *) {
-            return
-        }
-
-        guard let containerView = superview else {
-            return
-        }
-
-        let targetClassName = "_UIBarBackground"
-        for backgroundView in containerView.subviews {
-            guard String(describing: type(of: backgroundView)) == targetClassName else {
-                continue
-            }
-
-            backgroundView.isHidden = true
-        }
-    }
-
     /// Applies Simplenote's Style
     ///
     @objc

--- a/Simplenote/Classes/UISearchBar+Simplenote.swift
+++ b/Simplenote/Classes/UISearchBar+Simplenote.swift
@@ -34,4 +34,37 @@ extension UISearchBar {
             backgroundView.isHidden = true
         }
     }
+
+    /// Applies Simplenote's Style
+    ///
+    @objc
+    func applySimplenoteStyle() {
+        let bgImage = UIImage()
+        let bgColor = UIColor.color(name: .backgroundColor)?.withAlphaComponent(Constants.backgroundAlpha)
+        let searchIconColor = UIColor.color(name: .simplenoteSlateGrey)
+        let searchIconImage = UIImage.image(name: .searchIconImage)?.withOverlayColor(searchIconColor)
+
+        backgroundColor = bgColor
+        setBackgroundImage(bgImage, for: .any, barMetrics: .default)
+
+        setImage(searchIconImage, for: .search, state: .normal)
+        setSearchFieldBackgroundImage(.searchBarBackgroundImage, for: .normal)
+
+        // Apply font to search field by traversing subviews
+        for textField in subviewsOfType(UITextField.self) {
+            textField.font = .preferredFont(forTextStyle: .body)
+            textField.textColor = .color(name: .textColor)
+            textField.keyboardAppearance = SPUserInterface.isDark ? .dark : .default
+        }
+    }
+}
+
+
+// MARK: - Constants
+//
+private enum Constants {
+
+    /// SearchBar's Background Alpha, so that it matches with the navigationBar!
+    ///
+    static let backgroundAlpha = CGFloat(0.9)
 }

--- a/Simplenote/SPConstants.h
+++ b/Simplenote/SPConstants.h
@@ -35,6 +35,7 @@ extern NSInteger const kOnePasswordGeneratedMaxLength;
 extern NSString *const kFirstLaunchKey;
 extern NSString *const kSelectedTagKey;
 extern NSString *const kSelectedNoteKey;
+extern NSString *const kSimplenoteTagTrashKey;
 extern NSString *const kSimplenotePinKey;
 extern NSString *const kSimplenotePinLegacyKey;
 extern NSString *const kSimplenoteUseBiometryKey;

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -42,6 +42,7 @@ NSInteger const kOnePasswordGeneratedMaxLength      = 50;
 NSString *const kFirstLaunchKey                     = @"SPFirstLaunch";
 NSString *const kSelectedTagKey                     = @"SPSelectedTag";
 NSString *const kSelectedNoteKey                    = @"SPSelectedNote";
+NSString *const kSimplenoteTagTrashKey              = @"trash";
 NSString *const kSimplenotePinKey                   = @"SimplenotePin";
 NSString *const kSimplenotePinLegacyKey             = @"PIN";
 NSString *const kSimplenoteUseBiometryKey           = @"SimplenoteUseTouchID";


### PR DESCRIPTION
### Description:
This PR introduces zero new features. We're splitting large methods into smallers, and moving code around. 

Goal: reduce #432's footprint!

@SergioEstevao sir, can I bug you with a... hopefully-easy-to-test PR?
**Thank you** for being so awesome!!

### Details:
- Notes List
  - We've split (part of the) initializer into a smaller method
  - Converted several ivars into proper ObjC properties
  - New **configureNavigationButtons** method, to be called by the initializer
- New **UISearchBar** extension
- SidebarContainer: New hook
- Wired proper constants here and there!

### Test:
**Please** perform a smoke test on the Notes List:

- [x] Verify: SearchBar's UI looks properly (position to be adjusted via #432!)
- [x] Verify: Notes List gets properly updated when Dark Mode is enabled
- [x] Verify: Condensed List mode refreshes proprely the Notes List
- [x] Verify: Navigation Bar shows the `Show Sidebar` button (top left)
- [x] Verify: Navigation Bar shows the `New Note` button (top right)
- [x] Verify: Navigation Bar shows the `Empty Trash` button (top right + viewing Trashed notes)
