### PR TITLE
Fixing iOS13 Aggressive Links Behavior

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 -   Notes List refreshed to display Pinned state on the right hand side.
 -   iOS 11 Is now the minimum supported OS.
 -   Fixed a bug in which the Editor Colors might not be properly initialized
+-   Fixed an iOS 13 bug that caused links to be accidentally opened
 
 4.10.0
 ======

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -11,6 +11,11 @@
 
 extern NSString *const CheckListRegExPattern;
 
+@protocol SPEditorTextViewDelegate <UITextViewDelegate>
+- (void)textView:(UITextView *)textView receivedInteractionWithURL:(NSURL *)url;
+@end
+
+
 @interface SPEditorTextView : SPTextView
 
 @property (nonatomic) BOOL editing;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -10,7 +10,7 @@
 @class SPEditorTextView;
 @class SPOutsideTouchView;
 
-@interface SPNoteEditorViewController : UIViewController  <UITextViewDelegate, SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {
+@interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {
     
     // Other Objects
     NSTimer *saveTimer;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -51,7 +51,10 @@ CGFloat const SPBarButtonYOriginAdjustment       = -1.0f;
 CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
 
 
-@interface SPNoteEditorViewController ()<SPInteractivePushViewControllerProvider, UIPopoverPresentationControllerDelegate> {
+@interface SPNoteEditorViewController ()<SPEditorTextViewDelegate,
+                                        SPInteractivePushViewControllerProvider,
+                                        UIPopoverPresentationControllerDelegate>
+{
     NSUInteger cursorLocationBeforeRemoteUpdate;
     NSString *noteContentBeforeRemoteUpdate;
     BOOL bounceMarkdownPreviewOnActivityViewDismiss;
@@ -1138,20 +1141,13 @@ CGFloat const SPMultitaskingCompactOneThirdWidth = 320.0f;
     [self save];
 }
 
-- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction
-{
-    if (![URL containsHttpScheme]) {
-        return YES;
-    }
-    
-    if ([SFSafariViewController class]) {
-        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
-        [self presentViewController:sfvc animated:YES completion:nil];
-    } else {
-        [[UIApplication sharedApplication] openURL:URL options:@{} completionHandler:nil];
-    }
-    
-    return NO;
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction {
+    return ![URL containsHttpScheme];
+}
+
+- (void)textView:(UITextView *)textView receivedInteractionWithURL:(NSURL *)url {
+    SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:url];
+    [self presentViewController:sfvc animated:YES completion:nil];
 }
 
 - (BOOL)isDictatingText {


### PR DESCRIPTION
### Fix:
In this PR we're patching up an iOS 13 behavior that's causing Links to be open, accidentally, during scroll gestures.

@aerych May I bug you with a quick review?
**Thank you!!!**

[WPiOS Sibling Issue Here](https://github.com/wordpress-mobile/WordPress-iOS/pull/12612)

### Test:
1. Log into your account
2. Add a note with multiple links
3. Close the note and reopen

- [ ] Verify that placing your finger over any of the links doesn't immediately open SFSafariViewController
- [ ] Verify that tapping over any link effectively opens a WebView

### Release
`RELEASE-NOTES.txt` was updated in a5de8d5 with:

> Fixed an iOS 13 bug that caused links to be accidentally opened
