### PR TITLE
Disabling Markdown Swipe during Text Selection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -   Fixed a bug that caused the StatusBar to be hidden when Simplenote's Settings were displayed
 -   Fixed a bug that caused Swipe to Dismiss gesture not to properly work in the Editor
 -   Fixed a bug that allowed Peek and Pop to open notes in the Trash.
+-   Fixed a bug tht caused Text Selection in the editor to push the Markdown Preview UI.
 
 4.12
 ====

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		B52F35CF22F3243900724793 /* SPThemeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52F35CE22F3243900724793 /* SPThemeViewController.swift */; };
 		B52F35D122F3254800724793 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52F35D022F3254800724793 /* Theme.swift */; };
 		B52F35D322F356F500724793 /* UserDefaults+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52F35D222F356F500724793 /* UserDefaults+Tests.swift */; };
+		B5358C5A2371DFBC007604E0 /* UITextView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5358C592371DFBC007604E0 /* UITextView+Simplenote.swift */; };
 		B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B53971A11AB8DCDC00B1A582 /* SPTracker.m */; };
 		B53C5A5A230330CD00DA2143 /* SPNoteListViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53C5A59230330CD00DA2143 /* SPNoteListViewController+Extensions.swift */; };
 		B546BE97234E64F200A126DA /* SPTagListViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B546BE96234E64F200A126DA /* SPTagListViewCell.xib */; };
@@ -442,6 +443,7 @@
 		B52F35CE22F3243900724793 /* SPThemeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPThemeViewController.swift; path = Classes/SPThemeViewController.swift; sourceTree = "<group>"; };
 		B52F35D022F3254800724793 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Theme.swift; path = Classes/Theme.swift; sourceTree = "<group>"; };
 		B52F35D222F356F500724793 /* UserDefaults+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Tests.swift"; sourceTree = "<group>"; };
+		B5358C592371DFBC007604E0 /* UITextView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITextView+Simplenote.swift"; path = "Classes/UITextView+Simplenote.swift"; sourceTree = "<group>"; };
 		B53971A01AB8DCDC00B1A582 /* SPTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = SPTracker.h; path = Classes/SPTracker.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		B53971A11AB8DCDC00B1A582 /* SPTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = SPTracker.m; path = Classes/SPTracker.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		B53C5A59230330CD00DA2143 /* SPNoteListViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SPNoteListViewController+Extensions.swift"; path = "Classes/SPNoteListViewController+Extensions.swift"; sourceTree = "<group>"; };
@@ -1046,6 +1048,7 @@
 				B58039852322D4F90083C916 /* UIView+ImageRepresentation.swift */,
 				B50E99F3234242130092F274 /* UISearchBar+Simplenote.swift */,
 				B524AE0E2352BE9200EA11D4 /* UITableView+Simplenote.swift */,
+				B5358C592371DFBC007604E0 /* UITextView+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2037,6 +2040,7 @@
 				B5BE05541AB75C3B002417BF /* Settings.m in Sources */,
 				B58039862322D4F90083C916 /* UIView+ImageRepresentation.swift in Sources */,
 				46A3C9AD17DFA81A002865AE /* VSThemeLoader.m in Sources */,
+				B5358C5A2371DFBC007604E0 /* UITextView+Simplenote.swift in Sources */,
 				46A3C9AE17DFA81A002865AE /* SPTextView.m in Sources */,
 				37FD30481FC4CFA2008D0B78 /* KeychainMigrator.swift in Sources */,
 				B521A1961BC8446900E1CF2A /* SPAutomatticTracker.m in Sources */,

--- a/Simplenote/Classes/SPInteractivePushPopAnimationController.h
+++ b/Simplenote/Classes/SPInteractivePushPopAnimationController.h
@@ -12,7 +12,7 @@
 
 @protocol SPInteractivePushViewControllerProvider <NSObject>
 - (UIViewController *)nextViewControllerForInteractivePush;
-- (BOOL)interactivePushPopAnimationControllerShouldBeginPush:(SPInteractivePushPopAnimationController *)controller;
+- (BOOL)interactivePushPopAnimationControllerShouldBeginPush:(SPInteractivePushPopAnimationController *)controller touchPoint:(CGPoint)touchPoint;
 - (void)interactivePushPopAnimationControllerWillBeginPush:(SPInteractivePushPopAnimationController *)controller;
 @end
 

--- a/Simplenote/Classes/SPInteractivePushPopAnimationController.m
+++ b/Simplenote/Classes/SPInteractivePushPopAnimationController.m
@@ -70,7 +70,8 @@ CGFloat const SPPushAnimationDurationCompact = 0.3f;
     // TopViewController conforms to SPInteractivePushViewControllerProvider AND We're Swiping Right to Left: Support Push!
     if ([topViewController conformsToProtocol:@protocol(SPInteractivePushViewControllerProvider)] && isLeftTranslation) {
         UIViewController <SPInteractivePushViewControllerProvider> *pushProviderController = (UIViewController <SPInteractivePushViewControllerProvider> *)topViewController;
-        if (![pushProviderController interactivePushPopAnimationControllerShouldBeginPush:self]) {
+        CGPoint locationInView = [panGestureRecognizer locationInView:pushProviderController.view];
+        if (![pushProviderController interactivePushPopAnimationControllerShouldBeginPush:self touchPoint:locationInView]) {
             return NO;
         }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -51,7 +51,7 @@ CGFloat const SPBarButtonYOriginAdjustment          = -1.0f;
 CGFloat const SPMultitaskingCompactOneThirdWidth    = 320.0f;
 CGFloat const SPBackButtonImagePadding              = -18;
 CGFloat const SPBackButtonTitlePadding              = -15;
-
+CGFloat const SPSelectedAreaPadding                 = 20;
 
 @interface SPNoteEditorViewController ()<SPEditorTextViewDelegate,
                                         SPInteractivePushViewControllerProvider,
@@ -758,8 +758,20 @@ CGFloat const SPBackButtonTitlePadding              = -15;
 
 - (BOOL)interactivePushPopAnimationControllerShouldBeginPush:(SPInteractivePushPopAnimationController *)controller touchPoint:(CGPoint)touchPoint
 {
-    BOOL isTextUnselected = self.noteEditorTextView.selectedRange.length == 0;
-    return self.currentNote.markdown && isTextUnselected;
+    if (!self.currentNote.markdown) {
+        return NO;
+    }
+
+    if (!self.noteEditorTextView.isTextSelected) {
+        return YES;
+    }
+
+    // We'll check if the Push Gesture intersects with the Selected Text's bounds. If so, we'll deny the
+    // Push Interaction.
+    CGRect selectedSquare = CGRectInset(self.noteEditorTextView.selectedBounds, -SPSelectedAreaPadding, -SPSelectedAreaPadding);
+    CGPoint convertedPoint = [self.view convertPoint:touchPoint toView:self.noteEditorTextView];
+
+    return !CGRectContainsPoint(selectedSquare, convertedPoint);
 }
 
 - (void)interactivePushPopAnimationControllerWillBeginPush:(SPInteractivePushPopAnimationController *)controller

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -780,8 +780,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     // from happening interactively along with the push on iOS 9.
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.tagView endEditing:YES];
-        [self.noteEditorTextView endEditing:YES];
-        
+
         [self resetNavigationBarToIdentityWithAnimation:YES completion:^{
             self->bDisableShrinkingNavigationBar = YES;
         }];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -758,7 +758,8 @@ CGFloat const SPBackButtonTitlePadding              = -15;
 
 - (BOOL)interactivePushPopAnimationControllerShouldBeginPush:(SPInteractivePushPopAnimationController *)controller
 {
-    return self.currentNote.markdown;
+    BOOL isTextUnselected = self.noteEditorTextView.selectedRange.length == 0;
+    return self.currentNote.markdown && isTextUnselected;
 }
 
 - (void)interactivePushPopAnimationControllerWillBeginPush:(SPInteractivePushPopAnimationController *)controller

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -756,7 +756,7 @@ CGFloat const SPBackButtonTitlePadding              = -15;
     return previewViewController;
 }
 
-- (BOOL)interactivePushPopAnimationControllerShouldBeginPush:(SPInteractivePushPopAnimationController *)controller
+- (BOOL)interactivePushPopAnimationControllerShouldBeginPush:(SPInteractivePushPopAnimationController *)controller touchPoint:(CGPoint)touchPoint
 {
     BOOL isTextUnselected = self.noteEditorTextView.selectedRange.length == 0;
     return self.currentNote.markdown && isTextUnselected;

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -1,0 +1,26 @@
+import Foundation
+import UIKit
+
+
+// MARK: - UITextView's Simplenote Methods
+//
+extension UITextView {
+
+    /// Indicates if the receiver contains selected text
+    ///
+    @objc
+    var isTextSelected: Bool {
+        return selectedRange.length > 0
+    }
+
+    /// Returns the Selected Text's bounds
+    ///
+    @objc
+    var selectedBounds: CGRect {
+        guard selectedRange.length > 0 else {
+            return .zero
+        }
+
+        return layoutManager.boundingRect(forGlyphRange: selectedRange, in: textContainer)
+    }
+}


### PR DESCRIPTION
### Fix
In this PR we're disabling the Markdown Preview gesture, whenever there's text selected in the editor.

Fixes #472

@danielebogo Sir, may I bug you **yet again** with an easy one?

Thanks in advance!!

### Test
1. Open a note.
2. Enable Markdown
3. Double tap on a word to copy it

- [x] Verify that expanding the selected range (in any direction) won't trigger the Markdown Preview UI.
- [x] Verify that dragging from the right edge towards the left edge, anywhere outside the selected range, triggers the Markdown Preview interaction.

**Sample video below!!**

### Release
`RELEASE-NOTES.txt` was updated in f1f9c26 with:

> Fixes a bug that caused Markdown Preview to be pushed when extending Text Selection

### Test Case Demo!

![Demo](https://user-images.githubusercontent.com/1195260/68237629-3ea3e480-ffe6-11e9-854c-ce979547fa10.gif)
