### PR TITLE
Fix: Surrogate Pairs Crash!

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -29,7 +29,7 @@ abstract_target 'Automattic' do
 		#
 		pod 'Automattic-Tracks-iOS', '~> 0.4'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
-		pod 'Simperium', '~> 0.8.23'
+		pod 'Simperium', '~> 0.8.24'
 		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :tag => '1.0.7'
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,17 +22,17 @@ PODS:
   - Sentry (4.4.0):
     - Sentry/Core (= 4.4.0)
   - Sentry/Core (4.4.0)
-  - Simperium (0.8.23):
-    - Simperium/DiffMatchPach (= 0.8.23)
-    - Simperium/JRSwizzle (= 0.8.23)
-    - Simperium/SocketTrust (= 0.8.23)
-    - Simperium/SPReachability (= 0.8.23)
-    - Simperium/SSKeychain (= 0.8.23)
-  - Simperium/DiffMatchPach (0.8.23)
-  - Simperium/JRSwizzle (0.8.23)
-  - Simperium/SocketTrust (0.8.23)
-  - Simperium/SPReachability (0.8.23)
-  - Simperium/SSKeychain (0.8.23)
+  - Simperium (0.8.24):
+    - Simperium/DiffMatchPach (= 0.8.24)
+    - Simperium/JRSwizzle (= 0.8.24)
+    - Simperium/SocketTrust (= 0.8.24)
+    - Simperium/SPReachability (= 0.8.24)
+    - Simperium/SSKeychain (= 0.8.24)
+  - Simperium/DiffMatchPach (0.8.24)
+  - Simperium/JRSwizzle (0.8.24)
+  - Simperium/SocketTrust (0.8.24)
+  - Simperium/SPReachability (0.8.24)
+  - Simperium/SSKeychain (0.8.24)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
   - WordPress-AppbotX (1.0.7)
@@ -45,7 +45,7 @@ DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.4)
   - Gridicons (~> 0.18)
   - SAMKeychain (= 1.5.2)
-  - Simperium (~> 0.8.23)
+  - Simperium (~> 0.8.24)
   - SVProgressHUD (= 2.2.5)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, tag `1.0.7`)
   - WordPress-Ratings-iOS (= 0.0.2)
@@ -86,13 +86,13 @@ SPEC CHECKSUMS:
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SAMKeychain: 1865333198217411f35327e8da61b43de79b635b
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
-  Simperium: 71a5028fde163d1efead45b8b45adf4bdcf02039
+  Simperium: aeaf03461d8f75fd90d0cb199a5c8a1e9095ef15
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-AppbotX: 624387ac980fc0663cbb9425e22bf514329be96f
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 57ad14a30e6c2db4b27d28dda3fc87114016f80c
+PODFILE CHECKSUM: 55e827445fd46fbe90c9f5bf48aae678ed64c23a
 
 COCOAPODS: 1.7.5

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,8 @@
 ====
 -   Fixed a bug that prevented users from repositioning the caret in the Email field (Login / SignUp)
 -   Fixed a bug that caused the Markdown Preview UI to get dismissed accidentally
- 
+-   Fixed an issue that might crash the app with a specific emojis combination
+
 4.13
 ====
 -   Every Navigation Bar in Simplenote now has a super cool blur effect!


### PR DESCRIPTION
### Fix
In this PR we're mapping a (patched) version of Simperium, which makes sure `Surrogate Pairs` aren't split in the middle, and thus, causing invalid unicode strings.

@aerych May I bug you with a very very cool fix?
Thank you sir!!

Closes #524

### Test
1. Add a new note
2. Enter the following emojis: ☺️🖖🏿
3. Insert the following emoji in between: 😃

- [x] Verify the app doesn't break!

### Release
`RELEASE-NOTES.txt` was updated in acd509e with:
 
> Fixed an issue that might crash the app with a specific emojis combination
