### PR TITLE
Fixing Search Results Highlight

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -   Notes List refreshed to display Pinned state on the right hand side.
 -   iOS 11 Is now the minimum supported OS.
 -   Fixed a bug in which the Editor Colors might not be properly initialized
+-   Fixed a Search Highlight issue that affected the Notes List.
 
 4.10.0
 ======

--- a/Simplenote/Classes/NSTextStorage+Highlight.h
+++ b/Simplenote/Classes/NSTextStorage+Highlight.h
@@ -1,17 +1,8 @@
-//
-//  NSTextStorage+Highlight.h
-//  Simplenote
-//
-//  Created by Tom Witkin on 8/28/13.
-//  Copyright (c) 2013 Automattic. All rights reserved.
-//
-
 #import <UIKit/UIKit.h>
 
 @interface NSTextStorage (Highlight)
 
 - (void)applyColor:(UIColor *)color toSubstringMatchingKeywords:(NSString *)keywords;
 - (void)applyColorAttribute:(id)color forRanges:(NSArray *)wordRanges;
-- (void)applyAttributes:(NSDictionary *)attributes matchingStrings:(NSArray *)strings characterLimit:(NSInteger)characterLimit;
 
 @end

--- a/Simplenote/Classes/NSTextStorage+Highlight.h
+++ b/Simplenote/Classes/NSTextStorage+Highlight.h
@@ -3,6 +3,6 @@
 @interface NSTextStorage (Highlight)
 
 - (void)applyColor:(UIColor *)color toSubstringMatchingKeywords:(NSString *)keywords;
-- (void)applyColorAttribute:(id)color forRanges:(NSArray *)wordRanges;
+- (void)applyColor:(UIColor *)color toRanges:(NSArray *)wordRanges;
 
 @end

--- a/Simplenote/Classes/NSTextStorage+Highlight.m
+++ b/Simplenote/Classes/NSTextStorage+Highlight.m
@@ -30,7 +30,7 @@
         
         // Out of Range Failsafe
         NSRange range = rangeValue.rangeValue;
-        if (range.location + range.length >= maxLength) {
+        if (range.location + range.length > maxLength) {
             continue;
         }
         

--- a/Simplenote/Classes/NSTextStorage+Highlight.m
+++ b/Simplenote/Classes/NSTextStorage+Highlight.m
@@ -5,10 +5,10 @@
 
 - (void)applyColor:(UIColor *)color toSubstringMatchingKeywords:(NSString *)keywords {
     NSArray* ranges = [self.string rangesForTerms:keywords];
-    [self applyColorAttribute:color forRanges:ranges];
+    [self applyColor:color toRanges:ranges];
 }
 
-- (void)applyColorAttribute:(id)color forRanges:(NSArray *)wordRanges {
+- (void)applyColor:(UIColor *)color toRanges:(NSArray *)wordRanges {
     
     if (!color) {
         return;

--- a/Simplenote/Classes/NSTextStorage+Highlight.m
+++ b/Simplenote/Classes/NSTextStorage+Highlight.m
@@ -35,11 +35,7 @@
         }
         
         // Maintain current Font
-        NSMutableDictionary *attributes = [[NSMutableDictionary alloc] initWithDictionary:[self attributesAtIndex:range.location effectiveRange:nil]];
-        
-        [attributes setObject:color forKey:NSForegroundColorAttributeName];
-        
-        [self setAttributes:attributes range:rangeValue.rangeValue];
+        [self addAttribute:NSForegroundColorAttributeName value:color range:rangeValue.rangeValue];
     }
     
     [self endEditing];

--- a/Simplenote/Classes/NSTextStorage+Highlight.m
+++ b/Simplenote/Classes/NSTextStorage+Highlight.m
@@ -22,7 +22,7 @@
         
         // Out of Range Failsafe
         NSRange range = rangeValue.rangeValue;
-        if (range.location + range.length > maxLength) {
+        if (NSMaxRange(range) > maxLength) {
             continue;
         }
         

--- a/Simplenote/Classes/NSTextStorage+Highlight.m
+++ b/Simplenote/Classes/NSTextStorage+Highlight.m
@@ -1,11 +1,3 @@
-//
-//  NSTextStorage+Highlight.m
-//  Simplenote
-//
-//  Created by Tom Witkin on 8/28/13.
-//  Copyright (c) 2013 Automattic. All rights reserved.
-//
-
 #import "NSTextStorage+Highlight.h"
 #import "NSString+Search.h"
 
@@ -40,35 +32,5 @@
     
     [self endEditing];
 }
-
-- (void)applyAttributes:(NSDictionary *)attributes matchingStrings:(NSArray *)strings characterLimit:(NSInteger)characterLimit {
-    
-    
-    NSString *content = self.string;
-    
-    [self beginEditing];
-    
-    for (NSString *matchString in strings) {
-        
-        // find all occurances of the matching string
-        
-        NSUInteger count = 0, length = MIN([content length], characterLimit);
-        NSRange range = NSMakeRange(0, length);
-        while(range.location != NSNotFound)
-        {
-            range = [content rangeOfString:matchString options:NSCaseInsensitiveSearch range:range];
-            if(range.location != NSNotFound) {
-                
-                [self setAttributes:attributes range:range];
-                
-                range = NSMakeRange(range.location + range.length, length - (range.location + range.length));
-                count++;
-            }
-        }
-    }
-    
-    [self endEditing];
-}
-
 
 @end

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -48,7 +48,6 @@
     SPHorizontalPickerView *versionPickerView;
     
     BOOL bSearching;
-    NSArray *searchResultRanges;
     NSInteger highlightedSearchResultIndex;
     
     UILabel *searchDetailLabel;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -57,6 +57,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     BOOL bounceMarkdownPreviewOnActivityViewDismiss;
 }
 
+@property (nonatomic, strong) NSArray                   *searchResultRanges;
 @property (nonatomic, assign) CGFloat                   keyboardHeight;
 
 // if a newly created tag is deleted within a certain time span,
@@ -245,7 +246,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 - (void)highlightSearchResultsIfNeeded
 {
-    if (!bSearching || _searchString.length == 0 || searchResultRanges) {
+    if (!bSearching || _searchString.length == 0 || self.searchResultRanges) {
         return;
     }
     
@@ -253,14 +254,14 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
         
-        self->searchResultRanges = [searchText rangesForTerms:self->_searchString];
+        self.searchResultRanges = [searchText rangesForTerms:self->_searchString];
         
         dispatch_async(dispatch_get_main_queue(), ^{
             
             UIColor *tintColor = [UIColor colorWithName:UIColorNameTintColor];
-            [self->_noteEditorTextView.textStorage applyColorAttribute:tintColor forRanges:self->searchResultRanges];
+            [self.noteEditorTextView.textStorage applyColor:tintColor toRanges:self.searchResultRanges];
             
-            NSInteger count = self->searchResultRanges.count;
+            NSInteger count = self.searchResultRanges.count;
             
             NSString *searchDetailFormat = count == 1 ? NSLocalizedString(@"%d Result", @"Number of found search results") : NSLocalizedString(@"%d Results", @"Number of found search results");
             self->searchDetailLabel.text = [NSString stringWithFormat:searchDetailFormat, count];
@@ -758,14 +759,14 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     if (string.length > 0) {
         bSearching = YES;
         _searchString = string;
-        searchResultRanges = nil;
+        self.searchResultRanges = nil;
         [self.navigationController setToolbarHidden:NO animated:YES];
     }
 }
 
 - (void)highlightNextSearchResult:(id)sender {
     
-    highlightedSearchResultIndex = MIN(highlightedSearchResultIndex + 1, searchResultRanges.count);
+    highlightedSearchResultIndex = MIN(highlightedSearchResultIndex + 1, self.searchResultRanges.count);
     [self highlightSearchResultAtIndex:highlightedSearchResultIndex];
 }
 
@@ -777,14 +778,14 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 - (void)highlightSearchResultAtIndex:(NSInteger)index {
     
-    NSInteger searchResultCount = searchResultRanges.count;
+    NSInteger searchResultCount = self.searchResultRanges.count;
     if (index >= 0 && index < searchResultCount) {
         
         // enable or disbale search result puttons accordingly
         prevSearchButton.enabled = index > 0;
         nextSearchButton.enabled = index < searchResultCount - 1;
         
-        [_noteEditorTextView highlightRange:[(NSValue *)searchResultRanges[index] rangeValue]
+        [_noteEditorTextView highlightRange:[(NSValue *)self.searchResultRanges[index] rangeValue]
                            animated:YES
                           withBlock:^(CGRect highlightFrame) {
 
@@ -809,7 +810,7 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     [_noteEditorTextView processChecklists];
     
     _searchString = nil;
-    searchResultRanges = nil;
+    self.searchResultRanges = nil;
     
     [_noteEditorTextView clearHighlights:(sender ? YES : NO)];
     


### PR DESCRIPTION
### Fix
This PR fixes a bug in which the Search Highlight mechanism would fail, if the target word was the last one in a given string. This is due to a faulty NSRange check.

@SergioEstevao may I bug you with a (hopefully quick) review?

Thanks in advance!!


### Test
1. Log into your account
2. Add a new note with the following payload:
  ```
Title here
Body should go here
  ```
3. Hit the top left button to get back to the Notes List
4. Tap over the Search field to enter into Search Mode
5. Type `here` as the search keyword

- [ ] Verify that the word `here` gets properly highlighted, right in the Notes List.

### Release
`RELEASE-NOTES.txt` was updated in ceb2f72 with:

> Fixed a Search Highlight issue that affected the Notes List
