### PR TITLE
Update Fastlane to upload Simplenote Internal to AppCenter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,7 @@ DEPENDENCIES
   cocoapods-repo-update (~> 0.0.3)!
   dotenv!
   fastlane (= 2.133.0)!
-  fastlane-plugin-appcenter
+  fastlane-plugin-appcenter (= 1.6.0)
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-appcenter (1.6.0)
     fastlane-plugin-sentry (1.5.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -254,6 +255,7 @@ DEPENDENCIES
   cocoapods-repo-update (~> 0.0.3)!
   dotenv!
   fastlane (= 2.133.0)!
+  fastlane-plugin-appcenter
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -191,13 +191,13 @@ ENV["PROJECT_ROOT_FOLDER"]="./"
 
     sh("mv ../build/Simplenote.ipa \"../build/Simplenote Internal.ipa\"")
 
-    hockey(
-        api_token: ENV["HOCKEY_API_TOKEN"],        
-        public_identifier: ENV["HOCKEY_PUBLIC_ID"],
-        notify: "0",
-        status: "1",
-        ipa: "./build/Simplenote Internal.ipa",
-        dsym: "./build/Simplenote.app.dSYM.zip",
+    appcenter_upload(
+      api_token: ENV["APPCENTER_API_TOKEN"],
+      owner_name: "Hogwarts-Organization",
+      owner_type: "organization", 
+      app_name: "Simplenote",
+      file: "./build/Simplenote\ Internal.ipa",
+      notify_testers: false 
     )
 
     sentry_upload_dsym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -191,12 +191,14 @@ ENV["PROJECT_ROOT_FOLDER"]="./"
 
     sh("mv ../build/Simplenote.ipa \"../build/Simplenote Internal.ipa\"")
 
+    # NOTE: "ipa" parameter is deprecated in appcenter_upload 1.6.0, but there's a bug in the action that
+    # makes the default gym output override the "file" parameter. 
     appcenter_upload(
       api_token: ENV["APPCENTER_API_TOKEN"],
       owner_name: "Hogwarts-Organization",
       owner_type: "organization", 
       app_name: "Simplenote",
-      file: "./build/Simplenote\ Internal.ipa",
+      ipa: "./build/Simplenote Internal.ipa",
       notify_testers: false 
     )
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,4 +4,4 @@
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
-gem 'fastlane-plugin-appcenter'
+gem 'fastlane-plugin-appcenter', "1.6.0"

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,3 +4,4 @@
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
+gem 'fastlane-plugin-appcenter'


### PR DESCRIPTION
This PR updates the Fastlane configuration to switch binary upload from HockeyApp to MSAppCenter because of HockeyApp sunsetting. 

### Test
1. Create a new [API Token in AppCenter](https://appcenter.ms/settings/apitokens).
2. Add a `APPCENTER_API_TOKEN` entry to your `~/.simplenoteios-env.default` with the token above. 
3. Bump the version of the app.
4. `bundle install`.
5. Run `bundle exec fastlane build_and_upload_internal` and verify that the app is built and uploaded to App Center.

### Review
 Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
