### PR TITLE
Fixing Dark Mode Glitch

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -121,6 +121,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
                                                    object:nil];
 
         // Apply the current style right away!
+        [self startListeningToThemeNotifications];
         [self applyStyle];
     }
     
@@ -177,8 +178,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     _noteEditorTextView.delegate = self;
 
     self.navigationItem.title = nil;
-    
-    [self startListeningToNotifications];
+
     [self setupBarItems];
     [self swapTagViewPositionForVoiceover];
 }
@@ -203,6 +203,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     [self ensureEditorIsFirstResponder];
     [self ensureTagViewIsVisible];
     [self highlightSearchResultsIfNeeded];
+    [self startListeningToKeyboardNotifications];
 }
 
 - (void)setupNavigationController {
@@ -236,9 +237,18 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     _noteEditorTextView.frame = viewFrame;
 }
 
-- (void)startListeningToNotifications {
+- (void)startListeningToKeyboardNotifications {
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
+}
+
+- (void)stopListeningToKeyboardNotifications {
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    [nc removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
+}
+
+- (void)startListeningToThemeNotifications {
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(themeDidChange) name:VSThemeManagerThemeDidChangeNotification object:nil];
 }
 
@@ -284,6 +294,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     
     [super viewWillDisappear:animated];
     [self.navigationController setToolbarHidden:YES animated:YES];
+    [self stopListeningToKeyboardNotifications];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator


### PR DESCRIPTION
### Fix
In this PR we're fixing a Dark Mode issue that affects iOS 11 devices.

cc @aerych (Thank you!!!)

### Test
1. Launch Simplenote on a device running iOS 11
2. Log into your account
3. Tap over the top left icon and press over the **Settings** row
4. Switch to Dark Mode
5. Open any notes from your list

Verify that the Editor's background is actually dark!

### Release
These changes do not require release notes, since affect only 4.12 (unreleased!).

