### PR TITLE
Updates Authentication Strings

### DIFF
--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -174,7 +174,7 @@ private extension SPOnboardingViewController {
 //
 private struct OnboardingStrings {
     static let brandText = NSLocalizedString("Simplenote", comment: "Our mighty brand!")
-    static let signupText = NSLocalizedString("Create an account", comment: "Signup Action")
+    static let signupText = NSLocalizedString("Sign Up", comment: "Signup Action")
     static let loginText = NSLocalizedString("Log In", comment: "Login Action")
     static let headerText = NSLocalizedString("The simplest way to keep notes.", comment: "Onboarding Header Text")
     static let loginWithEmailText = NSLocalizedString("Log in with email", comment: "Presents the regular Email signin flow")


### PR DESCRIPTION
### Details:
In this PR we're renaming `Create an account` > `Sign Up`, in order to match other platforms.

cc @frosty May I trouble you with a real quick one James?
Thank you!


### Testing:
1. Perform a fresh install
2. Verify the top action reads as `Sign Up`

<img src="https://user-images.githubusercontent.com/1195260/67205353-f4b3df80-f3e5-11e9-9c8b-be6c6e6805d2.png" width="300">


