### PR TITLE
Fixing Darkness

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 -   Search Bar style refresh!
 -   Notes List refreshed to display Pinned state on the right hand side.
 -   iOS 11 Is now the minimum supported OS.
+-   Fixed a bug in which the Editor Colors might not be properly nitialized
 
 4.10.0
 ======

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 -   Search Bar style refresh!
 -   Notes List refreshed to display Pinned state on the right hand side.
 -   iOS 11 Is now the minimum supported OS.
--   Fixed a bug in which the Editor Colors might not be properly nitialized
+-   Fixed a bug in which the Editor Colors might not be properly initialized
 
 4.10.0
 ======

--- a/Simplenote/Classes/SPInteractiveTextStorage.m
+++ b/Simplenote/Classes/SPInteractiveTextStorage.m
@@ -4,10 +4,9 @@ NSString *const SPDefaultTokenName = @"SPDefaultTokenName";
 NSString *const SPHeadlineTokenName = @"SPHeadlineTokenName";
 
 @interface SPInteractiveTextStorage ()
-{
-    NSMutableAttributedString *_backingStore;
-    BOOL _dynamicTextNeedsUpdate;
-}
+
+@property (nonatomic, strong) NSMutableAttributedString *backingStore;
+@property (nonatomic, assign) BOOL dynamicTextNeedsUpdate;
 
 @end
 
@@ -63,7 +62,7 @@ NSString *const SPHeadlineTokenName = @"SPHeadlineTokenName";
     [self applyTokenAttributesToRange:extendedRange];
 }
 
--(void)processEditing
+- (void)processEditing
 {
     if(_dynamicTextNeedsUpdate)
     {

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -1,11 +1,3 @@
-//
-//  SPNoteEditorViewController.h
-//  Simplenote
-//
-//  Created by Tom Witkin on 7/9/13.
-//  Copyright (c) 2013 Automattic. All rights reserved.
-//
-
 #import <UIKit/UIKit.h>
 #import "SPActionSheet.h"
 #import "SPActivityView.h"

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -116,6 +116,9 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
                                                  selector:@selector(didReceiveVoiceOverNotification:)
                                                      name:UIAccessibilityVoiceOverStatusDidChangeNotification
                                                    object:nil];
+
+        // Apply the current style right away!
+        [self applyStyle];
     }
     
     return self;
@@ -140,7 +143,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
     _noteEditorTextView.font = bodyFont;
     _noteEditorTextView.backgroundColor = [UIColor colorWithName:UIColorNameBackgroundColor];
-    
     _noteEditorTextView.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
 
     _noteEditorTextView.interactiveTextStorage.tokens = @{
@@ -174,7 +176,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     self.navigationItem.title = nil;
     
     [self startListeningToNotifications];
-    [self applyStyle];
     [self setupBarItems];
     [self swapTagViewPositionForVoiceover];
 }

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -133,28 +133,32 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 - (void)applyStyle {
     
-    _bodyFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    _headlineFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
-    _fontColor = [UIColor colorWithName:UIColorNameNoteHeadlineFontColor];
-    _lightFontColor = [UIColor colorWithName:UIColorNameNoteBodyFontPreviewColor];
+    UIFont *bodyFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    UIFont *headlineFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    UIColor *fontColor = [UIColor colorWithName:UIColorNameNoteHeadlineFontColor];
 
-    _noteEditorTextView.font = _bodyFont;
+    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+    paragraphStyle.lineSpacing = bodyFont.lineHeight * [self.theme floatForKey:@"noteBodyLineHeightPercentage"];
+
     _tagView = _noteEditorTextView.tagView;
     [_tagView applyStyle];
-    
-    _paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    _paragraphStyle.lineSpacing = _bodyFont.lineHeight * [self.theme floatForKey:@"noteBodyLineHeightPercentage"];
-    
-    _noteEditorTextView.interactiveTextStorage.tokens = @{SPDefaultTokenName : @{ NSForegroundColorAttributeName : _fontColor,
-                                                                                  NSFontAttributeName : _bodyFont,
-                                                                                  NSParagraphStyleAttributeName : _paragraphStyle},
-                                                          SPHeadlineTokenName : @{NSForegroundColorAttributeName: _fontColor,
-                                                                                  NSFontAttributeName : _headlineFont} };
-    
+
+    _noteEditorTextView.font = bodyFont;
     _noteEditorTextView.backgroundColor = [UIColor colorWithName:UIColorNameBackgroundColor];
     
     _noteEditorTextView.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
 
+    _noteEditorTextView.interactiveTextStorage.tokens = @{
+        SPDefaultTokenName : @{
+                NSFontAttributeName : bodyFont,
+                NSForegroundColorAttributeName : fontColor,
+                NSParagraphStyleAttributeName : paragraphStyle
+        },
+        SPHeadlineTokenName : @{
+                NSFontAttributeName : headlineFont,
+                NSForegroundColorAttributeName: fontColor,
+        }
+    };
 }
 
 - (void)viewDidLoad

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -57,11 +57,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     BOOL bounceMarkdownPreviewOnActivityViewDismiss;
 }
 
-@property (nonatomic, strong) UIFont                    *bodyFont;
-@property (nonatomic, strong) NSMutableParagraphStyle   *paragraphStyle;
-@property (nonatomic, strong) UIFont                    *headlineFont;
-@property (nonatomic, strong) UIColor                   *fontColor;
-@property (nonatomic, strong) UIColor                   *lightFontColor;
 @property (nonatomic, assign) CGFloat                   keyboardHeight;
 
 // if a newly created tag is deleted within a certain time span,

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1,11 +1,3 @@
-//
-//  SPNoteEditorViewController.m
-//  Simplenote
-//
-//  Created by Tom Witkin on 7/9/13.
-//  Copyright (c) 2013 Automattic. All rights reserved.
-//
-
 #import "SPNoteEditorViewController.h"
 #import "Note.h"
 #import "VSThemeManager.h"

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -210,12 +210,12 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 - (void)ensureTagViewIsVisible
 {
-    if (_tagView.alpha >= 1.0) {
+    if (_tagView.alpha >= UIKitConstants.alphaFull) {
         return;
     }
 
-    [UIView animateWithDuration:0.3 animations:^{
-        self.tagView.alpha = 1.0;
+    [UIView animateWithDuration:UIKitConstants.animationShortDuration animations:^{
+        self.tagView.alpha = UIKitConstants.alphaFull;
      }];
 }
 
@@ -273,7 +273,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 - (void)viewWillDisappear:(BOOL)animated {
     
     [super viewWillDisappear:animated];
-    
     [self.navigationController setToolbarHidden:YES animated:YES];
 }
 
@@ -296,7 +295,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
         self->bDisableShrinkingNavigationBar = YES;
         [self sizeNavigationContainer];
-    } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+    } completion:^(id<UIViewControllerTransitionCoordinatorContext> _Nonnull context) {
         self->bDisableShrinkingNavigationBar = NO;
     }];
 }
@@ -630,7 +629,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
     // hide the tags field
     if (!bVoiceoverEnabled) {
-        self.tagView.alpha = 0.0;
+        self.tagView.alpha = UIKitConstants.alphaZero;
     }
 }
 
@@ -767,7 +766,6 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     
     highlightedSearchResultIndex = MAX(0, highlightedSearchResultIndex - 1);
     [self highlightSearchResultAtIndex:highlightedSearchResultIndex];
-    
 }
 
 - (void)highlightSearchResultAtIndex:(NSInteger)index {


### PR DESCRIPTION
### Fix
This PR fixes an issue in which the TextView's Attributes wouldn't be properly set, the first time the editor is open.

cc @aerych Eric!! SORRY!!! yet another quick fix!!
Thank you!!!

Closes #40


### Test
1. Fresh install the app
2. Log into your account
3. Enable Dark Mode `(Settings > Theme)`
4. Kill the app + relaunch
5. Open any of the notes

- [ ] Verify the Foreground and Background colors are properly set.

### Release
`RELEASE-NOTES.txt` was updated in 91b74c3 with: 
> Added markdown support
