### PR TITLE
Disabling Peek and Pop in Trash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.13
 -----
- 
+-   Fixed a bug that allowed Peek and Pop to open notes in the Trash.
+
 4.12
 -----
 -   Simplenote just got brand new Icons!

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -88,8 +88,11 @@ extension SPNoteListViewController {
 extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
 
     public func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        guard tableView.isUserInteractionEnabled, let indexPath = tableView.indexPathForRow(at: location) else {
-            return nil
+        guard tableView.isUserInteractionEnabled,
+            tagFilterType != .deleted,
+            let indexPath = tableView.indexPathForRow(at: location)
+            else {
+                return nil
         }
 
         /// Prevent any Pan gesture from passing thru

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -23,8 +23,6 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
     BOOL bListViewIsEmpty;
     BOOL bIndexingNotes;
     BOOL bShouldShowSidePanel;
-
-    SPTagFilterType tagFilterType;
 }
 
 @property (nonatomic, strong) NSFetchedResultsController<Note *>    *fetchedResultsController;
@@ -34,6 +32,7 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
 @property (nonatomic, strong, readonly) UISearchBar                 *searchBar;
 @property (nonatomic, strong) SPEmptyListView                       *emptyListView;
 @property (nonatomic, strong) UITableView                           *tableView;
+@property (nonatomic, assign, readonly) SPTagFilterType                     tagFilterType;
 
 - (Note *)noteForKey:(NSString *)key;
 - (void)update;

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -25,14 +25,14 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
     BOOL bShouldShowSidePanel;
 }
 
-@property (nonatomic, strong) NSFetchedResultsController<Note *>    *fetchedResultsController;
-@property (nonatomic, strong) NSString                              *searchText;
-@property (nonatomic) BOOL                                          firstLaunch;
+@property (nonatomic, strong, readonly) NSFetchedResultsController<Note *>  *fetchedResultsController;
+@property (nonatomic, strong) NSString                                      *searchText;
+@property (nonatomic) BOOL                                                  firstLaunch;
 
-@property (nonatomic, strong, readonly) UISearchBar                 *searchBar;
-@property (nonatomic, strong) SPEmptyListView                       *emptyListView;
-@property (nonatomic, strong) UITableView                           *tableView;
+@property (nonatomic, strong, readonly) UISearchBar                         *searchBar;
 @property (nonatomic, assign, readonly) SPTagFilterType                     tagFilterType;
+@property (nonatomic, strong, readonly) SPEmptyListView                     *emptyListView;
+@property (nonatomic, strong, readonly) UITableView                         *tableView;
 
 - (Note *)noteForKey:(NSString *)key;
 - (void)update;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -53,6 +53,7 @@
 
 @property (nonatomic, assign) BOOL                      bTitleViewAnimating;
 @property (nonatomic, assign) BOOL                      bResetTitleView;
+@property (nonatomic, assign) SPTagFilterType                       tagFilterType;
 
 @end
 
@@ -218,13 +219,10 @@
 }
 
 - (void)updateNavigationBar {
-    if (tagFilterType == SPTagFilterTypeDeleted) {
-        [self.navigationItem setRightBarButtonItem:_emptyTrashButton animated:YES];
-        [self.navigationItem setLeftBarButtonItem:_sidebarButton animated:YES];
-    } else {
-        [self.navigationItem setRightBarButtonItem:_addButton animated:YES];
-        [self.navigationItem setLeftBarButtonItem:_sidebarButton animated:YES];
-    }
+    UIBarButtonItem *rightButton = (self.tagFilterType == SPTagFilterTypeDeleted) ? _emptyTrashButton : _addButton;
+
+    [self.navigationItem setRightBarButtonItem:rightButton animated:YES];
+    [self.navigationItem setLeftBarButtonItem:_sidebarButton animated:YES];
 }
 
 
@@ -463,7 +461,7 @@
 - (NSArray *)tableView:(UITableView*)tableView editActionsForRowAtIndexPath:(nonnull NSIndexPath *)indexPath{
     
     Note *note = [self.fetchedResultsController objectAtIndexPath:indexPath];
-    if (tagFilterType == SPTagFilterTypeDeleted) {
+    if (self.tagFilterType == SPTagFilterTypeDeleted) {
         return [self rowActionsForDeletedNote:note];
     }
 
@@ -708,7 +706,7 @@
     [self updateFetchPredicate];
     [self refreshTitle];
 
-    BOOL isTrashOnScreen = tagFilterType == SPTagFilterTypeDeleted;
+    BOOL isTrashOnScreen = self.tagFilterType == SPTagFilterTypeDeleted;
     self.emptyTrashButton.enabled = isTrashOnScreen && self.numNotes > 0;
     self.tableView.allowsSelection = !isTrashOnScreen;
     
@@ -721,11 +719,11 @@
 {
     NSString *selectedTag = [[SPAppDelegate sharedDelegate] selectedTag];
     if ([selectedTag isEqualToString:kSimplenoteTrashKey]) {
-        tagFilterType = SPTagFilterTypeDeleted;
+        self.tagFilterType = SPTagFilterTypeDeleted;
     } else if ([selectedTag isEqualToString:kSimplenoteUntaggedKey]) {
-        tagFilterType = SPTagFilterTypeUntagged;
+        self.tagFilterType = SPTagFilterTypeUntagged;
     } else {
-        tagFilterType = SPTagFilterTypeUserTag;
+        self.tagFilterType = SPTagFilterTypeUserTag;
     }
 
     [NSFetchedResultsController deleteCacheWithName:@"Root"];
@@ -749,9 +747,9 @@
     SPAppDelegate *appDelegate = [SPAppDelegate sharedDelegate];
     NSMutableArray *predicateList = [NSMutableArray arrayWithCapacity:3];
 
-    [predicateList addObject: [NSPredicate predicateForNotesWithDeletedStatus:(tagFilterType == SPTagFilterTypeDeleted)]];
+    [predicateList addObject: [NSPredicate predicateForNotesWithDeletedStatus:(self.tagFilterType == SPTagFilterTypeDeleted)]];
 
-    switch (tagFilterType) {
+    switch (self.tagFilterType) {
         case SPTagFilterTypeShared:
             [predicateList addObject:[NSPredicate predicateForSystemTagWith:kSimplenoteSystemTagShared]];
             break;
@@ -960,7 +958,7 @@
 - (void)setWaitingForIndex:(BOOL)waiting {
     
     // if the current tag is the deleted tag, do not show the activity spinner
-    if (tagFilterType == SPTagFilterTypeDeleted && waiting) {
+    if (self.tagFilterType == SPTagFilterTypeDeleted && waiting) {
         return;
     }
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -223,10 +223,10 @@
 }
 
 - (void)updateNavigationBar {
-    UIBarButtonItem *rightButton = (self.tagFilterType == SPTagFilterTypeDeleted) ? _emptyTrashButton : _addButton;
+    UIBarButtonItem *rightButton = (self.tagFilterType == SPTagFilterTypeDeleted) ? self.emptyTrashButton : self.addButton;
 
     [self.navigationItem setRightBarButtonItem:rightButton animated:YES];
-    [self.navigationItem setLeftBarButtonItem:_sidebarButton animated:YES];
+    [self.navigationItem setLeftBarButtonItem:self.sidebarButton animated:YES];
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -41,19 +41,23 @@
                                         SPSearchControllerPresentationContextProvider,
                                         SPTransitionControllerDelegate>
 
-@property (nonatomic, strong) UIBarButtonItem           *addButton;
-@property (nonatomic, strong) UIBarButtonItem           *sidebarButton;
-@property (nonatomic, strong) UIBarButtonItem           *emptyTrashButton;
+@property (nonatomic, strong) NSFetchedResultsController<Note *>    *fetchedResultsController;
 
-@property (nonatomic, strong) SPSearchController        *searchController;
-@property (nonatomic, strong) UIActivityIndicatorView   *activityIndicator;
+@property (nonatomic, strong) UIBarButtonItem                       *addButton;
+@property (nonatomic, strong) UIBarButtonItem                       *sidebarButton;
+@property (nonatomic, strong) UIBarButtonItem                       *emptyTrashButton;
 
-@property (nonatomic, strong) SPTransitionController    *transitionController;
-@property (nonatomic, assign) CGFloat                   keyboardHeight;
+@property (nonatomic, strong) UITableView                           *tableView;
 
-@property (nonatomic, assign) BOOL                      bTitleViewAnimating;
-@property (nonatomic, assign) BOOL                      bResetTitleView;
+@property (nonatomic, strong) SPSearchController                    *searchController;
+@property (nonatomic, strong) UIActivityIndicatorView               *activityIndicator;
+
+@property (nonatomic, strong) SPTransitionController                *transitionController;
+@property (nonatomic, assign) CGFloat                               keyboardHeight;
+
 @property (nonatomic, assign) SPTagFilterType                       tagFilterType;
+@property (nonatomic, assign) BOOL                                  bTitleViewAnimating;
+@property (nonatomic, assign) BOOL                                  bResetTitleView;
 
 @end
 


### PR DESCRIPTION
### Fix
In this PR we're fixing a minor glitch that allowed users to actually edit notes that were trashed.

Closes #459

@aerych (Me again!!! SORRY!!! And of course, thank you!!!!)

### Test
1. Log into your account
2. Delete any of your notes
3. Press over the top left icon to reveal the Tags List
4. Press over `Trash`
5. Perform Force Press over the trashed note

- [x] Verify the trashed note doesn't get previewed

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 7d41b3e with:

> Fixed a bug that allowed Peek and Pop to open notes in the Trash.
