### PR TITLE
Add configure to rake dependencies

### DIFF
--- a/.configure
+++ b/.configure
@@ -3,8 +3,8 @@
   "pinned_hash": "eed3c3f412a87e2804f4c0291dde7523e24877fa",
   "files_to_copy": [
     {
-      "file": "iOS/simplenote/config.plist",
-      "destination": "Simplenote/config.plist"
+      "file": "iOS/simplenote/SPCredentials.swift",
+      "destination": "Simplenote/Credentials/SPCredentials.swift"
     }
   ],
   "file_dependencies": [

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ desc "Install required dependencies"
 task :dependencies => %w[dependencies:check]
 
 namespace :dependencies do
-  task :check => %w[bundler:check bundle:check pod:check lint:check]
+  task :check => %w[bundler:check bundle:check credentials:apply pod:check lint:check]
 
   namespace :bundler do
     task :check do
@@ -51,6 +51,13 @@ namespace :dependencies do
     end
     CLOBBER << "vendor/bundle"
     CLOBBER << ".bundle"
+  end
+
+  namespace :credentials do
+    task :apply do
+      next unless Dir.exist?(File.join(Dir.home, '.mobile-secrets/.git')) || ENV.key?('CONFIGURE_ENCRYPTION_KEY')
+      sh('FASTLANE_SKIP_UPDATE_CHECK=1 FASTLANE_ENV_PRINTER=1 bundle exec fastlane run configure_apply force:true')
+    end
   end
 
   namespace :pod do


### PR DESCRIPTION
This PR adds a step to `rake dependencies` in order to call `configure apply` that makes sure that the `SPCredentials.swift` used during the build is the one specified in `.configure`.

### Test
1. Delete your local `Simplenote/Credentials/SPCredentials.swif`.
2. Run `rake dependencies`.
3. Verify that `Simplenote/Credentials/SPCredentials.swif` has been created again with the right values. 
4. Build the app and verify that it works as expected.
 
These changes do not require release notes.
