### PR TITLE
Add localize to the code freeze lane

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: c8007b8c11c282ea3e9f97f722d1971271959770
-  tag: 0.8.0
+  revision: 63806fe4d1c870c16c7ab7114959dd420152e4b0
+  tag: 0.8.1
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.8.0)
+    fastlane-plugin-wpmreleasetoolkit (0.8.1)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -182,7 +182,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -190,7 +190,7 @@ GEM
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
-    parallel (1.18.0)
+    parallel (1.19.1)
     plist (3.5.0)
     progress_bar (1.3.0)
       highline (>= 1.6, < 3)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,6 +38,7 @@ ENV["PROJECT_ROOT_FOLDER"]="./"
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
 
+    ios_localize_project()
     ios_tag_build()
     get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/simplenoteios_prs_list_#{old_version}_#{new_version}.txt")
   end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,5 +3,5 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-sentry'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.1'
 gem 'fastlane-plugin-appcenter', "1.6.0"


### PR DESCRIPTION
This PR adds a call to the `localize.py` script into the `code_freeze` lane, so that localization is performed at every code freeze.

These changes do not require release notes.
