### PR TITLE
SearchResults: Specialized ViewController

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		B5358C5A2371DFBC007604E0 /* UITextView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5358C592371DFBC007604E0 /* UITextView+Simplenote.swift */; };
 		B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B53971A11AB8DCDC00B1A582 /* SPTracker.m */; };
 		B53C5A5A230330CD00DA2143 /* SPNoteListViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53C5A59230330CD00DA2143 /* SPNoteListViewController+Extensions.swift */; };
+		B5418BA023870ABC00CD47BF /* FeatureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5418B9F23870ABC00CD47BF /* FeatureManager.swift */; };
 		B546BE97234E64F200A126DA /* SPTagListViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B546BE96234E64F200A126DA /* SPTagListViewCell.xib */; };
 		B546BE9E234F6CB700A126DA /* SPTagHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B546BE9D234F6CB700A126DA /* SPTagHeaderView.swift */; };
 		B546BEA0234F6DA000A126DA /* SPTagHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B546BE9F234F6DA000A126DA /* SPTagHeaderView.xib */; };
@@ -451,6 +452,7 @@
 		B53971A01AB8DCDC00B1A582 /* SPTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = SPTracker.h; path = Classes/SPTracker.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		B53971A11AB8DCDC00B1A582 /* SPTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = SPTracker.m; path = Classes/SPTracker.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		B53C5A59230330CD00DA2143 /* SPNoteListViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SPNoteListViewController+Extensions.swift"; path = "Classes/SPNoteListViewController+Extensions.swift"; sourceTree = "<group>"; };
+		B5418B9F23870ABC00CD47BF /* FeatureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FeatureManager.swift; path = Classes/FeatureManager.swift; sourceTree = "<group>"; };
 		B546BE96234E64F200A126DA /* SPTagListViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPTagListViewCell.xib; path = Classes/SPTagListViewCell.xib; sourceTree = "<group>"; };
 		B546BE9D234F6CB700A126DA /* SPTagHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPTagHeaderView.swift; path = Classes/SPTagHeaderView.swift; sourceTree = "<group>"; };
 		B546BE9F234F6DA000A126DA /* SPTagHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPTagHeaderView.xib; path = Classes/SPTagHeaderView.xib; sourceTree = "<group>"; };
@@ -1139,6 +1141,7 @@
 		B5BE053E1AB751FD002417BF /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				B5418B9F23870ABC00CD47BF /* FeatureManager.swift */,
 				B5CBEF3F22D3AD92009DBE67 /* MigrationsHandler.swift */,
 				B5BE053F1AB75225002417BF /* SPIntegrityHelper.h */,
 				B5BE05401AB75225002417BF /* SPIntegrityHelper.m */,
@@ -1978,6 +1981,7 @@
 				B5BD6AF51BF66093004ECE33 /* SPMarkdownPreviewViewController.m in Sources */,
 				B513F2B42319A8D50021CFA4 /* SPNoteTableViewCell.swift in Sources */,
 				46A3C99117DFA81A002865AE /* NSString+Search.m in Sources */,
+				B5418BA023870ABC00CD47BF /* FeatureManager.swift in Sources */,
 				375D24B321E01131007AB25A /* autolink.c in Sources */,
 				B512AF971C20B14200FE76D8 /* SPAnimations.m in Sources */,
 				46A3C99217DFA81A002865AE /* SPEditorTextView.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		B546BE97234E64F200A126DA /* SPTagListViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B546BE96234E64F200A126DA /* SPTagListViewCell.xib */; };
 		B546BE9E234F6CB700A126DA /* SPTagHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B546BE9D234F6CB700A126DA /* SPTagHeaderView.swift */; };
 		B546BEA0234F6DA000A126DA /* SPTagHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B546BE9F234F6DA000A126DA /* SPTagHeaderView.xib */; };
+		B54CDD62237F437100234520 /* SPSearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54CDD61237F437100234520 /* SPSearchResultsViewController.swift */; };
+		B54CDD64237F43AD00234520 /* SPSearchResultsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B54CDD63237F43AD00234520 /* SPSearchResultsViewController.xib */; };
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B550F93122BA65CD00091939 /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93022BA65CD00091939 /* ActivityType.swift */; };
 		B550F93322BA6A3300091939 /* ShortcutsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93222BA6A3300091939 /* ShortcutsHandler.swift */; };
@@ -452,6 +454,8 @@
 		B546BE96234E64F200A126DA /* SPTagListViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPTagListViewCell.xib; path = Classes/SPTagListViewCell.xib; sourceTree = "<group>"; };
 		B546BE9D234F6CB700A126DA /* SPTagHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPTagHeaderView.swift; path = Classes/SPTagHeaderView.swift; sourceTree = "<group>"; };
 		B546BE9F234F6DA000A126DA /* SPTagHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPTagHeaderView.xib; path = Classes/SPTagHeaderView.xib; sourceTree = "<group>"; };
+		B54CDD61237F437100234520 /* SPSearchResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSearchResultsViewController.swift; path = Classes/SPSearchResultsViewController.swift; sourceTree = "<group>"; };
+		B54CDD63237F43AD00234520 /* SPSearchResultsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSearchResultsViewController.xib; path = Classes/SPSearchResultsViewController.xib; sourceTree = "<group>"; };
 		B55051811A4328B9002A1093 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		B550F93022BA65CD00091939 /* ActivityType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ActivityType.swift; path = Classes/ActivityType.swift; sourceTree = "<group>"; };
 		B550F93222BA6A3300091939 /* ShortcutsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShortcutsHandler.swift; path = Classes/ShortcutsHandler.swift; sourceTree = "<group>"; };
@@ -1434,6 +1438,8 @@
 				B53C5A59230330CD00DA2143 /* SPNoteListViewController+Extensions.swift */,
 				E20DED0217AE07340086AB5F /* SPPopoverContainerViewController.h */,
 				E20DED0317AE07340086AB5F /* SPPopoverContainerViewController.m */,
+				B54CDD61237F437100234520 /* SPSearchResultsViewController.swift */,
+				B54CDD63237F43AD00234520 /* SPSearchResultsViewController.xib */,
 				E2922AC0180CA06B003AF914 /* SPSidebarContainerViewController.h */,
 				E2922AC1180CA06B003AF914 /* SPSidebarContainerViewController.m */,
 				E215C797180B130B00AD36B5 /* SPTableViewController.h */,
@@ -1669,6 +1675,7 @@
 			files = (
 				46A3C9C217DFA81A002865AE /* InfoPlist.strings in Resources */,
 				46A3C9C317DFA81A002865AE /* Images.xcassets in Resources */,
+				B54CDD64237F43AD00234520 /* SPSearchResultsViewController.xib in Resources */,
 				B5AA4B5A22F46B300072BF5D /* Colors.xcassets in Resources */,
 				B5767F9122FDF2B900052D81 /* LaunchScreen.storyboard in Resources */,
 				46A3C9C417DFA81A002865AE /* Simplenote-DB5.plist in Resources */,
@@ -2026,6 +2033,7 @@
 				B5358C5A2371DFBC007604E0 /* UITextView+Simplenote.swift in Sources */,
 				46A3C9AE17DFA81A002865AE /* SPTextView.m in Sources */,
 				37FD30481FC4CFA2008D0B78 /* KeychainMigrator.swift in Sources */,
+				B54CDD62237F437100234520 /* SPSearchResultsViewController.swift in Sources */,
 				B584DA36236722D400B2844A /* SPBlurEffectView.swift in Sources */,
 				B521A1961BC8446900E1CF2A /* SPAutomatticTracker.m in Sources */,
 				375D24B121E01131007AB25A /* html5_blocks.c in Sources */,

--- a/Simplenote/Classes/FeatureManager.swift
+++ b/Simplenote/Classes/FeatureManager.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+
+// MARK: - Simple mechanism to keep track of Work in Progress features
+//
+struct FeatureManager {
+
+    /// Indicates if Advanced Search is Enabled
+    ///
+    static let advancedSearchEnabled = false
+}

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -39,7 +39,7 @@ extension SPNoteListViewController {
         ])
     }
 
-    /// Attaches the specified SearchResultsView to the receiver's main view
+    /// Attaches the specified SearchResultsView to the receiver's main view below the SearchBar + NavigationBarBackground views
     ///
     private func attachSearchResultsView(_ resultsView: UIView) {
         resultsView.translatesAutoresizingMaskIntoConstraints = false
@@ -81,7 +81,7 @@ extension SPNoteListViewController {
 //
 extension SPNoteListViewController {
 
-    /// Attaches a new SearchResultsController instance to the receiver
+    /// Displays the SearchResultsController onScreen
     ///
     @objc
     func displaySearchResultsController() {
@@ -94,17 +94,13 @@ extension SPNoteListViewController {
         searchResultsViewController.view.fadeIn()
     }
 
-    /// Detaches the active SearchResultsController instance, if any
+    /// Dismisses the active SearchResultsController
     ///
     @objc
     func dismissSearchResultsController() {
-        guard let resultsController = searchResultsViewController else {
-            return
-        }
-
-        resultsController.view.fadeOut {
-            resultsController.view.removeFromSuperview()
-            resultsController.removeFromParent()
+        searchResultsViewController.view.fadeOut {
+            self.searchResultsViewController.view.removeFromSuperview()
+            self.searchResultsViewController.removeFromParent()
         }
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -52,9 +52,6 @@ extension SPNoteListViewController {
             resultsView.topAnchor.constraint(equalTo: view.topAnchor)
         ])
 
-        // Forward the SearchBar's height
-        resultsView.layoutMargins.top = searchBar.frame.height
-
         // Layout right away: Avoid the Results' View Layout to get caught in the SearchController's animation.
         view.layoutIfNeeded()
     }
@@ -92,6 +89,7 @@ extension SPNoteListViewController {
     @objc
     func displaySearchResultsController() {
         let resultsViewController = SPSearchResultsViewController()
+        resultsViewController.additionalSafeAreaInsets.top = searchBar.frame.size.height
         addChild(resultsViewController)
 
         displaySearchResultsView(resultsViewController.view)

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -39,6 +39,20 @@ extension SPNoteListViewController {
         ])
     }
 
+    /// Attaches the specified SearchResultsView to the receiver's main view
+    ///
+    private func attachSearchResultsView(_ resultsView: UIView) {
+        resultsView.translatesAutoresizingMaskIntoConstraints = false
+        view.insertSubview(resultsView, belowSubview: navigationBarBackground)
+
+        NSLayoutConstraint.activate([
+            resultsView.leftAnchor.constraint(equalTo: view.leftAnchor),
+            resultsView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            resultsView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            resultsView.topAnchor.constraint(equalTo: view.topAnchor)
+        ])
+    }
+
     /// Adjust the TableView's Insets, so that the content falls below the searchBar
     ///
     @objc
@@ -59,6 +73,41 @@ extension SPNoteListViewController {
         }
 
         tableView.contentOffset.y = tableView.adjustedContentInset.top * -1
+    }
+}
+
+
+// MARK: - SearchResultsViewController
+//
+extension SPNoteListViewController {
+
+    /// Attaches a new SearchResultsController instance to the receiver
+    ///
+    @objc
+    func displaySearchResultsController() {
+        let resultsViewController = SPSearchResultsViewController()
+        addChild(resultsViewController)
+
+        attachSearchResultsView(resultsViewController.view)
+        resultsViewController.view.fadeIn()
+
+        self.searchResultsViewController = resultsViewController
+
+    }
+
+    /// Detaches the active SearchResultsController instance, if any
+    ///
+    @objc
+    func dismissSearchResultsController() {
+        guard let resultsController = searchResultsViewController else {
+            return
+        }
+
+        resultsController.view.fadeOut {
+            resultsController.view.removeFromSuperview()
+            resultsController.removeFromParent()
+            self.searchResultsViewController = nil
+        }
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -41,7 +41,7 @@ extension SPNoteListViewController {
 
     /// Attaches the specified SearchResultsView to the receiver's main view
     ///
-    private func displaySearchResultsView(_ resultsView: UIView) {
+    private func attachSearchResultsView(_ resultsView: UIView) {
         resultsView.translatesAutoresizingMaskIntoConstraints = false
         view.insertSubview(resultsView, belowSubview: navigationBarBackground)
 
@@ -51,9 +51,6 @@ extension SPNoteListViewController {
             resultsView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             resultsView.topAnchor.constraint(equalTo: view.topAnchor)
         ])
-
-        // Layout right away: Avoid the Results' View Layout to get caught in the SearchController's animation.
-        view.layoutIfNeeded()
     }
 
     /// Adjust the TableView's Insets, so that the content falls below the searchBar
@@ -88,15 +85,13 @@ extension SPNoteListViewController {
     ///
     @objc
     func displaySearchResultsController() {
-        let resultsViewController = SPSearchResultsViewController()
-        resultsViewController.additionalSafeAreaInsets.top = searchBar.frame.size.height
-        addChild(resultsViewController)
+        searchResultsViewController.additionalSafeAreaInsets.top = searchBar.frame.size.height
+        addChild(searchResultsViewController)
 
-        displaySearchResultsView(resultsViewController.view)
-        resultsViewController.view.fadeIn()
+        attachSearchResultsView(searchResultsViewController.view)
+        view.layoutIfNeeded()
 
-        self.searchResultsViewController = resultsViewController
-
+        searchResultsViewController.view.fadeIn()
     }
 
     /// Detaches the active SearchResultsController instance, if any
@@ -110,7 +105,6 @@ extension SPNoteListViewController {
         resultsController.view.fadeOut {
             resultsController.view.removeFromSuperview()
             resultsController.removeFromParent()
-            self.searchResultsViewController = nil
         }
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -41,7 +41,7 @@ extension SPNoteListViewController {
 
     /// Attaches the specified SearchResultsView to the receiver's main view
     ///
-    private func attachSearchResultsView(_ resultsView: UIView) {
+    private func displaySearchResultsView(_ resultsView: UIView) {
         resultsView.translatesAutoresizingMaskIntoConstraints = false
         view.insertSubview(resultsView, belowSubview: navigationBarBackground)
 
@@ -51,6 +51,12 @@ extension SPNoteListViewController {
             resultsView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             resultsView.topAnchor.constraint(equalTo: view.topAnchor)
         ])
+
+        // Forward the SearchBar's height
+        resultsView.layoutMargins.top = searchBar.frame.height
+
+        // Layout right away: Avoid the Results' View Layout to get caught in the SearchController's animation.
+        view.layoutIfNeeded()
     }
 
     /// Adjust the TableView's Insets, so that the content falls below the searchBar
@@ -88,7 +94,7 @@ extension SPNoteListViewController {
         let resultsViewController = SPSearchResultsViewController()
         addChild(resultsViewController)
 
-        attachSearchResultsView(resultsViewController.view)
+        displaySearchResultsView(resultsViewController.view)
         resultsViewController.view.fadeIn()
 
         self.searchResultsViewController = resultsViewController

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -39,20 +39,6 @@ extension SPNoteListViewController {
         ])
     }
 
-    /// Attaches the specified SearchResultsView to the receiver's main view below the SearchBar + NavigationBarBackground views
-    ///
-    private func attachSearchResultsView(_ resultsView: UIView) {
-        resultsView.translatesAutoresizingMaskIntoConstraints = false
-        view.insertSubview(resultsView, belowSubview: navigationBarBackground)
-
-        NSLayoutConstraint.activate([
-            resultsView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            resultsView.rightAnchor.constraint(equalTo: view.rightAnchor),
-            resultsView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            resultsView.topAnchor.constraint(equalTo: view.topAnchor)
-        ])
-    }
-
     /// Adjust the TableView's Insets, so that the content falls below the searchBar
     ///
     @objc
@@ -73,35 +59,6 @@ extension SPNoteListViewController {
         }
 
         tableView.contentOffset.y = tableView.adjustedContentInset.top * -1
-    }
-}
-
-
-// MARK: - SearchResultsViewController
-//
-extension SPNoteListViewController {
-
-    /// Displays the SearchResultsController onScreen
-    ///
-    @objc
-    func displaySearchResultsController() {
-        searchResultsViewController.additionalSafeAreaInsets.top = searchBar.frame.size.height
-        addChild(searchResultsViewController)
-
-        attachSearchResultsView(searchResultsViewController.view)
-        view.layoutIfNeeded()
-
-        searchResultsViewController.view.fadeIn()
-    }
-
-    /// Dismisses the active SearchResultsController
-    ///
-    @objc
-    func dismissSearchResultsController() {
-        searchResultsViewController.view.fadeOut {
-            self.searchResultsViewController.view.removeFromSuperview()
-            self.searchResultsViewController.removeFromParent()
-        }
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -24,8 +24,6 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
     BOOL bListViewIsEmpty;
     BOOL bIndexingNotes;
     BOOL bShouldShowSidePanel;
-
-    SPTagFilterType tagFilterType;
 }
 
 @property (nonatomic, strong, readonly) NSFetchedResultsController<Note *>  *fetchedResultsController;

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -28,7 +28,6 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
 }
 
 @property (nonatomic, strong, readonly) NSFetchedResultsController<Note *>  *fetchedResultsController;
-@property (nonatomic, strong, readonly) SPSearchResultsViewController       *searchResultsViewController;
 @property (nonatomic, strong) NSString                                      *searchText;
 @property (nonatomic) BOOL                                                  firstLaunch;
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -5,6 +5,7 @@
 
 @class SPEmptyListView;
 @class SPBlurEffectView;
+@class SPSearchResultsViewController;
 
 typedef NS_ENUM(NSInteger, SPTagFilterType) {
 	SPTagFilterTypeUserTag = 0,
@@ -27,6 +28,7 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
 }
 
 @property (nonatomic, strong, readonly) NSFetchedResultsController<Note *>  *fetchedResultsController;
+@property (nonatomic, strong) SPSearchResultsViewController                 *searchResultsViewController;
 @property (nonatomic, strong) NSString                                      *searchText;
 @property (nonatomic) BOOL                                                  firstLaunch;
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
 }
 
 @property (nonatomic, strong, readonly) NSFetchedResultsController<Note *>  *fetchedResultsController;
-@property (nonatomic, strong) SPSearchResultsViewController                 *searchResultsViewController;
+@property (nonatomic, strong, readonly) SPSearchResultsViewController       *searchResultsViewController;
 @property (nonatomic, strong) NSString                                      *searchText;
 @property (nonatomic) BOOL                                                  firstLaunch;
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -5,7 +5,6 @@
 
 @class SPEmptyListView;
 @class SPBlurEffectView;
-@class SPSearchResultsViewController;
 
 typedef NS_ENUM(NSInteger, SPTagFilterType) {
 	SPTagFilterTypeUserTag = 0,

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -364,8 +364,6 @@
 
 - (void)searchControllerWillBeginSearch:(SPSearchController *)controller
 {
-    NSAssert(controller.resultsViewController.view.superview != nil, @"Results's View is not yet attached!");
-
     // Ensure our custom NavigationBar + SearchBar are always on top (!)
     [self.view bringSubviewToFront:self.navigationBarBackground];
     [self.view bringSubviewToFront:self.searchBar];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -362,6 +362,15 @@
     
 }
 
+- (void)searchControllerWillBeginSearch:(SPSearchController *)controller
+{
+    NSAssert(controller.resultsViewController.view.superview != nil, @"Results's View is not yet attached!");
+
+    // Ensure our custom NavigationBar + SearchBar are always on top (!)
+    [self.view bringSubviewToFront:self.navigationBarBackground];
+    [self.view bringSubviewToFront:self.searchBar];
+}
+
 - (void)searchControllerDidEndSearch:(SPSearchController *)controller
 {
     [self endSearching];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -302,7 +302,7 @@
     // Note: For performance reasons, we'll keep the Results always prebuilt. Same mechanism seen in UISearchController
     self.resultsViewController = [SPSearchResultsViewController new];
 
-    self.searchController = [[SPSearchController alloc] initWithResultsController:self.resultsViewController];
+    self.searchController = [[SPSearchController alloc] initWithResultsViewController:self.resultsViewController];
     self.searchController.delegate = self;
     self.searchController.presenter = self;
 
@@ -362,19 +362,19 @@
     
 }
 
-- (void)searchControllerWillBeginSearch:(SPSearchController *)controller
-{
-    [self displaySearchResultsController];
-}
-
 - (void)searchControllerDidEndSearch:(SPSearchController *)controller
 {
     [self endSearching];
 }
 
-- (UINavigationController *)navigationControllerForSearchController:(UISearchController *)controller
+- (UINavigationController *)navigationControllerForSearchController:(SPSearchController *)controller
 {
     return self.navigationController;
+}
+
+- (UIViewController *)resultsParentControllerForSearchController:(SPSearchController *)controller
+{
+    return self;
 }
 
 - (void)performSearch
@@ -401,7 +401,6 @@
 {
     bSearching = NO;
     self.searchText = nil;
-    [self dismissSearchResultsController];
 
     [self update];
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -42,7 +42,7 @@
                                         SPTransitionControllerDelegate>
 
 @property (nonatomic, strong) NSFetchedResultsController<Note *>    *fetchedResultsController;
-@property (nonatomic, strong) SPSearchResultsViewController         *searchResultsViewController;
+@property (nonatomic, strong) SPSearchResultsViewController         *resultsViewController;
 
 @property (nonatomic, strong) SPBlurEffectView                      *navigationBarBackground;
 @property (nonatomic, strong) UIBarButtonItem                       *addButton;
@@ -73,7 +73,6 @@
         [self configureNavigationBarBackground];
         [self configureTableView];
         [self configureSearchController];
-        [self configureResultsController];
         [self configureRootView];
         [self updateRowHeight];
         [self startListeningToNotifications];
@@ -298,19 +297,16 @@
 
 - (void)configureSearchController {
     NSAssert(_searchController == nil, @"_searchController is already initialized!");
-
-    self.searchController = [SPSearchController new];
-    self.searchController.delegate = self;
-    self.searchController.presenter = self;
-    [self.searchBar applySimplenoteStyle];
-}
-
-- (void)configureResultsController
-{
-    NSAssert(_searchResultsViewController == nil, @"_resultsController is already initialized!");
+    NSAssert(_resultsViewController == nil, @"_resultsController is already initialized!");
 
     // Note: For performance reasons, we'll keep the Results always prebuilt. Same mechanism seen in UISearchController
-    self.searchResultsViewController = [SPSearchResultsViewController new];
+    self.resultsViewController = [SPSearchResultsViewController new];
+
+    self.searchController = [[SPSearchController alloc] initWithResultsController:self.resultsViewController];
+    self.searchController.delegate = self;
+    self.searchController.presenter = self;
+
+    [self.searchBar applySimplenoteStyle];
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -369,6 +369,9 @@
     // Ensure our custom NavigationBar + SearchBar are always on top (!)
     [self.view bringSubviewToFront:self.navigationBarBackground];
     [self.view bringSubviewToFront:self.searchBar];
+
+    // We want the results UI to always have the Blur Background active
+    [self.navigationBarBackground fadeIn];
 }
 
 - (void)searchControllerDidEndSearch:(SPSearchController *)controller

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -42,6 +42,7 @@
                                         SPTransitionControllerDelegate>
 
 @property (nonatomic, strong) NSFetchedResultsController<Note *>    *fetchedResultsController;
+@property (nonatomic, strong) SPSearchResultsViewController         *searchResultsViewController;
 
 @property (nonatomic, strong) SPBlurEffectView                      *navigationBarBackground;
 @property (nonatomic, strong) UIBarButtonItem                       *addButton;
@@ -72,8 +73,8 @@
         [self configureNavigationBarBackground];
         [self configureTableView];
         [self configureSearchController];
+        [self configureResultsController];
         [self configureRootView];
-
         [self updateRowHeight];
         [self startListeningToNotifications];
         
@@ -302,6 +303,14 @@
     self.searchController.delegate = self;
     self.searchController.presenter = self;
     [self.searchBar applySimplenoteStyle];
+}
+
+- (void)configureResultsController
+{
+    NSAssert(_searchResultsViewController == nil, @"_resultsController is already initialized!");
+
+    // Note: For performance reasons, we'll keep the Results always prebuilt. Same mechanism seen in UISearchController
+    self.searchResultsViewController = [SPSearchResultsViewController new];
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -41,7 +41,6 @@
                                         SPSearchControllerPresentationContextProvider,
                                         SPTransitionControllerDelegate>
 
-@property (nonatomic, strong) SPSearchResultsViewController         *searchResultsViewController;
 @property (nonatomic, strong) NSFetchedResultsController<Note *>    *fetchedResultsController;
 
 @property (nonatomic, strong) SPBlurEffectView                      *navigationBarBackground;
@@ -360,7 +359,7 @@
 
 - (void)searchControllerWillBeginSearch:(SPSearchController *)controller
 {
-    [self attachSearchResultsController];
+    [self displaySearchResultsController];
 }
 
 - (void)searchControllerDidEndSearch:(SPSearchController *)controller
@@ -397,35 +396,9 @@
 {
     bSearching = NO;
     self.searchText = nil;
-    [self detachSearchResultsController];
+    [self dismissSearchResultsController];
 
     [self update];
-}
-
-
-#pragma mark - SearchResultsViewController
-
-- (void)attachSearchResultsController
-{
-    SPSearchResultsViewController *resultsViewController = [SPSearchResultsViewController new];
-    [self addChildViewController:resultsViewController];
-    self.searchResultsViewController = resultsViewController;
-
-    UIView *resultsView = resultsViewController.view;
-    [self.view insertSubview:resultsView belowSubview:self.navigationBarBackground];
-    [resultsView fadeIn];
-}
-
-- (void)detachSearchResultsController
-{
-    __weak typeof(self) weakSelf = self;
-
-    UIView *resultsView = self.searchResultsViewController.view;
-    [resultsView fadeOutWithCompletion:^{
-        [resultsView removeFromSuperview];
-        [weakSelf.searchResultsViewController removeFromParentViewController];
-        weakSelf.searchResultsViewController = nil;
-    }];
 }
 
 

--- a/Simplenote/Classes/SPSearchController.swift
+++ b/Simplenote/Classes/SPSearchController.swift
@@ -26,6 +26,10 @@ protocol SPSearchControllerPresentationContextProvider: NSObjectProtocol {
 @objcMembers
 class SPSearchController: NSObject {
 
+    /// ResultsController in which Search Results would be rendered
+    ///
+    let resultsController: UIViewController
+
     /// Internal SearchBar Instance
     ///
     let searchBar = UISearchBar()
@@ -41,7 +45,8 @@ class SPSearchController: NSObject {
 
     /// Designated Initializer
     ///
-    override init() {
+    init(resultsController: UIViewController) {
+        self.resultsController = resultsController
         super.init()
         setupSearchBar()
     }

--- a/Simplenote/Classes/SPSearchController.swift
+++ b/Simplenote/Classes/SPSearchController.swift
@@ -26,16 +26,6 @@ protocol SPSearchControllerPresentationContextProvider: NSObjectProtocol {
 @objcMembers
 class SPSearchController: NSObject {
 
-    /// When the navigationBar is hidden, there'll be a gap between the top of the screen and the searchBar. We intend to compensate for that with a helper BG View!
-    ///
-    private lazy var statusBarBackground: UIView = {
-        let backgroundView = UIView()
-        backgroundView.alpha = UIKitConstants.alphaZero
-        backgroundView.isUserInteractionEnabled = false
-        backgroundView.translatesAutoresizingMaskIntoConstraints = false
-        return backgroundView
-    }()
-
     /// Internal SearchBar Instance
     ///
     let searchBar = UISearchBar()
@@ -89,17 +79,10 @@ private extension SPSearchController {
                 return
         }
 
-        statusBarBackground.backgroundColor = searchBar.backgroundColor
-        statusBarBackground.alpha = hidden ? UIKitConstants.alphaMid : UIKitConstants.alphaFull
-
         navigationController.setNavigationBarHidden(hidden, animated: true)
 
-        let duration = TimeInterval(UINavigationController.hideShowBarDuration)
-        let topView = navigationController.topViewController?.view
-
-        UIView.animate(withDuration: duration) { [weak self] in
-            self?.statusBarBackground.alpha = hidden ? UIKitConstants.alphaFull : UIKitConstants.alphaZero
-            topView?.layoutIfNeeded()
+        UIView.animate(withDuration: TimeInterval(UINavigationController.hideShowBarDuration)) {
+            navigationController.topViewController?.view?.layoutIfNeeded()
         }
     }
 

--- a/Simplenote/Classes/SPSearchController.swift
+++ b/Simplenote/Classes/SPSearchController.swift
@@ -102,6 +102,10 @@ private extension SPSearchController {
     }
 
     func updateResultsView(visible: Bool) {
+        guard FeatureManager.advancedSearchEnabled else {
+            return
+        }
+
         guard visible else {
             dismissResultsViewController()
             return

--- a/Simplenote/Classes/SPSearchController.swift
+++ b/Simplenote/Classes/SPSearchController.swift
@@ -8,6 +8,7 @@ import UIKit
 protocol SPSearchControllerDelegate: NSObjectProtocol {
     func searchControllerShouldBeginSearch(_ controller: SPSearchController) -> Bool
     func searchController(_ controller: SPSearchController, updateSearchResults keyword: String)
+    func searchControllerWillBeginSearch(_ controller: SPSearchController)
     func searchControllerDidEndSearch(_ controller: SPSearchController)
 }
 
@@ -111,7 +112,7 @@ private extension SPSearchController {
 }
 
 
-// MARK: - SPSearchController
+// MARK: - ResultsViewController Methods
 //
 private extension SPSearchController {
 
@@ -150,7 +151,6 @@ private extension SPSearchController {
     func attach(resultsView: UIView, into containerView: UIView) {
         resultsView.translatesAutoresizingMaskIntoConstraints = false
         containerView.insertSubview(resultsView, belowSubview: searchBar)
-//        containerView.insertSubview(resultsView, belowSubview: navigationBarBackground)
 
         NSLayoutConstraint.activate([
             resultsView.leftAnchor.constraint(equalTo: containerView.leftAnchor),
@@ -173,6 +173,9 @@ extension SPSearchController: UISearchBarDelegate {
         }
 
         updateStatus(active: shouldBeginEditing)
+        if shouldBeginEditing {
+            delegate?.searchControllerWillBeginSearch(self)
+        }
 
         return shouldBeginEditing
     }

--- a/Simplenote/Classes/SPSearchController.swift
+++ b/Simplenote/Classes/SPSearchController.swift
@@ -8,6 +8,7 @@ import UIKit
 protocol SPSearchControllerDelegate: NSObjectProtocol {
     func searchControllerShouldBeginSearch(_ controller: SPSearchController) -> Bool
     func searchController(_ controller: SPSearchController, updateSearchResults keyword: String)
+    func searchControllerWillBeginSearch(_ controller: SPSearchController)
     func searchControllerDidEndSearch(_ controller: SPSearchController)
 }
 
@@ -119,6 +120,10 @@ extension SPSearchController: UISearchBarDelegate {
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
         guard let shouldBeginEditing = delegate?.searchControllerShouldBeginSearch(self) else {
             return false
+        }
+
+        if shouldBeginEditing {
+            delegate?.searchControllerWillBeginSearch(self)
         }
 
         updateStatus(active: shouldBeginEditing)

--- a/Simplenote/Classes/SPSearchResultsViewController.swift
+++ b/Simplenote/Classes/SPSearchResultsViewController.swift
@@ -60,7 +60,7 @@ extension SPSearchResultsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return 15
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Simplenote/Classes/SPSearchResultsViewController.swift
+++ b/Simplenote/Classes/SPSearchResultsViewController.swift
@@ -6,4 +6,72 @@ import UIKit
 //
 class SPSearchResultsViewController: UIViewController {
 
+    /// Results TableView
+    ///
+    @IBOutlet weak var tableView: UITableView!
+
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTableView()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        refreshStyle()
+    }
+}
+
+
+// MARK: - Interface Initialization
+//
+private extension SPSearchResultsViewController {
+
+    /// Sets up the TableView
+    ///
+    func configureTableView() {
+        tableView.register(SPNoteTableViewCell.loadNib(), forCellReuseIdentifier: SPNoteTableViewCell.reuseIdentifier)
+        tableView.tableFooterView = UIView()
+    }
+
+    /// Refreshes the UI Style (iOS <13 DarkMode Support)
+    ///
+    func refreshStyle() {
+        // Refresh the Container's UI
+        view.backgroundColor = .simplenoteBackgroundColor
+
+        // Refresh the Table's UI
+        tableView.applySimplenotePlainStyle()
+        tableView.reloadData()
+    }
+}
+
+
+// MARK: - UITableViewDataSource Methods
+//
+extension SPSearchResultsViewController: UITableViewDataSource {
+
+    // TODO: Demo code. Replace with the actual CoreData fetch!
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SPNoteTableViewCell.reuseIdentifier, for: indexPath) as? SPNoteTableViewCell else {
+            fatalError()
+        }
+
+        cell.titleText = "Some Title"
+        cell.bodyText = "Body Here!"
+        cell.backgroundColor = .white
+
+        return cell
+    }
 }

--- a/Simplenote/Classes/SPSearchResultsViewController.swift
+++ b/Simplenote/Classes/SPSearchResultsViewController.swift
@@ -1,0 +1,9 @@
+import Foundation
+import UIKit
+
+
+// MARK: - SPSearchResultsViewController
+//
+class SPSearchResultsViewController: UIViewController {
+
+}

--- a/Simplenote/Classes/SPSearchResultsViewController.swift
+++ b/Simplenote/Classes/SPSearchResultsViewController.swift
@@ -70,7 +70,6 @@ extension SPSearchResultsViewController: UITableViewDataSource {
 
         cell.titleText = "Some Title"
         cell.bodyText = "Body Here!"
-        cell.backgroundColor = .white
 
         return cell
     }

--- a/Simplenote/Classes/SPSearchResultsViewController.swift
+++ b/Simplenote/Classes/SPSearchResultsViewController.swift
@@ -8,7 +8,7 @@ class SPSearchResultsViewController: UIViewController {
 
     /// Results TableView
     ///
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet private weak var tableView: UITableView!
 
 
     // MARK: - View Lifecycle

--- a/Simplenote/Classes/SPSearchResultsViewController.xib
+++ b/Simplenote/Classes/SPSearchResultsViewController.xib
@@ -20,17 +20,17 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="d4Q-ou-XCC">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="9xf-Qv-hmj"/>
                     </connections>
                 </tableView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="d4Q-ou-XCC" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="7b7-sl-OHD"/>
-                <constraint firstItem="d4Q-ou-XCC" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" id="Biz-tg-6rW"/>
+                <constraint firstItem="d4Q-ou-XCC" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Biz-tg-6rW"/>
                 <constraint firstItem="d4Q-ou-XCC" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Uo6-DB-WW0"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="d4Q-ou-XCC" secondAttribute="bottom" id="cLa-em-y1z"/>
             </constraints>

--- a/Simplenote/Classes/SPSearchResultsViewController.xib
+++ b/Simplenote/Classes/SPSearchResultsViewController.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SPSearchResultsViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="d4Q-ou-XCC" id="JjX-l7-InZ"/>
                 <outlet property="view" destination="iN0-l3-epB" id="2q0-I1-cGm"/>
             </connections>
         </placeholder>
@@ -17,7 +18,22 @@
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="d4Q-ou-XCC">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="9xf-Qv-hmj"/>
+                    </connections>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="d4Q-ou-XCC" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="7b7-sl-OHD"/>
+                <constraint firstItem="d4Q-ou-XCC" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" id="Biz-tg-6rW"/>
+                <constraint firstItem="d4Q-ou-XCC" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Uo6-DB-WW0"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="d4Q-ou-XCC" secondAttribute="bottom" id="cLa-em-y1z"/>
+            </constraints>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="139" y="153"/>
         </view>

--- a/Simplenote/Classes/SPSearchResultsViewController.xib
+++ b/Simplenote/Classes/SPSearchResultsViewController.xib
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SPSearchResultsViewController" customModule="Simplenote" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="2q0-I1-cGm"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="139" y="153"/>
+        </view>
+    </objects>
+</document>

--- a/Simplenote/Classes/UIView+Animations.swift
+++ b/Simplenote/Classes/UIView+Animations.swift
@@ -21,7 +21,6 @@ extension UIView {
 
     /// Fades In the receiver
     ///
-    @objc
     func fadeIn() {
         self.alpha = UIKitConstants.alphaZero
         UIView.animate(withDuration: UIKitConstants.animationQuickDuration) {
@@ -31,12 +30,11 @@ extension UIView {
 
     /// Fades Out the receiver
     ///
-    @objc
-    func fadeOut(completion: @escaping () -> Void) {
+    func fadeOut(completion: (() -> Void)? = nil) {
         UIView.animate(withDuration: UIKitConstants.animationQuickDuration, animations: {
             self.alpha = UIKitConstants.alphaZero
         }, completion: { _ in
-            completion()
+            completion?()
         })
     }
 }

--- a/Simplenote/Classes/UIView+Animations.swift
+++ b/Simplenote/Classes/UIView+Animations.swift
@@ -20,11 +20,13 @@ extension UIView {
 
     /// Fades In the receiver
     ///
-    func fadeIn() {
+    func fadeIn(completion: (() -> Void)? = nil) {
         self.alpha = UIKitConstants.alphaZero
-        UIView.animate(withDuration: UIKitConstants.animationQuickDuration) {
+        UIView.animate(withDuration: UIKitConstants.animationQuickDuration, animations: {
             self.alpha = UIKitConstants.alphaFull
-        }
+        }, completion: { _ in
+            completion?()
+        })
     }
 
     /// Fades Out the receiver

--- a/Simplenote/Classes/UIView+Animations.swift
+++ b/Simplenote/Classes/UIView+Animations.swift
@@ -8,6 +8,7 @@ extension UIView {
 
     /// Animates a visibility switch, when applicable
     ///
+    @objc
     func animateVisibility(isHidden: Bool, duration: TimeInterval = 0.3) {
         guard self.isHidden != isHidden else {
             return
@@ -16,5 +17,26 @@ extension UIView {
         UIView.animate(withDuration: duration) {
             self.isHidden = isHidden
         }
+    }
+
+    /// Fades In the receiver
+    ///
+    @objc
+    func fadeIn() {
+        self.alpha = UIKitConstants.alphaZero
+        UIView.animate(withDuration: UIKitConstants.animationQuickDuration) {
+            self.alpha = UIKitConstants.alphaFull
+        }
+    }
+
+    /// Fades Out the receiver
+    ///
+    @objc
+    func fadeOut(completion: @escaping () -> Void) {
+        UIView.animate(withDuration: UIKitConstants.animationQuickDuration, animations: {
+            self.alpha = UIKitConstants.alphaZero
+        }, completion: { _ in
+            completion()
+        })
     }
 }

--- a/Simplenote/Classes/UIView+Animations.swift
+++ b/Simplenote/Classes/UIView+Animations.swift
@@ -20,17 +20,17 @@ extension UIView {
 
     /// Fades In the receiver
     ///
-    func fadeIn(completion: (() -> Void)? = nil) {
+    @objc
+    func fadeIn() {
         self.alpha = UIKitConstants.alphaZero
-        UIView.animate(withDuration: UIKitConstants.animationQuickDuration, animations: {
+        UIView.animate(withDuration: UIKitConstants.animationQuickDuration) {
             self.alpha = UIKitConstants.alphaFull
-        }, completion: { _ in
-            completion?()
-        })
+        }
     }
 
     /// Fades Out the receiver
     ///
+    @objc
     func fadeOut(completion: (() -> Void)? = nil) {
         UIView.animate(withDuration: UIKitConstants.animationQuickDuration, animations: {
             self.alpha = UIKitConstants.alphaZero

--- a/Simplenote/Classes/UIView+Animations.swift
+++ b/Simplenote/Classes/UIView+Animations.swift
@@ -8,7 +8,6 @@ extension UIView {
 
     /// Animates a visibility switch, when applicable
     ///
-    @objc
     func animateVisibility(isHidden: Bool, duration: TimeInterval = 0.3) {
         guard self.isHidden != isHidden else {
             return


### PR DESCRIPTION
### Details:
In this PR we're implementing **SearchResultsViewController**, a specialized VC in charge of rendering search results.

Since this is one of multiple PR's, in order to test this `Advanced Search` feature must be enabled.

@aerych I'm **VERY CURIOUS** about your thoughts on this one. I've done my best to... keep things simple + encapsulated, but we do have a number of custom things (inhouse SearchController, Blurred NavigationBar), and ... things require extra thought!!

Thank you in advance!!!

Ref. #507

### Test
1. Edit the [advancedSearchEnabled flag](https://github.com/Automattic/simplenote-ios/pull/527/files#diff-fdfb519fc818957652b45426448307d7R10) and set it to true
2. Log into your account
3. Tap over the **SearchBar**

- [x] Verify the new SearchResultsController shows up onscreen

### Release
These changes do not require release notes.
