### PR TITLE
Bugfix: UI Freeze!

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -22,7 +22,6 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
     BOOL bSearching;
     BOOL bListViewIsEmpty;
     BOOL bIndexingNotes;
-    BOOL bShouldShowSidePanel;
 
     SPTagFilterType tagFilterType;
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -375,7 +375,6 @@
     bSearching = NO;
 
     self.searchText = nil;
-    [self.searchController dismiss];
 
     [self update];
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -305,7 +305,6 @@
 - (void)sidebarButtonAction:(id)sender {
     
     [self.tableView setEditing:NO];
-    bShouldShowSidePanel = YES;
 
     [SPTracker trackSidebarButtonPresed];
     [[[SPAppDelegate sharedDelegate] sidebarViewController] toggleSidebar];
@@ -917,11 +916,6 @@
 
 - (BOOL)sidebarContainerShouldDisplaySidebar:(SPSidebarContainerViewController *)sidebarContainer
 {
-    if (bShouldShowSidePanel) {
-        bShouldShowSidePanel = NO;
-        return YES;
-    }
-
     // Checking for self.tableView.isEditing prevents showing the sidebar when you use swipe to cancel delete/restore.
     return !(self.tableView.dragging || self.tableView.isEditing || bSearching);
 }

--- a/Simplenote/Classes/SPSearchController.swift
+++ b/Simplenote/Classes/SPSearchController.swift
@@ -91,10 +91,14 @@ private extension SPSearchController {
         statusBarBackground.backgroundColor = searchBar.backgroundColor
         statusBarBackground.alpha = hidden ? UIKitConstants.alphaMid : UIKitConstants.alphaFull
 
-        UIView.animate(withDuration: UIKitConstants.animationShortDuration) { [weak self] in
+        navigationController.setNavigationBarHidden(hidden, animated: true)
+
+        let duration = TimeInterval(UINavigationController.hideShowBarDuration)
+        let topView = navigationController.topViewController?.view
+
+        UIView.animate(withDuration: duration) { [weak self] in
             self?.statusBarBackground.alpha = hidden ? UIKitConstants.alphaFull : UIKitConstants.alphaZero
-            navigationController.setNavigationBarHidden(hidden, animated: true)
-            navigationController.view.layoutIfNeeded()
+            topView?.layoutIfNeeded()
         }
     }
 

--- a/Simplenote/Classes/SPSearchController.swift
+++ b/Simplenote/Classes/SPSearchController.swift
@@ -151,7 +151,7 @@ extension SPSearchController: UISearchBarDelegate {
     }
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        updateStatus(active: false)
+        dismiss()
         delegate?.searchControllerDidEndSearch(self)
     }
 }

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -72,7 +72,6 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
             
             [navigationController.interactivePopGestureRecognizer addTarget:self
                                                                      action:@selector(handlePan:)];
-            navigationController.interactivePopGestureRecognizer.delegate = self;
         }
 
         self.pushPopAnimationController = [[SPInteractivePushPopAnimationController alloc] initWithNavigationController:navigationController];
@@ -753,19 +752,6 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     
     [[NSNotificationCenter defaultCenter] postNotificationName:SPTransitionControllerPopGestureTriggeredNotificationName
                                                         object:self];
-}
-
-
-#pragma mark - GestureDelegate
-
-- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)recognizer
-{
-    // Note: navigationController.interactivePopGestureRecognizer **must only begin** whenever there's more than
-    // one ViewController.
-    //
-    // Otherwise we... seriously risk all sorts of weird behaviors. And not cool weird behaviors, precisely.
-    //
-    return self.navigationController.viewControllers.count > 1;
 }
 
 @end

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -565,10 +565,11 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
                 }
             }
 
-            // Snapshot: SearchBar
-            SPTransitionSnapshot *searchBarSnapshot = [self backSearchBarSnapshotForListController:listController containerView:containerView];
-            [self storeTransitionSnapshot:searchBarSnapshot];
         }
+
+        // Snapshot: SearchBar
+        SPTransitionSnapshot *searchBarSnapshot = [self backSearchBarSnapshotForListController:listController containerView:containerView];
+        [self storeTransitionSnapshot:searchBarSnapshot];
     }
 }
 

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -755,4 +755,17 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
                                                         object:self];
 }
 
+
+#pragma mark - GestureDelegate
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)recognizer
+{
+    // Note: navigationController.interactivePopGestureRecognizer **must only begin** whenever there's more than
+    // one ViewController.
+    //
+    // Otherwise we... seriously risk all sorts of weird behaviors. And not cool weird behaviors, precisely.
+    //
+    return self.navigationController.viewControllers.count > 1;
+}
+
 @end


### PR DESCRIPTION
### Fix
In this PR we're fixing a critical bug that caused complete freeze of the UI. Plus we're also fixing a (related) bug that might have also led to an invalid state.

@etoledom May I trouble you, YET AGAIN, to verify if this is okay on your end?

Thanks in advance!!!

Closes #487

### Scenario: Frozen UI
0. Launch Simplenote and log into your account
1. Swipe right to reveal tags
2. Swipe left to hide tags
3. Press over the Search Bar
4. Open any note (no need to type any keyword!)
5. Hit back
6. Swipe from the left edge of the screen, towards the center
7. Press the **Cance** button

- [x] Verify the UI isn't completely frozen

**Note:** With these repro steps, I've managed to reproduce the original issue 10/10

### Scenario: Invalid Tag Menu OP
0. Launch Simplenote and log into your account
1. Tap the top left navigation bar button to reveal the tags
2. Swipe from the center of the screen towards the left edge, to hide the Tags UI
3. Press over the search bar to activate search
4. Swipe from the left edge towards the center

- [x] Verify the Tags List doesn't show up while there's a Search Active

### Release
These changes do not require release notes.
