### PR TITLE
Bugfix: Dark Mode Regression (iOS 11)

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -149,8 +149,11 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     [_tagView applyStyle];
 
     _noteEditorTextView.font = bodyFont;
-    _noteEditorTextView.backgroundColor = [UIColor colorWithName:UIColorNameBackgroundColor];
     _noteEditorTextView.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
+
+    UIColor *backgroundColor = [UIColor colorWithName:UIColorNameBackgroundColor];
+    self.noteEditorTextView.backgroundColor = backgroundColor;
+    self.view.backgroundColor = backgroundColor;
 
     _noteEditorTextView.interactiveTextStorage.tokens = @{
         SPDefaultTokenName : @{

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -55,6 +55,7 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     [self configureView];
     [self attachMainView];
     [self attachSidebarView];
+    [self startListeningToNotifications];
 }
 
 - (BOOL)shouldAutomaticallyForwardAppearanceMethods
@@ -200,6 +201,22 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     sidebarView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleRightMargin;
 
     [self.view insertSubview:sidebarView atIndex:0];
+}
+
+
+#pragma mark - Notifications
+
+- (void)startListeningToNotifications
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(refreshStyle)
+                                                 name:VSThemeManagerThemeDidChangeNotification
+                                               object:nil];
+}
+
+- (void)refreshStyle
+{
+    self.view.backgroundColor = [UIColor colorWithName:UIColorNameBackgroundColor];
 }
 
 


### PR DESCRIPTION
### Fix
This PR fixes a glitch that affects devices running iOS 11. Right after switching the Theme, we had a View that wasn't being properly refreshed, causing UI inconsistencies.

Closes #504

@aerych (Me again!!!!) Thank you Eric!!!

### Test
1. Launch Simplenote in any device running iOS 11
2. Log into your account
3. Press over the top left button to reveal the sidebar
4. Press over Settings
5. Switch over to the Dark Mode
6. Close the sidebar
7. Open any note

- [x] Verify the transition looks as expected!


### Release
These changes do not require release notes.
