### PR TITLE
Fixing Rotation Bug

### DIFF
--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -296,16 +296,7 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
 
 - (UIViewPropertyAnimator *)animatorForSidebarVisibility:(BOOL)visible
 {
-    CGRect mainFrame = self.mainView.frame;
-    CGRect sideFrame = self.sidebarView.frame;
-
-    if (self.isSidebarVisible) {
-        mainFrame.origin.x = 0;
-        sideFrame.origin.x = -sideFrame.size.width;
-    } else {
-        mainFrame.origin.x = SPSidebarWidth;
-        sideFrame.origin.x = 0;
-    }
+    CGAffineTransform transform = visible ? CGAffineTransformMakeTranslation(SPSidebarWidth, 0) : CGAffineTransformIdentity;
 
     UISpringTimingParameters *parameters = [[UISpringTimingParameters alloc] initWithDampingRatio:SPSidebarAnimationDamping
                                                                                   initialVelocity:SPSidebarAnimationInitialVelocity];
@@ -314,8 +305,8 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
                                                                        timingParameters:parameters];
 
     [animator addAnimations:^{
-        self.mainView.frame = mainFrame;
-        self.sidebarView.frame = sideFrame;
+        self.mainView.transform = transform;
+        self.sidebarView.transform = transform;
     }];
 
     return animator;

--- a/Simplenote/Classes/SPTagsListViewController.xib
+++ b/Simplenote/Classes/SPTagsListViewController.xib
@@ -17,7 +17,7 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="SPBorderedView">
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>


### PR DESCRIPTION
### Fix
In this PR we're fixing an issue triggered whenever the user performs the Sidebar Interactive Swipe (to either reveal or hide the Tags List), along with a device rotation.

@aerych May I bug you (YET!!!) again?
**Thank you!!!**

### Test
0. Launch Simplenote on an iPad device (I've tested this both on the device + simulator)
1. With the device in portrait, open the sidebar.
2. Start to drag the sidebar closed, and then rotate the device while the sidebar is partially closed (keeping your finger on the screen).

- [x] Verify the UI is laid out as expected!

### Release
These changes do not require release notes.
