### PR TITLE
Updates Log Out Strings

### DIFF
--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -437,7 +437,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     break;
                 }
                 case SPOptionsAccountRowLogout: {
-                    cell.textLabel.text = NSLocalizedString(@"Sign Out", @"Sign out of the active account in the app");
+                    cell.textLabel.text = NSLocalizedString(@"Log Out", @"Log out of the active account in the app");
                     break;
                 }
                 default:
@@ -676,7 +676,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                 preferredStyle:UIAlertControllerStyleAlert];
 
     UIAlertAction* signOutAction = [UIAlertAction
-                                    actionWithTitle:NSLocalizedString(@"Delete Notes", @"Verb: Delete notes and sign out of the app")
+                                    actionWithTitle:NSLocalizedString(@"Delete Notes", @"Verb: Delete notes and log out of the app")
                                     style:UIAlertActionStyleDestructive
                                     handler:^(UIAlertAction * action) {
                                         [SPTracker trackUserSignedOut];


### PR DESCRIPTION
### Fix
In this PR we're rewriting `Sign Out` > `Log Out`.

@SergioEstevao (Me again!!! sorry to bug you, extremely small and inoccuous PR!)

Thanks in advance!

### Test
1. Log into Simplenote
2. Press the top left corner to reveal the Tags List
3. Press over **Settings**

- [ ] Verify the row immediately below Privacy reads as `Log Out`

### Release
These changes do not require release notes.
