### PR TITLE
Update Fastlane to the new org name in AppCenter

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,7 +195,7 @@ ENV["PROJECT_ROOT_FOLDER"]="./"
     # makes the default gym output override the "file" parameter. 
     appcenter_upload(
       api_token: ENV["APPCENTER_API_TOKEN"],
-      owner_name: "Hogwarts-Organization",
+      owner_name: "automattic",
       owner_type: "organization", 
       app_name: "Simplenote",
       ipa: "./build/Simplenote Internal.ipa",


### PR DESCRIPTION
This PR updates Fastlane to the new organization name used in AppCenter.

### To test:
- Run `bundle exec fastlane build_and_upload_internal` and verify that the build is successfully uploaded to AppCenter.
- Delete the build from AppCenter.
