### PR TITLE
Update fastlane and release-toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org' do
   gem 'xcpretty-travis-formatter'
   gem 'octokit', "~> 4.0"
   gem 'dotenv'
-  gem 'rubyzip', "~> 1.2.2"
-  gem 'fastlane', "2.127.2"
+  gem 'rubyzip', "~> 1.3"
+  gem 'fastlane', "2.133.0"
 end
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,11 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: b57127b313fd06519cbebfd4a3f6784eec1ef5fc
-  tag: 0.7.1
+  revision: c8007b8c11c282ea3e9f97f722d1971271959770
+  tag: 0.8.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.7.1)
+    fastlane-plugin-wpmreleasetoolkit (0.8.0)
+      activesupport (~> 4)
+      chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
@@ -26,7 +28,8 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     atomos (0.1.3)
-    babosa (1.0.2)
+    babosa (1.0.3)
+    chroma (0.2.0)
     claide (1.0.3)
     cocoapods (1.7.5)
       activesupport (>= 4.0.2, < 5)
@@ -77,7 +80,7 @@ GEM
     dotenv (2.7.4)
     emoji_regex (1.0.1)
     escape (0.0.4)
-    excon (0.65.0)
+    excon (0.67.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -85,8 +88,8 @@ GEM
       http-cookie (~> 1.0.0)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.5)
-    fastlane (2.127.2)
+    fastimage (2.1.7)
+    fastlane (2.133.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -96,9 +99,9 @@ GEM
       dotenv (>= 2.1.1, < 3.0.0)
       emoji_regex (>= 0.1, < 2.0)
       excon (>= 0.45.0, < 1.0.0)
-      faraday (~> 0.9)
+      faraday (< 0.16.0)
       faraday-cookie_jar (~> 0.0.6)
-      faraday_middleware (~> 0.9)
+      faraday_middleware (< 0.16.0)
       fastimage (>= 2.1.0, < 3.0.0)
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-api-client (>= 0.21.2, < 0.24.0)
@@ -111,7 +114,7 @@ GEM
       multipart-post (~> 2.0.0)
       plist (>= 3.1.0, < 4.0.0)
       public_suffix (~> 2.0.0)
-      rubyzip (>= 1.2.2, < 2.0.0)
+      rubyzip (>= 1.3.0, < 2.0.0)
       security (= 0.1.3)
       simctl (~> 1.6.3)
       slack-notifier (>= 2.0.0, < 3.0.0)
@@ -136,9 +139,9 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.9)
-    google-cloud-core (1.3.0)
+    google-cloud-core (1.3.1)
       google-cloud-env (~> 1.0)
-    google-cloud-env (1.2.0)
+    google-cloud-env (1.2.1)
       faraday (~> 0.11)
     google-cloud-storage (1.16.0)
       digest-crc (~> 0.4)
@@ -164,9 +167,9 @@ GEM
       optimist (~> 3)
     jwt (2.1.0)
     memoist (0.16.0)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.1009)
     mini_magick (4.9.5)
     mini_portile2 (2.4.0)
     minitest (5.12.0)
@@ -182,18 +185,18 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.9.0)
+    oj (3.9.2)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
-    parallel (1.17.0)
+    parallel (1.18.0)
     plist (3.5.0)
     progress_bar (1.3.0)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
     rake (12.3.2)
-    rake-compiler (1.0.7)
+    rake-compiler (1.0.8)
       rake
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -202,17 +205,17 @@ GEM
     retriable (3.1.2)
     rouge (2.0.7)
     ruby-macho (1.4.0)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
     security (0.1.3)
-    signet (0.11.0)
+    signet (0.12.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simctl (1.6.5)
+    simctl (1.6.6)
       CFPropertyList
       naturally
     slack-notifier (2.3.2)
@@ -250,12 +253,12 @@ DEPENDENCIES
   cocoapods (= 1.7.5)!
   cocoapods-repo-update (~> 0.0.3)!
   dotenv!
-  fastlane (= 2.127.2)!
+  fastlane (= 2.133.0)!
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!
   rake!
-  rubyzip (~> 1.2.2)!
+  rubyzip (~> 1.3)!
   xcpretty-travis-formatter!
 
 BUNDLED WITH

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,4 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-sentry'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.7.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'


### PR DESCRIPTION
This PR updates release-toolkit to import some fixes in the release notes handling for iOS.
It also updates fastlane due to the security issue with rubyzip.

These changes do not require release notes.
