### PR TITLE
Adding Missing UIImageName Cases

### DIFF
--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -108,7 +108,7 @@ class SPAuthViewController: UIViewController {
     private lazy var onePasswordButton: UIButton = {
         let button = UIButton(type: .custom)
         button.tintColor = .color(name: .simplenoteSlateGrey)
-        button.setImage(.image(name: .onePasswordImage), for: .normal)
+        button.setImage(.image(name: .onePassword), for: .normal)
         button.addTarget(self, action: mode.onePasswordSelector, for: .touchUpInside)
         button.sizeToFit()
         return button
@@ -117,11 +117,11 @@ class SPAuthViewController: UIViewController {
     /// # Reveal Password Button
     ///
     private lazy var revealPasswordButton: UIButton = {
-        let selected = UIImage.image(name: .visibilityOnImage)
+        let selected = UIImage.image(name: .visibilityOn)
         let button = UIButton(type: .custom)
         button.tintColor = .color(name: .simplenoteSlateGrey)
         button.addTarget(self, action: #selector(revealPasswordWasPressed), for: [.touchDown])
-        button.setImage(.image(name: .visibilityOffImage), for: .normal)
+        button.setImage(.image(name: .visibilityOff), for: .normal)
         button.setImage(selected, for: .highlighted)
         button.setImage(selected, for: .selected)
         button.sizeToFit()

--- a/Simplenote/Classes/SPEntryListCell.m
+++ b/Simplenote/Classes/SPEntryListCell.m
@@ -33,8 +33,8 @@
         secondaryLabel.textColor = [UIColor colorWithName:UIColorNameCollaboratorTextColor];
         [self.contentView addSubview:secondaryLabel];
         
-        UIImage *checkedImage = [UIImage imageWithName:UIImageNameCheckmarkCheckedImage];
-        UIImage *uncheckedImage = [UIImage imageWithName:UIImageNameCheckmarkUncheckedImage];
+        UIImage *checkedImage = [UIImage imageWithName:UIImageNameCheckmarkChecked];
+        UIImage *uncheckedImage = [UIImage imageWithName:UIImageNameCheckmarkUnchecked];
 
         checkmarkImageView = [[UIImageView alloc] initWithImage:uncheckedImage
                                                highlightedImage:checkedImage];

--- a/Simplenote/Classes/SPEntryListCell.m
+++ b/Simplenote/Classes/SPEntryListCell.m
@@ -33,9 +33,9 @@
         secondaryLabel.textColor = [UIColor colorWithName:UIColorNameCollaboratorTextColor];
         [self.contentView addSubview:secondaryLabel];
         
-        UIImage *checkedImage = [[UIImage imageNamed:@"icon_checkmark_checked"] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
-        UIImage *uncheckedImage = [UIImage imageNamed:@"icon_checkmark_unchecked"];
-        
+        UIImage *checkedImage = [UIImage imageWithName:UIImageNameCheckmarkCheckedImage];
+        UIImage *uncheckedImage = [UIImage imageWithName:UIImageNameCheckmarkUncheckedImage];
+
         checkmarkImageView = [[UIImageView alloc] initWithImage:uncheckedImage
                                                highlightedImage:checkedImage];
         checkmarkImageView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin;

--- a/Simplenote/Classes/SPEntryListViewController.m
+++ b/Simplenote/Classes/SPEntryListViewController.m
@@ -64,7 +64,7 @@ static NSString *autoCompleteCellIdentifier = @"autoCompleteCell";
     [entryFieldBackground addSubview:entryTextField];
     
     entryFieldPlusButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    UIImage *pickerImage = [[UIImage imageNamed:@"icon_add"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    UIImage *pickerImage = [UIImage imageWithName:UIImageNameAddImage];
     [entryFieldPlusButton setImage:pickerImage forState:UIControlStateNormal];
     entryFieldPlusButton.frame = CGRectMake(0, 0, pickerImage.size.width, pickerImage.size.height);
     [entryFieldPlusButton addTarget:self

--- a/Simplenote/Classes/SPEntryListViewController.m
+++ b/Simplenote/Classes/SPEntryListViewController.m
@@ -64,7 +64,7 @@ static NSString *autoCompleteCellIdentifier = @"autoCompleteCell";
     [entryFieldBackground addSubview:entryTextField];
     
     entryFieldPlusButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    UIImage *pickerImage = [UIImage imageWithName:UIImageNameAddImage];
+    UIImage *pickerImage = [UIImage imageWithName:UIImageNameAdd];
     [entryFieldPlusButton setImage:pickerImage forState:UIControlStateNormal];
     entryFieldPlusButton.frame = CGRectMake(0, 0, pickerImage.size.width, pickerImage.size.height);
     [entryFieldPlusButton addTarget:self

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -416,7 +416,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     actionButton.accessibilityLabel = NSLocalizedString(@"Menu", @"Terminoligy used for sidebar UI element where tags are displayed");
     actionButton.accessibilityHint = NSLocalizedString(@"menu-accessibility-hint", @"VoiceOver accessibiliity hint on button which shows or hides the menu");
     
-    checklistButton = [UIButton buttonWithImage:[UIImage imageNamed:@"icon_checklist"]
+    checklistButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameChecklistImage]
                                       target:self
                                     selector:@selector(insertChecklistAction:)];
     

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -376,8 +376,8 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     self.navigationItem.hidesBackButton = YES;
 
     // Load Assets
-    UIImage *chevronRightImage = [UIImage imageWithName:UIImageNameChevronRightImage];
-    UIImage *chevronLeftImage = [UIImage imageWithName:UIImageNameChevronLeftImage];
+    UIImage *chevronRightImage = [UIImage imageWithName:UIImageNameChevronRight];
+    UIImage *chevronLeftImage = [UIImage imageWithName:UIImageNameChevronLeft];
 
     // container view
     SPOutsideTouchView *titleView = [[SPOutsideTouchView alloc] init];
@@ -410,23 +410,23 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     
     
     // setup right buttons
-    actionButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameInfoImage]
+    actionButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameInfo]
                                       target:self
                                     selector:@selector(actionButtonAction:)];
     actionButton.accessibilityLabel = NSLocalizedString(@"Menu", @"Terminoligy used for sidebar UI element where tags are displayed");
     actionButton.accessibilityHint = NSLocalizedString(@"menu-accessibility-hint", @"VoiceOver accessibiliity hint on button which shows or hides the menu");
     
-    checklistButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameChecklistImage]
+    checklistButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameChecklist]
                                       target:self
                                     selector:@selector(insertChecklistAction:)];
     
-    newButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameNewNoteImage]
+    newButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameNewNote]
                                    target:self
                                  selector:@selector(newButtonAction:)];
     newButton.accessibilityLabel = NSLocalizedString(@"New note", @"Label to create a new note");
     newButton.accessibilityHint = NSLocalizedString(@"Create a new note", nil);
     
-    keyboardButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameHideKeyboardImage]
+    keyboardButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameHideKeyboard]
                                         target:self
                                       selector:@selector(keyboardButtonAction:)];
     keyboardButton.accessibilityLabel = NSLocalizedString(@"Dismiss keyboard", nil);
@@ -1393,10 +1393,10 @@ CGFloat const SPBackButtonTitlePadding              = -15;
                       NSLocalizedString(@"History...", @"Action - view the version history of a note"),
                       NSLocalizedString(@"Collaborate", @"Verb - work with others on a note"),
                       NSLocalizedString(@"Trash-verb", @"Trash (verb) - the action of deleting a note")];
-    actionImages = @[[UIImage imageWithName:UIImageNameShareImage],
-                     [UIImage imageWithName:UIImageNameHistoryImage],
-                     [UIImage imageWithName:UIImageNameCollaborateImage],
-                     [UIImage imageWithName:UIImageNameTrashImage]];
+    actionImages = @[[UIImage imageWithName:UIImageNameShare],
+                     [UIImage imageWithName:UIImageNameHistory],
+                     [UIImage imageWithName:UIImageNameCollaborate],
+                     [UIImage imageWithName:UIImageNameTrash]];
     toggleTitles = @[NSLocalizedString(@"Publish", @"Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others"),
                     NSLocalizedString(@"Pin to Top", @"Denotes when note is pinned to the top of the note list"), NSLocalizedString(@"Markdown", @"Special formatting that can be turned on for notes")];
     toggleSelectedTitles = @[NSLocalizedString(@"Published", nil),

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -426,7 +426,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     newButton.accessibilityLabel = NSLocalizedString(@"New note", @"Label to create a new note");
     newButton.accessibilityHint = NSLocalizedString(@"Create a new note", nil);
     
-    keyboardButton = [UIButton buttonWithImage:[UIImage imageNamed:@"icon_hide_keyboard"]
+    keyboardButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameHideKeyboardImage]
                                         target:self
                                       selector:@selector(keyboardButtonAction:)];
     keyboardButton.accessibilityLabel = NSLocalizedString(@"Dismiss keyboard", nil);

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -420,7 +420,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
                                       target:self
                                     selector:@selector(insertChecklistAction:)];
     
-    newButton = [UIButton buttonWithImage:[UIImage imageNamed:@"icon_new_note"]
+    newButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameNewNoteImage]
                                    target:self
                                  selector:@selector(newButtonAction:)];
     newButton.accessibilityLabel = NSLocalizedString(@"New note", @"Label to create a new note");

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1394,7 +1394,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
                       NSLocalizedString(@"Collaborate", @"Verb - work with others on a note"),
                       NSLocalizedString(@"Trash-verb", @"Trash (verb) - the action of deleting a note")];
     actionImages = @[[UIImage imageWithName:UIImageNameShareImage],
-                     [UIImage imageNamed:@"icon_history"],
+                     [UIImage imageWithName:UIImageNameHistoryImage],
                      [UIImage imageNamed:@"icon_collaborate"],
                      [UIImage imageNamed:@"icon_trash"]];
     toggleTitles = @[NSLocalizedString(@"Publish", @"Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others"),

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1395,7 +1395,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
                       NSLocalizedString(@"Trash-verb", @"Trash (verb) - the action of deleting a note")];
     actionImages = @[[UIImage imageWithName:UIImageNameShareImage],
                      [UIImage imageWithName:UIImageNameHistoryImage],
-                     [UIImage imageNamed:@"icon_collaborate"],
+                     [UIImage imageWithName:UIImageNameCollaborateImage],
                      [UIImage imageNamed:@"icon_trash"]];
     toggleTitles = @[NSLocalizedString(@"Publish", @"Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others"),
                     NSLocalizedString(@"Pin to Top", @"Denotes when note is pinned to the top of the note list"), NSLocalizedString(@"Markdown", @"Special formatting that can be turned on for notes")];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1393,7 +1393,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
                       NSLocalizedString(@"History...", @"Action - view the version history of a note"),
                       NSLocalizedString(@"Collaborate", @"Verb - work with others on a note"),
                       NSLocalizedString(@"Trash-verb", @"Trash (verb) - the action of deleting a note")];
-    actionImages = @[[UIImage imageNamed:@"icon_share"],
+    actionImages = @[[UIImage imageWithName:UIImageNameShareImage],
                      [UIImage imageNamed:@"icon_history"],
                      [UIImage imageNamed:@"icon_collaborate"],
                      [UIImage imageNamed:@"icon_trash"]];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -410,7 +410,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     
     
     // setup right buttons
-    actionButton = [UIButton buttonWithImage:[UIImage imageNamed:@"icon_info"]
+    actionButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameInfoImage]
                                       target:self
                                     selector:@selector(actionButtonAction:)];
     actionButton.accessibilityLabel = NSLocalizedString(@"Menu", @"Terminoligy used for sidebar UI element where tags are displayed");

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1396,7 +1396,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     actionImages = @[[UIImage imageWithName:UIImageNameShareImage],
                      [UIImage imageWithName:UIImageNameHistoryImage],
                      [UIImage imageWithName:UIImageNameCollaborateImage],
-                     [UIImage imageNamed:@"icon_trash"]];
+                     [UIImage imageWithName:UIImageNameTrashImage]];
     toggleTitles = @[NSLocalizedString(@"Publish", @"Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others"),
                     NSLocalizedString(@"Pin to Top", @"Denotes when note is pinned to the top of the note list"), NSLocalizedString(@"Markdown", @"Special formatting that can be turned on for notes")];
     toggleSelectedTitles = @[NSLocalizedString(@"Published", nil),

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -229,7 +229,7 @@
 
     /// Button: New Note
     ///
-    self.addButton = [UIBarButtonItem barButtonWithImage:[UIImage imageWithName:UIImageNameNewNoteImage]
+    self.addButton = [UIBarButtonItem barButtonWithImage:[UIImage imageWithName:UIImageNameNewNote]
                                           imageAlignment:UIBarButtonImageAlignmentRight
                                                   target:self
                                                 selector:@selector(addButtonAction:)];
@@ -239,7 +239,7 @@
 
     /// Button: Display Tags
     ///
-    self.sidebarButton = [UIBarButtonItem barButtonContainingCustomViewWithImage:[UIImage imageWithName:UIImageNameMenuImage]
+    self.sidebarButton = [UIBarButtonItem barButtonContainingCustomViewWithImage:[UIImage imageWithName:UIImageNameMenu]
                                                                   imageAlignment:UIBarButtonImageAlignmentLeft
                                                                           target:self
                                                                         selector:@selector(sidebarButtonAction:)];
@@ -425,8 +425,8 @@
     cell.accessibilityLabel = note.titlePreview;
     cell.accessibilityHint = NSLocalizedString(@"Open note", @"Select a note to view in the note editor");
 
-    cell.accessoryLeftImage = note.published ? [UIImage imageWithName:UIImageNameSharedImage] : nil;
-    cell.accessoryRightImage = note.pinned ? [UIImage imageWithName:UIImageNamePinImage] : nil;
+    cell.accessoryLeftImage = note.published ? [UIImage imageWithName:UIImageNameShared] : nil;
+    cell.accessoryRightImage = note.pinned ? [UIImage imageWithName:UIImageNamePin] : nil;
     cell.accessoryLeftTintColor = previewColor;
     cell.accessoryRightTintColor = previewColor;
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -229,7 +229,7 @@
 
     /// Button: New Note
     ///
-    self.addButton = [UIBarButtonItem barButtonWithImage:[UIImage imageNamed:@"icon_new_note"]
+    self.addButton = [UIBarButtonItem barButtonWithImage:[UIImage imageWithName:UIImageNameNewNoteImage]
                                           imageAlignment:UIBarButtonImageAlignmentRight
                                                   target:self
                                                 selector:@selector(addButtonAction:)];
@@ -239,7 +239,7 @@
 
     /// Button: Display Tags
     ///
-    self.sidebarButton = [UIBarButtonItem barButtonContainingCustomViewWithImage:[UIImage imageNamed:@"icon_menu"]
+    self.sidebarButton = [UIBarButtonItem barButtonContainingCustomViewWithImage:[UIImage imageWithName:UIImageNameMenuImage]
                                                                   imageAlignment:UIBarButtonImageAlignmentLeft
                                                                           target:self
                                                                         selector:@selector(sidebarButtonAction:)];

--- a/Simplenote/Classes/SPTagPill.m
+++ b/Simplenote/Classes/SPTagPill.m
@@ -97,7 +97,7 @@
         _deletionOverlayView.layer.borderColor = [UIColor colorWithName:UIColorNameTagViewDeletionBackgroundBorderColor].CGColor;
         _deletionOverlayView.layer.borderWidth = 1.0 / [[UIScreen mainScreen] scale];
 
-        UIImage *image = [UIImage imageWithName:UIImageNameTagViewDeletionImage];
+        UIImage *image = [UIImage imageWithName:UIImageNameTagViewDeletion];
         _deletionButtonImageView = [[UIImageView alloc] initWithImage:image];
         [_deletionButtonImageView sizeToFit];
         

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -106,9 +106,9 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
            forCellReuseIdentifier:cellWithIconIdentifier];
     [self.tableView setTableHeaderView:[self buildTableHeaderView]];
     
-    _settingsImage = [UIImage imageWithName:UIImageNameSettingsImage];
-    _allNotesImage = [UIImage imageWithName:UIImageNameAllNotesImage];
-    _trashImage = [UIImage imageWithName:UIImageNameTrashImage];
+    _settingsImage = [UIImage imageWithName:UIImageNameSettings];
+    _allNotesImage = [UIImage imageWithName:UIImageNameAllNotes];
+    _trashImage = [UIImage imageWithName:UIImageNameTrash];
 
     // add rename item to manu
     SEL renameSelector = sel_registerName("rename:");
@@ -804,7 +804,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
     settingsButton = [UIButton buttonWithType:UIButtonTypeCustom];
     settingsButton.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [settingsButton.titleLabel setFont:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]];
-    [settingsButton setImage:[UIImage imageWithName:UIImageNameSettingsImage] forState:UIControlStateNormal];
+    [settingsButton setImage:[UIImage imageWithName:UIImageNameSettings] forState:UIControlStateNormal];
     [settingsButton setContentHorizontalAlignment:UIControlContentHorizontalAlignmentLeft];
     [settingsButton setContentEdgeInsets:SPButtonContentInsets];
     [settingsButton setImageEdgeInsets:SPButtonImageInsets];
@@ -824,7 +824,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 
     allNotesButton = [self buildHeaderButton];
     allNotesButton.frame = CGRectMake(0, 10, headerView.frame.size.width, 32);
-    [allNotesButton setImage:[[UIImage imageWithName:UIImageNameAllNotesImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+    [allNotesButton setImage:[[UIImage imageWithName:UIImageNameAllNotes] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
     [allNotesButton setTitle:NSLocalizedString(@"All Notes", nil) forState:UIControlStateNormal];
     [allNotesButton addTarget:self action:@selector(allNotesTap:) forControlEvents:UIControlEventTouchUpInside];
 
@@ -832,7 +832,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 
     trashButton = [self buildHeaderButton];
     trashButton.frame = CGRectMake(0, 42, headerView.frame.size.width, 32);
-    [trashButton setImage:[[UIImage imageWithName:UIImageNameTrashImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+    [trashButton setImage:[[UIImage imageWithName:UIImageNameTrash] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
     [trashButton setTitle:NSLocalizedString(@"Trash-noun", nil) forState:UIControlStateNormal];
     [trashButton addTarget:self action:@selector(trashTap:) forControlEvents:UIControlEventTouchUpInside];
 

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -106,9 +106,9 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
            forCellReuseIdentifier:cellWithIconIdentifier];
     [self.tableView setTableHeaderView:[self buildTableHeaderView]];
     
-    _allNotesImage = [[UIImage imageNamed:@"icon_allnotes"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     _trashImage = [[UIImage imageNamed:@"icon_trash"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     _settingsImage = [UIImage imageWithName:UIImageNameSettingsImage];
+    _allNotesImage = [UIImage imageWithName:UIImageNameAllNotesImage];
 
     // add rename item to manu
     SEL renameSelector = sel_registerName("rename:");
@@ -824,7 +824,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 
     allNotesButton = [self buildHeaderButton];
     allNotesButton.frame = CGRectMake(0, 10, headerView.frame.size.width, 32);
-    [allNotesButton setImage:[[UIImage imageNamed:@"icon_allnotes"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+    [allNotesButton setImage:[[UIImage imageWithName:UIImageNameAllNotesImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
     [allNotesButton setTitle:NSLocalizedString(@"All Notes", nil) forState:UIControlStateNormal];
     [allNotesButton addTarget:self action:@selector(allNotesTap:) forControlEvents:UIControlEventTouchUpInside];
 

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -106,9 +106,9 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
            forCellReuseIdentifier:cellWithIconIdentifier];
     [self.tableView setTableHeaderView:[self buildTableHeaderView]];
     
-    _trashImage = [[UIImage imageNamed:@"icon_trash"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     _settingsImage = [UIImage imageWithName:UIImageNameSettingsImage];
     _allNotesImage = [UIImage imageWithName:UIImageNameAllNotesImage];
+    _trashImage = [UIImage imageWithName:UIImageNameTrashImage];
 
     // add rename item to manu
     SEL renameSelector = sel_registerName("rename:");
@@ -832,7 +832,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
 
     trashButton = [self buildHeaderButton];
     trashButton.frame = CGRectMake(0, 42, headerView.frame.size.width, 32);
-    [trashButton setImage:[[UIImage imageNamed:@"icon_trash"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+    [trashButton setImage:[[UIImage imageWithName:UIImageNameTrashImage] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
     [trashButton setTitle:NSLocalizedString(@"Trash-noun", nil) forState:UIControlStateNormal];
     [trashButton addTarget:self action:@selector(trashTap:) forControlEvents:UIControlEventTouchUpInside];
 

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -106,9 +106,9 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
            forCellReuseIdentifier:cellWithIconIdentifier];
     [self.tableView setTableHeaderView:[self buildTableHeaderView]];
     
-    _settingsImage = [[UIImage imageNamed:@"icon_settings"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     _allNotesImage = [[UIImage imageNamed:@"icon_allnotes"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     _trashImage = [[UIImage imageNamed:@"icon_trash"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    _settingsImage = [UIImage imageWithName:UIImageNameSettingsImage];
 
     // add rename item to manu
     SEL renameSelector = sel_registerName("rename:");
@@ -804,7 +804,7 @@ static UIEdgeInsets SPButtonImageInsets = {0, -10, 0, 0};
     settingsButton = [UIButton buttonWithType:UIButtonTypeCustom];
     settingsButton.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [settingsButton.titleLabel setFont:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]];
-    [settingsButton setImage:[[UIImage imageNamed:@"icon_settings"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+    [settingsButton setImage:[UIImage imageWithName:UIImageNameSettingsImage] forState:UIControlStateNormal];
     [settingsButton setContentHorizontalAlignment:UIControlContentHorizontalAlignmentLeft];
     [settingsButton setContentEdgeInsets:SPButtonContentInsets];
     [settingsButton setImageEdgeInsets:SPButtonImageInsets];

--- a/Simplenote/Classes/SnapshotRenderer.swift
+++ b/Simplenote/Classes/SnapshotRenderer.swift
@@ -112,8 +112,8 @@ private extension SnapshotRenderer {
     func configure(tableViewCell: SPNoteTableViewCell, note: Note, searchQuery: String?) {
         tableViewCell.titleText = note.titlePreview
         tableViewCell.bodyText = note.bodyPreview
-        tableViewCell.accessoryLeftImage = note.published ? .image(name: .sharedImage) : nil
-        tableViewCell.accessoryRightImage = note.pinned ? .image(name: .pinImage) : nil
+        tableViewCell.accessoryLeftImage = note.published ? .image(name: .shared) : nil
+        tableViewCell.accessoryRightImage = note.pinned ? .image(name: .pin) : nil
         tableViewCell.accessoryLeftTintColor = bodyColor
         tableViewCell.accessoryRightTintColor = bodyColor
         tableViewCell.rendersInCondensedMode = Options.shared.condensedNotesList

--- a/Simplenote/Classes/UIBarButtonItem+Images.m
+++ b/Simplenote/Classes/UIBarButtonItem+Images.m
@@ -55,7 +55,7 @@ static CGFloat const UIBarButtonWidth               = 44.0;
 {    
     UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
     UIColor *tintColor = [UIColor colorWithName:UIColorNameTintColor];
-    UIImage *backImage = [UIImage imageWithName:UIImageNameChevronLeftImage];
+    UIImage *backImage = [UIImage imageWithName:UIImageNameChevronLeft];
 
     [button setImage:[backImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
             forState:UIControlStateNormal];

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -11,6 +11,7 @@ enum UIImageName: Int, CaseIterable {
     case checkmarkUncheckedImage
     case chevronLeftImage
     case chevronRightImage
+    case infoImage
     case pinImage
     case sharedImage
     case navigationBarBackgroundImage
@@ -40,6 +41,8 @@ extension UIImageName {
             return "icon_chevron_left"
         case .chevronRightImage:
             return "icon_chevron_right"
+        case .infoImage:
+            return "icon_info"
         case .pinImage:
             return "icon_pin"
         case .sharedImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -6,6 +6,7 @@ import UIKit
 //
 @objc
 enum UIImageName: Int, CaseIterable {
+    case addImage
     case checkmarkCheckedImage
     case checkmarkUncheckedImage
     case chevronLeftImage
@@ -29,6 +30,8 @@ extension UIImageName {
     ///
     var lightAssetFilename: String {
         switch self {
+        case .addImage:
+            return "icon_add"
         case .checkmarkCheckedImage:
             return "icon_checkmark_checked"
         case .checkmarkUncheckedImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -6,31 +6,30 @@ import UIKit
 //
 @objc
 enum UIImageName: Int, CaseIterable {
-    case addImage
-    case allNotesImage
-    case checklistImage
-    case checkmarkCheckedImage
-    case checkmarkUncheckedImage
-    case chevronLeftImage
-    case chevronRightImage
-    case collaborateImage
-    case hideKeyboardImage
-    case historyImage
-    case infoImage
-    case menuImage
-    case newNoteImage
-    case pinImage
-    case settingsImage
-    case shareImage
-    case sharedImage
-    case trashImage
-    case navigationBarBackgroundImage
-    case navigationBarBackgroundPromptImage
-    case onePasswordImage
-    case tagViewDeletionImage
-    case trashIcon
-    case visibilityOnImage
-    case visibilityOffImage
+    case add
+    case allNotes
+    case checklist
+    case checkmarkChecked
+    case checkmarkUnchecked
+    case chevronLeft
+    case chevronRight
+    case collaborate
+    case hideKeyboard
+    case history
+    case info
+    case menu
+    case newNote
+    case pin
+    case settings
+    case share
+    case shared
+    case trash
+    case navigationBarBackground
+    case navigationBarBackgroundPrompt
+    case onePassword
+    case tagViewDeletion
+    case visibilityOn
+    case visibilityOff
 }
 
 
@@ -42,55 +41,53 @@ extension UIImageName {
     ///
     var lightAssetFilename: String {
         switch self {
-        case .addImage:
+        case .add:
             return "icon_add"
-        case .allNotesImage:
+        case .allNotes:
             return "icon_allnotes"
-        case .checklistImage:
+        case .checklist:
             return "icon_checklist"
-        case .checkmarkCheckedImage:
+        case .checkmarkChecked:
             return "icon_checkmark_checked"
-        case .checkmarkUncheckedImage:
+        case .checkmarkUnchecked:
             return "icon_checkmark_unchecked"
-        case .chevronLeftImage:
+        case .chevronLeft:
             return "icon_chevron_left"
-        case .chevronRightImage:
+        case .chevronRight:
             return "icon_chevron_right"
-        case .collaborateImage:
+        case .collaborate:
             return "icon_collaborate"
-        case .hideKeyboardImage:
+        case .hideKeyboard:
             return "icon_hide_keyboard"
-        case .historyImage:
+        case .history:
             return "icon_history"
-        case .infoImage:
+        case .info:
             return "icon_info"
-        case .menuImage:
+        case .menu:
             return "icon_menu"
-        case .newNoteImage:
+        case .newNote:
             return "icon_new_note"
-        case .pinImage:
+        case .pin:
             return "icon_pin"
-        case .settingsImage:
+        case .settings:
             return "icon_settings"
-        case .shareImage:
+        case .share:
             return "icon_share"
-        case .sharedImage:
+        case .shared:
             return "icon_shared"
-        case .trashImage:
+        case .trash:
             return "icon_trash"
-        case .navigationBarBackgroundImage:
+        case .navigationBarBackground:
             return "navigation_bar_background"
-        case .navigationBarBackgroundPromptImage:
+        case .navigationBarBackgroundPrompt:
             return "navigation_bar_background_prompt"
-        case .onePasswordImage:
+        case .onePassword:
             return "icon_onepassword"
-        case .tagViewDeletionImage:
+        case .tagViewDeletion:
             return "button_delete_small"
-        case .trashIcon:
-            return "icon_trash"
-        case .visibilityOnImage:
+        case .visibilityOn:
             return "icon_visibility_on"
-        case .visibilityOffImage:
+        case .visibilityOff:
             return "icon_visibility_off"
         }
     }
@@ -99,11 +96,11 @@ extension UIImageName {
     ///
     var darkAssetFilename: String? {
         switch self {
-        case .navigationBarBackgroundImage:
+        case .navigationBarBackground:
             return "navigation_bar_background_dark"
-        case .navigationBarBackgroundPromptImage:
+        case .navigationBarBackgroundPrompt:
             return "navigation_bar_background_prompt_dark"
-        case .tagViewDeletionImage:
+        case .tagViewDeletion:
             return "button_delete_small_dark"
         default:
             return nil

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -12,6 +12,7 @@ enum UIImageName: Int, CaseIterable {
     case checkmarkUncheckedImage
     case chevronLeftImage
     case chevronRightImage
+    case hideKeyboardImage
     case infoImage
     case newNoteImage
     case pinImage
@@ -45,6 +46,8 @@ extension UIImageName {
             return "icon_chevron_left"
         case .chevronRightImage:
             return "icon_chevron_right"
+        case .hideKeyboardImage:
+            return "icon_hide_keyboard"
         case .infoImage:
             return "icon_info"
         case .newNoteImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -12,6 +12,7 @@ enum UIImageName: Int, CaseIterable {
     case checkmarkUncheckedImage
     case chevronLeftImage
     case chevronRightImage
+    case collaborateImage
     case hideKeyboardImage
     case historyImage
     case infoImage
@@ -48,6 +49,8 @@ extension UIImageName {
             return "icon_chevron_left"
         case .chevronRightImage:
             return "icon_chevron_right"
+        case .collaborateImage:
+            return "icon_collaborate"
         case .hideKeyboardImage:
             return "icon_hide_keyboard"
         case .historyImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -20,6 +20,7 @@ enum UIImageName: Int, CaseIterable {
     case pinImage
     case shareImage
     case sharedImage
+    case trashImage
     case navigationBarBackgroundImage
     case navigationBarBackgroundPromptImage
     case onePasswordImage
@@ -65,6 +66,8 @@ extension UIImageName {
             return "icon_share"
         case .sharedImage:
             return "icon_shared"
+        case .trashImage:
+            return "icon_trash"
         case .navigationBarBackgroundImage:
             return "navigation_bar_background"
         case .navigationBarBackgroundPromptImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -7,6 +7,7 @@ import UIKit
 @objc
 enum UIImageName: Int, CaseIterable {
     case addImage
+    case checklistImage
     case checkmarkCheckedImage
     case checkmarkUncheckedImage
     case chevronLeftImage
@@ -33,6 +34,8 @@ extension UIImageName {
         switch self {
         case .addImage:
             return "icon_add"
+        case .checklistImage:
+            return "icon_checklist"
         case .checkmarkCheckedImage:
             return "icon_checkmark_checked"
         case .checkmarkUncheckedImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -13,6 +13,7 @@ enum UIImageName: Int, CaseIterable {
     case chevronLeftImage
     case chevronRightImage
     case hideKeyboardImage
+    case historyImage
     case infoImage
     case newNoteImage
     case pinImage
@@ -49,6 +50,8 @@ extension UIImageName {
             return "icon_chevron_right"
         case .hideKeyboardImage:
             return "icon_hide_keyboard"
+        case .historyImage:
+            return "icon_history"
         case .infoImage:
             return "icon_info"
         case .newNoteImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -16,6 +16,7 @@ enum UIImageName: Int, CaseIterable {
     case infoImage
     case newNoteImage
     case pinImage
+    case shareImage
     case sharedImage
     case navigationBarBackgroundImage
     case navigationBarBackgroundPromptImage
@@ -54,6 +55,8 @@ extension UIImageName {
             return "icon_new_note"
         case .pinImage:
             return "icon_pin"
+        case .shareImage:
+            return "icon_share"
         case .sharedImage:
             return "icon_shared"
         case .navigationBarBackgroundImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -17,6 +17,7 @@ enum UIImageName: Int, CaseIterable {
     case hideKeyboardImage
     case historyImage
     case infoImage
+    case menuImage
     case newNoteImage
     case pinImage
     case settingsImage
@@ -63,6 +64,8 @@ extension UIImageName {
             return "icon_history"
         case .infoImage:
             return "icon_info"
+        case .menuImage:
+            return "icon_menu"
         case .newNoteImage:
             return "icon_new_note"
         case .pinImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -13,6 +13,7 @@ enum UIImageName: Int, CaseIterable {
     case chevronLeftImage
     case chevronRightImage
     case infoImage
+    case newNoteImage
     case pinImage
     case sharedImage
     case navigationBarBackgroundImage
@@ -46,6 +47,8 @@ extension UIImageName {
             return "icon_chevron_right"
         case .infoImage:
             return "icon_info"
+        case .newNoteImage:
+            return "icon_new_note"
         case .pinImage:
             return "icon_pin"
         case .sharedImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -18,6 +18,7 @@ enum UIImageName: Int, CaseIterable {
     case infoImage
     case newNoteImage
     case pinImage
+    case settingsImage
     case shareImage
     case sharedImage
     case trashImage
@@ -62,6 +63,8 @@ extension UIImageName {
             return "icon_new_note"
         case .pinImage:
             return "icon_pin"
+        case .settingsImage:
+            return "icon_settings"
         case .shareImage:
             return "icon_share"
         case .sharedImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -7,6 +7,7 @@ import UIKit
 @objc
 enum UIImageName: Int, CaseIterable {
     case addImage
+    case allNotesImage
     case checklistImage
     case checkmarkCheckedImage
     case checkmarkUncheckedImage
@@ -41,6 +42,8 @@ extension UIImageName {
         switch self {
         case .addImage:
             return "icon_add"
+        case .allNotesImage:
+            return "icon_allnotes"
         case .checklistImage:
             return "icon_checklist"
         case .checkmarkCheckedImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -6,6 +6,8 @@ import UIKit
 //
 @objc
 enum UIImageName: Int, CaseIterable {
+    case checkmarkCheckedImage
+    case checkmarkUncheckedImage
     case chevronLeftImage
     case chevronRightImage
     case pinImage
@@ -27,6 +29,10 @@ extension UIImageName {
     ///
     var lightAssetFilename: String {
         switch self {
+        case .checkmarkCheckedImage:
+            return "icon_checkmark_checked"
+        case .checkmarkUncheckedImage:
+            return "icon_checkmark_unchecked"
         case .chevronLeftImage:
             return "icon_chevron_left"
         case .chevronRightImage:

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -27,6 +27,7 @@ enum UIImageName: Int, CaseIterable {
     case navigationBarBackgroundPromptImage
     case onePasswordImage
     case tagViewDeletionImage
+    case trashIcon
     case visibilityOnImage
     case visibilityOffImage
 }
@@ -82,6 +83,8 @@ extension UIImageName {
             return "icon_onepassword"
         case .tagViewDeletionImage:
             return "button_delete_small"
+        case .trashIcon:
+            return "icon_trash"
         case .visibilityOnImage:
             return "icon_visibility_on"
         case .visibilityOffImage:

--- a/Simplenote/DB5/VSThemeManager.m
+++ b/Simplenote/DB5/VSThemeManager.m
@@ -118,8 +118,8 @@ NSString *const VSThemeManagerThemePrefKey = @"VSThemeManagerThemePrefKey";
     ///
     UIColor *barTintColor = [UIColor colorWithName:UIColorNameBackgroundColor];
     UIImage *navbarShadowImage = [UIImage new];
-    UIImage *navbarBackgroundImage = [UIImage imageWithName:UIImageNameNavigationBarBackgroundImage];
-    UIImage *navbarPromptImage = [UIImage imageWithName:UIImageNameNavigationBarBackgroundPromptImage];
+    UIImage *navbarBackgroundImage = [UIImage imageWithName:UIImageNameNavigationBarBackground];
+    UIImage *navbarPromptImage = [UIImage imageWithName:UIImageNameNavigationBarBackgroundPrompt];
 
     if (@available(iOS 13, *)) {
         // WHY we're disabling the `resizableImage:` for iOS +13:

--- a/Simplenote/Images.xcassets/Icons/icon_add.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_add.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_allnotes.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_allnotes.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_settings.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_settings.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_task_checked.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_task_checked.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_task_unchecked.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_task_unchecked.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_trash.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_trash.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
### Details:
This is a tech debt PR: 

1. `UIImageName` enum cases will not have `Image` as a prefix, anymore. It was... terribly redundant.
1. We're adding missing UIImageName definitions
2. And, of course, we're wiring them. All over

**Note:** Template Images are now marked as such via Assets Catalog. Ain't that epic?

cc @aerych (SORRY to bug you so much, lately!!!)
Ref. #408

### Test
- [x] Verify the Notes List looks correctly in Light + Dark Mode
- [x] Verify the Tags List looks correctly in Light + Dark Mode
- [x] Verify the Editor looks correctly in Light + Dark Mode

Please repeat for iOS 11 and iOS 13, since both OSs now end up hitting a different resolution API.