### PR TITLE
Disabling iOS 13 Aggressive Links Workaround

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.15
 -----
- 
+-   Fixed a bug that affects tap detections over links.
+
 4.14
 ====
 -   Fixed a bug that prevented users from repositioning the caret in the Email field (Login / SignUp)

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -30,4 +30,13 @@ extern NSString *const CheckListRegExPattern;
 - (NSString *)getPlainTextContent;
 - (void)insertOrRemoveChecklist;
 
+/// iOS 13.0 + 13.1 had an usability issue that rendered link interactions within a UITextView next to impossible.
+/// Since such issue has bene fixed in 13.2, we're containing the custom behavior to the broken release.
+///
+/// Whenever this method returns *true*, link interactions will be passed along via the `textView:receivedInteractionWithURL:` delegate method.
+///
+/// Ref.: https://github.com/Automattic/simplenote-ios/pull/470
+///
+- (BOOL)performsAggressiveLinkWorkaround;
+
 @end

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -577,6 +577,10 @@ NSInteger const ChecklistCursorAdjustment = 2;
 
 - (BOOL)handlePressedLinkAtIndex:(NSUInteger)characterIndex
 {
+    if (![self performsAggressiveLinkWorkaround]) {
+        return NO;
+    }
+
     NSURL *link = [self.attributedText attribute:NSLinkAttributeName atIndex:characterIndex effectiveRange:nil];
     if ([link isKindOfClass:[NSURL class]] == NO || [link containsHttpScheme] == NO) {
         return NO;
@@ -585,6 +589,19 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self.editorTextDelegate textView:self receivedInteractionWithURL:link];
 
     return YES;
+}
+
+- (BOOL)performsAggressiveLinkWorkaround
+{
+    if (@available(iOS 13.2, *)) {
+        return NO;
+    }
+
+    if (@available(iOS 13, *)) {
+        return YES;
+    }
+
+    return NO;
 }
 
 - (id<SPEditorTextViewDelegate>)editorTextDelegate

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1205,10 +1205,27 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 }
 
 - (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction {
-    return ![URL containsHttpScheme];
+    BOOL containsHttpScheme = [URL containsHttpScheme];
+
+    // When `performsAggressiveLinkWorkaround` is true we'll get link interactions via `receivedInteractionWithURL:`
+    if (containsHttpScheme && !_noteEditorTextView.performsAggressiveLinkWorkaround) {
+        [self presentSafariViewControllerAtURL:URL];
+    }
+
+    return !containsHttpScheme;
 }
 
-- (void)textView:(UITextView *)textView receivedInteractionWithURL:(NSURL *)url {
+- (void)textView:(UITextView *)textView receivedInteractionWithURL:(NSURL *)url
+{
+    /// This API is expected to only be called in iOS (13.0.x, 13.1.x)
+    [self presentSafariViewControllerAtURL:url];
+}
+
+
+#pragma mark - SafariViewController Methods
+
+- (void)presentSafariViewControllerAtURL:(NSURL *)url
+{
     SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:url];
     [self presentViewController:sfvc animated:YES completion:nil];
 }


### PR DESCRIPTION
### Fix:
We've received reports of users having trouble opening links.As far as I've been able to see, anything that's not a quick tap might not be properly handled.

Rather than reversing UITextView's default inner behavior (which probably involves long press and tap!), we're disabling the Aggressive Links workaround that was shipped via #470 for iOS 13.0 - 13.1.

@aerych you were right... as always. We should probably have never shipped that workaround =D

Closes #533

### Test
1. Log into your account
2. Open a note that contains links

- [x] Verify pressing a link ends up with SafariViewController onScreen

**Please:** Repeat for iOS 13.0 (or 13.1) and iOS 13.2.

### Release
`RELEASE-NOTES.txt` was updated in e020d48 with:
 
> Fixed a bug that affects tap detections over links.
