### PR TITLE
Enables Preserve Vector Data flag in assets

### DIFF
--- a/Simplenote/Images.xcassets/Icons/icon_add.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_add.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_allnotes.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_allnotes.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_arrow_top_right.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_arrow_top_right.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_checklist.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_checklist.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_chevron_left.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_chevron_left.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_chevron_right.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_chevron_right.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_collaborate.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_collaborate.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_hide_keyboard.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_hide_keyboard.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_history.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_history.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_info.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_info.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_menu.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_menu.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_new_note.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_new_note.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_onepassword.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_onepassword.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_pin.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_pin.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_settings.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_settings.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_share.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_share.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_shared.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_shared.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_tag.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_tag.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_trash.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_trash.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_untagged.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_untagged.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_user.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_user.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_visibility_off.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_visibility_off.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_visibility_on.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_visibility_on.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
-    "template-rendering-intent" : "template"
+    "template-rendering-intent" : "template",
+    "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
### Fix
We've got reports that some images are a bit blurry... when they shouldn't. Bottom line: Xcode compiles vectorial images into Static Images, and runtime resizing may result in blurry images.

In this PR we're enabling the Assets Catalogue `Preserve Vector Data` flag. (Wow!).

@aerych Eric, May i bug you with an (inoccuous) review?. 
Zero code changes on this one, and... well, I wasn't aware of this flag!

**Thank you!!!**

### Test
Please verify the app builds fine!

### Release
These changes do not require release notes.
