### PR TITLE
Ensuring First Row is always visible at launch

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -45,7 +45,7 @@ extension SPNoteListViewController {
     ///
     @objc
     func ensureFirstRowIsVisible() {
-        guard tableView.isHidden == false else {
+        guard !tableView.isHidden else {
             return
         }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -37,6 +37,20 @@ extension SPNoteListViewController {
         tableView.contentInset.top = searchBar.frame.height
         tableView.scrollIndicatorInsets.top = searchBar.frame.height
     }
+
+    /// Workaround: Scroll to the very first row. Expected to be called *just* once, right after the view has been laid out, and has been moved
+    /// to its parent ViewController.
+    ///
+    /// Ref. Issue #452
+    ///
+    @objc
+    func ensureFirstRowIsVisible() {
+        guard tableView.isHidden == false else {
+            return
+        }
+
+        tableView.contentOffset.y = tableView.adjustedContentInset.top * -1
+    }
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -96,9 +96,14 @@
 
 #pragma mark - View Lifecycle
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
     [self refreshTableViewInsets];
+}
+
+- (void)didMoveToParentViewController:(UIViewController *)parent {
+    [super didMoveToParentViewController:parent];
+    [self ensureFirstRowIsVisible];
 }
 
 - (void)viewDidAppear:(BOOL)animated {


### PR DESCRIPTION
### Fix:
I've been unable to reproduce Issue #452 on my end. This PR is meant to act as a workaround, if the worst case scenario happens, for unknown reasons.

We're force-scrolling the NoteList's TableView to the very first row, as soon as the ViewController is moved to its parent.

cc @aerych Sir, may I bug you with this one?
Thank you!!

### Test
1. Launch the app and log into your account
2. Verify the first Note Row is visible
3. Kill the app
4. Relaunch and verify the first row is visible
