### PR TITLE
Preventing Interactive Animation Race Condition

### DIFF
--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -349,8 +349,10 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
         BOOL didBecomeVisible = self.isSidebarVisible;
 
         [self.animator addCompletion:^(UIViewAnimatingPosition finalPosition) {
-            weakSelf.isPanningActive = NO;
-            [weakSelf endSidebarTransition:didBecomeVisible];
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+
+            strongSelf.isPanningActive = NO;
+            [strongSelf endSidebarTransition:didBecomeVisible];
             [UIViewController attemptRotationToDeviceOrientation];
         }];
 

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -303,6 +303,7 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
 {
     CGAffineTransform transform = visible ? CGAffineTransformMakeTranslation(SPSidebarWidth, 0) : CGAffineTransformIdentity;
 
+    CGFloat alpha = visible ? UIKitConstants.alphaFull : UIKitConstants.alphaZero;
     UISpringTimingParameters *parameters = [[UISpringTimingParameters alloc] initWithDampingRatio:SPSidebarAnimationDamping
                                                                                   initialVelocity:SPSidebarAnimationInitialVelocity];
 
@@ -312,6 +313,7 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     [animator addAnimations:^{
         self.mainView.transform = transform;
         self.sidebarView.transform = transform;
+        self.sidebarView.alpha = alpha;
     }];
 
     return animator;

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -6,9 +6,9 @@
 
 static const CGFloat SPSidebarWidth                         = 300;
 static const CGFloat SPSidebarAnimationThreshold            = 0.15;
-static const CGFloat SPSidebarAnimationDuration             = 0.4;
-static const CGFloat SPSidebarAnimationDamping              = 1.5;
-static const CGVector SPSidebarAnimationInitialVelocity     = {6, 0};
+static const CGFloat SPSidebarAnimationDuration             = 0.35;
+static const CGFloat SPSidebarAnimationDamping              = 10;
+static const CGVector SPSidebarAnimationInitialVelocity     = {-10, 0};
 static const CGFloat SPSidebarAnimationCompletionMin        = 0.001;
 static const CGFloat SPSidebarAnimationCompletionMax        = 0.999;
 static const CGFloat SPSidebarAnimationCompletionFactorFull = 1.0;

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -303,7 +303,8 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
 {
     CGAffineTransform transform = visible ? CGAffineTransformMakeTranslation(SPSidebarWidth, 0) : CGAffineTransformIdentity;
 
-    CGFloat alpha = visible ? UIKitConstants.alphaFull : UIKitConstants.alphaZero;
+    CGFloat alphaSidebar = visible ? UIKitConstants.alphaFull : UIKitConstants.alphaZero;
+    CGFloat alphaMain = visible ? UIKitConstants.alphaMid : UIKitConstants.alphaFull;
     UISpringTimingParameters *parameters = [[UISpringTimingParameters alloc] initWithDampingRatio:SPSidebarAnimationDamping
                                                                                   initialVelocity:SPSidebarAnimationInitialVelocity];
 
@@ -312,8 +313,9 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
 
     [animator addAnimations:^{
         self.mainView.transform = transform;
+        self.mainView.alpha = alphaMain;
         self.sidebarView.transform = transform;
-        self.sidebarView.alpha = alpha;
+        self.sidebarView.alpha = alphaSidebar;
     }];
 
     return animator;

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -243,6 +243,11 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
         return NO;
     }
 
+    // Scenario G: We're still tracking something?
+    if (self.isPanningActive) {
+        return NO;
+    }
+
     return YES;
 }
 
@@ -340,12 +345,12 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
         BOOL didBecomeVisible = self.isSidebarVisible;
 
         [self.animator addCompletion:^(UIViewAnimatingPosition finalPosition) {
+            weakSelf.isPanningActive = NO;
             [weakSelf endSidebarTransition:didBecomeVisible];
             [UIViewController attemptRotationToDeviceOrientation];
         }];
 
         [self.animator continueAnimationWithTimingParameters:nil durationFactor:SPSidebarAnimationCompletionFactorFull];
-        self.isPanningActive = NO;
 
     } else {
         CGPoint translation = [gesture translationInView:self.mainView];


### PR DESCRIPTION
### Fix
In this PR we're fixing a race condition, triggered whenever a Swipe gesture is performed, before the **Sidebar Animation** concludes.

We're also fine tunning the Sidebar animation: new FadeIn, and properties adjusted.

@danielebogo May I bug you with (YET) another fun PR?
Thank you sir!!


### Test
1. Swipe Left to Right / Right to left, repeatedly, quickly

- [x] Verify that everytime the Notes List is onscreen, vertical scroll is not possible!
- [x] Verify the Tags List now has a Fade In (supersmooth) animation
- [x] Verify the Notes List is slightly faded out, whenever the Tags List is revealed 


### Release
> These changes do not require release notes.