### PR TITLE
Fixing Update-Translations Script

### DIFF
--- a/Scripts/update-translations.rb
+++ b/Scripts/update-translations.rb
@@ -92,28 +92,12 @@ langs.each do |code,local|
   # Backup the current file
   system "if [ -e #{lang_dir}/Localizable.strings ]; then cp #{lang_dir}/Localizable.strings #{lang_dir}/Localizable.strings.bak; fi"
 
-  # Download translations in JSON format in order to get the string keys
-  system "curl -sSfL --globoff -o #{lang_dir}/Localizable.json https://translate.wordpress.com/projects/simplenote%2Fios/#{code}/default/export-translations?format=json" or begin
-    puts "Error downloading #{code}"
-  end
-  trans_json = JSON.parse(File.read("#{lang_dir}/Localizable.json"))
-
   # Download translations in strings format in order to get the comments
-  system "curl -sSfL --globoff -o #{lang_dir}/Localizable.strings.tmp https://translate.wordpress.com/projects/simplenote%2Fios/#{code}/default/export-translations?format=strings" or begin
+  system "curl -fLso #{lang_dir}/Localizable.strings https://translate.wordpress.com/projects/simplenote%2Fios/#{code}/default/export-translations?format=strings" or begin
     puts "Error downloading #{code}"
   end
-  trans_strings = File.read("#{lang_dir}/Localizable.strings.tmp")
-  
-  File.open("#{lang_dir}/Localizable.strings", "w") do |f|
-    copy_header(f, trans_strings)
-    Hash[trans_json.to_a.reverse].each do | key, value |
-      copy_comment(f, trans_strings, value[0]) unless value[0].nil?
-      f.write("\"#{key.split("\u0004")[0]}\" = \"#{value[0]}\";\n\n") unless value[0].nil?
-    end
-  end
+
   system "./Scripts/fix-translation #{lang_dir}/Localizable.strings"
   system "plutil -lint #{lang_dir}/Localizable.strings" and system "rm #{lang_dir}/Localizable.strings.bak"
-  system "rm #{lang_dir}/Localizable.strings.tmp"
-  system "rm #{lang_dir}/Localizable.json"
   system "grep -a '\\x00\\x20\\x00\\x22\\x00\\x22\\x00\\x3b$' #{lang_dir}/Localizable.strings"
 end

--- a/Simplenote/ar.lproj/Localizable.strings
+++ b/Simplenote/ar.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: ar */
 
-/* Number of found search results */
-"%d Result" = "%d من النتائج";
+/* Number of Characters in a note */
+"%@ Character" = "%@ Character";
 
-/* Number of found search results */
-"%d Results" = "%d من النتائج";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ Characters";
 
 /* Number of words in a note */
 "%@ Word" = "%@ من الكلمات";
@@ -15,6 +15,37 @@
 /* Number of words in a note */
 "%@ Words" = "%@ من الكلمات";
 
+/* Number of found search results */
+"%d Result" = "%d من النتائج";
+
+/* Number of found search results */
+"%d Results" = "%d من النتائج";
+
+/* 1 minute passcode lock timeout */
+"1 Minute" = "1 Minute";
+
+/* 15 seconds passcode lock timeout */
+"15 Seconds" = "15 Seconds";
+
+/* 2 minutes passcode lock timeout */
+"2 Minutes" = "2 Minutes";
+
+/* 3 minutes passcode lock timeout */
+"3 Minutes" = "3 Minutes";
+
+/* 30 seconds passcode lock timeout */
+"30 Seconds" = "30 Seconds";
+
+/* 4 minutes passcode lock timeout */
+"4 Minutes" = "4 Minutes";
+
+/* 5 minutes passcode lock timeout */
+"5 Minutes" = "5 Minutes";
+
+/* Display app about screen */
+"About" = "نبذة عن";
+
+/* Accept Action
    Label of accept button on alert dialog */
 "Accept" = "قبول";
 
@@ -24,211 +55,87 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "إضافة مشارك جديد...";
 
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "العلامة...";
+
 /* Label on button to add a new tag to a note */
 "Add tag" = "إضافة وسم";
 
 /* Title: No filters applied */
 "All Notes" = "كل الملاحظات";
 
+/* Sort Mode: Alphabetically, ascending */
+"Alphabetically: A-Z" = "Alphabetically: A-Z";
+
+/* Sort Mode: Alphabetically, descending */
+"Alphabetically: Z-A" = "Alphabetically: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "An error was encountered while signing in.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Appearance";
+
+/* Other Simplenote apps */
+"Apps" = "Apps";
+
+/* Automattic hiring description */
+"Are you a developer? Automattic is hiring." = "Are you a developer? Automattic is hiring.";
+
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Are you sure you want to empty the trash? This cannot be undone.";
+
+/* Message for alert when user tries to send feedback without an email address */
+"Are you sure you want to send without your email? We won't be able reply to you." = "Are you sure you want to send without your email? We won't be able reply to you.";
+
+/* Title for prompt when user tries to close the feedback view */
+"Are you sure?" = "Are you sure?";
+
+/* User Authenticated */
+"Authenticated" = "Authenticated";
+
+/* Title of Back button for Markdown preview */
+"Back" = "رجوع";
+
+/* The Simplenote blog */
+"Blog" = "المدونة";
+
+/* Terms of Service Legend *PREFIX*: printed in dark color */
+"By creating an account you agree to our" = "By creating an account you agree to our";
+
+/* No comment provided by engineer. */
+"Can't Access." = "Can't Access.";
+
+/* Cancel Action
    Verb, cancel an alert dialog */
 "Cancel" = "إلغاء";
+
+/* No comment provided by engineer. */
+"Choose Photo" = "Choose Photo";
+
+/* No comment provided by engineer. */
+"Close" = "Close";
 
 /* Verb - work with others on a note */
 "Collaborate" = "تشارك";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "تمكين الآخرين للتعاون";
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Collaboration has moved";
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "المشاركون";
 
-/* No comment provided by engineer. */
-"collaborators-description" = "أضف عنوان بريد إلكتروني لمشاركة هذه الملاحظة مع شخص ما. بعدها يمكنكما إجراء التغييرات عليها.";
-
 /* Option to make the note list show only 1 line of text. The default is 3. */
 "Condensed Note List" = "قائمة الملاحظات الموجزة";
 
-/* No comment provided by engineer. */
-"Create a new note" = "إنشاء ملاحظة جديدة";
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "جهة الاتصال";
 
-/* No comment provided by engineer. */
-"Current Collaborators" = "المشاركون الحاليون";
+/* Contribute to the Simplenote apps on github */
+"Contribute" = "Contribute";
 
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "تم حذف هذه الملاحظة من جهاز آخر.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "تجاهل لوحة المفاتيح";
-
-/* Error for bad email or password */
-"Done" = "تم";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "فارغ";
-
-/* Remove all notes from the trash */
-"Empty trash" = "إفراغ سلة المهملات";
-
-/* Noun - the version history of a note */
-"History" = "سجل الأحداث";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "استعادة ملاحظة إلى إصدار سابق";
-
-/* Action - view the version history of a note */
-"History..." = "سجل الأحداث...";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "القائمة";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "عرض خيارات للملاحظة";
-
-/* No comment provided by engineer. */
-"New note" = "ملاحظة جديدة";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "لا توجد ملاحظات";
-
-/* Message shown when no notes match a search string */
-"No Results" = "لا توجد نتائج";
-
-/* No comment provided by engineer. */
-"Note not published" = "لم يتم نشر الملاحظة";
-
-/* Title: No filters applied */
-"Notes" = "ملاحظات";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "إغلاق الملاحظة الحالية";
-
-/* Instant passcode lock timeout */
-"Off" = "إيقاف تشغيل";
-
-/* Dismisses an AlertController */
-"OK" = "موافق";
-
-/* Instant passcode lock timeout */
-"On" = "تشغيل";
-
-/* Select a note to view in the note editor */
-"Open note" = "فتح الملاحظة";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "رمز المرور";
-
-/* Action to mark a note as pinned */
-"Pin note" = "تثبيت الملاحظة";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "تثبيت في المقدمة";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "تبديل التثبيت";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "تم التثبيت";
-
-/* No comment provided by engineer. */
-"Publish" = "نشر";
-
-/* No comment provided by engineer. */
-"Publish note" = "نشر الملاحظة";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "تبديل النشر";
-
-/* No comment provided by engineer. */
-"Published" = "منشور";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "جار النشر...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "إزالة كل الملاحظات من سلة المهملات";
-
-/* Rename a tag */
-"Rename" = "إعادة التسمية";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "استعادة";
-
-/* Restore a note to a previous version */
-"Restore Note" = "استعادة الملاحظة";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "إرسال";
-
-/* Privacy Settings */
-"Settings" = "إعدادات";
-
-/* No comment provided by engineer. */
-"Share note" = "مشاركة الملاحظة";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "مشاركة محتوى الملاحظة الحالية";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "الشريط الجانبي";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "إضافة وسم إلى الملاحظة الحالية";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "إزالة وسم من الملاحظة الحالية";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "اليوم";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "تبديل الشريط الجانبي للوسوم";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "نقل الملاحظة الحالية إلى سلة المهملات";
-
-/* Remove all notes from the trash */
-"Trash-noun" = "سلة المهملات";
-
-/* Remove all notes from the trash */
-"Trash-verb" = "سلة المهملات";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "إلغاء تثبيت الملاحظة";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "إلغاء نشر الملاحظة";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "جارٍ إلغاء النشر...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "النسخة";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "الاتصال بالإنترنت للوصول إلى الإصدارات السابقة";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "التحول إلى هذا الإصدار";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "جلب الإصدار";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "أمس";
-
-"welcomeNote-iOS" = "أهلاً بك في Simplenote لنظام التشغيل iOS!
-
-لإضافة ملاحظة، انقر فوق زر علامة الزائد.
-
-انقر على القائمة لتصفح ملاحظاتك. انقر فوق عنوان لعرض ملاحظة، ثم انقر فوق محتوياتها لتغييرها.
-
-يمكنك البحث في جميع ملاحظاتك بالكتابة في حقل البحث أعلى قائمة الملاحظات.
-
-انقر فوق زر السهم أعلى اليسار أو اسحب بإصبعك عبر قائمة الملاحظات لعرض الوسوم. يمكنك إضافة وسوم إلى ملاحظة بأسفل محرر الملاحظات، ثم استخدام الشريط الجانبي لمساعدتك في المحافظة على التنظيم.
-
-هناك المزيد من خيارات الملاحظات إذا كنت بحاجة إليها. حيث يمكنك إضافة أفراد آخرين كمساهمين إلى ملاحظة أو نشر ملاحظة كصفحة ويب.
-
-استخدم Simplenote على جهاز Mac أو جهاز Android الخاص بك أو في متصفح الويب على http://simplenote.com. تبقى ملاحظاتك مُحدَّثة في كل مكان تلقائيًا.";
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "قد يكون أفضل";
 
 /* Error for bad email or password */
 "Could not create an account with the provided email address and password." = "تعذر إنشاء حساب بعنوان البريد الإلكتروني وكلمة المرور اللذين تم إدخالهما.";
@@ -236,20 +143,136 @@
 /* Message displayed when login fails */
 "Could not login with the provided email address and password." = "تعذر تسجيل الدخول بعنوان البريد الإلكتروني وكلمة المرور اللذين تم إدخالهما.";
 
-/* Error for bad email or password */
-"Password" = "كلمة المرور";
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "هل بإمكانك إبلاغنا بكيفية تحسين ذلك؟";
 
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "يجب أن تحتوي كلمة المرور على 6 أحرف على الأقل.";
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Couldn't Sign In";
 
-   SignUp Interface Title */
-"Sign Up" = "التسجيل";
+/* Siri Suggestion to create a New Note */
+"Create a New Note" = "Create a New Note";
 
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "عنوان البريد الإلكتروني الخاص بك غير صالح.";
+/* No comment provided by engineer. */
+"Create a new note" = "إنشاء ملاحظة جديدة";
 
+/* Sort Mode: Creation Date, descending */
+"Created: Newest" = "Created: Newest";
+
+/* Sort Mode: Creation Date, ascending */
+"Created: Oldest" = "Created: Oldest";
+
+/* No comment provided by engineer. */
+"Current Collaborators" = "المشاركون الحاليون";
+
+/* Theme: Dark */
+"Dark" = "Dark";
+
+/* Debug Screen Title
    Display internal debug status */
 "Debug" = "إصلاح الخطأ";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "حذف";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Delete Notes";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Disable Markdown formatting";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "تجاهل لوحة المفاتيح";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "تم";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Edit";
+
+/* Email TextField Placeholder */
+"Email" = "البريد الإلكتروني";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Email Address" = "Email Address";
+
+/* Email Taken Alert Title */
+"Email in use" = "Email in use";
+
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "فارغ";
+
+/* Remove all notes from the trash */
+"Empty trash" = "إفراغ سلة المهملات";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Enable Markdown formatting";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Enqueued";
+
+/* No comment provided by engineer. */
+"Error" = "خطأ";
+
+/* No comment provided by engineer. */
+"Error uploading." = "Error uploading.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
+
+/* Password Reset Action */
+"Forgotten password?" = "Forgotten password?";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "عظيم! هل يمكن أن تترك لنا مراجعة لطيفة؟\n\nإنها تساعد حقًا.";
+
+/* Privacy Details */
+"Help us improve Simplenote by sharing usage data with our analytics tool." = "Help us improve Simplenote by sharing usage data with our analytics tool.";
+
+/* Noun - the version history of a note */
+"History" = "سجل الأحداث";
+
+/* Action - view the version history of a note */
+"History..." = "سجل الأحداث...";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "كيف نساعدك؟";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "يعجبني هذا";
+
+/* Title for alert that a user has entered an invalid email address */
+"Invalid Email Address." = "Invalid Email Address.";
+
+/* Last Message timestamp */
+"LastSeen" = "LastSeen";
+
+/* Learn More Action */
+"Learn more" = "تعرف على المزيد";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "اترك رأيًا";
+
+/* Theme: Light */
+"Light" = "Light";
+
+/* Setting for when the passcode lock should enable */
+"Lock Timeout" = "Lock Timeout";
+
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
+"Log In" = "تسجيل الدخول";
+
+/* Log out of the active account in the app */
+"Log Out" = "تسجيل الخروج";
+
+/* Allows the user to SignIn using their WPCOM Account */
+"Log in with WordPress.com" = "Log in with WordPress.com";
+
+/* Presents the regular Email signin flow */
+"Log in with email" = "Log in with email";
 
 /* Month and day date formatter */
 "MMM d" = "MMM d";
@@ -263,103 +286,117 @@
 /* Month and year date formatter */
 "MMM yyyy" = "MMM yyyy";
 
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "معرف اللمس";
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
 
-/* No comment provided by engineer. */
-"Security" = "الأمان";
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown toggle";
 
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "ما رأيك في Simplenote؟";
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "القائمة";
 
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "يعجبني هذا";
+/* Sort Mode: Modified Date, descending */
+"Modified: Newest" = "Modified: Newest";
 
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "قد يكون أفضل";
+/* Sort Mode: Creation Date, ascending */
+"Modified: Oldest" = "Modified: Oldest";
 
-"Great! Could you leave us a nice review?
-It really helps." = "عظيم! هل يمكن أن تترك لنا مراجعة لطيفة؟
+/* Label to create a new note */
+"New note" = "ملاحظة جديدة";
 
-إنها تساعد حقًا.";
+/* Empty Note Placeholder */
+"New note..." = "New note...";
 
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "اترك رأيًا";
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "No";
+
+/* Title for alert when user tires to send feedback without an email address */
+"No Email." = "No Email.";
+
+/* Text that appears in an alert to the user when there is no internet */
+"No Internet" = "No Internet";
+
+/* Title for message when user tries to send feedback without any text */
+"No Message." = "No Message.";
+
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "لا توجد ملاحظات";
+
+/* Message shown when no notes match a search string */
+"No Results" = "لا توجد نتائج";
 
 /* This is one of the buttons we display when prompting the user for a review */
 "No Thanks" = "لا شكرًا";
 
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "هل بإمكانك إبلاغنا بكيفية تحسين ذلك؟";
+/* No comment provided by engineer. */
+"Note not published" = "لم يتم نشر الملاحظة";
 
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "إرسال الملاحظات";
+/* Plural form of notes */
+"Notes" = "ملاحظات";
 
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "جهة الاتصال";
+/* Dismisses an AlertController */
+"OK" = "موافق";
 
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "بريدك الإلكتروني:";
+/* Instant passcode lock timeout */
+"Off" = "إيقاف تشغيل";
 
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "كيف نساعدك؟";
+/* No comment provided by engineer. */
+"On" = "تشغيل";
 
-/* Title of Back button for Markdown preview */
-"Back" = "رجوع";
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "Open \"(preview)\"";
 
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "حذف";
+/* Siri Suggestion to open our app */
+"Open Simplenote" = "Open Simplenote";
+
+/* Select a note to view in the note editor */
+"Open note" = "فتح الملاحظة";
+
+/* AlertController's Payload for the broken Sort Options Fix */
+"Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Our update may have changed the order in which your notes appear. Would you like to review sort settings?";
+
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "رمز المرور";
+
+/* Password TextField Placeholder */
+"Password" = "كلمة المرور";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Password must contain at least 4 characters";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "يجب أن تحتوي كلمة المرور على 6 أحرف على الأقل.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Pendings";
+
+/* Pin (verb) - the action of Pinning a note */
+"Pin" = "Pin";
+
+/* Action to mark a note as pinned */
+"Pin note" = "تثبيت الملاحظة";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "تثبيت في المقدمة";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "تبديل التثبيت";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "تم التثبيت";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Please activate your WordPress.com account via email and try again.";
+
+/* Message for alert that user has entered an invalid email address */
+"Please check your email address, it appears to be invalid." = "Please check your email address, it appears to be invalid.";
+
+/* Message for alert when user tires to send feedback without any text */
+"Please enter a message." = "Please enter a message.";
 
 /* Title of Markdown preview screen */
 "Preview" = "معاينة";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "سيؤدي تسجيل الخروج إلى حذف أي ملحوظات غير متزامنة. يمكنك التحقق من ملحوظاتك المتزامنة عن طريق تسجيل الدخول إلى تطبيق الويب.";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "تم الكشف عن ملحوظات غير متزامنة";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "نعم";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "العلامة...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "مشاركة";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "ملحوظات غير مميزة";
-
-   Sort Order for the Notes List */
-"Sort Order" = "ترتيب الفرز";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "مشاركة التحليلات";
-
-/* Error for bad email or password */
-"Email" = "البريد الإلكتروني";
-
-/* Option to enable the dark app theme. */
-"Theme" = "قالب";
-
-/* The Simplenote blog */
-"Blog" = "المدونة";
-
-   Display internal debug status */
-"Error" = "خطأ";
-
-/* Display app about screen */
-"About" = "نبذة عن";
-
-/* Learn More Action */
-"Learn more" = "تعرف على المزيد";
-
-/* Message displayed when login fails */
-"Log In" = "تسجيل الدخول";
-
-/* Log out of the active account in the app */
-"Log Out" = "تسجيل الخروج";
 
 /* Simplenote privacy policy */
 "Privacy Policy" = "سياسة الخصوصية";
@@ -367,12 +404,260 @@ It really helps." = "عظيم! هل يمكن أن تترك لنا مراجعة �
 /* Privacy Settings */
 "Privacy Settings" = "إعدادات الخصوصية";
 
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "نشر";
+
+/* Action which published a note to a web page */
+"Publish note" = "نشر الملاحظة";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "تبديل النشر";
+
+/* No comment provided by engineer. */
+"Published" = "منشور";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "جار النشر...";
+
+/* Reachs Internet */
+"Reachability" = "Reachability";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "إزالة كل الملاحظات من سلة المهملات";
+
+/* Rename a tag */
+"Rename" = "إعادة التسمية";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "استعادة";
+
+/* Restore a note to a previous version */
+"Restore Note" = "استعادة الملاحظة";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Search";
+
+/* No comment provided by engineer. */
+"Security" = "الأمان";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "إرسال";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "إرسال الملاحظات";
+
+/* For debugging use */
+"Send a Test Crash" = "Send a Test Crash";
+
+/* Label that is shown when feedback from the user is sending */
+"Sending..." = "Sending...";
+
+/* Title of options screen */
+"Settings" = "إعدادات";
+
+/* Share (verb) - the action of Sharing a note */
+"Share" = "مشاركة";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "مشاركة التحليلات";
+
+/* No comment provided by engineer. */
+"Share note" = "مشاركة الملاحظة";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Sharing notes is now accessed through the action menu from the toolbar.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "الشريط الجانبي";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "التسجيل";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "سيؤدي تسجيل الخروج إلى حذف أي ملحوظات غير متزامنة. يمكنك التحقق من ملحوظاتك المتزامنة عن طريق تسجيل الدخول إلى تطبيق الويب.";
+
+/* Our mighty brand! */
+"Simplenote" = "Simplenote";
+
+/* Authentication Error Alert Title */
+"Sorry!" = "Sorry!";
+
+/* Option to sort tags alphabetically. The default is by manual ordering. */
+"Sort Alphabetically" = "Sort Alphabetically";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "ترتيب الفرز";
+
+/* Theme: Matches iOS Settings */
+"System Default" = "System Default";
+
+/* No comment provided by engineer. */
+"Tags" = "Tags";
+
+/* No comment provided by engineer. */
+"Take Photo" = "Take Photo";
+
+/* Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue */
+"Terms and Conditions" = "Terms and Conditions";
+
 /* Simplenote terms of service */
 "Terms of Service" = "شروط الخدمة";
+
+/* No comment provided by engineer. */
+"Thanks" = "Thanks";
+
+/* Error when address is in use */
+"The email you've entered is already associated with a Simplenote account." = "The email you've entered is already associated with a Simplenote account.";
+
+/* Onboarding Header Text */
+"The simplest way to keep notes." = "The simplest way to keep notes.";
+
+/* Option to enable the dark app theme. */
+"Theme" = "قالب";
+
+/* Simplenote Themes */
+"Themes" = "Themes";
+
+/* No comment provided by engineer. */
+"There was an error sending your feedback, please try again." = "There was an error sending your feedback, please try again.";
+
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "اليوم";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "تبديل الشريط الجانبي للوسوم";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "معرف اللمس";
+
+/* Title: Trash Tag is selected */
+"Trash" = "سلة المهملات";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "سلة المهملات";
+
+/* Unpin (verb) - the action of Unpinning a note */
+"Unpin" = "Unpin";
+
+/* Action to mark a note as unpinned */
+"Unpin note" = "إلغاء تثبيت الملاحظة";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "إلغاء نشر الملاحظة";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "جارٍ إلغاء النشر...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "تم الكشف عن ملحوظات غير متزامنة";
+
+/* Title: Untagged Notes are onscreen */
+"Untagged" = "Untagged";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "ملحوظات غير مميزة";
+
+/* No comment provided by engineer. */
+"Use Latest Photo" = "Use Latest Photo";
 
 /* A user's Simplenote account */
 "Username" = "اسم المستخدم";
 
+/* Represents a snapshot in time for a note */
+"Version" = "النسخة";
+
 /* App version number */
 "Version %@" = "الإصدار %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Visit Web App";
+
+/* No comment provided by engineer. */
+"We can't access your photos, please ensure this application has access in Settings." = "We can't access your photos, please ensure this application has access in Settings.";
+
+/* No comment provided by engineer. */
+"We couldn't upload the photo, please try again." = "We couldn't upload the photo, please try again.";
+
+/* No comment provided by engineer. */
+"We have received your feedback and will be in contact soon." = "We have received your feedback and will be in contact soon.";
+
+/* Generic error */
+"We're having problems. Please try again soon." = "We're having problems. Please try again soon.";
+
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "ما رأيك في Simplenote؟";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about WordPress?" = "What do you think about WordPress?";
+
+/* Work at Automattic */
+"Work With Us" = "Work With Us";
+
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "نعم";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "أمس";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "بريدك الإلكتروني:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "عنوان البريد الإلكتروني الخاص بك غير صالح.";
+
+/* Message for prompt when user tries to close feedback view after having entered text */
+"Your message will be lost." = "Your message will be lost.";
+
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "attach a file";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "تمكين الآخرين للتعاون";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "أضف عنوان بريد إلكتروني لمشاركة هذه الملاحظة مع شخص ما. بعدها يمكنكما إجراء التغييرات عليها.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "تم حذف هذه الملاحظة من جهاز آخر.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "استعادة ملاحظة إلى إصدار سابق";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "عرض خيارات للملاحظة";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "إغلاق الملاحظة الحالية";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "مشاركة محتوى الملاحظة الحالية";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "إضافة وسم إلى الملاحظة الحالية";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "إزالة وسم من الملاحظة الحالية";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "نقل الملاحظة الحالية إلى سلة المهملات";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "الاتصال بالإنترنت للوصول إلى الإصدارات السابقة";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "التحول إلى هذا الإصدار";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "جلب الإصدار";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "أهلاً بك في Simplenote لنظام التشغيل iOS!\n\nلإضافة ملاحظة، انقر فوق زر علامة الزائد.\n\nانقر على القائمة لتصفح ملاحظاتك. انقر فوق عنوان لعرض ملاحظة، ثم انقر فوق محتوياتها لتغييرها.\n\nيمكنك البحث في جميع ملاحظاتك بالكتابة في حقل البحث أعلى قائمة الملاحظات.\n\nانقر فوق زر السهم أعلى اليسار أو اسحب بإصبعك عبر قائمة الملاحظات لعرض الوسوم. يمكنك إضافة وسوم إلى ملاحظة بأسفل محرر الملاحظات، ثم استخدام الشريط الجانبي لمساعدتك في المحافظة على التنظيم.\n\nهناك المزيد من خيارات الملاحظات إذا كنت بحاجة إليها. حيث يمكنك إضافة أفراد آخرين كمساهمين إلى ملاحظة أو نشر ملاحظة كصفحة ويب.\n\nاستخدم Simplenote على جهاز Mac أو جهاز Android الخاص بك أو في متصفح الويب على http:\/\/simplenote.com. تبقى ملاحظاتك مُحدَّثة في كل مكان تلقائيًا.";
 

--- a/Simplenote/cy.lproj/Localizable.strings
+++ b/Simplenote/cy.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: cy_GB */
 
-/* Number of found search results */
-"%d Result" = "%d Canlyniad";
+/* Number of Characters in a note */
+"%@ Character" = "%@ Character";
 
-/* Number of found search results */
-"%d Results" = "%d Canlyniad ";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ Characters";
 
 /* Number of words in a note */
 "%@ Word" = "%@ Gair";
@@ -15,6 +15,37 @@
 /* Number of words in a note */
 "%@ Words" = "%@ Gair";
 
+/* Number of found search results */
+"%d Result" = "%d Canlyniad";
+
+/* Number of found search results */
+"%d Results" = "%d Canlyniad ";
+
+/* 1 minute passcode lock timeout */
+"1 Minute" = "1 Minute";
+
+/* 15 seconds passcode lock timeout */
+"15 Seconds" = "15 Seconds";
+
+/* 2 minutes passcode lock timeout */
+"2 Minutes" = "2 Minutes";
+
+/* 3 minutes passcode lock timeout */
+"3 Minutes" = "3 Minutes";
+
+/* 30 seconds passcode lock timeout */
+"30 Seconds" = "30 Seconds";
+
+/* 4 minutes passcode lock timeout */
+"4 Minutes" = "4 Minutes";
+
+/* 5 minutes passcode lock timeout */
+"5 Minutes" = "5 Minutes";
+
+/* Display app about screen */
+"About" = "About";
+
+/* Accept Action
    Label of accept button on alert dialog */
 "Accept" = "Derbyn";
 
@@ -24,44 +55,149 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Ychwanegu cydweithredwr newydd...";
 
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Tag...";
+
 /* Label on button to add a new tag to a note */
 "Add tag" = "Ychwanegu tag";
 
 /* Title: No filters applied */
 "All Notes" = "Pob Nodyn";
 
+/* Sort Mode: Alphabetically, ascending */
+"Alphabetically: A-Z" = "Alphabetically: A-Z";
+
+/* Sort Mode: Alphabetically, descending */
+"Alphabetically: Z-A" = "Alphabetically: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "An error was encountered while signing in.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Appearance";
+
+/* Other Simplenote apps */
+"Apps" = "Apps";
+
+/* Automattic hiring description */
+"Are you a developer? Automattic is hiring." = "Are you a developer? Automattic is hiring.";
+
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Are you sure you want to empty the trash? This cannot be undone.";
+
+/* Message for alert when user tries to send feedback without an email address */
+"Are you sure you want to send without your email? We won't be able reply to you." = "Are you sure you want to send without your email? We won't be able reply to you.";
+
+/* Title for prompt when user tries to close the feedback view */
+"Are you sure?" = "Are you sure?";
+
+/* User Authenticated */
+"Authenticated" = "Authenticated";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Nôl";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
+
+/* Terms of Service Legend *PREFIX*: printed in dark color */
+"By creating an account you agree to our" = "By creating an account you agree to our";
+
+/* No comment provided by engineer. */
+"Can't Access." = "Can't Access.";
+
+/* Cancel Action
    Verb, cancel an alert dialog */
 "Cancel" = "Canslo";
+
+/* No comment provided by engineer. */
+"Choose Photo" = "Choose Photo";
+
+/* No comment provided by engineer. */
+"Close" = "Close";
 
 /* Verb - work with others on a note */
 "Collaborate" = "Cydweithredu";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Galluogi i eraill gydweithredu";
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Collaboration has moved";
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Cydweithredwyr";
 
-/* No comment provided by engineer. */
-"collaborators-description" = "Ychwanegwch gyfeiriad e-bost i rannu'r nodyn hwn gyda rhywun. Yna byddwch chi'n dau yn gallu gwneud newidiadau iddo.";
-
 /* Option to make the note list show only 1 line of text. The default is 3. */
 "Condensed Note List" = "Rhestr Gryno o Nodiadau";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Cysylltu";
+
+/* Contribute to the Simplenote apps on github */
+"Contribute" = "Contribute";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Gallai Fod yn Well";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Nid oedd modd creu cyfrif gyda'r cyfeiriad e-bost a chyfrinair a ddarparwyd.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Nid oedd modd mewngofnodi gyda'r cyfeiriad e-bost a chyfrinair a ddarparwyd. ";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Dwedwch wrthym sut y gallwn ni ei wella?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Couldn't Sign In";
+
+/* Siri Suggestion to create a New Note */
+"Create a New Note" = "Create a New Note";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Creu nodyn newydd";
 
+/* Sort Mode: Creation Date, descending */
+"Created: Newest" = "Created: Newest";
+
+/* Sort Mode: Creation Date, ascending */
+"Created: Oldest" = "Created: Oldest";
+
 /* No comment provided by engineer. */
 "Current Collaborators" = "Cydweithredwyr Cyfredol";
 
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Dilëwyd y nodyn hwn ar ddyfais arall.";
+/* Theme: Dark */
+"Dark" = "Dark";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Dadfygio";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Dileu";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Delete Notes";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Disable Markdown formatting";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Cau'r bysellfwrdd";
 
+/* Done toolbar button
    Verb: Close current view */
 "Done" = "Gorffen";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Edit";
+
+/* Email TextField Placeholder */
+"Email" = "E-bost";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Email Address" = "Email Address";
+
+/* Email Taken Alert Title */
+"Email in use" = "Email in use";
 
 /* Verb - empty causes all notes to be removed permenently from the trash */
 "Empty" = "Gwagio";
@@ -69,23 +205,120 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Clirio'r sbwriel";
 
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Enable Markdown formatting";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Enqueued";
+
+/* No comment provided by engineer. */
+"Error" = "Gwall";
+
+/* No comment provided by engineer. */
+"Error uploading." = "Error uploading.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
+
+/* Password Reset Action */
+"Forgotten password?" = "Forgotten password?";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Gwych! Hoffech chi adael adolygiad da?\n\n\nMae wir yn helpu.";
+
+/* Privacy Details */
+"Help us improve Simplenote by sharing usage data with our analytics tool." = "Help us improve Simplenote by sharing usage data with our analytics tool.";
+
 /* Noun - the version history of a note */
 "History" = "Hanes";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Adfer y nodyn i'r fersiwn blaenorol";
 
 /* Action - view the version history of a note */
 "History..." = "Hanes...";
 
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Sut gallwn ni helpu?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Rydw i'n ei Hoffi";
+
+/* Title for alert that a user has entered an invalid email address */
+"Invalid Email Address." = "Invalid Email Address.";
+
+/* Last Message timestamp */
+"LastSeen" = "LastSeen";
+
+/* Learn More Action */
+"Learn more" = "Learn more";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Gadael Adolygiad";
+
+/* Theme: Light */
+"Light" = "Light";
+
+/* Setting for when the passcode lock should enable */
+"Lock Timeout" = "Lock Timeout";
+
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
+"Log In" = "Log In";
+
+/* Log out of the active account in the app */
+"Log Out" = "Log Out";
+
+/* Allows the user to SignIn using their WPCOM Account */
+"Log in with WordPress.com" = "Log in with WordPress.com";
+
+/* Presents the regular Email signin flow */
+"Log in with email" = "Log in with email";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "MMM d, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown toggle";
+
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Dewislen";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Dangos y dewisiadau ar gyfer y nodyn";
+/* Sort Mode: Modified Date, descending */
+"Modified: Newest" = "Modified: Newest";
+
+/* Sort Mode: Creation Date, ascending */
+"Modified: Oldest" = "Modified: Oldest";
 
 /* Label to create a new note */
 "New note" = "Nodyn newydd";
+
+/* Empty Note Placeholder */
+"New note..." = "New note...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "No";
+
+/* Title for alert when user tires to send feedback without an email address */
+"No Email." = "No Email.";
+
+/* Text that appears in an alert to the user when there is no internet */
+"No Internet" = "No Internet";
+
+/* Title for message when user tries to send feedback without any text */
+"No Message." = "No Message.";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Dim Nodiadau";
@@ -93,29 +326,53 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Dim Canlyniadau";
 
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Dim Diolch";
+
 /* No comment provided by engineer. */
 "Note not published" = "Nodyn heb ei gyhoeddi";
 
-/* Option to make the note list show only 1 line of text. The default is 3. */
+/* Plural form of notes */
 "Notes" = "Nodiadau";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Cau'r nodyn cyfredol";
-
-/* Instant passcode lock timeout */
-"Off" = "I ffwrdd";
 
 /* Dismisses an AlertController */
 "OK" = "IAWN";
 
+/* Instant passcode lock timeout */
+"Off" = "I ffwrdd";
+
 /* No comment provided by engineer. */
 "On" = "Ymlaen";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "Open \"(preview)\"";
+
+/* Siri Suggestion to open our app */
+"Open Simplenote" = "Open Simplenote";
 
 /* Select a note to view in the note editor */
 "Open note" = "Agor nodyn";
 
+/* AlertController's Payload for the broken Sort Options Fix */
+"Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Our update may have changed the order in which your notes appear. Would you like to review sort settings?";
+
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Cod cyfrin";
+
+/* Password TextField Placeholder */
+"Password" = "Cyfrinair";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Password must contain at least 4 characters";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Rhaid i'r cyfrinair gynnwys o leiaf 6 nod.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Pendings";
+
+/* Pin (verb) - the action of Pinning a note */
+"Pin" = "Pin";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Pinio'r nodyn";
@@ -128,6 +385,24 @@
 
 /* Pinned notes are stuck to the note of the note list */
 "Pinned" = "Piniwyd";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Please activate your WordPress.com account via email and try again.";
+
+/* Message for alert that user has entered an invalid email address */
+"Please check your email address, it appears to be invalid." = "Please check your email address, it appears to be invalid.";
+
+/* Message for alert when user tires to send feedback without any text */
+"Please enter a message." = "Please enter a message.";
+
+/* Title of Markdown preview screen */
+"Preview" = "Rhagolwg";
+
+/* Simplenote privacy policy */
+"Privacy Policy" = "Privacy Policy";
+
+/* Privacy Settings */
+"Privacy Settings" = "Privacy Settings";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Cyhoeddi";
@@ -144,6 +419,9 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Wrthi'n cyhoeddi...";
 
+/* Reachs Internet */
+"Reachability" = "Reachability";
+
 /* No comment provided by engineer. */
 "Remove all notes from trash" = "Cael gwared â'r holl nodiadau o'r sbwriel";
 
@@ -156,26 +434,96 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Adfer Nodyn";
 
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Search";
+
+/* No comment provided by engineer. */
+"Security" = "Diogelwch";
+
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Anfon";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Anfon Adborth";
+
+/* For debugging use */
+"Send a Test Crash" = "Send a Test Crash";
+
+/* Label that is shown when feedback from the user is sending */
+"Sending..." = "Sending...";
 
 /* Title of options screen */
 "Settings" = "Gosodiadau";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Rhannu";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Share Analytics";
+
 /* No comment provided by engineer. */
 "Share note" = "Rhannu nodyn";
 
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Rhannu cynnwys y nodyn cyfredol";
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Sharing notes is now accessed through the action menu from the toolbar.";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Bar ochr";
 
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Ychwanegu tag i'r nodyn cyfredol";
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Cofrestru";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Bydd all-gofnodi'n dileu unrhyw nodau heb eu cydweddu. Gallwch ddilysu eich nodau wedi eu cydweddu drwy fewngofnodi i'r Web App.";
+
+/* Our mighty brand! */
+"Simplenote" = "Simplenote";
+
+/* Authentication Error Alert Title */
+"Sorry!" = "Sorry!";
+
+/* Option to sort tags alphabetically. The default is by manual ordering. */
+"Sort Alphabetically" = "Sort Alphabetically";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Trefn didoli";
+
+/* Theme: Matches iOS Settings */
+"System Default" = "System Default";
 
 /* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Tynnu'r tag o'r nodyn cyfredol";
+"Tags" = "Tags";
+
+/* No comment provided by engineer. */
+"Take Photo" = "Take Photo";
+
+/* Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue */
+"Terms and Conditions" = "Terms and Conditions";
+
+/* Simplenote terms of service */
+"Terms of Service" = "Terms of Service";
+
+/* No comment provided by engineer. */
+"Thanks" = "Thanks";
+
+/* Error when address is in use */
+"The email you've entered is already associated with a Simplenote account." = "The email you've entered is already associated with a Simplenote account.";
+
+/* Onboarding Header Text */
+"The simplest way to keep notes." = "The simplest way to keep notes.";
+
+/* Option to enable the dark app theme. */
+"Theme" = "Thema";
+
+/* Simplenote Themes */
+"Themes" = "Themes";
+
+/* No comment provided by engineer. */
+"There was an error sending your feedback, please try again." = "There was an error sending your feedback, please try again.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Heddiw";
@@ -183,14 +531,17 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Bar ochr toglo tagiau";
 
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Symud y nodyn cyfredol i'r sbwriel";
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Enw Cyffwrdd";
 
 /* Title: Trash Tag is selected */
-"Trash-noun" = "Sbwriel";
+"Trash" = "Sbwriel";
 
-/* Title: Trash Tag is selected */
-"Trash-verb" = "Sbwriel";
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Sbwriel";
+
+/* Unpin (verb) - the action of Unpinning a note */
+"Unpin" = "Unpin";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Dadbinio'r nodyn";
@@ -201,143 +552,112 @@
 /* Message shown when a note is in the processes of being unpublished */
 "Unpublishing..." = "Wrthi'n dad-gyhoeddi...";
 
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Wedi Canfod Nodau Heb eu Cydweddu";
+
+/* Title: Untagged Notes are onscreen */
+"Untagged" = "Untagged";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Untagged Notes";
+
+/* No comment provided by engineer. */
+"Use Latest Photo" = "Use Latest Photo";
+
+/* A user's Simplenote account */
+"Username" = "Username";
+
 /* Represents a snapshot in time for a note */
 "Version" = "Fersiwn";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Cysylltwch â'r rhyngrwyd i gael mynediad at fersiynau blaenorol";
+/* App version number */
+"Version %@" = "Version %@";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Newid i'r fersiwn hwn";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Wrthi'n ôl y fersiwn";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Ddoe";
-
-"welcomeNote-iOS" = "Croeso i Simplenote ar gyfer iOS!
-
-I ychwanegu nodyn, tapiwch y botwm adio.
-
-Ffliciwch y rhestr i bori'ch nodiadau. Tapiwch deitl i weld nodyn, yna tapiwch y cynnwys i'w newid.
-
-Gallwch chwilio trwy bob un o'ch nodiadau trwy deipio yn y maes chwilio ar frig y rhestr o nodiadau.
-
-Tapiwch y botwm saeth ar y brig ar yr ochr chwith neu llusgwch ar draws eich rhestr o nodiadau i weld eich tagiau. Gallwch ychwanegu tagiau i nodyn ar waelod y golygydd nodiadau, ac yna defnyddio'r bar ochr i'ch helpu i gadw trefn ar bethau.
-
-Mae mwy o ddewisiadau nodiadau os ydych chi eu hangen. Gallwch ychwanegu rhai eraill fel cydweithredwyr i nodyn, neu gyhoeddi nodyn fel tudalen we.
-
-Defnyddiwch Simplenote ar eich Mac, dyfais Android, neu yn eich porwr gwe ar http://simplenote.com. Bydd eich nodiadau yn diweddaru ym mhob man yn awtomatig.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Nid oedd modd creu cyfrif gyda'r cyfeiriad e-bost a chyfrinair a ddarparwyd.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Nid oedd modd mewngofnodi gyda'r cyfeiriad e-bost a chyfrinair a ddarparwyd. ";
-
-/* Password TextField Placeholder */
-"Password" = "Cyfrinair";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Rhaid i'r cyfrinair gynnwys o leiaf 6 nod.";
-
-   SignUp Interface Title */
-"Sign Up" = "Cofrestru";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Nid yw eich cyfeiriad e-bost yn ddilys.";
-
-   Display internal debug status */
-"Debug" = "Dadfygio";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "MMM d, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Enw Cyffwrdd";
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Visit Web App";
 
 /* No comment provided by engineer. */
-"Security" = "Diogelwch";
+"We can't access your photos, please ensure this application has access in Settings." = "We can't access your photos, please ensure this application has access in Settings.";
+
+/* No comment provided by engineer. */
+"We couldn't upload the photo, please try again." = "We couldn't upload the photo, please try again.";
+
+/* No comment provided by engineer. */
+"We have received your feedback and will be in contact soon." = "We have received your feedback and will be in contact soon.";
+
+/* Generic error */
+"We're having problems. Please try again soon." = "We're having problems. Please try again soon.";
+
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
 
 /* This is the string we display when prompting the user to review the app */
 "What do you think about Simplenote?" = "Beth ydych chi'n ei feddwl Simplenote?";
 
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Rydw i'n ei Hoffi";
+/* This is the string we display when prompting the user to review the app */
+"What do you think about WordPress?" = "What do you think about WordPress?";
 
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Gallai Fod yn Well";
+/* Work at Automattic */
+"Work With Us" = "Work With Us";
 
-"Great! Could you leave us a nice review?
-It really helps." = "Gwych! Hoffech chi adael adolygiad da?
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Yes";
 
-
-Mae wir yn helpu.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Gadael Adolygiad";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Dim Diolch";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Dwedwch wrthym sut y gallwn ni ei wella?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Anfon Adborth";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Cysylltu";
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Ddoe";
 
 /* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Your Email:" = "Eich Cyfeiriad E-bost:";
 
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Sut gallwn ni helpu?";
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Nid yw eich cyfeiriad e-bost yn ddilys.";
 
-/* Title of Back button for Markdown preview */
-"Back" = "Nôl";
+/* Message for prompt when user tries to close feedback view after having entered text */
+"Your message will be lost." = "Your message will be lost.";
 
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Dileu";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "attach a file";
 
-/* Title of Markdown preview screen */
-"Preview" = "Rhagolwg";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Bydd all-gofnodi'n dileu unrhyw nodau heb eu cydweddu. Gallwch ddilysu eich nodau wedi eu cydweddu drwy fewngofnodi i'r Web App.";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Wedi Canfod Nodau Heb eu Cydweddu";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Tag...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Rhannu";
-
-   Sort Order for the Notes List */
-"Sort Order" = "Trefn didoli";
-
-/* Email TextField Placeholder */
-"Email" = "E-bost";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Thema";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Galluogi i eraill gydweithredu";
 
 /* No comment provided by engineer. */
-"Error" = "Gwall";
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Ychwanegwch gyfeiriad e-bost i rannu'r nodyn hwn gyda rhywun. Yna byddwch chi'n dau yn gallu gwneud newidiadau iddo.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Dilëwyd y nodyn hwn ar ddyfais arall.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Adfer y nodyn i'r fersiwn blaenorol";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Dangos y dewisiadau ar gyfer y nodyn";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Cau'r nodyn cyfredol";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Rhannu cynnwys y nodyn cyfredol";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Ychwanegu tag i'r nodyn cyfredol";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Tynnu'r tag o'r nodyn cyfredol";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Symud y nodyn cyfredol i'r sbwriel";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Cysylltwch â'r rhyngrwyd i gael mynediad at fersiynau blaenorol";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Newid i'r fersiwn hwn";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Wrthi'n ôl y fersiwn";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Croeso i Simplenote ar gyfer iOS!\n\nI ychwanegu nodyn, tapiwch y botwm adio.\n\nFfliciwch y rhestr i bori'ch nodiadau. Tapiwch deitl i weld nodyn, yna tapiwch y cynnwys i'w newid.\n\nGallwch chwilio trwy bob un o'ch nodiadau trwy deipio yn y maes chwilio ar frig y rhestr o nodiadau.\n\nTapiwch y botwm saeth ar y brig ar yr ochr chwith neu llusgwch ar draws eich rhestr o nodiadau i weld eich tagiau. Gallwch ychwanegu tagiau i nodyn ar waelod y golygydd nodiadau, ac yna defnyddio'r bar ochr i'ch helpu i gadw trefn ar bethau.\n\nMae mwy o ddewisiadau nodiadau os ydych chi eu hangen. Gallwch ychwanegu rhai eraill fel cydweithredwyr i nodyn, neu gyhoeddi nodyn fel tudalen we.\n\nDefnyddiwch Simplenote ar eich Mac, dyfais Android, neu yn eich porwr gwe ar http:\/\/simplenote.com. Bydd eich nodiadau yn diweddaru ym mhob man yn awtomatig.";
 

--- a/Simplenote/de.lproj/Localizable.strings
+++ b/Simplenote/de.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: de */
 
-/* Number of found search results */
-"%d Result" = "%d Ergebnis";
+/* Number of Characters in a note */
+"%@ Character" = "%@ Zeichen";
 
-/* Number of found search results */
-"%d Results" = "%d Ergebnisse";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ Zeichen";
 
 /* Number of words in a note */
 "%@ Word" = "%@ Wort";
@@ -15,408 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ Wörter";
 
-   Label of accept button on alert dialog */
-"Accept" = "Akzeptieren";
-
-/* No comment provided by engineer. */
-"Account" = "Konto";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Neuen Mitarbeiter hinzufügen…";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Schlagwort hinzufügen";
-
-/* Title: No filters applied */
-"All Notes" = "Alle Notizen";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "Abbrechen";
-
-/* Verb - work with others on a note */
-"Collaborate" = "Zusammenarbeiten";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Mitarbeit durch andere Personen ermöglichen";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Mitarbeiter";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "Füge eine E-Mail-Adresse hinzu, um diese Notiz mit jemandem zu teilen. Dann könnt ihr beide Änderungen daran vornehmen.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Notizenliste Kurzfassung";
-
-/* Siri Suggestion to create a New Note */
-"Create a new note" = "Neue Notiz erstellen";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Aktuelle Mitarbeiter";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Diese Notiz wurde auf einem anderen Gerät gelöscht.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Tastatur ausblenden";
-
-   Verb: Close current view */
-"Done" = "Fertig";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "Leer";
-
-/* Remove all notes from the trash */
-"Empty trash" = "Papierkorb leeren";
-
-/* Noun - the version history of a note */
-"History" = "Verlauf";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Vorherige Version der Notiz wiederherstellen";
-
-/* Action - view the version history of a note */
-"History..." = "Verlauf…";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "Menü";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Optionen für Notiz anzeigen";
-
-/* Siri Suggestion to create a New Note */
-"New note" = "Neue Notiz";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "Keine Notizen";
-
-/* Message shown when no notes match a search string */
-"No Results" = "Keine Ergebnisse";
-
-/* No comment provided by engineer. */
-"Note not published" = "Notiz nicht veröffentlicht";
-
-/* Title: No filters applied */
-"Notes" = "Notizen";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Aktuelle Notiz schließen";
-
-/* Instant passcode lock timeout */
-"Off" = "Aus";
-
-/* Dismisses an AlertController */
-"OK" = "OK";
-
-/* No comment provided by engineer. */
-"On" = "Ein";
-
-/* Select a note to view in the note editor */
-"Open note" = "Notiz öffnen";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Passcode";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Notiz anheften";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "An Anfang heften";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "Umschalter Anheften";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Angeheftet";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Veröffentlichen";
-
-/* Action which published a note to a web page */
-"Publish note" = "Notiz veröffentlichen";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "Umschalter Veröffentlichung";
-
-/* No comment provided by engineer. */
-"Published" = "Veröffentlicht";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Veröffentlichung läuft…";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Alle Notizen aus Papierkorb entfernen";
-
-/* Rename a tag */
-"Rename" = "Umbenennen";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Wiederherstellen";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Notiz wiederherstellen";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "Senden";
-
-/* Title of options screen */
-"Settings" = "Einstellungen";
-
-/* No comment provided by engineer. */
-"Share note" = "Notiz teilen";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Inhalt der aktuellen Notiz teilen";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Seitenleiste";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Tag zur aktuellen Notiz hinzufügen";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Tag aus aktueller Notiz entfernen";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Heute";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Schlagwort-Seitenleiste umschalten";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Aktuelle Notiz in den Papierkorb verschieben";
-
-/* Empty Trash Warning */
-"Trash-noun" = "Papierkorb";
-
-/* Empty Trash Warning */
-"Trash-verb" = "Papierkorb";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Notiz lösen";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Veröffentlichung von Notiz rückgängig machen";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Veröffentlichung wird aufgehoben…";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Version";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Stelle eine Verbindung mit dem Internet her, um auf frühere Versionen zuzugreifen";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Zu dieser Version wechseln";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Version wird abgerufen";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Gestern";
-
-"welcomeNote-iOS" = "Willkommen bei Simplenote für iOS!
-
-Tippe auf das Pluszeichen, um eine Notiz hinzuzufügen.
-
-Blättere die Liste durch, um deine Notizen zu durchsuchen. Tippe auf einen Titel, um eine Notiz anzuzeigen, und tippe dann auf den Inhalt, um sie zu bearbeiten.
-
-Du kannst alle Notizen durchsuchen, indem du im Suchfeld am oberen Rand der Notizliste Text eingibst.
-
-Tippe auf die Pfeilschaltfläche oben links oder wische über die Notizliste, um deine Tags anzuzeigen. Du kannst einer Notiz am unteren Rand des Notiz-Editors Tags hinzufügen und dann die Seitenleiste verwenden, um den Überblick zu behalten.
-
-Es gibt noch mehr Notizoptionen, falls du noch welche benötigst. Du kannst andere Personen als Mitwirkende zu einer Notiz hinzufügen oder eine Notiz als Webseite veröffentlichen.
-
-Verwende Simplenote auf deinem Mac, Android-Gerät oder in deinem Webbrowser unter http://simplenote.com. Deine Notizen werden überall automatisch aktualisiert.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Mit der angegebenen E-Mail-Adresse und dem Passwort konnte kein Konto erstellt werden.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Mit der angegebenen E-Mail-Adresse und dem Passwort war keine Anmeldung möglich.";
-
-/* Error for bad email or password */
-"Password" = "Passwort";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Das Passwort muss mindestens 6 Zeichen lang sein.";
-
-   SignUp Interface Title */
-"Sign Up" = "Registrieren";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Deine E-Mail-Adresse ist ungültig.";
-
-/* User Authenticated */
-"Authenticated" = "Authentifiziert";
-
-   Display internal debug status */
-"Debug" = "Debuggen";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "In der Warteschlange";
-
-/* Last Message timestamp */
-"LastSeen" = "Zuletzt angesehen";
-
-/* Month and day date formatter */
-"MMM d" = "d. MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d. MMM H:mm";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d. MMM yyyy";
-
-/* Month, day, and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "Ausstehend";
-
-/* Reachs Internet */
-"Reachability" = "Erreichbarkeit";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Sicherheit";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Was hältst du von Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Gefällt mir";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Könnte besser sein";
-
-"Great! Could you leave us a nice review?
-It really helps." = "Toll! Kannst Du uns eine Referenz hinterlassen? 
-
-Das hilft uns wirklich.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Rezension schreiben";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Nein danke";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Könntest du uns Verbesserungsvorschläge machen?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Feedback senden";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Kontakt";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "Deine E-Mail-Adresse:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Wie können wir helfen?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "Bei der Anmeldung ist ein Fehler aufgetreten.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "Soll der Papierkorb wirklich geleert werden? Dies kann nicht rückgängig gemacht werden.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Zurück";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "Zusammenarbeit wurde verschoben";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "Anmeldung nicht möglich";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Notizen löschen";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Markdown-Formatierung deaktivieren";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "Bearbeiten";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Markdown-Formatierung aktivieren";
-
-
-"Face ID" = "Face ID";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Markdown-Schalter";
-
-   Cancels Empty Trash Action */
-"No" = "Nein";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Aktiviere dein WordPress.com-Konto per E-Mail und versuche es erneut.";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Suche";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Du kannst Notizen jetzt über das Aktionsmenü in der Toolbar teilen.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Bei der Abmeldung werden alle nicht synchronisierten Notizen gelöscht. Du kannst überprüfen, ob deine Notizen synchronisiert wurden, indem du dich in der Web-App anmeldest.";
-
-/* No comment provided by engineer. */
-"Tags" = "Schlagwörter";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Nicht synchronisierte Notizen entdeckt";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Web-App aufrufen";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "Ja";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Teilen";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Nicht markierte Notizen";
-
-/* AlertController's Payload for the broken Sort Options Fix */
-"Sort Order" = "Sortierung";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Analysen teilen";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Email" = "E-Mail";
-
-
-"Theme" = "Theme";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
-
-/* Sign in error message */
-"Error" = "Fehler";
-
-/* No comment provided by engineer. */
-"Appearance" = "Design";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ Zeichen";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ Zeichen";
+/* Number of found search results */
+"%d Result" = "%d Ergebnis";
+
+/* Number of found search results */
+"%d Results" = "%d Ergebnisse";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 Minute";
@@ -442,11 +45,36 @@ Das hilft uns wirklich.";
 /* Display app about screen */
 "About" = "Über";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Akzeptieren";
+
+/* No comment provided by engineer. */
+"Account" = "Konto";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Neuen Mitarbeiter hinzufügen…";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Tag...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Schlagwort hinzufügen";
+
+/* Title: No filters applied */
+"All Notes" = "Alle Notizen";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "Alphabetisch: A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "Alphabetisch: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "Bei der Anmeldung ist ein Fehler aufgetreten.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Design";
 
 /* Other Simplenote apps */
 "Apps" = "Apps";
@@ -454,14 +82,23 @@ Das hilft uns wirklich.";
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "Bist du Entwickler? Bei Automattic gibt es vielleicht den passenden Job für dich.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Soll der Papierkorb wirklich geleert werden? Dies kann nicht rückgängig gemacht werden.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "Wirklich ohne deine E-Mail senden? Wir werden dir nicht antworten können.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "Bist du sicher?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "eine Datei anhängen";
+/* User Authenticated */
+"Authenticated" = "Authentifiziert";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Zurück";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "Indem du ein Konto erstellst, stimmst du Folgendem zu:";
@@ -469,17 +106,54 @@ Das hilft uns wirklich.";
 /* No comment provided by engineer. */
 "Can't Access." = "Zugriff nicht möglich.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "Abbrechen";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Foto auswählen";
 
 /* No comment provided by engineer. */
 "Close" = "Schließen";
 
+/* Verb - work with others on a note */
+"Collaborate" = "Zusammenarbeiten";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Zusammenarbeit wurde verschoben";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Mitarbeiter";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Notizenliste Kurzfassung";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Kontakt";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Beitragen";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Könnte besser sein";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Mit der angegebenen E-Mail-Adresse und dem Passwort konnte kein Konto erstellt werden.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Mit der angegebenen E-Mail-Adresse und dem Passwort war keine Anmeldung möglich.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Könntest du uns Verbesserungsvorschläge machen?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Anmeldung nicht möglich";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Neue Notiz erstellen";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Neue Notiz erstellen";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Erstellt: Neueste";
@@ -487,29 +161,97 @@ Das hilft uns wirklich.";
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Erstellt: Älteste";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Aktuelle Mitarbeiter";
+
 /* Theme: Dark */
 "Dark" = "Dunkel";
 
-/* Error for bad email or password */
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Debuggen";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Delete";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Notizen löschen";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Markdown-Formatierung deaktivieren";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Tastatur ausblenden";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Fertig";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Bearbeiten";
+
+/* Email TextField Placeholder */
+"Email" = "E-Mail";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "E-Mail-Adresse";
 
 /* Email Taken Alert Title */
 "Email in use" = "Verwendete E-Mail-Adresse";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Leer";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Papierkorb leeren";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Markdown-Formatierung aktivieren";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "In der Warteschlange";
+
+/* No comment provided by engineer. */
+"Error" = "Fehler";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Fehler beim Hochladen";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "Passwort vergessen?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Toll! Kannst Du uns eine Referenz hinterlassen? \n\nDas hilft uns wirklich.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Hilf uns, Simplenote zu verbessern, indem du Nutzungsdaten für unser Analysetool bereitstellst.";
+
+/* Noun - the version history of a note */
+"History" = "Verlauf";
+
+/* Action - view the version history of a note */
+"History..." = "Verlauf…";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Wie können wir helfen?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Gefällt mir";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Ungültige E-Mail-Adresse";
 
+/* Last Message timestamp */
+"LastSeen" = "Zuletzt angesehen";
+
 /* Learn More Action */
 "Learn more" = "Mehr erfahren";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Rezension schreiben";
 
 /* Theme: Light */
 "Light" = "Hell";
@@ -517,17 +259,41 @@ Das hilft uns wirklich.";
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Sperrtimeout";
 
+/* Log In Action
+   Login Action
+   LogIn Action
    LogIn Interface Title */
 "Log In" = "Anmelden";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "Mit E-Mail-Adresse anmelden";
+/* Log out of the active account in the app */
+"Log Out" = "Abmelden";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "Mit WordPress.com anmelden";
 
-/* Log out of the active account in the app */
-"Log Out" = "Abmelden";
+/* Presents the regular Email signin flow */
+"Log in with email" = "Mit E-Mail-Adresse anmelden";
+
+/* Month and day date formatter */
+"MMM d" = "d. MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d. MMM H:mm";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d. MMM yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown-Schalter";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Menü";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Geändert: Neueste";
@@ -535,8 +301,15 @@ Das hilft uns wirklich.";
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Geändert: Älteste";
 
+/* Label to create a new note */
+"New note" = "Neue Notiz";
+
 /* Empty Note Placeholder */
 "New note..." = "Neue Notiz…";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "Nein";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "Keine E-Mail.";
@@ -547,16 +320,74 @@ Das hilft uns wirklich.";
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Keine Nachricht.";
 
-"Open "(preview)"" = ""(preview)" öffnen";
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "Keine Notizen";
+
+/* Message shown when no notes match a search string */
+"No Results" = "Keine Ergebnisse";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Nein danke";
+
+/* No comment provided by engineer. */
+"Note not published" = "Notiz nicht veröffentlicht";
+
+/* Plural form of notes */
+"Notes" = "Notizen";
+
+/* Dismisses an AlertController */
+"OK" = "OK";
+
+/* Instant passcode lock timeout */
+"Off" = "Aus";
+
+/* No comment provided by engineer. */
+"On" = "Ein";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "\"(preview)\" öffnen";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Simplenote öffnen";
 
+/* Select a note to view in the note editor */
+"Open note" = "Notiz öffnen";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Durch unser Update kann sich die Reihenfolge ändern, in der deine Notizen angezeigt werden. Möchtest du die Sortierungseinstellungen überprüfen?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Passcode";
+
+/* Password TextField Placeholder */
+"Password" = "Passwort";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Das Passwort muss mindestens 4 Zeichen enthalten";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Das Passwort muss mindestens 6 Zeichen lang sein.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Ausstehend";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Anheften";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Notiz anheften";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "An Anfang heften";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "Umschalter Anheften";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Angeheftet";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Aktiviere dein WordPress.com-Konto per E-Mail und versuche es erneut.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "Bitte überprüfe deine E-Mail-Adresse, sie scheint ungültig zu sein.";
@@ -564,11 +395,57 @@ Das hilft uns wirklich.";
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Bitte gib eine Nachricht ein.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Preview";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Datenschutzerklärung";
 
 /* Privacy Settings */
 "Privacy Settings" = "Datenschutzeinstellungen";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Veröffentlichen";
+
+/* Action which published a note to a web page */
+"Publish note" = "Notiz veröffentlichen";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Umschalter Veröffentlichung";
+
+/* No comment provided by engineer. */
+"Published" = "Veröffentlicht";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Veröffentlichung läuft…";
+
+/* Reachs Internet */
+"Reachability" = "Erreichbarkeit";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Alle Notizen aus Papierkorb entfernen";
+
+/* Rename a tag */
+"Rename" = "Umbenennen";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Wiederherstellen";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Notiz wiederherstellen";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Suche";
+
+/* No comment provided by engineer. */
+"Security" = "Sicherheit";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Senden";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Feedback senden";
 
 /* For debugging use */
 "Send a Test Crash" = "Testabsturz senden";
@@ -576,7 +453,33 @@ Das hilft uns wirklich.";
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Wird gesendet...";
 
+/* Title of options screen */
+"Settings" = "Einstellungen";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Teilen";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Analysen teilen";
+
+/* No comment provided by engineer. */
+"Share note" = "Notiz teilen";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Du kannst Notizen jetzt über das Aktionsmenü in der Toolbar teilen.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Seitenleiste";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Registrieren";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Bei der Abmeldung werden alle nicht synchronisierten Notizen gelöscht. Du kannst überprüfen, ob deine Notizen synchronisiert wurden, indem du dich in der Web-App anmeldest.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -585,8 +488,15 @@ Das hilft uns wirklich.";
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Alphabetisch sortieren";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Sortierung";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Systemstandard";
+
+/* No comment provided by engineer. */
+"Tags" = "Schlagwörter";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Foto aufnehmen";
@@ -594,7 +504,7 @@ Das hilft uns wirklich.";
 /* Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue */
 "Terms and Conditions" = "Geschäftsbedingungen";
 
-/* Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue */
+/* Simplenote terms of service */
 "Terms of Service" = "Geschäftsbedingungen";
 
 /* No comment provided by engineer. */
@@ -606,17 +516,50 @@ Das hilft uns wirklich.";
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "Die einfachste Art, sich Notizen zu machen.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "Theme";
 
+/* Simplenote Themes */
 "Themes" = "Themes";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "Bei der Übermittlung deines Feedbacks ist ein Fehler aufgetreten, bitte versuche es erneut.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Heute";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Schlagwort-Seitenleiste umschalten";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Papierkorb";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Papierkorb";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Lösen";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "Notiz lösen";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Veröffentlichung von Notiz rückgängig machen";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Veröffentlichung wird aufgehoben…";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Nicht synchronisierte Notizen entdeckt";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Nicht markiert";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Nicht markierte Notizen";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "Aktuelles Foto verwenden";
@@ -624,8 +567,14 @@ Das hilft uns wirklich.";
 /* A user's Simplenote account */
 "Username" = "Benutzername";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Version";
+
 /* App version number */
 "Version %@" = "Version %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Web-App aufrufen";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "Wir konnten auf deine Fotos nicht zugreifen. Bitte stelle sicher, dass diese Anwendung unter Einstellungen Zugriff darauf hat.";
@@ -639,15 +588,76 @@ Das hilft uns wirklich.";
 /* Generic error */
 "We're having problems. Please try again soon." = "Momentan gibt es ein paar Probleme. Bitte versuche es später erneut.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Was hältst du von Simplenote?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "Was ist deine Meinung zu WordPress?";
 
 /* Work at Automattic */
 "Work With Us" = "Mit uns arbeiten";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Ja";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Gestern";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Deine E-Mail-Adresse:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Deine E-Mail-Adresse ist ungültig.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Deine Nachricht geht verloren.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "Das Passwort muss mindestens 4 Zeichen enthalten";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "eine Datei anhängen";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Mitarbeit durch andere Personen ermöglichen";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Füge eine E-Mail-Adresse hinzu, um diese Notiz mit jemandem zu teilen. Dann könnt ihr beide Änderungen daran vornehmen.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Diese Notiz wurde auf einem anderen Gerät gelöscht.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Vorherige Version der Notiz wiederherstellen";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Optionen für Notiz anzeigen";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Aktuelle Notiz schließen";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Inhalt der aktuellen Notiz teilen";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Tag zur aktuellen Notiz hinzufügen";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Tag aus aktueller Notiz entfernen";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Aktuelle Notiz in den Papierkorb verschieben";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Stelle eine Verbindung mit dem Internet her, um auf frühere Versionen zuzugreifen";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Zu dieser Version wechseln";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Version wird abgerufen";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Willkommen bei Simplenote für iOS!\n\nTippe auf das Pluszeichen, um eine Notiz hinzuzufügen.\n\nBlättere die Liste durch, um deine Notizen zu durchsuchen. Tippe auf einen Titel, um eine Notiz anzuzeigen, und tippe dann auf den Inhalt, um sie zu bearbeiten.\n\nDu kannst alle Notizen durchsuchen, indem du im Suchfeld am oberen Rand der Notizliste Text eingibst.\n\nTippe auf die Pfeilschaltfläche oben links oder wische über die Notizliste, um deine Tags anzuzeigen. Du kannst einer Notiz am unteren Rand des Notiz-Editors Tags hinzufügen und dann die Seitenleiste verwenden, um den Überblick zu behalten.\n\nEs gibt noch mehr Notizoptionen, falls du noch welche benötigst. Du kannst andere Personen als Mitwirkende zu einer Notiz hinzufügen oder eine Notiz als Webseite veröffentlichen.\n\nVerwende Simplenote auf deinem Mac, Android-Gerät oder in deinem Webbrowser unter http:\/\/simplenote.com. Deine Notizen werden überall automatisch aktualisiert.";
 

--- a/Simplenote/el.lproj/Localizable.strings
+++ b/Simplenote/el.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: el_GR */
 
-/* Number of found search results */
-"%d Result" = "%d αποτέλεσμα";
+/* Number of Characters in a note */
+"%@ Character" = "%@ Character";
 
-/* Number of found search results */
-"%d Results" = "%d αποτελέσματα";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ Characters";
 
 /* Number of words in a note */
 "%@ Word" = "%@ λέξη";
@@ -15,6 +15,37 @@
 /* Number of words in a note */
 "%@ Words" = "%@ λέξεις";
 
+/* Number of found search results */
+"%d Result" = "%d αποτέλεσμα";
+
+/* Number of found search results */
+"%d Results" = "%d αποτελέσματα";
+
+/* 1 minute passcode lock timeout */
+"1 Minute" = "1 Minute";
+
+/* 15 seconds passcode lock timeout */
+"15 Seconds" = "15 Seconds";
+
+/* 2 minutes passcode lock timeout */
+"2 Minutes" = "2 Minutes";
+
+/* 3 minutes passcode lock timeout */
+"3 Minutes" = "3 Minutes";
+
+/* 30 seconds passcode lock timeout */
+"30 Seconds" = "30 Seconds";
+
+/* 4 minutes passcode lock timeout */
+"4 Minutes" = "4 Minutes";
+
+/* 5 minutes passcode lock timeout */
+"5 Minutes" = "5 Minutes";
+
+/* Display app about screen */
+"About" = "About";
+
+/* Accept Action
    Label of accept button on alert dialog */
 "Accept" = "Αποδοχή";
 
@@ -24,38 +55,149 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Προσθήκη συνεργάτη...";
 
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Tag...";
+
 /* Label on button to add a new tag to a note */
 "Add tag" = "Προσθήκη ετικέτας";
 
+/* Title: No filters applied */
+"All Notes" = "All Notes";
+
+/* Sort Mode: Alphabetically, ascending */
+"Alphabetically: A-Z" = "Alphabetically: A-Z";
+
+/* Sort Mode: Alphabetically, descending */
+"Alphabetically: Z-A" = "Alphabetically: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "An error was encountered while signing in.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Appearance";
+
+/* Other Simplenote apps */
+"Apps" = "Apps";
+
+/* Automattic hiring description */
+"Are you a developer? Automattic is hiring." = "Are you a developer? Automattic is hiring.";
+
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Are you sure you want to empty the trash? This cannot be undone.";
+
+/* Message for alert when user tries to send feedback without an email address */
+"Are you sure you want to send without your email? We won't be able reply to you." = "Are you sure you want to send without your email? We won't be able reply to you.";
+
+/* Title for prompt when user tries to close the feedback view */
+"Are you sure?" = "Are you sure?";
+
+/* User Authenticated */
+"Authenticated" = "Authenticated";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Back";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
+
+/* Terms of Service Legend *PREFIX*: printed in dark color */
+"By creating an account you agree to our" = "By creating an account you agree to our";
+
+/* No comment provided by engineer. */
+"Can't Access." = "Can't Access.";
+
+/* Cancel Action
    Verb, cancel an alert dialog */
 "Cancel" = "Ακύρωση";
+
+/* No comment provided by engineer. */
+"Choose Photo" = "Choose Photo";
+
+/* No comment provided by engineer. */
+"Close" = "Close";
 
 /* Verb - work with others on a note */
 "Collaborate" = "Συνεργασία";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Ενεργοποίηση συνεργατών";
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Collaboration has moved";
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Συνεργάτες";
 
-/* No comment provided by engineer. */
-"collaborators-description" = "Εισάγετε το email του συνεργάτη σας ώστε να ενεργοποιηθεί η δυνατότητα συνεργασίας και ταυτόχρονων αλλαγών στην σημείωση.";
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Condensed Note List";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Contact";
+
+/* Contribute to the Simplenote apps on github */
+"Contribute" = "Contribute";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Could Be Better";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Δεν ήταν δυνατή η δημιουργία λογαριασμού με αυτό το email και κωδικό.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Δεν ήταν δυνατή η σύνδεση με αυτό το email και κωδικό.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Could you tell us how we could improve?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Couldn't Sign In";
+
+/* Siri Suggestion to create a New Note */
+"Create a New Note" = "Create a New Note";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Δημιουργία σημείωσης";
 
+/* Sort Mode: Creation Date, descending */
+"Created: Newest" = "Created: Newest";
+
+/* Sort Mode: Creation Date, ascending */
+"Created: Oldest" = "Created: Oldest";
+
 /* No comment provided by engineer. */
 "Current Collaborators" = "Συνεργατες";
 
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Η σημείωση αυτή έχει διαγραφεί σε κάποια άλλη συσκευή";
+/* Theme: Dark */
+"Dark" = "Dark";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Debug";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Delete";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Delete Notes";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Disable Markdown formatting";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Απόκρυψη";
 
+/* Done toolbar button
    Verb: Close current view */
 "Done" = "OK";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Edit";
+
+/* Email TextField Placeholder */
+"Email" = "Email";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Email Address" = "Email Address";
+
+/* Email Taken Alert Title */
+"Email in use" = "Email in use";
 
 /* Verb - empty causes all notes to be removed permenently from the trash */
 "Empty" = "Διαγραφή";
@@ -63,20 +205,120 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Διαγραφή όλων";
 
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Enable Markdown formatting";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Enqueued";
+
+/* No comment provided by engineer. */
+"Error" = "Error";
+
+/* No comment provided by engineer. */
+"Error uploading." = "Error uploading.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
+
+/* Password Reset Action */
+"Forgotten password?" = "Forgotten password?";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Great! Could you leave us a nice review?\nIt really helps.";
+
+/* Privacy Details */
+"Help us improve Simplenote by sharing usage data with our analytics tool." = "Help us improve Simplenote by sharing usage data with our analytics tool.";
+
 /* Noun - the version history of a note */
 "History" = "Ιστορικό";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Ανάκτηση σημείωσης στην προηγούμενη έκδοση";
 
 /* Action - view the version history of a note */
 "History..." = "Ιστορικό...";
 
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "How can we help?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "I Like It";
+
+/* Title for alert that a user has entered an invalid email address */
+"Invalid Email Address." = "Invalid Email Address.";
+
+/* Last Message timestamp */
+"LastSeen" = "LastSeen";
+
+/* Learn More Action */
+"Learn more" = "Learn more";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Leave a Review";
+
+/* Theme: Light */
+"Light" = "Light";
+
+/* Setting for when the passcode lock should enable */
+"Lock Timeout" = "Lock Timeout";
+
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
+"Log In" = "Log In";
+
+/* Log out of the active account in the app */
+"Log Out" = "Log Out";
+
+/* Allows the user to SignIn using their WPCOM Account */
+"Log in with WordPress.com" = "Log in with WordPress.com";
+
+/* Presents the regular Email signin flow */
+"Log in with email" = "Log in with email";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "MMM d, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown toggle";
+
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Μενού";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Επιλογές σημείωσης";
+/* Sort Mode: Modified Date, descending */
+"Modified: Newest" = "Modified: Newest";
+
+/* Sort Mode: Creation Date, ascending */
+"Modified: Oldest" = "Modified: Oldest";
+
+/* Label to create a new note */
+"New note" = "New note";
+
+/* Empty Note Placeholder */
+"New note..." = "New note...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "No";
+
+/* Title for alert when user tires to send feedback without an email address */
+"No Email." = "No Email.";
+
+/* Text that appears in an alert to the user when there is no internet */
+"No Internet" = "No Internet";
+
+/* Title for message when user tries to send feedback without any text */
+"No Message." = "No Message.";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Καμία σημείωση";
@@ -84,35 +326,83 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Δεν βρέθηκε";
 
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "No Thanks";
+
+/* No comment provided by engineer. */
+"Note not published" = "Note not published";
+
 /* Plural form of notes */
 "Notes" = "Σημειώσεις";
 
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Κλείσιμο";
+/* Dismisses an AlertController */
+"OK" = "OK";
 
 /* Instant passcode lock timeout */
 "Off" = "Απενεργοποίηση";
 
-   Verb: Close current view */
-"OK" = "OK";
-
 /* No comment provided by engineer. */
 "On" = "Ενεργό";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "Open \"(preview)\"";
+
+/* Siri Suggestion to open our app */
+"Open Simplenote" = "Open Simplenote";
 
 /* Select a note to view in the note editor */
 "Open note" = "Άνοιγμα σημείωσης";
 
+/* AlertController's Payload for the broken Sort Options Fix */
+"Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Our update may have changed the order in which your notes appear. Would you like to review sort settings?";
+
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "Συνθηματικό";
 
-"Pin note" = "Επισ/νση";
+/* Password TextField Placeholder */
+"Password" = "Κωδικός";
 
-"Pin to Top" = "Επισ/νση";
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Password must contain at least 4 characters";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Ο κωδικός πρέπει να περιέχει τουλάχιστον 6 χαρακτήρες.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Pendings";
+
+/* Pin (verb) - the action of Pinning a note */
+"Pin" = "Pin";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Επισ\/νση";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "Επισ\/νση";
 
 /* Switch which marks a note as pinned or unpinned */
 "Pin toggle" = "Επισήμανση";
 
-"Pinned" = "Επ/θηκε";
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Επ\/θηκε";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Please activate your WordPress.com account via email and try again.";
+
+/* Message for alert that user has entered an invalid email address */
+"Please check your email address, it appears to be invalid." = "Please check your email address, it appears to be invalid.";
+
+/* Message for alert when user tires to send feedback without any text */
+"Please enter a message." = "Please enter a message.";
+
+/* Title of Markdown preview screen */
+"Preview" = "Preview";
+
+/* Simplenote privacy policy */
+"Privacy Policy" = "Privacy Policy";
+
+/* Privacy Settings */
+"Privacy Settings" = "Privacy Settings";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Αποστολή";
@@ -129,6 +419,9 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Δημοσίευση...";
 
+/* Reachs Internet */
+"Reachability" = "Reachability";
+
 /* No comment provided by engineer. */
 "Remove all notes from trash" = "Διαγραφή όλων των σημειώσεων";
 
@@ -141,23 +434,96 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Ανάκτηση σημείωσης";
 
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Search";
+
+/* No comment provided by engineer. */
+"Security" = "Security";
+
+/* Verb - send the content of the note by email, message, etc */
 "Send" = "Αποστολή";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Send Feedback";
+
+/* For debugging use */
+"Send a Test Crash" = "Send a Test Crash";
+
+/* Label that is shown when feedback from the user is sending */
+"Sending..." = "Sending...";
 
 /* Title of options screen */
 "Settings" = "Ρυθμίσεις";
 
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Κοινοποίηση σημείωσης";
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Share";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Share Analytics";
+
+/* No comment provided by engineer. */
+"Share note" = "Share note";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Sharing notes is now accessed through the action menu from the toolbar.";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Στήλη";
 
-/* Label on button to add a new tag to a note */
-"tag-add-accessibility-hint" = "Προσθήκη ετικέτας";
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Εγγραφή";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App.";
+
+/* Our mighty brand! */
+"Simplenote" = "Simplenote";
+
+/* Authentication Error Alert Title */
+"Sorry!" = "Sorry!";
+
+/* Option to sort tags alphabetically. The default is by manual ordering. */
+"Sort Alphabetically" = "Sort Alphabetically";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Sort Order";
+
+/* Theme: Matches iOS Settings */
+"System Default" = "System Default";
 
 /* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Διαγραφή ετικέτας";
+"Tags" = "Tags";
+
+/* No comment provided by engineer. */
+"Take Photo" = "Take Photo";
+
+/* Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue */
+"Terms and Conditions" = "Terms and Conditions";
+
+/* Simplenote terms of service */
+"Terms of Service" = "Terms of Service";
+
+/* No comment provided by engineer. */
+"Thanks" = "Thanks";
+
+/* Error when address is in use */
+"The email you've entered is already associated with a Simplenote account." = "The email you've entered is already associated with a Simplenote account.";
+
+/* Onboarding Header Text */
+"The simplest way to keep notes." = "The simplest way to keep notes.";
+
+/* Option to enable the dark app theme. */
+"Theme" = "Theme";
+
+/* Simplenote Themes */
+"Themes" = "Themes";
+
+/* No comment provided by engineer. */
+"There was an error sending your feedback, please try again." = "There was an error sending your feedback, please try again.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Σήμερα";
@@ -165,16 +531,19 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Εμφάνιση στήλης";
 
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Διαγραφή σημείωσης";
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
 
 /* Title: Trash Tag is selected */
-"Trash-noun" = "Διαγεγραμμένα";
+"Trash" = "Διαγεγραμμένα";
 
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Trash-verb" = "Διαγραφή";
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Διαγραφή";
 
-   Verb, cancel an alert dialog */
+/* Unpin (verb) - the action of Unpinning a note */
+"Unpin" = "Unpin";
+
+/* Action to mark a note as unpinned */
 "Unpin note" = "Ακύρωση";
 
 /* Action which unpublishes a note */
@@ -183,53 +552,112 @@
 /* Message shown when a note is in the processes of being unpublished */
 "Unpublishing..." = "Ακύρωση δημοσίευσης...";
 
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Unsynced Notes Detected";
+
+/* Title: Untagged Notes are onscreen */
+"Untagged" = "Untagged";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Untagged Notes";
+
+/* No comment provided by engineer. */
+"Use Latest Photo" = "Use Latest Photo";
+
+/* A user's Simplenote account */
+"Username" = "Username";
+
 /* Represents a snapshot in time for a note */
 "Version" = "Έκδοση";
 
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Συνδεθείτε στο internet για πρόσβαση στο ιστορικό";
+/* App version number */
+"Version %@" = "Version %@";
 
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Χρήση αυτής της έκδοσης";
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Visit Web App";
 
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Ανάγνωση έκδοσης";
+/* No comment provided by engineer. */
+"We can't access your photos, please ensure this application has access in Settings." = "We can't access your photos, please ensure this application has access in Settings.";
+
+/* No comment provided by engineer. */
+"We couldn't upload the photo, please try again." = "We couldn't upload the photo, please try again.";
+
+/* No comment provided by engineer. */
+"We have received your feedback and will be in contact soon." = "We have received your feedback and will be in contact soon.";
+
+/* Generic error */
+"We're having problems. Please try again soon." = "We're having problems. Please try again soon.";
+
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "What do you think about Simplenote?";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about WordPress?" = "What do you think about WordPress?";
+
+/* Work at Automattic */
+"Work With Us" = "Work With Us";
+
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Yes";
 
 /* Displayed as a date in the case where a note was modified yesterday, for example */
 "Yesterday" = "Εχθές";
 
-"welcomeNote-iOS" = "Καλώς ήρθατε στο Simplenote!
-
-Για νέα σημείωση πατήστε στο κουμπί συν.
-
-Πατήστε στον τίτλο της σημείωσης για άνοιγμα. Πατήστε στο περιεχόμενο για αλλαγές.
-
-Βρείτε σημειώσεις χρησιμοποιώντας το πεδίο αναζήτησης στο πάνω μέρος της οθόνης.
-
-Πατήστε στο κουμπί με το βέλος πάνω αριστερά ή σαρώστε προς τα δεξιά για να δείτε όλες τις ετικέτες. Προσθέστε ετικέτες σε κάθε σημειώση χρησιμοποιώντας το πεδίο Ετικέτες στο τέλος κάθε σημείωσης.
-
-Πατήστε στο κουμπί i για περισσότερες επιλογές. Προσθέστε συνεργάτες ή δημοσιεύστε την σημείωση ως ιστοσελίδα.
-
-Χρησιμοποιήστε το Simplenote σε Mac και Android ή στο http://simplenote.com. Όλες οι σημειώσεις συγχρονίζονται αυτόματα παντού.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Δεν ήταν δυνατή η δημιουργία λογαριασμού με αυτό το email και κωδικό.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Δεν ήταν δυνατή η σύνδεση με αυτό το email και κωδικό.";
-
-/* Password TextField Placeholder */
-"Password" = "Κωδικός";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Ο κωδικός πρέπει να περιέχει τουλάχιστον 6 χαρακτήρες.";
-
-   SignUp Interface Title */
-"Sign Up" = "Εγγραφή";
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Your Email:";
 
 /* Message displayed when email address is invalid */
 "Your email address is not valid" = "Μη έγκυρη διεύθυνση email.";
 
+/* Message for prompt when user tries to close feedback view after having entered text */
+"Your message will be lost." = "Your message will be lost.";
 
-"Touch ID" = "Touch ID";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "attach a file";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Ενεργοποίηση συνεργατών";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Εισάγετε το email του συνεργάτη σας ώστε να ενεργοποιηθεί η δυνατότητα συνεργασίας και ταυτόχρονων αλλαγών στην σημείωση.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Η σημείωση αυτή έχει διαγραφεί σε κάποια άλλη συσκευή";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Ανάκτηση σημείωσης στην προηγούμενη έκδοση";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Επιλογές σημείωσης";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Κλείσιμο";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Κοινοποίηση σημείωσης";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Προσθήκη ετικέτας";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Διαγραφή ετικέτας";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Διαγραφή σημείωσης";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Συνδεθείτε στο internet για πρόσβαση στο ιστορικό";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Χρήση αυτής της έκδοσης";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Ανάγνωση έκδοσης";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Καλώς ήρθατε στο Simplenote!\n\nΓια νέα σημείωση πατήστε στο κουμπί συν.\n\nΠατήστε στον τίτλο της σημείωσης για άνοιγμα. Πατήστε στο περιεχόμενο για αλλαγές.\n\nΒρείτε σημειώσεις χρησιμοποιώντας το πεδίο αναζήτησης στο πάνω μέρος της οθόνης.\n\nΠατήστε στο κουμπί με το βέλος πάνω αριστερά ή σαρώστε προς τα δεξιά για να δείτε όλες τις ετικέτες. Προσθέστε ετικέτες σε κάθε σημειώση χρησιμοποιώντας το πεδίο Ετικέτες στο τέλος κάθε σημείωσης.\n\nΠατήστε στο κουμπί i για περισσότερες επιλογές. Προσθέστε συνεργάτες ή δημοσιεύστε την σημείωση ως ιστοσελίδα.\n\nΧρησιμοποιήστε το Simplenote σε Mac και Android ή στο http:\/\/simplenote.com. Όλες οι σημειώσεις συγχρονίζονται αυτόματα παντού.";
 

--- a/Simplenote/es.lproj/Localizable.strings
+++ b/Simplenote/es.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: es */
 
-/* Number of found search results */
-"%d Result" = "%d Resultados";
+/* Number of Characters in a note */
+"%@ Character" = "%@ carácter";
 
-/* Number of found search results */
-"%d Results" = "%d Palabra";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ caracteres";
 
 /* Number of words in a note */
 "%@ Word" = "%@ Palabras";
@@ -15,417 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ Palabras";
 
-   Label of accept button on alert dialog */
-"Accept" = "Aceptar";
-
-/* No comment provided by engineer. */
-"Account" = "Cuenta";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Agregar Nuevo Colaborador";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Agregar Etiqueta";
-
-/* Title: No filters applied */
-"All Notes" = "Todas las notas";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "Cancelar";
-
-/* Verb - work with others on a note */
-"Collaborate" = "Colaborar";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Permitale a otros colaborar en esta nota";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Colaboradores";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "Agregue una direccion de correo electronico para compartir la nota con alguien. De esa forma ambos podran realizar cambios sobre la misma.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Lista de notas condensada";
-
-/* No comment provided by engineer. */
-"Create a new note" = "Crear Nueva Nota";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Colaboradores Actuales";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "La nota fue eliminada en otro dispositivo.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Ocultar Teclado";
-
-   Verb: Close current view */
-"Done" = "Listo";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "Vacio";
-
-/* Remove all notes from the trash */
-"Empty trash" = "Vaciar Papelera";
-
-/* Noun - the version history of a note */
-"History" = "Historial";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Restaurar una version antigua";
-
-/* Action - view the version history of a note */
-"History..." = "Historial...";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "Menu";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Ver Opciones";
-
-/* Label to create a new note */
-"New note" = "Nueva nota";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "No hay Notas";
-
-/* Message shown when no notes match a search string */
-"No Results" = "No hay resultados";
-
-/* No comment provided by engineer. */
-"Note not published" = "La nota no se ha publicado";
-
-/* Message shown in note list when no notes are in the current view */
-"Notes" = "Notas";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Cerrar la Nota Actual";
-
-/* Instant passcode lock timeout */
-"Off" = "Apagado";
-
-/* Dismisses an AlertController */
-"OK" = "OK";
-
-/* No comment provided by engineer. */
-"On" = "Encendido";
-
-/* Select a note to view in the note editor */
-"Open note" = "Abrir Nota";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Codigo";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Anclar nota";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "Anclar en la parte superior";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "Anclar el cambio";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Anclado";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Publicar";
-
-/* Action which published a note to a web page */
-"Publish note" = "Publicar Nota";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "Interruptor de Publicacion";
-
-/* No comment provided by engineer. */
-"Published" = "Publicado";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Publicando...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Eliminar todas las notas permanentemente";
-
-/* Rename a tag */
-"Rename" = "Renombrar";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Restaurar";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Restaurar Nota";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "Enviar";
-
-/* Title of options screen */
-"Settings" = "Configuracion";
-
-/* No comment provided by engineer. */
-"Share note" = "Compartir nota";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Compartir el contenido de la nota actual";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Barra Lateral";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Agregar una etiqueta a la nota actual";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Remover una etiqueta de la nota actual";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Hoy";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Cambiar barra lateral de etiquetas";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Mover la nota actual a la papelera";
-
-/* Remove all notes from the trash */
-"Trash-noun" = "Papelera";
-
-/* Trash (verb) - the action of deleting a note */
-"Trash-verb" = "Eliminar";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Desanclar nota";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Despublicar Nota";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Despublicando...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Version";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Conectese a Internet para acceder a antiguas revisiones";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Restaurar esta version";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Recuperando version";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Ayer";
-
-"welcomeNote-iOS" = "Bienvenido a Simplenote para iOS!
-
-Para agregar una nota, presione el boton con el signo de suma.
-
-Deslize su dedo sobre la lista para visualizar sus notas. Para ver el contenido de una nota, simplemente presione sobre la misma. Si desea editarla, presione nuevamente en el area del editor.
-
-Usted puede buscar en todas sus notas simplemente tipeando en la barra de busqueda ubicada al extremo superior de la lista de notas.
-
-Para visualizar las etiquetas, presione la flecha en el extremo superior izquierdo, o dirijase hacia el final del contenido de la nota que se encuentre visualizando. Usted puede agregar etiquetas en cualquier nota en el extremo inferior del editor, y luego utilizar la barra lateral para un rapido acceso.
-
-Si usted asi lo necesitara, tambien es posible agregar colaboradores para edicion en simultaneo, o publicar una nota como una pagina web.
-
-Utilice Simplenote en su Mac, dispositivo Android, o en su navegador web en http://simplenote.com. Sus notas se mantendran actualizadas automaticamente, en todos lados.
-
-";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "No se ha podido crear una cuenta con el correo y contraseña ingresados.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "No se ha podido iniciar sesion con el correo y contraseña ingresados.";
-
-/* Password TextField Placeholder */
-"Password" = "Contraseña";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Contraseña requiere tener al menos 6 caracteres.";
-
-   SignUp Interface Title */
-"Sign Up" = "Crear Cuenta";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Su dirección de correo electrónico no es valida.";
-
-/* User Authenticated */
-"Authenticated" = "Autenticado";
-
-
-"Debug" = "Debug";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "En cola";
-
-/* Last Message timestamp */
-"LastSeen" = "Vistos recientemente";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "Pendientes";
-
-/* Reachs Internet */
-"Reachability" = "Cobertura";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Seguridad";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "¿Qué opinas de Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Me gusta";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Podría ser mejor";
-
-"Great! Could you leave us a nice review?
-It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?\n\nRealmente ayuda.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Escribir una reseña";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "No, gracias";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "¿Por qué no nos dices cómo podríamos mejorar?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Enviar comentario";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Contacto";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "Tu email:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "¿Cómo podemos ayudarte?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "No se ha podido iniciar sesión.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "¿Seguro que quieres vaciar la papelera? Esta acción no se puede deshacer.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Volver";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "Se ha movido la colaboración";
-
-/* Sign in error message */
-"Couldn't Sign In" = "No se ha podido iniciar sesión";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Eliminar";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Eliminar notas";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Desactivar el formato de Markdown";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "Editar";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Activar el formato de Markdown";
-
-
-"Face ID" = "Face ID";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Interruptor de Markdown";
-
-   Cancels Empty Trash Action */
-"No" = "No.";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Activa tu cuenta de WordPress.com por correo electrónico e inténtalo de nuevo.";
-
-/* Title of Markdown preview screen */
-"Preview" = "Vista previa";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Buscar";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Puedes acceder al uso compartido de notas mediante el menú de acciones que hay en la barra de herramientas.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Si cierras sesión, se eliminarán las notas no sincronizadas. Inicia sesión en la aplicación web para verificar tus notas sincronizadas.";
-
-/* No comment provided by engineer. */
-"Tags" = "Etiquetas";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Se han detectado notas sin sincronizar";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Visitar aplicación web";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "Sí";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Etiqueta...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Compartir";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Notas sin etiquetar";
-
-   Sort Order for the Notes List */
-"Sort Order" = "Criterio de ordenación";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Compartir análisis";
-
-
-"Email" = "Email";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Tema";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
-
-
-"Error" = "Error";
-
-/* No comment provided by engineer. */
-"Appearance" = "Apariencia";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ carácter";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ caracteres";
+/* Number of found search results */
+"%d Result" = "%d Resultados";
+
+/* Number of found search results */
+"%d Results" = "%d Palabra";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 minuto";
@@ -451,11 +45,36 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Display app about screen */
 "About" = "Acerca de";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Aceptar";
+
+/* No comment provided by engineer. */
+"Account" = "Cuenta";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Agregar Nuevo Colaborador";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Etiqueta...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Agregar Etiqueta";
+
+/* Title: No filters applied */
+"All Notes" = "Todas las notas";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "Alfabéticamente: A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "Alfabéticamente: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "No se ha podido iniciar sesión.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Apariencia";
 
 /* Other Simplenote apps */
 "Apps" = "Aplicaciones";
@@ -463,14 +82,23 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "¿Eres desarrollador? Automattic busca personal.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "¿Seguro que quieres vaciar la papelera? Esta acción no se puede deshacer.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "¿Seguro que quieres realizar el envío sin tu correo electrónico? No podremos responderte.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "¿Seguro?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "adjuntar un archivo";
+/* User Authenticated */
+"Authenticated" = "Autenticado";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Volver";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "Al crear una cuenta, aceptas nuestros";
@@ -478,17 +106,54 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* No comment provided by engineer. */
 "Can't Access." = "No se puede acceder.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "Cancelar";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Elegir foto";
 
 /* No comment provided by engineer. */
 "Close" = "Cerrar";
 
+/* Verb - work with others on a note */
+"Collaborate" = "Colaborar";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Se ha movido la colaboración";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Colaboradores";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Lista de notas condensada";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Contacto";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Contribuir";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Podría ser mejor";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "No se ha podido crear una cuenta con el correo y contraseña ingresados.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "No se ha podido iniciar sesion con el correo y contraseña ingresados.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "¿Por qué no nos dices cómo podríamos mejorar?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "No se ha podido iniciar sesión";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Crear una nota";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Crear Nueva Nota";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Creación: Más nuevo";
@@ -496,8 +161,37 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Creación: Más antiguo";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Colaboradores Actuales";
+
 /* Theme: Dark */
 "Dark" = "Oscuro";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Debug";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Eliminar";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Eliminar notas";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Desactivar el formato de Markdown";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Ocultar Teclado";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Listo";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Editar";
+
+/* Email TextField Placeholder */
+"Email" = "Email";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "Dirección de correo electrónico";
@@ -505,20 +199,59 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Email Taken Alert Title */
 "Email in use" = "Correo electrónico en uso";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Vacio";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Vaciar Papelera";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Activar el formato de Markdown";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "En cola";
+
+/* No comment provided by engineer. */
+"Error" = "Error";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Error durante la carga.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "¿Olvidaste tu contraseña?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?\\n\\nRealmente ayuda.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Ayúdanos a mejorar Simplenote compartiendo los datos de uso con nuestra herramienta de análisis.";
+
+/* Noun - the version history of a note */
+"History" = "Historial";
+
+/* Action - view the version history of a note */
+"History..." = "Historial...";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "¿Cómo podemos ayudarte?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Me gusta";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Dirección de correo electrónico no válida.";
 
+/* Last Message timestamp */
+"LastSeen" = "Vistos recientemente";
+
 /* Learn More Action */
 "Learn more" = "Saber más";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Escribir una reseña";
 
 /* Theme: Light */
 "Light" = "Claro";
@@ -526,17 +259,41 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Tiempo de espera de bloqueo";
 
+/* Log In Action
+   Login Action
+   LogIn Action
    LogIn Interface Title */
 "Log In" = "Acceder";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "Accede con el correo electrónico";
+/* Log out of the active account in the app */
+"Log Out" = "Salir";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "Accede con WordPress.com";
 
-/* Log out of the active account in the app */
-"Log Out" = "Salir";
+/* Presents the regular Email signin flow */
+"Log in with email" = "Accede con el correo electrónico";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Interruptor de Markdown";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Menu";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Modificado: Más nuevo";
@@ -544,8 +301,15 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Modificado: Más antiguo";
 
+/* Label to create a new note */
+"New note" = "Nueva nota";
+
 /* Empty Note Placeholder */
 "New note..." = "Nueva nota...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "No.";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "Sin correo electrónico.";
@@ -556,16 +320,74 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Sin mensaje.";
 
-"Open "(preview)"" = "Abrir "(vista previa)"";
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "No hay Notas";
+
+/* Message shown when no notes match a search string */
+"No Results" = "No hay resultados";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "No, gracias";
+
+/* No comment provided by engineer. */
+"Note not published" = "La nota no se ha publicado";
+
+/* Plural form of notes */
+"Notes" = "Notas";
+
+/* Dismisses an AlertController */
+"OK" = "OK";
+
+/* Instant passcode lock timeout */
+"Off" = "Apagado";
+
+/* No comment provided by engineer. */
+"On" = "Encendido";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "Abrir \"(vista previa)\"";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Abrir Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "Abrir Nota";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Puede que nuestra actualización haya cambiado el orden en que aparecen tus notas. ¿Quieres revisar los ajustes de ordenación?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Codigo";
+
+/* Password TextField Placeholder */
+"Password" = "Contraseña";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "La contraseña debe contener al menos 4 caracteres";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Contraseña requiere tener al menos 6 caracteres.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Pendientes";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Anclar";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Anclar nota";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "Anclar en la parte superior";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "Anclar el cambio";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Anclado";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Activa tu cuenta de WordPress.com por correo electrónico e inténtalo de nuevo.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "Comprueba tu dirección de correo electrónico. Parece que no es válida.";
@@ -573,11 +395,57 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Escribe un mensaje.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Vista previa";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Política de privacidad";
 
 /* Privacy Settings */
 "Privacy Settings" = "Ajustes de privacidad";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Publicar";
+
+/* Action which published a note to a web page */
+"Publish note" = "Publicar Nota";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Interruptor de Publicacion";
+
+/* No comment provided by engineer. */
+"Published" = "Publicado";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Publicando...";
+
+/* Reachs Internet */
+"Reachability" = "Cobertura";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Eliminar todas las notas permanentemente";
+
+/* Rename a tag */
+"Rename" = "Renombrar";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Restaurar";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Restaurar Nota";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Buscar";
+
+/* No comment provided by engineer. */
+"Security" = "Seguridad";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Enviar";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Enviar comentario";
 
 /* For debugging use */
 "Send a Test Crash" = "Enviar una prueba de fallos";
@@ -585,7 +453,33 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Enviando...";
 
+/* Title of options screen */
+"Settings" = "Configuracion";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Compartir";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Compartir análisis";
+
+/* No comment provided by engineer. */
+"Share note" = "Compartir nota";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Puedes acceder al uso compartido de notas mediante el menú de acciones que hay en la barra de herramientas.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Barra Lateral";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Crear Cuenta";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Si cierras sesión, se eliminarán las notas no sincronizadas. Inicia sesión en la aplicación web para verificar tus notas sincronizadas.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -594,8 +488,15 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Ordenar alfabéticamente";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Criterio de ordenación";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Valores por defecto del sistema";
+
+/* No comment provided by engineer. */
+"Tags" = "Etiquetas";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Hacer foto";
@@ -615,17 +516,50 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "La forma más sencilla de guardar notas.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "Tema";
+
 /* Simplenote Themes */
 "Themes" = "Temas";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "No se ha podido enviar tu comentario. Inténtalo de nuevo.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Hoy";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Cambiar barra lateral de etiquetas";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Papelera";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Eliminar";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Desanclar";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "Desanclar nota";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Despublicar Nota";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Despublicando...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Se han detectado notas sin sincronizar";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Sin etiquetar";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Notas sin etiquetar";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "Usar la foto más reciente";
@@ -633,8 +567,14 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* A user's Simplenote account */
 "Username" = "Usuario";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Version";
+
 /* App version number */
 "Version %@" = "Versión %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Visitar aplicación web";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "No podemos acceder a tus fotos. Asegúrate de que esta aplicación tenga acceso en los ajustes.";
@@ -648,15 +588,76 @@ It really helps." = "¡Fantástico! ¿Podrías escribirnos una reseña positiva?
 /* Generic error */
 "We're having problems. Please try again soon." = "Estamos teniendo algunos problemas. Inténtalo de nuevo pronto.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "¿Qué opinas de Simplenote?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "¿Qué opinas de WordPress?";
 
 /* Work at Automattic */
 "Work With Us" = "Trabaja con nosotros";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Sí";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Ayer";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Tu email:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Su dirección de correo electrónico no es valida.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Se perderá tu mensaje.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "La contraseña debe contener al menos 4 caracteres";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "adjuntar un archivo";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Permitale a otros colaborar en esta nota";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Agregue una direccion de correo electronico para compartir la nota con alguien. De esa forma ambos podran realizar cambios sobre la misma.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "La nota fue eliminada en otro dispositivo.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Restaurar una version antigua";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Ver Opciones";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Cerrar la Nota Actual";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Compartir el contenido de la nota actual";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Agregar una etiqueta a la nota actual";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Remover una etiqueta de la nota actual";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Mover la nota actual a la papelera";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Conectese a Internet para acceder a antiguas revisiones";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Restaurar esta version";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Recuperando version";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Bienvenido a Simplenote para iOS!\n\nPara agregar una nota, presione el boton con el signo de suma.\n\nDeslize su dedo sobre la lista para visualizar sus notas. Para ver el contenido de una nota, simplemente presione sobre la misma. Si desea editarla, presione nuevamente en el area del editor.\n\nUsted puede buscar en todas sus notas simplemente tipeando en la barra de busqueda ubicada al extremo superior de la lista de notas.\n\nPara visualizar las etiquetas, presione la flecha en el extremo superior izquierdo, o dirijase hacia el final del contenido de la nota que se encuentre visualizando. Usted puede agregar etiquetas en cualquier nota en el extremo inferior del editor, y luego utilizar la barra lateral para un rapido acceso.\n\nSi usted asi lo necesitara, tambien es posible agregar colaboradores para edicion en simultaneo, o publicar una nota como una pagina web.\n\nUtilice Simplenote en su Mac, dispositivo Android, o en su navegador web en http:\/\/simplenote.com. Sus notas se mantendran actualizadas automaticamente, en todos lados.\n\n";
 

--- a/Simplenote/fr.lproj/Localizable.strings
+++ b/Simplenote/fr.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: fr */
 
-/* Number of found search results */
-"%d Result" = "%d résultats";
+/* Number of Characters in a note */
+"%@ Character" = "%@ caractère";
 
-/* Number of found search results */
-"%d Results" = "%d résultats";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ caractères";
 
 /* Number of words in a note */
 "%@ Word" = "%@ mot";
@@ -15,417 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ mots";
 
-   Label of accept button on alert dialog */
-"Accept" = "Accepter";
-
-/* No comment provided by engineer. */
-"Account" = "Compte";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Ajouter un nouveau collaborateur...";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Ajouter un tag";
-
-/* Title: No filters applied */
-"All Notes" = "Toutes les notes";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "Annuler";
-
-/* Verb - work with others on a note */
-"Collaborate" = "Collaborer";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Permettre aux autres de collaborer";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Collaborateurs";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "Ajouter une adresse e-mail pour partager cette note avec quelqu'un. Vous pourrez ensuite  la modifier tous les deux.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Liste de notes condensée";
-
-/* No comment provided by engineer. */
-"Create a new note" = "Créer une nouvelle note";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Collaborateurs actuels";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Cette note à été supprimée sur un autre appareil.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Cacher le clavier";
-
-   Verb: Close current view */
-"Done" = "Terminé";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "Vider";
-
-/* Remove all notes from the trash */
-"Empty trash" = "Vider la corbeille";
-
-/* Noun - the version history of a note */
-"History" = "Historique";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Restaurer une version précédente de la note";
-
-/* Action - view the version history of a note */
-"History..." = "Historique...";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "Menu";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Affiche toutes les options de la note";
-
-/* Label to create a new note */
-"New note" = "Nouvelle note";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "Pas de note";
-
-/* Message shown when no notes match a search string */
-"No Results" = "Aucun résultat";
-
-/* No comment provided by engineer. */
-"Note not published" = "Note non publiée";
-
-/* Title: No filters applied */
-"Notes" = "Notes";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Fermer cette note";
-
-/* Instant passcode lock timeout */
-"Off" = "Désactivé";
-
-/* Dismisses an AlertController */
-"OK" = "OK";
-
-/* No comment provided by engineer. */
-"On" = "Activé";
-
-/* Select a note to view in the note editor */
-"Open note" = "Ouvrir une note";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Code PIN";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Épingler la note";
-
-/* Pin (verb) - the action of Pinning a note */
-"Pin to Top" = "Épingler";
-
-"Pin toggle" = "Épingler/Désépingler";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Épinglé";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Publier";
-
-/* Action which published a note to a web page */
-"Publish note" = "Publier la note";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish toggle" = "Publier";
-
-/* No comment provided by engineer. */
-"Published" = "Publié";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Publication...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Retirer les notes de la corbeille";
-
-/* Rename a tag */
-"Rename" = "Renommer";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Restaurer";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Restaurer la note";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "Envoyer";
-
-/* Title of options screen */
-"Settings" = "Paramètres";
-
-/* No comment provided by engineer. */
-"Share note" = "Partager la note";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Partager le contenu de cette note";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Barre latérale";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Ajouter un tag à cette note";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Retirer un tag de cette note";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Aujourd'hui";
-
-"Toggle tag sidebar" = "Activer/désactiver la barre de tag";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Déplacer cette note dans la corbeille";
-
-/* Title: Trash Tag is selected */
-"Trash-noun" = "Corbeille";
-
-/* Trash (verb) - the action of deleting a note */
-"Trash-verb" = "Supprimer";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Désépingler la note";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Dépublier la note";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Dépublication...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Version";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Connectez-vous pour accéder aux versions précédentes";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Passer à cette version";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Récupération de version";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Hier";
-
-"welcomeNote-iOS" = "Bienvenue sur la version iOS de Simplenote !
-
-Pour créer une nouvelle note, touchez le bouton plus.
-
-Naviguez dans la liste de notes. Touchez un titre pour voir la totalité de la note et touchez ensuite le contenu de la note pour effectuer des changements.
-
-Cherchez parmi vos notes en touchant le champ de recherche en haut de la liste de notes.
-
-Touchez la flèche en haut ou faites glisser votre liste de notes pour voir vos tags. Vous pouvez ajouter des tags à une note en bas de l'éditeur, et ensuite utiliser le menu pour rester organisé.
-
-Vous avez une note vraiment importante ? Touchez le bouton favoris pendant la lecture d'une note pour la garder en tête de liste.
-
-D'autres options de notes existent si vous en avez besoin. Vous pouvez ajouter d'autres collaborateurs à une note, ou même publier une note comme une page web.
-
-Vous pouvez accéder à toutes vos notes sur le web ou sur vos autres appareils. Rendez-vous sur http://simplenote.com pour démarrer. Vos notes resteront à jour partout automatiquement.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Impossible de créer un compte avec l'e-mail et le mot de passe fourni.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Impossible de se connecter avec l'e-mail et le mot de passe fourni.";
-
-/* Password Reset Action */
-"Password" = "Mot de passe";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Le mot de passe doit contenir au moins 6 caractères.";
-
-   SignUp Interface Title */
-"Sign Up" = "S'inscrire";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Votre adresse e-mail n'est pas valide.";
-
-/* User Authenticated */
-"Authenticated" = "Authentifié";
-
-   Display internal debug status */
-"Debug" = "Débogage";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "En file d'attente";
-
-/* Last Message timestamp */
-"LastSeen" = "Dernière consultation";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM yyyy";
-
-/* Month, day, and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "En attente";
-
-/* Reachs Internet */
-"Reachability" = "Accessibilité";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Sécurité";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Que pensez-vous de Simplenote ?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "J’aime";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Pourrait être améliorée";
-
-"Great! Could you leave us a nice review?
-It really helps." = "Super ! Pouvez-vous nous laisser un commentaire ?
-
-Cela nous aide vraiment.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Laisser un avis";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Non merci";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Pouvez-vous nous signaler des pistes d’amélioration ?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Envoyez votre avis";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Contact";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "Votre e-mail :";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Comment pouvons-nous vous aider ?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "Une erreur est survenue lors de la connexion.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "Voulez-vous vraiment vider la corbeille ? Cette opération ne pourra pas être annulée.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Retour";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "Collaboration déplacée";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "Connexion impossible";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Supprimer";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Supprimer les notes";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Désactiver le formatage Markdown";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "Modifier";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Activer la mise en forme en Markdown";
-
-
-"Face ID" = "Face ID";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Activation du Markdown";
-
-   Cancels Empty Trash Action */
-"No" = "Non";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Merci d’activer votre compte WordPress.com par e-mail avant de réessayer. ";
-
-/* Title of Markdown preview screen */
-"Preview" = "Aperçu";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Recherche";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Le partage des notes peut désormais être accédé depuis le menu d’actions de la barre d’outils.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "La déconnexion entraînera la suppression de l’ensemble des notes non synchronisées. Vous pouvez vérifier vos notes synchronisées en vous connectant à l’application Web. ";
-
-/* No comment provided by engineer. */
-"Tags" = "Étiquettes";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Notes non-synchronisées détectées";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Visiter l'application Web";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "Oui";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Étiquette...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Partager";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Notes non étiquetées";
-
-/* Option to sort tags alphabetically. The default is by manual ordering. */
-"Sort Order" = "Trier par";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Partager des analyses";
-
-
-"Email" = "Email";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Thème";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
-
-/* No comment provided by engineer. */
-"Error" = "Erreur";
-
-/* No comment provided by engineer. */
-"Appearance" = "Apparence";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ caractère";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ caractères";
+/* Number of found search results */
+"%d Result" = "%d résultats";
+
+/* Number of found search results */
+"%d Results" = "%d résultats";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 minute";
@@ -451,11 +45,36 @@ Cela nous aide vraiment.";
 /* Display app about screen */
 "About" = "À propos";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Accepter";
+
+/* No comment provided by engineer. */
+"Account" = "Compte";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Ajouter un nouveau collaborateur...";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Étiquette...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Ajouter un tag";
+
+/* Title: No filters applied */
+"All Notes" = "Toutes les notes";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "Par ordre alphabétique : A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "Par ordre alphabétique : Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "Une erreur est survenue lors de la connexion.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Apparence";
 
 /* Other Simplenote apps */
 "Apps" = "Applications";
@@ -463,14 +82,23 @@ Cela nous aide vraiment.";
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "Vous êtes développeur ? Automattic embauche.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Voulez-vous vraiment vider la corbeille ? Cette opération ne pourra pas être annulée.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "Voulez-vous vraiment valider l'envoi sans votre e-mail ? Nous ne pourrons pas vous répondre.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "Êtes-vous sûr ?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "joindre un fichier";
+/* User Authenticated */
+"Authenticated" = "Authentifié";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Retour";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "En créant un compte, vous acceptez nos";
@@ -478,17 +106,54 @@ Cela nous aide vraiment.";
 /* No comment provided by engineer. */
 "Can't Access." = "Accès impossible.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "Annuler";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Choisir une photo";
 
 /* No comment provided by engineer. */
 "Close" = "Fermer";
 
+/* Verb - work with others on a note */
+"Collaborate" = "Collaborer";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Collaboration déplacée";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Collaborateurs";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Liste de notes condensée";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Contact";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Contribuer";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Pourrait être améliorée";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Impossible de créer un compte avec l'e-mail et le mot de passe fourni.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Impossible de se connecter avec l'e-mail et le mot de passe fourni.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Pouvez-vous nous signaler des pistes d’amélioration ?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Connexion impossible";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Créer une note";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Créer une nouvelle note";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Création : Plus récentes";
@@ -496,8 +161,37 @@ Cela nous aide vraiment.";
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Création : Plus anciennes";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Collaborateurs actuels";
+
 /* Theme: Dark */
 "Dark" = "Sombre";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Débogage";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Supprimer";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Supprimer les notes";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Désactiver le formatage Markdown";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Cacher le clavier";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Terminé";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Modifier";
+
+/* Email TextField Placeholder */
+"Email" = "Email";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "Adresse e-mail";
@@ -505,20 +199,59 @@ Cela nous aide vraiment.";
 /* Email Taken Alert Title */
 "Email in use" = "Adresse e-mail utilisée";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Vider";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Vider la corbeille";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Activer la mise en forme en Markdown";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "En file d'attente";
+
+/* No comment provided by engineer. */
+"Error" = "Erreur";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Erreur lors du chargement.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "Mot de passe oublié ?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Super ! Pouvez-vous nous laisser un commentaire ?\n\nCela nous aide vraiment.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Aidez-nous à améliorer Simplenote en partageant les données d'utilisation avec notre outil d'analyse.";
+
+/* Noun - the version history of a note */
+"History" = "Historique";
+
+/* Action - view the version history of a note */
+"History..." = "Historique...";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Comment pouvons-nous vous aider ?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "J’aime";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Adresse e-mail non valide.";
 
+/* Last Message timestamp */
+"LastSeen" = "Dernière consultation";
+
 /* Learn More Action */
 "Learn more" = "En apprendre plus";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Laisser un avis";
 
 /* Theme: Light */
 "Light" = "Clair";
@@ -526,17 +259,41 @@ Cela nous aide vraiment.";
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Expiration du verrouillage";
 
-/* Alert dialog title displayed on sign in error */
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
 "Log In" = "Connexion";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "Se connecter avec une adresse e-mail";
+/* Log out of the active account in the app */
+"Log Out" = "Se déconnecter";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "Se connecter avec WordPress.com";
 
-/* Log out of the active account in the app */
-"Log Out" = "Se déconnecter";
+/* Presents the regular Email signin flow */
+"Log in with email" = "Se connecter avec une adresse e-mail";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Activation du Markdown";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Menu";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Modification : Plus récentes";
@@ -544,8 +301,15 @@ Cela nous aide vraiment.";
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Modification : Plus anciennes";
 
+/* Label to create a new note */
+"New note" = "Nouvelle note";
+
 /* Empty Note Placeholder */
 "New note..." = "Nouvelle note...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "Non";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "Pas d'e-mail.";
@@ -556,17 +320,74 @@ Cela nous aide vraiment.";
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Aucun message.";
 
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "Pas de note";
+
+/* Message shown when no notes match a search string */
+"No Results" = "Aucun résultat";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Non merci";
+
+/* No comment provided by engineer. */
+"Note not published" = "Note non publiée";
+
+/* Plural form of notes */
+"Notes" = "Notes";
+
+/* Dismisses an AlertController */
+"OK" = "OK";
+
+/* Instant passcode lock timeout */
+"Off" = "Désactivé";
+
+/* No comment provided by engineer. */
+"On" = "Activé";
+
 /* Siri Suggestion to open a specific Note */
-"Open "(preview)"" = "Ouvrir « (aperçu) »";
+"Open \"(preview)\"" = "Ouvrir « (aperçu) »";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Ouvrir Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "Ouvrir une note";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Il se peut que notre mise à jour ait modifié l'ordre d'affichage de vos notes. Voulez-vous vérifier les paramètres de tri ?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Code PIN";
+
+/* Password TextField Placeholder */
+"Password" = "Mot de passe";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Le mot de passe doit contenir au moins 4 caractères.";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Le mot de passe doit contenir au moins 6 caractères.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "En attente";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Épingler";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Épingler la note";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "Épingler";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "Épingler\/Désépingler";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Épinglé";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Merci d’activer votre compte WordPress.com par e-mail avant de réessayer. ";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "Vérifiez votre adresse e-mail, il semble qu'elle ne soit pas valide.";
@@ -574,11 +395,57 @@ Cela nous aide vraiment.";
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Entrez un message.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Aperçu";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Politique de confidentialité";
 
 /* Privacy Settings */
 "Privacy Settings" = "Réglages de confidentialité";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Publier";
+
+/* Action which published a note to a web page */
+"Publish note" = "Publier la note";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Publier";
+
+/* No comment provided by engineer. */
+"Published" = "Publié";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Publication...";
+
+/* Reachs Internet */
+"Reachability" = "Accessibilité";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Retirer les notes de la corbeille";
+
+/* Rename a tag */
+"Rename" = "Renommer";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Restaurer";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Restaurer la note";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Recherche";
+
+/* No comment provided by engineer. */
+"Security" = "Sécurité";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Envoyer";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Envoyez votre avis";
 
 /* For debugging use */
 "Send a Test Crash" = "Envoyer un incident de test";
@@ -586,7 +453,33 @@ Cela nous aide vraiment.";
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Envoi en cours...";
 
+/* Title of options screen */
+"Settings" = "Paramètres";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Partager";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Partager des analyses";
+
+/* No comment provided by engineer. */
+"Share note" = "Partager la note";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Le partage des notes peut désormais être accédé depuis le menu d’actions de la barre d’outils.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Barre latérale";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "S'inscrire";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "La déconnexion entraînera la suppression de l’ensemble des notes non synchronisées. Vous pouvez vérifier vos notes synchronisées en vous connectant à l’application Web. ";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -595,8 +488,15 @@ Cela nous aide vraiment.";
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Trier par ordre alphabétique";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Trier par";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Paramètres par défaut du système";
+
+/* No comment provided by engineer. */
+"Tags" = "Étiquettes";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Prendre une photo";
@@ -607,7 +507,7 @@ Cela nous aide vraiment.";
 /* Simplenote terms of service */
 "Terms of Service" = "Conditions d’utilisation";
 
-/* Error message displayed when user has not verified their WordPress.com account */
+/* No comment provided by engineer. */
 "Thanks" = "Merci";
 
 /* Error when address is in use */
@@ -616,17 +516,50 @@ Cela nous aide vraiment.";
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "La manière la plus simple de conserver des notes.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "Thème";
+
 /* Simplenote Themes */
 "Themes" = "Thèmes";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "Une erreur s'est produite lors de l'envoi de votre commentaire, veuillez réessayer.";
 
-/* Switch which marks a note as pinned or unpinned */
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Aujourd'hui";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Activer\/désactiver la barre de tag";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Corbeille";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Supprimer";
+
+/* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Désépingler";
+
+/* Action to mark a note as unpinned */
+"Unpin note" = "Désépingler la note";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Dépublier la note";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Dépublication...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Notes non-synchronisées détectées";
 
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Sans étiquette";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Notes non étiquetées";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "Utiliser la photo la plus récente";
@@ -634,8 +567,14 @@ Cela nous aide vraiment.";
 /* A user's Simplenote account */
 "Username" = "Identifiant";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Version";
+
 /* App version number */
 "Version %@" = "Version %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Visiter l'application Web";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "Nous ne pouvons pas accéder à vos photos, vérifiez que cette application est accessible dans Paramètres.";
@@ -649,15 +588,76 @@ Cela nous aide vraiment.";
 /* Generic error */
 "We're having problems. Please try again soon." = "Nous rencontrons des problèmes. Veuillez réessayer dans quelques instants.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Que pensez-vous de Simplenote ?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "Que pensez-vous de WordPress ?";
 
 /* Work at Automattic */
 "Work With Us" = "Rejoignez-nous";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Oui";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Hier";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Votre e-mail :";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Votre adresse e-mail n'est pas valide.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Votre message sera perdu.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "Le mot de passe doit contenir au moins 4 caractères.";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "joindre un fichier";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Permettre aux autres de collaborer";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Ajouter une adresse e-mail pour partager cette note avec quelqu'un. Vous pourrez ensuite  la modifier tous les deux.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Cette note à été supprimée sur un autre appareil.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Restaurer une version précédente de la note";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Affiche toutes les options de la note";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Fermer cette note";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Partager le contenu de cette note";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Ajouter un tag à cette note";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Retirer un tag de cette note";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Déplacer cette note dans la corbeille";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Connectez-vous pour accéder aux versions précédentes";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Passer à cette version";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Récupération de version";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Bienvenue sur la version iOS de Simplenote !\n\nPour créer une nouvelle note, touchez le bouton plus.\n\nNaviguez dans la liste de notes. Touchez un titre pour voir la totalité de la note et touchez ensuite le contenu de la note pour effectuer des changements.\n\nCherchez parmi vos notes en touchant le champ de recherche en haut de la liste de notes.\n\nTouchez la flèche en haut ou faites glisser votre liste de notes pour voir vos tags. Vous pouvez ajouter des tags à une note en bas de l'éditeur, et ensuite utiliser le menu pour rester organisé.\n\nVous avez une note vraiment importante ? Touchez le bouton favoris pendant la lecture d'une note pour la garder en tête de liste.\n\nD'autres options de notes existent si vous en avez besoin. Vous pouvez ajouter d'autres collaborateurs à une note, ou même publier une note comme une page web.\n\nVous pouvez accéder à toutes vos notes sur le web ou sur vos autres appareils. Rendez-vous sur http:\/\/simplenote.com pour démarrer. Vos notes resteront à jour partout automatiquement.";
 

--- a/Simplenote/he.lproj/Localizable.strings
+++ b/Simplenote/he.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: he_IL */
 
-/* Number of found search results */
-"%d Result" = "תוצאה %d";
+/* Number of Characters in a note */
+"%@ Character" = "תו %@";
 
-/* Number of found search results */
-"%d Results" = "%d תוצאות";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ תווים";
 
 /* Number of words in a note */
 "%@ Word" = "מילה %@";
@@ -15,418 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ מילים";
 
-   Label of accept button on alert dialog */
-"Accept" = "קבלה";
-
-/* No comment provided by engineer. */
-"Account" = "חשבון";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "הוספת שותף עריכה חדש...";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "הוספת תגית";
-
-/* Title: No filters applied */
-"All Notes" = "כל הפתקים";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "ביטול";
-
-/* Verb - work with others on a note */
-"Collaborate" = "שיתוף פעולה בעריכה";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "מאפשר לאחרים לשתף פעולה";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "שותפי עריכה";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "יש להוסיף כתובת אימייל כדי לשתף פתק זה עם מישהו. לאחר מכן תוכלו שניכם לערוך בו שינויים.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "רשימת פתקים מכווצת";
-
-/* No comment provided by engineer. */
-"Create a new note" = "יצירת פתק חדש";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "שותפי עריכה קיימים";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "הפתק נמחק במכשיר אחר.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "ביטול מקלדת";
-
-/* User Authenticated */
-"Done" = "בוצע";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "ריק";
-
-/* Empty Trash Warning */
-"Empty trash" = "לרוקן את הפח";
-
-/* Noun - the version history of a note */
-"History" = "היסטוריה";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "החזרת פתק לגרסה הקודמת";
-
-/* Action - view the version history of a note */
-"History..." = "היסטוריה...";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "תפריט";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "הצגת אפשרויות לפתק";
-
-/* Siri Suggestion to create a New Note */
-"New note" = "פתק חדש";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "אין פתקים";
-
-/* Message shown when no notes match a search string */
-"No Results" = "אין תוצאות";
-
-/* No comment provided by engineer. */
-"Note not published" = "הפתק לא פורסם";
-
-/* Title: No filters applied */
-"Notes" = "פתקים";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "סגירת פתק נוכחי";
-
-/* Instant passcode lock timeout */
-"Off" = "כבוי";
-
-/* Dismisses an AlertController */
-"OK" = "אישור";
-
-/* No comment provided by engineer. */
-"On" = "מופעל";
-
-/* Select a note to view in the note editor */
-"Open note" = "פתיחת פתק";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "קוד סיסמה";
-
-/* Action to mark a note as pinned */
-"Pin note" = "הצמדת פתק";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "הצמדה לראש העמוד";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "החלפת מצב הצמדה";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "הוצמד";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "לפרסם";
-
-/* Action which published a note to a web page */
-"Publish note" = "פרסום פתק";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "החלפת מצב תרגום";
-
-/* No comment provided by engineer. */
-"Published" = "פורסם";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "מפרסם...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "הסרת כל הפתקים מהפח";
-
-/* Rename a tag */
-"Rename" = "שינוי שם";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "שחזור";
-
-/* Restore a note to a previous version */
-"Restore Note" = "שחזור פתק";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "שליחה";
-
-/* AlertController's Payload for the broken Sort Options Fix */
-"Settings" = "הגדרות";
-
-/* No comment provided by engineer. */
-"Share note" = "שיתוף פתק";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "שיתוף תוכן הפתק הנוכחי";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "סרגל צדדי";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "הוספת תגית לפתק הנוכחי";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "הסרת תגית מהפתק הנוכחי";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "היום";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "החלפת מצב סרגל צדדי";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "העבר את הפתק הנוכחי לפח";
-
-/* Title: Trash Tag is selected */
-"Trash-noun" = "העברה לפח";
-
-/* Title: Trash Tag is selected */
-"Trash-verb" = "העברה לפח";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "ביטול הצמדת פתק";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "ביטול פרסום פתק";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "ביטול פרסום...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "גרסה";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "התחברות לאינטרנט לצורך גישה לגרסאות קודמות";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "מעבר לגרסה זו";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "הורדת גרסה";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "אתמול";
-
-"welcomeNote-iOS" = "ברוכים הבאים אל Simplenote עבור iOS!
-
-כדי להוסיף פתק, יש להקיש על לחצן הפלוס.
-
-רפרוף ברשימה כדי לעיין בפתקים שלך. יש להקיש על כותרת כדי להציג פתק, ולאחר מכן להקיש על התוכן שלו כדי לשנות אותו.
-
-אפשר לחפש בכל הפתקים באמצעות הקלדה בשדה החיפוש בחלק העליון של רשימת הפתקים.
-
-יש להקיש על לחצן החץ בחלק הימני העליון, או להחליק על רשימת הפתקים כדי להציג את התגיות שלך. אפשר להוסיף תגיות לפתק בתחתית עורך הפתקים, ולאחר מכן להשתמש בסרגל הצדדי כדי לעזור לך לשמור על הסדר.
-
-קיימות אפשרויות נוספות לפתקים במקרה הצורך. אפשר להוסיף אחרים כמשתפי פעולה לפתק, או לפרסם פתק כדף אינטרנט.
-
-ניתן להשתמש ב-Simplenote במחשב Mac, מכשיר Android, או בדפדפן האינטרנט, בכתובת http://simplenote.com. הפתקים שלך יישארו מעודכנים בכל מקום, באופן אוטומטי.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "לא ניתן ליצור חשבון באמצעות כתובת האימייל והסיסמה שסופקו.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "לא ניתן להיכנס באמצעות כתובת האימייל והסיסמה שסופקו.";
-
-/* Error for bad email or password */
-"Password" = "סיסמה";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "הסיסמה חייבת להכיל לפחות ארבעה תווים.";
-
-   SignUp Interface Title */
-"Sign Up" = "הרשמה";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "כתובת האימייל שלך אינה חוקית.";
-
-/* User Authenticated */
-"Authenticated" = "האימות בוצע";
-
-   Display internal debug status */
-"Debug" = "איתור באגים";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "צורף לתור";
-
-/* Last Message timestamp */
-"LastSeen" = "LastSeen";
-
-/* Month and day date formatter */
-"MMM d" = "d ‏MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d ‏MMM, ‏hh:mm";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d ‏MMM, ‏yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM ‏yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "בהמתנה";
-
-/* Reachs Internet */
-"Reachability" = "נגישות";
-
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "מזהה מגע";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "אבטחה";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "מה דעתך על Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "אהבתי את זה";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "יכול להיות יותר טוב";
-
-"Great! Could you leave us a nice review?
-It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
-
-
-זה ממש יעזור.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "השארת חוות דעת";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "לא תודה";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "באפשרותך לומר לנו כיצד נוכל להשתפר?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "שליחת משוב";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "איש קשר";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "כתובת האימייל שלך:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "כיצד נוכל לעזור?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "נתקלנו בשגיאה בתהליך ההתחברות.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "האם ברצונך לרוקן את הפח? לא ניתן לבטל את הפעולה.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "חזרה";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "שיתוף הפעולה עבר למקום אחר";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "לא הייתה אפשרות להתחבר";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "מחיקה";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "למחוק את הפתקים";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "להשבית את העיצוב של Markdown";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Edit" = "עריכה";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "להפעיל את העיצוב של Markdown";
-
-/* Offer to enable Face ID support if available and passcode is on. */
-"Face ID" = "זיהוי פנים";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "שינוי Markdown";
-
-/* Empty Trash Warning */
-"No" = "לא";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "יש להפעיל את החשבון שלך ב-WordPress.com באמצעות האימייל ולנסות שוב.";
-
-/* Siri Suggestion to open a specific Note */
-"Preview" = "תצוגה מקדימה";
-
-   Using Search instead of Back if user is searching */
-"Search" = "חיפוש";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "ניתן כעת לגשת לשיתוף הפתקים דרך תפריט הפעולות מסרגל הכלים.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "לאחר ההתנתקות, כל הפתקים שלא סוכרנו יימחקו. אפשר לאמת אילו פתקים סונכרנו באמצעות התחברות לאפליקציית הרשת.";
-
-/* No comment provided by engineer. */
-"Tags" = "תגיות";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "אותרו הערות שלא סונכרנו";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "מעבר לאפליקציית הרשת";
-
-/* Sort Mode: Modified Date, descending */
-"Yes" = "כן";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "תגית...";
-
-/* Verb - work with others on a note */
-"Share" = "שיתוף";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "הסרת התגיות מהערות";
-
-/* Option to sort tags alphabetically. The default is by manual ordering. */
-"Sort Order" = "מיון לפי";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "שיתוף הניתוח";
-
-/* Email TextField Placeholder */
-"Email" = "לשלוח מייל";
-
-/* No comment provided by engineer. */
-"Theme" = "עיצוב";
-
-/* The Simplenote blog */
-"Blog" = "בלוג";
-
-/* Sign in error message */
-"Error" = "שגיאה";
-
-/* No comment provided by engineer. */
-"Appearance" = "מראה";
-
-/* Number of Characters in a note */
-"%@ Character" = "תו %@";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ תווים";
+/* Number of found search results */
+"%d Result" = "תוצאה %d";
+
+/* Number of found search results */
+"%d Results" = "%d תוצאות";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "דקה אחת";
@@ -452,11 +45,36 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Display app about screen */
 "About" = "אודות";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "קבלה";
+
+/* No comment provided by engineer. */
+"Account" = "חשבון";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "הוספת שותף עריכה חדש...";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "תגית...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "הוספת תגית";
+
+/* Title: No filters applied */
+"All Notes" = "כל הפתקים";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "סדר אלפביתי: A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "סדר אלפביתי: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "נתקלנו בשגיאה בתהליך ההתחברות.";
+
+/* No comment provided by engineer. */
+"Appearance" = "מראה";
 
 /* Other Simplenote apps */
 "Apps" = "אפליקציות";
@@ -464,20 +82,33 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "האם יש לך ניסיון בפיתוח? חברת Automattic מחפשת עובדים.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "האם ברצונך לרוקן את הפח? לא ניתן לבטל את הפעולה.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "ביקשת לשלוח ללא כתובת אימייל - ההחלטה סופית? לא נוכל לענות לך.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "האם ההחלטה סופית?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "צירוף קובץ";
+/* User Authenticated */
+"Authenticated" = "האימות בוצע";
+
+/* Title of Back button for Markdown preview */
+"Back" = "חזרה";
+
+/* The Simplenote blog */
+"Blog" = "בלוג";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "יצירת חשבון מהווה את הסכמתך אל";
 
 /* No comment provided by engineer. */
 "Can't Access." = "אין גישה.";
+
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "ביטול";
 
 /* No comment provided by engineer. */
 "Choose Photo" = "בחירת תמונה";
@@ -486,10 +117,43 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 "Close" = "סגור";
 
 /* Verb - work with others on a note */
+"Collaborate" = "שיתוף פעולה בעריכה";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "שיתוף הפעולה עבר למקום אחר";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "שותפי עריכה";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "רשימת פתקים מכווצת";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "איש קשר";
+
+/* Contribute to the Simplenote apps on github */
 "Contribute" = "שיתוף";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "יכול להיות יותר טוב";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "לא ניתן ליצור חשבון באמצעות כתובת האימייל והסיסמה שסופקו.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "לא ניתן להיכנס באמצעות כתובת האימייל והסיסמה שסופקו.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "באפשרותך לומר לנו כיצד נוכל להשתפר?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "לא הייתה אפשרות להתחבר";
 
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "ליצור פתק חדש";
+
+/* No comment provided by engineer. */
+"Create a new note" = "יצירת פתק חדש";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "נוצר: החדש ביותר";
@@ -497,29 +161,97 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "נוצר: הישן ביותר";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "שותפי עריכה קיימים";
+
 /* Theme: Dark */
 "Dark" = "צבעים כהים";
 
-/* Message for alert when user tries to send feedback without an email address */
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "איתור באגים";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "מחיקה";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "למחוק את הפתקים";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "להשבית את העיצוב של Markdown";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "ביטול מקלדת";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "בוצע";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "עריכה";
+
+/* Email TextField Placeholder */
+"Email" = "לשלוח מייל";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "כתובת אימייל";
 
 /* Email Taken Alert Title */
 "Email in use" = "כתובת האימייל בשימוש";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "ריק";
+
+/* Remove all notes from the trash */
+"Empty trash" = "לרוקן את הפח";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "להפעיל את העיצוב של Markdown";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "צורף לתור";
+
+/* No comment provided by engineer. */
+"Error" = "שגיאה";
+
 /* No comment provided by engineer. */
 "Error uploading." = "שגיאה בהעלאה.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "זיהוי פנים";
 
 /* Password Reset Action */
 "Forgotten password?" = "שכחת את הסיסמה?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "נהדר! תוכל\/י אולי לדרג אותנו?\n\n\nזה ממש יעזור.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "שיתוף נתוני השימוש שלך בכלי הניתוח שלנו יעזור לנו לשפר את Simplenote.";
+
+/* Noun - the version history of a note */
+"History" = "היסטוריה";
+
+/* Action - view the version history of a note */
+"History..." = "היסטוריה...";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "כיצד נוכל לעזור?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "אהבתי את זה";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "כתובת הדואר האלקטרוני לא תקפה.";
 
+/* Last Message timestamp */
+"LastSeen" = "LastSeen";
+
 /* Learn More Action */
 "Learn more" = "מידע נוסף";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "השארת חוות דעת";
 
 /* Theme: Light */
 "Light" = "צבעים בהירים";
@@ -527,17 +259,41 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "זמן קצוב לנעילה";
 
-/* Sign in error message */
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
 "Log In" = "התחבר";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "התחברות באמצעות אימייל";
+/* Log out of the active account in the app */
+"Log Out" = "התנתקות";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "התחברו באמצעות WordPress.com";
 
-/* Log out of the active account in the app */
-"Log Out" = "התנתקות";
+/* Presents the regular Email signin flow */
+"Log in with email" = "התחברות באמצעות אימייל";
+
+/* Month and day date formatter */
+"MMM d" = "d ‏MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d ‏MMM, ‏hh:mm";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d ‏MMM, ‏yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM ‏yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "שינוי Markdown";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "תפריט";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "עודכן: החדש ביותר";
@@ -545,8 +301,15 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "עודכן: הישן ביותר";
 
+/* Label to create a new note */
+"New note" = "פתק חדש";
+
 /* Empty Note Placeholder */
 "New note..." = "פתק חדש...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "לא";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "אין אימייל.";
@@ -557,16 +320,74 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "אין הודעה.";
 
-"Open "(preview)"" = "פתיחה "(תצוגה מקדימה)"";
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "אין פתקים";
+
+/* Message shown when no notes match a search string */
+"No Results" = "אין תוצאות";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "לא תודה";
+
+/* No comment provided by engineer. */
+"Note not published" = "הפתק לא פורסם";
+
+/* Plural form of notes */
+"Notes" = "פתקים";
+
+/* Dismisses an AlertController */
+"OK" = "אישור";
+
+/* Instant passcode lock timeout */
+"Off" = "כבוי";
+
+/* No comment provided by engineer. */
+"On" = "מופעל";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "פתיחה \"(תצוגה מקדימה)\"";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "לפתוח את Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "פתיחת פתק";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "בעקבות העדכון שלנו, סדר התצוגה של הפתקים שלך אולי השתנה. האם ברצונך לבדוק את הגדרות המיון?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "קוד סיסמה";
+
+/* Password TextField Placeholder */
+"Password" = "סיסמה";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "הסיסמה חייבת להכיל לפחות 4 תווים";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "הסיסמה חייבת להכיל לפחות ארבעה תווים.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "בהמתנה";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "לנעוץ";
+
+/* Action to mark a note as pinned */
+"Pin note" = "הצמדת פתק";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "הצמדה לראש העמוד";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "החלפת מצב הצמדה";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "הוצמד";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "יש להפעיל את החשבון שלך ב-WordPress.com באמצעות האימייל ולנסות שוב.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "כדאי לך לבדוק את כתובת הדואר האלקטרוני שלך, נראה שהיא אינה תקפה.";
@@ -574,11 +395,57 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "יש להזין הודעה.";
 
+/* Title of Markdown preview screen */
+"Preview" = "תצוגה מקדימה";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "מדיניות פרטיות";
 
 /* Privacy Settings */
 "Privacy Settings" = "הגדרות פרטיות";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "לפרסם";
+
+/* Action which published a note to a web page */
+"Publish note" = "פרסום פתק";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "החלפת מצב תרגום";
+
+/* No comment provided by engineer. */
+"Published" = "פורסם";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "מפרסם...";
+
+/* Reachs Internet */
+"Reachability" = "נגישות";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "הסרת כל הפתקים מהפח";
+
+/* Rename a tag */
+"Rename" = "שינוי שם";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "שחזור";
+
+/* Restore a note to a previous version */
+"Restore Note" = "שחזור פתק";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "חיפוש";
+
+/* No comment provided by engineer. */
+"Security" = "אבטחה";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "שליחה";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "שליחת משוב";
 
 /* For debugging use */
 "Send a Test Crash" = "לשלוח קריסה של בדיקה";
@@ -586,7 +453,33 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "שולח...";
 
+/* Title of options screen */
+"Settings" = "הגדרות";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "שיתוף";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "שיתוף הניתוח";
+
+/* No comment provided by engineer. */
+"Share note" = "שיתוף פתק";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "ניתן כעת לגשת לשיתוף הפתקים דרך תפריט הפעולות מסרגל הכלים.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "סרגל צדדי";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "הרשמה";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "לאחר ההתנתקות, כל הפתקים שלא סוכרנו יימחקו. אפשר לאמת אילו פתקים סונכרנו באמצעות התחברות לאפליקציית הרשת.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -595,8 +488,15 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "מיון לפי סדר אלפביתי";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "מיון לפי";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "ברירת המחדל לפי המערכת";
+
+/* No comment provided by engineer. */
+"Tags" = "תגיות";
 
 /* No comment provided by engineer. */
 "Take Photo" = "צילום תמונה";
@@ -607,7 +507,7 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Simplenote terms of service */
 "Terms of Service" = "תנאי השירות";
 
-/* This is one of the buttons we display when prompting the user for a review */
+/* No comment provided by engineer. */
 "Thanks" = "תודה";
 
 /* Error when address is in use */
@@ -616,17 +516,50 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "הדרך הפשוטה ביותר לרשום פתקים.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "עיצוב";
+
 /* Simplenote Themes */
 "Themes" = "ערכות עיצוב";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "אירעה שגיאה בשליחת המשוב שלך, יש לנסות שוב.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "היום";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "החלפת מצב סרגל צדדי";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "מזהה מגע";
+
+/* Title: Trash Tag is selected */
+"Trash" = "העברה לפח";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "העברה לפח";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "להסיר את הנעץ";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "ביטול הצמדת פתק";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "ביטול פרסום פתק";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "ביטול פרסום...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "אותרו הערות שלא סונכרנו";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "התיוג הוסר";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "הסרת התגיות מהערות";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "שימוש בתמונה האחרונה";
@@ -634,8 +567,14 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* A user's Simplenote account */
 "Username" = "שם משתמש";
 
+/* Represents a snapshot in time for a note */
+"Version" = "גרסה";
+
 /* App version number */
 "Version %@" = "גרסה %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "מעבר לאפליקציית הרשת";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "לא יכולנו לגשת אל התמונות שלך, יש לוודא שליישום זה מוענקת גישה ב'הגדרות'.";
@@ -649,15 +588,76 @@ It really helps." = "נהדר! תוכל/י אולי לדרג אותנו?
 /* Generic error */
 "We're having problems. Please try again soon." = "נתקלנו בבעיות. יש לנסות שוב בקרוב.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "מה דעתך על Simplenote?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "מה דעתך על WordPress?";
 
 /* Work at Automattic */
 "Work With Us" = "הצטרפות לכוח העבודה שלנו";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "כן";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "אתמול";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "כתובת האימייל שלך:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "כתובת האימייל שלך אינה חוקית.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "ההודעה שלך תלך לאיבוד.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "הסיסמה חייבת להכיל לפחות 4 תווים";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "צירוף קובץ";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "מאפשר לאחרים לשתף פעולה";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "יש להוסיף כתובת אימייל כדי לשתף פתק זה עם מישהו. לאחר מכן תוכלו שניכם לערוך בו שינויים.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "הפתק נמחק במכשיר אחר.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "החזרת פתק לגרסה הקודמת";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "הצגת אפשרויות לפתק";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "סגירת פתק נוכחי";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "שיתוף תוכן הפתק הנוכחי";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "הוספת תגית לפתק הנוכחי";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "הסרת תגית מהפתק הנוכחי";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "העבר את הפתק הנוכחי לפח";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "התחברות לאינטרנט לצורך גישה לגרסאות קודמות";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "מעבר לגרסה זו";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "הורדת גרסה";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "ברוכים הבאים אל Simplenote עבור iOS!\n\nכדי להוסיף פתק, יש להקיש על לחצן הפלוס.\n\nרפרוף ברשימה כדי לעיין בפתקים שלך. יש להקיש על כותרת כדי להציג פתק, ולאחר מכן להקיש על התוכן שלו כדי לשנות אותו.\n\nאפשר לחפש בכל הפתקים באמצעות הקלדה בשדה החיפוש בחלק העליון של רשימת הפתקים.\n\nיש להקיש על לחצן החץ בחלק הימני העליון, או להחליק על רשימת הפתקים כדי להציג את התגיות שלך. אפשר להוסיף תגיות לפתק בתחתית עורך הפתקים, ולאחר מכן להשתמש בסרגל הצדדי כדי לעזור לך לשמור על הסדר.\n\nקיימות אפשרויות נוספות לפתקים במקרה הצורך. אפשר להוסיף אחרים כמשתפי פעולה לפתק, או לפרסם פתק כדף אינטרנט.\n\nניתן להשתמש ב-Simplenote במחשב Mac, מכשיר Android, או בדפדפן האינטרנט, בכתובת http:\/\/simplenote.com. הפתקים שלך יישארו מעודכנים בכל מקום, באופן אוטומטי.";
 

--- a/Simplenote/id.lproj/Localizable.strings
+++ b/Simplenote/id.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: id */
 
-/* Number of found search results */
-"%d Result" = "%d Hasil";
+/* Number of Characters in a note */
+"%@ Character" = "%@ Karakter";
 
-/* Number of found search results */
-"%d Results" = "%d Hasil";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ Karakter";
 
 /* Number of words in a note */
 "%@ Word" = "%@ Kata";
@@ -15,415 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ Kata";
 
-   Label of accept button on alert dialog */
-"Accept" = "Terima";
-
-/* No comment provided by engineer. */
-"Account" = "Account";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Tambahkan kolaborator baru...";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Tambahkan label";
-
-/* Title: No filters applied */
-"All Notes" = "Semua Catatan";
-
-
-"Cancel" = "Cancel";
-
-/* Verb - work with others on a note */
-"Collaborate" = "Kolaborasi";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Aktifkan yang lain untuk berkolaborasi";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Kolaborator";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "Tambahkan alamat email untuk berbagi catatan ini dengan seseorang. Kemudian Anda dan orang yang Anda bagi catatan tersebut dapat melakukan perubahan.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Daftar Catatan Ringkas";
-
-/* No comment provided by engineer. */
-"Create a new note" = "Buat catatan baru";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Kolaborator Saat Ini";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Catatan ini dihapus pada perangkat lain.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Abaikan keyboard";
-
-   Verb: Close current view */
-"Done" = "Selesai";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "Kosong";
-
-/* Remove all notes from the trash */
-"Empty trash" = "Kosongkan sampah";
-
-/* Noun - the version history of a note */
-"History" = "Riwayat";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Pulihkan catatan ke versi sebelumnya";
-
-/* Action - view the version history of a note */
-"History..." = "Riwayat...";
-
-/* Sort Mode: Alphabetically, ascending */
-"Menu" = "Menu";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Tampilkan opsi untuk catatan";
-
-/* Label to create a new note */
-"New note" = "Catatan baru";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "Tidak ada Catatan";
-
-/* Message shown when no notes match a search string */
-"No Results" = "Tidak ada Hasil";
-
-/* No comment provided by engineer. */
-"Note not published" = "Catatan tidak diterbitkan";
-
-/* Title: No filters applied */
-"Notes" = "Catatan";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Tutup catatan saat ini";
-
-/* Instant passcode lock timeout */
-"Off" = "Matikan";
-
-/* Dismisses an AlertController */
-"OK" = "OK";
-
-/* No comment provided by engineer. */
-"On" = "Menyala";
-
-/* Select a note to view in the note editor */
-"Open note" = "Buka catatan";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Kode sandi";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Sematkan catatan";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "Sematkan ke Atas";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "Sematkan pilihan";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Disematkan";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Terbitkan";
-
-/* Action which published a note to a web page */
-"Publish note" = "Terbitkan catatan";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "Terbitkan pilihan";
-
-/* No comment provided by engineer. */
-"Published" = "Diterbitkan";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Menerbitkan...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Buang semua catatan dari sampah";
-
-/* Rename a tag */
-"Rename" = "Ubah Nama";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Pulihkan";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Pulihkan Catatan";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "Kirim";
-
-
-"Settings" = "Settings";
-
-/* No comment provided by engineer. */
-"Share note" = "Bagikan catatan";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Bagikan konten dari catatan saat ini";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Panel Sisi";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Tambahkan label pada catatan saat ini";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Buang label dari catatan saat ini";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Hari ini";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Panel sisi label pilihan";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Pindahkan catatan saat ini ke sampah";
-
-/* Title: Trash Tag is selected */
-"Trash-noun" = "Sampah";
-
-/* Title: Trash Tag is selected */
-"Trash-verb" = "Sampah";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Lepas sematan catatan";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Batalkan menerbitkan catatan";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Batal menerbitkan...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Versi";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Hubungkan ke Internet untuk Mengakses Versi Sebelumnya";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Beralih ke versi ini";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Mengambil versi";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Kemarin";
-
-"welcomeNote-iOS" = "Selamat Datang di Simplenote untuk iOS!
-
-Untuk menambahkan catatan, ketuk tombol plus.
-
-Sentil daftar untuk menjelajahi catatan Anda. Ketuk judul untuk melihat catatan, kemudian ketuk isi untuk mengubahnya.
-
-Anda dapat mencari semua catatan Anda dengan mengetik di bidang pencarian pada bagian atas daftar catatan.
-
-Ketuk tombol panah di bagian kiri atas atau sapukan jari pada daftar catatan untuk melihat label. Anda dapat menambahkan label pada catatan di bagian bawah penyunting catatan, lalu gunakan panel sisi untuk menjaga tetap teratur.
-
-Ada opsi catatan lainnya jika Anda memerlukan. Anda dapat menambahkan lainnya sebagai kolaborator pada catatan, atau menerbitkan catatan sebagai sebuah halaman web.
-
-Gunakan Simplenote di perangkat Mac, Android, atau di browser web Anda di http://simplenote.com. Catatan Anda akan tetap diperbarui di mana saja secara otomatis.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Tidak dapat membuat akun dengan alamat email dan kata sandi yang diberikan.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Tidak dapat masuk dengan alamat email dan kata sandi yang diberikan.";
-
-/* Password TextField Placeholder */
-"Password" = "Kata sandi";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Kata sandi harus berisi sedikitnya 6 karakter.";
-
-   SignUp Interface Title */
-"Sign Up" = "Mendaftar";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Alamat email Anda tidak valid.";
-
-/* User Authenticated */
-"Authenticated" = "Diautentikasi";
-
-
-"Debug" = "Debug";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "Dalam antrean";
-
-/* Last Message timestamp */
-"LastSeen" = "TerakhirDilihat";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM yyyy";
-
-/* Month, day, and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "Tertunda";
-
-/* Reachs Internet */
-"Reachability" = "Keterjangkauan";
-
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "ID Sentuhan";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Keamanan";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Apa pendapat Anda tentang Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Saya Menyukainya";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Bisa Lebih Baik";
-
-"Great! Could you leave us a nice review?
-It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nIni benar-benar membantu.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Berikan Tinjauan";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Tidak, Terima Kasih";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Menurut Anda, penyempurnaan apa yang dapat kami lakukan?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Kirim Masukan";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Hubungi";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "Email Anda:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Apa yang dapat kami bantu?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "Terjadi error saat mencoba masuk.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "Anda yakin ingin mengosongkan tempat sampah? Ini tidak dapat dibatalkan.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Kembali";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "Kolaborasi telah dipindah";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "Tidak Dapat Masuk";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Hapus";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Hapus Catatan";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Nonaktifkan pemformatan Markdown";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "Sunting";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Aktifkan pemformatan Markdown";
-
-
-"Face ID" = "Face ID";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Tombol Markdown";
-
-/* No comment provided by engineer. */
-"No" = "Tidak";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Harap aktifkan akun WordPress.com Anda melalui email dan coba lagi.";
-
-/* Title of Markdown preview screen */
-"Preview" = "Pratinjau";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Cari";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Berbagi catatan kini dapat diakses melalui menu tindakan dari bilah peralatan.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Catatan yang tidak disinkronkan akan dihapus saat Anda keluar. Anda dapat memverifikasi catatan Anda yang disinkronkan dengan masuk ke Aplikasi Web.";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tags" = "Tag";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Catatan yang Tidak Disinkronkan Terdeteksi";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Kunjungi Aplikasi Web";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "Ya";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Tag...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Bagikan";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Catatan Tanpa Tag";
-
-/* Option to sort tags alphabetically. The default is by manual ordering. */
-"Sort Order" = "Urutkan";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Berbagi analitik";
-
-
-"Email" = "Email";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Tema";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
-
-/* No comment provided by engineer. */
-"Error" = "Kesalahan";
-
-/* No comment provided by engineer. */
-"Appearance" = "Tampilan";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ Karakter";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ Karakter";
+/* Number of found search results */
+"%d Result" = "%d Hasil";
+
+/* Number of found search results */
+"%d Results" = "%d Hasil";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 Menit";
@@ -449,11 +45,36 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Display app about screen */
 "About" = "Tentang";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Terima";
+
+/* No comment provided by engineer. */
+"Account" = "Account";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Tambahkan kolaborator baru...";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Tag...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Tambahkan label";
+
+/* Title: No filters applied */
+"All Notes" = "Semua Catatan";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "Menurut Abjad: A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "Menurut Abjad: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "Terjadi error saat mencoba masuk.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Tampilan";
 
 /* Other Simplenote apps */
 "Apps" = "Aplikasi";
@@ -461,14 +82,23 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "Apakah Anda pengembang? Automattic sedang membuka lowongan pekerjaan.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Anda yakin ingin mengosongkan tempat sampah? Ini tidak dapat dibatalkan.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "Anda yakin ingin mengirim tanpa email Anda? Kami tidak dapat membalas kepada Anda.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "Anda yakin?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "tambahkan file";
+/* User Authenticated */
+"Authenticated" = "Diautentikasi";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Kembali";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "Dengan membuat akun, Anda menyetujui";
@@ -476,17 +106,54 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* No comment provided by engineer. */
 "Can't Access." = "Tidak Dapat Mengakses.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "Cancel";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Pilih Foto";
 
 /* No comment provided by engineer. */
 "Close" = "Tutup";
 
+/* Verb - work with others on a note */
+"Collaborate" = "Kolaborasi";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Kolaborasi telah dipindah";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Kolaborator";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Daftar Catatan Ringkas";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Hubungi";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Kontribusi";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Bisa Lebih Baik";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Tidak dapat membuat akun dengan alamat email dan kata sandi yang diberikan.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Tidak dapat masuk dengan alamat email dan kata sandi yang diberikan.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Menurut Anda, penyempurnaan apa yang dapat kami lakukan?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Tidak Dapat Masuk";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Buat Catatan Baru";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Buat catatan baru";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Dibuat: Paling baru";
@@ -494,8 +161,37 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Dibuat: Paling lama";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Kolaborator Saat Ini";
+
 /* Theme: Dark */
 "Dark" = "Gelap";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Debug";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Hapus";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Hapus Catatan";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Nonaktifkan pemformatan Markdown";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Abaikan keyboard";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Selesai";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Sunting";
+
+/* Email TextField Placeholder */
+"Email" = "Email";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "Alamat Email";
@@ -503,20 +199,59 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Email Taken Alert Title */
 "Email in use" = "Email digunakan";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Kosong";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Kosongkan sampah";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Aktifkan pemformatan Markdown";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Dalam antrean";
+
+/* No comment provided by engineer. */
+"Error" = "Kesalahan";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Error saat mengunggah.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "Lupa kata sandi?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\\n\\nIni benar-benar membantu.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Bantu kami menyempurnakan Simplenote dengan berbagi data penggunaan dengan alat analitik kami.";
+
+/* Noun - the version history of a note */
+"History" = "Riwayat";
+
+/* Action - view the version history of a note */
+"History..." = "Riwayat...";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Apa yang dapat kami bantu?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Saya Menyukainya";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Alamat Email Tidak Valid.";
 
+/* Last Message timestamp */
+"LastSeen" = "TerakhirDilihat";
+
 /* Learn More Action */
 "Learn more" = "Pelajari lebih lanjut";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Berikan Tinjauan";
 
 /* Theme: Light */
 "Light" = "Terang";
@@ -524,17 +259,41 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Waktu Habis Penguncian";
 
-/* Alert dialog title displayed on sign in error */
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
 "Log In" = "Masuk";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "Login dengan email";
+/* Log out of the active account in the app */
+"Log Out" = "Logout";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "Login dengan WordPress.com";
 
-/* Log out of the active account in the app */
-"Log Out" = "Logout";
+/* Presents the regular Email signin flow */
+"Log in with email" = "Login dengan email";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Tombol Markdown";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Menu";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Diubah: Paling baru";
@@ -542,8 +301,15 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Diubah: Paling lama";
 
+/* Label to create a new note */
+"New note" = "Catatan baru";
+
 /* Empty Note Placeholder */
 "New note..." = "Catatan baru...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "Tidak";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "Tidak Ada Email.";
@@ -554,16 +320,74 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Tidak Ada Pesan.";
 
-"Open "(preview)"" = "Buka "(pratinjau)"";
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "Tidak ada Catatan";
+
+/* Message shown when no notes match a search string */
+"No Results" = "Tidak ada Hasil";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Tidak, Terima Kasih";
+
+/* No comment provided by engineer. */
+"Note not published" = "Catatan tidak diterbitkan";
+
+/* Plural form of notes */
+"Notes" = "Catatan";
+
+/* Dismisses an AlertController */
+"OK" = "OK";
+
+/* Instant passcode lock timeout */
+"Off" = "Matikan";
+
+/* No comment provided by engineer. */
+"On" = "Menyala";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "Buka \"(pratinjau)\"";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Buka Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "Buka catatan";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Pembaruan kami dapat mengubah susunan tampilan catatan Anda. Apakah Anda ingin meninjau pengaturan penyusunan?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Kode sandi";
+
+/* Password TextField Placeholder */
+"Password" = "Kata sandi";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Kata sandi harus berisi setidaknya 4 karakter";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Kata sandi harus berisi sedikitnya 6 karakter.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Tertunda";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Sematkan";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Sematkan catatan";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "Sematkan ke Atas";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "Sematkan pilihan";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Disematkan";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Harap aktifkan akun WordPress.com Anda melalui email dan coba lagi.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "Harap periksa alamat email Anda, nampaknya tidak valid.";
@@ -571,11 +395,57 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Masukkan pesan.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Pratinjau";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Kebijakan Privasi";
 
 /* Privacy Settings */
 "Privacy Settings" = "Pengaturan Privasi";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Terbitkan";
+
+/* Action which published a note to a web page */
+"Publish note" = "Terbitkan catatan";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Terbitkan pilihan";
+
+/* No comment provided by engineer. */
+"Published" = "Diterbitkan";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Menerbitkan...";
+
+/* Reachs Internet */
+"Reachability" = "Keterjangkauan";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Buang semua catatan dari sampah";
+
+/* Rename a tag */
+"Rename" = "Ubah Nama";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Pulihkan";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Pulihkan Catatan";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Cari";
+
+/* No comment provided by engineer. */
+"Security" = "Keamanan";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Kirim";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Kirim Masukan";
 
 /* For debugging use */
 "Send a Test Crash" = "Kirim Uji Kesalahan";
@@ -583,7 +453,33 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Mengirim...";
 
+/* Title of options screen */
+"Settings" = "Settings";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Bagikan";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Berbagi analitik";
+
+/* No comment provided by engineer. */
+"Share note" = "Bagikan catatan";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Berbagi catatan kini dapat diakses melalui menu tindakan dari bilah peralatan.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Panel Sisi";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Mendaftar";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Catatan yang tidak disinkronkan akan dihapus saat Anda keluar. Anda dapat memverifikasi catatan Anda yang disinkronkan dengan masuk ke Aplikasi Web.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -592,8 +488,15 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Urutkan Menurut Abjad";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Urutkan";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Pengaturan Asal Sistem";
+
+/* No comment provided by engineer. */
+"Tags" = "Tag";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Ambil Foto";
@@ -614,16 +517,49 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 "The simplest way to keep notes." = "Cara paling mudah menyimpan catatan.";
 
 /* Option to enable the dark app theme. */
+"Theme" = "Tema";
+
+/* Simplenote Themes */
 "Themes" = "Tema";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "Terjadi error saat mengirimkan masukan Anda, harap coba lagi.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Hari ini";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Panel sisi label pilihan";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "ID Sentuhan";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Sampah";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Sampah";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Lapas sematan";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "Lepas sematan catatan";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Batalkan menerbitkan catatan";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Batal menerbitkan...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Catatan yang Tidak Disinkronkan Terdeteksi";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Tidak ditandai";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Catatan Tanpa Tag";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "Gunakan Foto Terbaru";
@@ -631,8 +567,14 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* A user's Simplenote account */
 "Username" = "Nama pengguna";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Versi";
+
 /* App version number */
 "Version %@" = "Versi %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Kunjungi Aplikasi Web";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "Kami tidak dapat mengakses foto Anda, pastikan aplikasi ini mendapatkan akses di Pengaturan.";
@@ -646,15 +588,76 @@ It really helps." = "Bagus! Dapatkah Anda memberi kami ulasan yang menarik?\n\nI
 /* Generic error */
 "We're having problems. Please try again soon." = "Kami mengalami masalah. Harap coba lagi nanti.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Apa pendapat Anda tentang Simplenote?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "Apa pendapat Anda tentang WordPress?";
 
 /* Work at Automattic */
 "Work With Us" = "Bekerja Bersama Kami";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Ya";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Kemarin";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Email Anda:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Alamat email Anda tidak valid.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Pesan Anda akan hilang.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "Kata sandi harus berisi setidaknya 4 karakter";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "tambahkan file";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Aktifkan yang lain untuk berkolaborasi";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Tambahkan alamat email untuk berbagi catatan ini dengan seseorang. Kemudian Anda dan orang yang Anda bagi catatan tersebut dapat melakukan perubahan.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Catatan ini dihapus pada perangkat lain.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Pulihkan catatan ke versi sebelumnya";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Tampilkan opsi untuk catatan";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Tutup catatan saat ini";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Bagikan konten dari catatan saat ini";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Tambahkan label pada catatan saat ini";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Buang label dari catatan saat ini";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Pindahkan catatan saat ini ke sampah";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Hubungkan ke Internet untuk Mengakses Versi Sebelumnya";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Beralih ke versi ini";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Mengambil versi";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Selamat Datang di Simplenote untuk iOS!\n\nUntuk menambahkan catatan, ketuk tombol plus.\n\nSentil daftar untuk menjelajahi catatan Anda. Ketuk judul untuk melihat catatan, kemudian ketuk isi untuk mengubahnya.\n\nAnda dapat mencari semua catatan Anda dengan mengetik di bidang pencarian pada bagian atas daftar catatan.\n\nKetuk tombol panah di bagian kiri atas atau sapukan jari pada daftar catatan untuk melihat label. Anda dapat menambahkan label pada catatan di bagian bawah penyunting catatan, lalu gunakan panel sisi untuk menjaga tetap teratur.\n\nAda opsi catatan lainnya jika Anda memerlukan. Anda dapat menambahkan lainnya sebagai kolaborator pada catatan, atau menerbitkan catatan sebagai sebuah halaman web.\n\nGunakan Simplenote di perangkat Mac, Android, atau di browser web Anda di http:\/\/simplenote.com. Catatan Anda akan tetap diperbarui di mana saja secara otomatis.";
 

--- a/Simplenote/it.lproj/Localizable.strings
+++ b/Simplenote/it.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: it */
 
-/* Number of found search results */
-"%d Result" = "%d Resultato";
+/* Number of Characters in a note */
+"%@ Character" = "%@ Character";
 
-/* Number of found search results */
-"%d Results" = "%d Resultati";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ Characters";
 
 /* Number of words in a note */
 "%@ Word" = "%@ Parola";
@@ -15,6 +15,37 @@
 /* Number of words in a note */
 "%@ Words" = "%@ Parole";
 
+/* Number of found search results */
+"%d Result" = "%d Resultato";
+
+/* Number of found search results */
+"%d Results" = "%d Resultati";
+
+/* 1 minute passcode lock timeout */
+"1 Minute" = "1 Minute";
+
+/* 15 seconds passcode lock timeout */
+"15 Seconds" = "15 Seconds";
+
+/* 2 minutes passcode lock timeout */
+"2 Minutes" = "2 Minutes";
+
+/* 3 minutes passcode lock timeout */
+"3 Minutes" = "3 Minutes";
+
+/* 30 seconds passcode lock timeout */
+"30 Seconds" = "30 Seconds";
+
+/* 4 minutes passcode lock timeout */
+"4 Minutes" = "4 Minutes";
+
+/* 5 minutes passcode lock timeout */
+"5 Minutes" = "5 Minutes";
+
+/* Display app about screen */
+"About" = "Informazioni";
+
+/* Accept Action
    Label of accept button on alert dialog */
 "Accept" = "Ok";
 
@@ -24,44 +55,149 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Aggiungi un nuovo collaboratore...";
 
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Tag...";
+
 /* Label on button to add a new tag to a note */
 "Add tag" = "Aggiungi tag";
 
 /* Title: No filters applied */
 "All Notes" = "Tutte le note";
 
+/* Sort Mode: Alphabetically, ascending */
+"Alphabetically: A-Z" = "Alphabetically: A-Z";
+
+/* Sort Mode: Alphabetically, descending */
+"Alphabetically: Z-A" = "Alphabetically: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "An error was encountered while signing in.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Appearance";
+
+/* Other Simplenote apps */
+"Apps" = "Apps";
+
+/* Automattic hiring description */
+"Are you a developer? Automattic is hiring." = "Are you a developer? Automattic is hiring.";
+
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Are you sure you want to empty the trash? This cannot be undone.";
+
+/* Message for alert when user tries to send feedback without an email address */
+"Are you sure you want to send without your email? We won't be able reply to you." = "Are you sure you want to send without your email? We won't be able reply to you.";
+
+/* Title for prompt when user tries to close the feedback view */
+"Are you sure?" = "Are you sure?";
+
+/* User Authenticated */
+"Authenticated" = "Authenticated";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Indietro";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
+
+/* Terms of Service Legend *PREFIX*: printed in dark color */
+"By creating an account you agree to our" = "By creating an account you agree to our";
+
+/* No comment provided by engineer. */
+"Can't Access." = "Can't Access.";
+
+/* Cancel Action
    Verb, cancel an alert dialog */
 "Cancel" = "Annulla";
+
+/* No comment provided by engineer. */
+"Choose Photo" = "Choose Photo";
+
+/* No comment provided by engineer. */
+"Close" = "Close";
 
 /* Verb - work with others on a note */
 "Collaborate" = "Collabora";
 
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Aggiungi collaboratori";
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Collaboration has moved";
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Collaboratori";
 
-/* No comment provided by engineer. */
-"collaborators-description" = "Aggiungi un indirizzo email con cui condividere questa nota. Dopo la condivisione entrambi gli utenti potranno modificare la nota.";
-
 /* Option to make the note list show only 1 line of text. The default is 3. */
 "Condensed Note List" = "Elenco note ristretto";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Contatto";
+
+/* Contribute to the Simplenote apps on github */
+"Contribute" = "Contribute";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Potrebbe essere meglio";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Non è possibile creare un account con l'indirizzo email e la password forniti.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Nome utente o password errata.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Puoi dirci come possiamo migliorare?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Couldn't Sign In";
+
+/* Siri Suggestion to create a New Note */
+"Create a New Note" = "Create a New Note";
 
 /* No comment provided by engineer. */
 "Create a new note" = "Crea una nuova nota";
 
+/* Sort Mode: Creation Date, descending */
+"Created: Newest" = "Created: Newest";
+
+/* Sort Mode: Creation Date, ascending */
+"Created: Oldest" = "Created: Oldest";
+
 /* No comment provided by engineer. */
 "Current Collaborators" = "Collaboratori attuali";
 
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Questa nota è stata cancellata da un altro dispositivo.";
+/* Theme: Dark */
+"Dark" = "Dark";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Debug";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Elimina";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Delete Notes";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Disable Markdown formatting";
 
 /* No comment provided by engineer. */
 "Dismiss keyboard" = "Nascondi la tastiera";
 
+/* Done toolbar button
    Verb: Close current view */
 "Done" = "Fatto";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Edit";
+
+/* Email TextField Placeholder */
+"Email" = "Email";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Email Address" = "Email Address";
+
+/* Email Taken Alert Title */
+"Email in use" = "Email in use";
 
 /* Verb - empty causes all notes to be removed permenently from the trash */
 "Empty" = "Svuota";
@@ -69,23 +205,120 @@
 /* Remove all notes from the trash */
 "Empty trash" = "Svuota cestino";
 
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Enable Markdown formatting";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Enqueued";
+
+/* No comment provided by engineer. */
+"Error" = "Errore";
+
+/* No comment provided by engineer. */
+"Error uploading." = "Error uploading.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
+
+/* Password Reset Action */
+"Forgotten password?" = "Forgotten password?";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Grande! Potresti lasciarci una recensione?\\n\\n\\nAiuterebbe molto.";
+
+/* Privacy Details */
+"Help us improve Simplenote by sharing usage data with our analytics tool." = "Help us improve Simplenote by sharing usage data with our analytics tool.";
+
 /* Noun - the version history of a note */
 "History" = "Storia";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Ripristina da una versione precedente";
 
 /* Action - view the version history of a note */
 "History..." = "Storia...";
 
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Come possiamo aiutarti?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Mi piace";
+
+/* Title for alert that a user has entered an invalid email address */
+"Invalid Email Address." = "Invalid Email Address.";
+
+/* Last Message timestamp */
+"LastSeen" = "LastSeen";
+
+/* Learn More Action */
+"Learn more" = "Per saperne di più";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Lascia una recensione";
+
+/* Theme: Light */
+"Light" = "Light";
+
+/* Setting for when the passcode lock should enable */
+"Lock Timeout" = "Lock Timeout";
+
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
+"Log In" = "Accedi";
+
+/* Log out of the active account in the app */
+"Log Out" = "Esci";
+
+/* Allows the user to SignIn using their WPCOM Account */
+"Log in with WordPress.com" = "Log in with WordPress.com";
+
+/* Presents the regular Email signin flow */
+"Log in with email" = "Log in with email";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown toggle";
+
 /* Terminoligy used for sidebar UI element where tags are displayed */
 "Menu" = "Menu";
 
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Mostra opzioni nota";
+/* Sort Mode: Modified Date, descending */
+"Modified: Newest" = "Modified: Newest";
+
+/* Sort Mode: Creation Date, ascending */
+"Modified: Oldest" = "Modified: Oldest";
 
 /* Label to create a new note */
 "New note" = "Nuova nota";
+
+/* Empty Note Placeholder */
+"New note..." = "New note...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "No";
+
+/* Title for alert when user tires to send feedback without an email address */
+"No Email." = "No Email.";
+
+/* Text that appears in an alert to the user when there is no internet */
+"No Internet" = "No Internet";
+
+/* Title for message when user tries to send feedback without any text */
+"No Message." = "No Message.";
 
 /* Message shown in note list when no notes are in the current view */
 "No Notes" = "Nessuna nota presente";
@@ -93,34 +326,58 @@
 /* Message shown when no notes match a search string */
 "No Results" = "Nessun risultato";
 
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "No grazie";
+
 /* No comment provided by engineer. */
 "Note not published" = "Nota non pubblicata";
 
-/* Title: No filters applied */
+/* Plural form of notes */
 "Notes" = "Note";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Chiudi la nota";
-
-
-"Off" = "Off";
 
 /* Dismisses an AlertController */
 "OK" = "OK";
 
+/* Instant passcode lock timeout */
+"Off" = "Off";
+
 /* No comment provided by engineer. */
 "On" = "On";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "Open \"(preview)\"";
+
+/* Siri Suggestion to open our app */
+"Open Simplenote" = "Open Simplenote";
 
 /* Select a note to view in the note editor */
 "Open note" = "Apri nota";
 
+/* AlertController's Payload for the broken Sort Options Fix */
+"Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Our update may have changed the order in which your notes appear. Would you like to review sort settings?";
+
 /* A 4-digit code to lock the app when it is closed */
 "Passcode" = "PIN";
+
+/* Password TextField Placeholder */
+"Password" = "Password";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Password must contain at least 4 characters";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "La password deve contenere almeno 6 caratteri.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Pendings";
+
+/* Pin (verb) - the action of Pinning a note */
+"Pin" = "Pin";
 
 /* Action to mark a note as pinned */
 "Pin note" = "Aggancia";
 
-/* Action to mark a note as pinned */
+/* Denotes when note is pinned to the top of the note list */
 "Pin to Top" = "Aggancia";
 
 /* Switch which marks a note as pinned or unpinned */
@@ -128,6 +385,24 @@
 
 /* Pinned notes are stuck to the note of the note list */
 "Pinned" = "Agganciata";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Please activate your WordPress.com account via email and try again.";
+
+/* Message for alert that user has entered an invalid email address */
+"Please check your email address, it appears to be invalid." = "Please check your email address, it appears to be invalid.";
+
+/* Message for alert when user tires to send feedback without any text */
+"Please enter a message." = "Please enter a message.";
+
+/* Title of Markdown preview screen */
+"Preview" = "Visualizzare in anteprima";
+
+/* Simplenote privacy policy */
+"Privacy Policy" = "Politica sulla privacy";
+
+/* Privacy Settings */
+"Privacy Settings" = "Impostazioni privacy";
 
 /* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
 "Publish" = "Pubblica";
@@ -144,6 +419,9 @@
 /* Message shown when a note is in the processes of being published */
 "Publishing..." = "Pubblicazione in corso...";
 
+/* Reachs Internet */
+"Reachability" = "Reachability";
+
 /* No comment provided by engineer. */
 "Remove all notes from trash" = "Elimina tutte le note dal cestino";
 
@@ -156,26 +434,96 @@
 /* Restore a note to a previous version */
 "Restore Note" = "Ripristina la nota";
 
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Search";
+
+/* No comment provided by engineer. */
+"Security" = "Sicurezza";
+
 /* Verb - send the content of the note by email, message, etc */
 "Send" = "Invia";
 
-/* Privacy Settings */
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Invia un feedback";
+
+/* For debugging use */
+"Send a Test Crash" = "Send a Test Crash";
+
+/* Label that is shown when feedback from the user is sending */
+"Sending..." = "Sending...";
+
+/* Title of options screen */
 "Settings" = "Impostazioni";
+
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Condividi";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Condividi analisi";
 
 /* No comment provided by engineer. */
 "Share note" = "Condividi nota";
 
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Condividi il contenuto della nota";
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Sharing notes is now accessed through the action menu from the toolbar.";
 
 /* UI region to the left of the note list which shows all of a users tags */
 "Sidebar" = "Barra laterale";
 
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Aggiungi un tag alla nota";
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Crea account";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "La disconnessione causerà l’eliminazione di tutte le note non sincronizzate. È possibile verificare le note sincronizzate accedendo all’app web.";
+
+/* Our mighty brand! */
+"Simplenote" = "Simplenote";
+
+/* Authentication Error Alert Title */
+"Sorry!" = "Sorry!";
+
+/* Option to sort tags alphabetically. The default is by manual ordering. */
+"Sort Alphabetically" = "Sort Alphabetically";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Ordina per";
+
+/* Theme: Matches iOS Settings */
+"System Default" = "System Default";
 
 /* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Rimuovi il tag dalla nota";
+"Tags" = "Tags";
+
+/* No comment provided by engineer. */
+"Take Photo" = "Take Photo";
+
+/* Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue */
+"Terms and Conditions" = "Terms and Conditions";
+
+/* Simplenote terms of service */
+"Terms of Service" = "Termini di Servizio";
+
+/* No comment provided by engineer. */
+"Thanks" = "Thanks";
+
+/* Error when address is in use */
+"The email you've entered is already associated with a Simplenote account." = "The email you've entered is already associated with a Simplenote account.";
+
+/* Onboarding Header Text */
+"The simplest way to keep notes." = "The simplest way to keep notes.";
+
+/* Option to enable the dark app theme. */
+"Theme" = "Tema";
+
+/* Simplenote Themes */
+"Themes" = "Themes";
+
+/* No comment provided by engineer. */
+"There was an error sending your feedback, please try again." = "There was an error sending your feedback, please try again.";
 
 /* Displayed as a date in the case where a note was modified today, for example */
 "Today" = "Oggi";
@@ -183,14 +531,17 @@
 /* Accessibility hint used to show or hide the sidebar */
 "Toggle tag sidebar" = "Mostra barra laterale";
 
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Sposta la nota nel cestino";
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
 
 /* Title: Trash Tag is selected */
-"Trash-noun" = "Cestino";
+"Trash" = "Cestino";
 
 /* Trash (verb) - the action of deleting a note */
-"Trash-verb" = "Elimina";
+"Trash" = "Elimina";
+
+/* Unpin (verb) - the action of Unpinning a note */
+"Unpin" = "Unpin";
 
 /* Action to mark a note as unpinned */
 "Unpin note" = "Sgancia";
@@ -201,176 +552,112 @@
 /* Message shown when a note is in the processes of being unpublished */
 "Unpublishing..." = "Rimuovendo dalla pubblicazione";
 
-/* Represents a snapshot in time for a note */
-"Version" = "Versione";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Collegati ad internet per accedere alle versioni precedenti";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Usa questa versione";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Caricamento versioni";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Ieri";
-
-"welcomeNote-iOS" = "Benvenuto in Simplenote per iOS!
-
-Per creare una nuova nota, clicca sul bottone con il segno +.
-
-Scorri la lista per vedere tutte le tue note. Tocca il titolo della nota per aprire il dettaglio, e tocca il contenuto per modificarlo.
-
-Per effettuare una ricerca, scrivi nella barra di ricerca presente in alto nella schermata delle note.
-
-Clicca il pulsante in alto a sinistra della nota, oppure effettua uno swiping su di essa, per accedere ai tags. E' possibile aggiungere nuovi tags alla nota usando l'apposito campo presente in basso nella schermata di editing. Usa la barra laterale per accedere alle note filtrare per tag.
-
-Ci sono anche altre opzioni se le desideri. E' per esempio possibile aggiungere collaboratori ad una nota, oppure pubblicare una nota su una pagina web.
-
-Usa Simplenote per Mac, per Android, oppure visita http://simplenote.com per accedere alle tue note da qualunque posto e da qualunque dispositivo.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Non è possibile creare un account con l'indirizzo email e la password forniti.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Nome utente o password errata.";
-
-
-"Password" = "Password";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "La password deve contenere almeno 6 caratteri.";
-
-   SignUp Interface Title */
-"Sign Up" = "Crea account";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Il tuo indirizzo email non è valido.";
-
-
-"Debug" = "Debug";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM yyyy";
-
-/* Month, day, and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-
-"Touch ID" = "Touch ID";
-
-/* No comment provided by engineer. */
-"Security" = "Sicurezza";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Che cosa pensi di Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Mi piace";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Potrebbe essere meglio";
-
-"Great! Could you leave us a nice review?
-It really helps." = "Grande! Potresti lasciarci una recensione?\n\n\nAiuterebbe molto.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Lascia una recensione";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "No grazie";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Puoi dirci come possiamo migliorare?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Invia un feedback";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Contatto";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "La tua Email:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Come possiamo aiutarti?";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Indietro";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Elimina";
-
-/* Title of Markdown preview screen */
-"Preview" = "Visualizzare in anteprima";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "La disconnessione causerà l’eliminazione di tutte le note non sincronizzate. È possibile verificare le note sincronizzate accedendo all’app web.";
-
 /* Alert title displayed in settings when an account has unsynced notes */
 "Unsynced Notes Detected" = "Note non sincronizzate rilevate";
 
-
-"Yes" = "Si";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Tag...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Condividi";
+/* Title: Untagged Notes are onscreen */
+"Untagged" = "Untagged";
 
 /* Allows selecting notes with no tags */
 "Untagged Notes" = "Note rimosse";
 
-   Sort Order for the Notes List */
-"Sort Order" = "Ordina per";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Condividi analisi";
-
-
-"Email" = "Email";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Tema";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
-
 /* No comment provided by engineer. */
-"Error" = "Errore";
+"Use Latest Photo" = "Use Latest Photo";
 
-/* Display app about screen */
-"About" = "Informazioni";
-
-/* Learn More Action */
-"Learn more" = "Per saperne di più";
-
-   LogIn Interface Title */
-"Log In" = "Accedi";
-
-/* Log out of the active account in the app */
-"Log Out" = "Esci";
-
-/* Simplenote privacy policy */
-"Privacy Policy" = "Politica sulla privacy";
-
-/* Privacy Settings */
-"Privacy Settings" = "Impostazioni privacy";
-
-/* Simplenote terms of service */
-"Terms of Service" = "Termini di Servizio";
-
-/* Message displayed when login fails */
+/* A user's Simplenote account */
 "Username" = "Nome utente";
+
+/* Represents a snapshot in time for a note */
+"Version" = "Versione";
 
 /* App version number */
 "Version %@" = "Versione %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Visit Web App";
+
+/* No comment provided by engineer. */
+"We can't access your photos, please ensure this application has access in Settings." = "We can't access your photos, please ensure this application has access in Settings.";
+
+/* No comment provided by engineer. */
+"We couldn't upload the photo, please try again." = "We couldn't upload the photo, please try again.";
+
+/* No comment provided by engineer. */
+"We have received your feedback and will be in contact soon." = "We have received your feedback and will be in contact soon.";
+
+/* Generic error */
+"We're having problems. Please try again soon." = "We're having problems. Please try again soon.";
+
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Che cosa pensi di Simplenote?";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about WordPress?" = "What do you think about WordPress?";
+
+/* Work at Automattic */
+"Work With Us" = "Work With Us";
+
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Si";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Ieri";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "La tua Email:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Il tuo indirizzo email non è valido.";
+
+/* Message for prompt when user tries to close feedback view after having entered text */
+"Your message will be lost." = "Your message will be lost.";
+
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "attach a file";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Aggiungi collaboratori";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Aggiungi un indirizzo email con cui condividere questa nota. Dopo la condivisione entrambi gli utenti potranno modificare la nota.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Questa nota è stata cancellata da un altro dispositivo.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Ripristina da una versione precedente";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Mostra opzioni nota";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Chiudi la nota";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Condividi il contenuto della nota";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Aggiungi un tag alla nota";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Rimuovi il tag dalla nota";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Sposta la nota nel cestino";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Collegati ad internet per accedere alle versioni precedenti";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Usa questa versione";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Caricamento versioni";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Benvenuto in Simplenote per iOS!\n\nPer creare una nuova nota, clicca sul bottone con il segno +.\n\nScorri la lista per vedere tutte le tue note. Tocca il titolo della nota per aprire il dettaglio, e tocca il contenuto per modificarlo.\n\nPer effettuare una ricerca, scrivi nella barra di ricerca presente in alto nella schermata delle note.\n\nClicca il pulsante in alto a sinistra della nota, oppure effettua uno swiping su di essa, per accedere ai tags. E' possibile aggiungere nuovi tags alla nota usando l'apposito campo presente in basso nella schermata di editing. Usa la barra laterale per accedere alle note filtrare per tag.\n\nCi sono anche altre opzioni se le desideri. E' per esempio possibile aggiungere collaboratori ad una nota, oppure pubblicare una nota su una pagina web.\n\nUsa Simplenote per Mac, per Android, oppure visita http:\/\/simplenote.com per accedere alle tue note da qualunque posto e da qualunque dispositivo.";
 

--- a/Simplenote/ja.lproj/Localizable.strings
+++ b/Simplenote/ja.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: ja_JP */
 
-/* Number of found search results */
-"%d Result" = "%d件の検索結果";
+/* Number of Characters in a note */
+"%@ Character" = "%@ 文字";
 
-/* Number of found search results */
-"%d Results" = "%d件の検索結果";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ 文字";
 
 /* Number of words in a note */
 "%@ Word" = "%@語";
@@ -15,416 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@単語";
 
-   Label of accept button on alert dialog */
-"Accept" = "承認";
-
-/* No comment provided by engineer. */
-"Account" = "アカウント";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "共同編集者を追加";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "タグを追加";
-
-/* Title: No filters applied */
-"All Notes" = "すべてのノート";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "キャンセル";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborate" = "共同編集";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "ノートの共同編集を有効化";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "共同編集者";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "ノートを共同編集したい人のメールアドレスを入力してください。その人も編集できるようになります。";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "要約ノート一覧";
-
-/* Siri Suggestion to create a New Note */
-"Create a new note" = "新規ノートを作成";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "現在の共同編集者";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "このノートは他のデバイスから削除されました。";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "キーボードを閉じる";
-
-   Verb: Close current view */
-"Done" = "完了";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "空にする";
-
-/* Remove all notes from the trash */
-"Empty trash" = "ゴミ箱を空にする";
-
-/* Noun - the version history of a note */
-"History" = "履歴";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "以前のバージョンにノートを復元";
-
-/* Action - view the version history of a note */
-"History..." = "履歴…";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "メニュー";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "ノートのオプションを表示";
-
-/* Siri Suggestion to create a New Note */
-"New note" = "新規ノート";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "ノートがありません";
-
-/* Message shown when no notes match a search string */
-"No Results" = "一致する結果がありません";
-
-/* No comment provided by engineer. */
-"Note not published" = "非公開ノート";
-
-/* Plural form of notes */
-"Notes" = "メモ";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "現在のノートを閉じる";
-
-/* Instant passcode lock timeout */
-"Off" = "オフ";
-
-/* Dismisses an AlertController */
-"OK" = "OK";
-
-/* No comment provided by engineer. */
-"On" = "オン";
-
-/* Select a note to view in the note editor */
-"Open note" = "ノートを開く";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "パスコード";
-
-/* Action to mark a note as pinned */
-"Pin note" = "ノートを上部固定";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "上部に固定";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "固定切り替え";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "上部固定中";
-
-/* No comment provided by engineer. */
-"Publish" = "公開";
-
-/* Action which published a note to a web page */
-"Publish note" = "ノートを公開";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "公開の切り替え";
-
-/* No comment provided by engineer. */
-"Published" = "公開済み";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "公開中";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "ゴミ箱からノートを完全消去";
-
-/* Rename a tag */
-"Rename" = "タイトル変更";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "復元";
-
-/* Restore a note to a previous version */
-"Restore Note" = "ノートを復元";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Send" = "送信";
-
-/* AlertController's Payload for the broken Sort Options Fix */
-"Settings" = "設定";
-
-/* No comment provided by engineer. */
-"Share note" = "ノートを共有";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "現在のノートのコンテンツを共有";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "サイドバー";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "現在のノートにタグを追加";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "現在のノートからタグを削除";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "今日";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "タグサイドバーを切り替え";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "現在のノートをゴミ箱へ移動";
-
-/* Empty Trash Warning */
-"Trash-noun" = "ゴミ箱";
-
-/* Trash (verb) - the action of deleting a note */
-"Trash-verb" = "ゴミ箱に移動";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "固定表示を解除";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "ノートを非公開";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "非公開設定中…";
-
-/* Represents a snapshot in time for a note */
-"Version" = "バージョン";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "以前のバージョンにアクセスするにはインターネットに接続してください。";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "このバージョンにスイッチ";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "バージョンを取得中";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "昨日";
-
-"welcomeNote-iOS" = "Simplenote for iOS へようこそ !
-
-ノートを新規作成するには、「＋」ボタンをタップしてください。
-
-一覧を使ってノートをブラウズできます。ノートの内容を表示するにはタイトルをタップしてください。次の画面で本文をタップすると編集できます。
-
-ノートを検索するには、ノート一覧の上に検索キーワードを入力してください。
-
-左上の矢印ボタンをタップするか、ノート一覧画面で左から右にスワイプするとタグを表示できます。タグを追加するには、エディタの一番下をタップして入力してください。
-
-ノートには他にもオプションがあります。共同編集者を追加したり、ノートを Web ページとして公開したりできます。
-
-http://simplenote.com で Mac・Android アプリやブラウザからのアクセス方法をご覧いただけます。ノートはすべてのデバイスで自動的に更新されます。";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "入力されたメールアドレスとパスワードではアカウントを作成できませんでした。";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "入力されたメールアドレスとパスワードではログインできませんでした。";
-
-/* Error for bad email or password */
-"Password" = "パスワード";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "パスワードは6文字以上にしてください。";
-
-   SignUp Interface Title */
-"Sign Up" = "登録";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "無効なメールアドレスです。";
-
-/* User Authenticated */
-"Authenticated" = "認証済み";
-
-   Display internal debug status */
-"Debug" = "デバッグ";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "待機状態";
-
-/* Last Message timestamp */
-"LastSeen" = "LastSeen";
-
-/* Month and day date formatter */
-"MMM d" = "M月d日";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "M月d日 h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "yyyy年M月d日";
-
-/* Month, day, and year date formatter */
-"MMM yyyy" = "yyyy年M月";
-
-/* Number of changes pending to be sent */
-"Pendings" = "保留中";
-
-/* Reachs Internet */
-"Reachability" = "到達の可能性";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "セキュリティ";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Simplenote アプリに満足していますか ?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "満足している";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "不満がある";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
-"Great! Could you leave us a nice review?
-It really helps." = "ありがとうございます。レビューを書いてもらえると、とても助かります。";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "レビューを書く";
-
-   Cancels Empty Trash Action */
-"No Thanks" = "いいえ";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "改善方法についてご意見いただけますか ?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "意見を送る";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "連絡";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "メールアドレス:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "どのようなサポートをお求めですか ?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "ログイン時にエラーが発生しました。";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "ゴミ箱を空にしてもよいですか ?この操作は元に戻すことができません。";
-
-/* Title of Back button for Markdown preview */
-"Back" = "戻る";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "コラボレーションは移動しました";
-
-/* Message displayed when login fails */
-"Couldn't Sign In" = "ログインできません";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "削除";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "ノートを削除";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Markdown フォーマットを無効化";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Edit" = "編集";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Markdown フォーマットを有効化";
-
-
-"Face ID" = "Face ID";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Markdown 切り替え";
-
-   Cancels Empty Trash Action */
-"No" = "いいえ";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "メールから WordPress.com アカウントを有効にして、もう一度試してください。";
-
-/* Siri Suggestion to open a specific Note */
-"Preview" = "プレビュー";
+/* Number of found search results */
+"%d Result" = "%d件の検索結果";
 
 /* Number of found search results */
-"Search" = "検索";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "ノートの共有はツールバーのアクションメニューからアクセスできます。";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "ログアウトすると、同期されていないメモはすべて削除されます。同期したメモを確認するには、Web アプリにログインします。";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tags" = "タグ";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "同期されていないメモが検出されました";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Web アプリにアクセス";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "はい";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "タグ ...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "共有";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "タグがつけられていないメモ";
-
-   Sort Order for the Notes List */
-"Sort Order" = "ソート順";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "分析を共有";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Email" = "メールアドレス";
-
-/* Option to enable the dark app theme. */
-"Theme" = "テーマ";
-
-/* The Simplenote blog */
-"Blog" = "ブログ";
-
-/* Sign in error message */
-"Error" = "エラー";
-
-/* No comment provided by engineer. */
-"Appearance" = "外観";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ 文字";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ 文字";
+"%d Results" = "%d件の検索結果";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1分";
@@ -450,11 +45,36 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Display app about screen */
 "About" = "このサイトについて";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "承認";
+
+/* No comment provided by engineer. */
+"Account" = "アカウント";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "共同編集者を追加";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "タグ ...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "タグを追加";
+
+/* Title: No filters applied */
+"All Notes" = "すべてのノート";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "アルファベット順 :A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "アルファベット順 :Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "ログイン時にエラーが発生しました。";
+
+/* No comment provided by engineer. */
+"Appearance" = "外観";
 
 /* Other Simplenote apps */
 "Apps" = "アプリ";
@@ -462,14 +82,23 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "開発者の方ですか ?Automattic では人材を募集しています。";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "ゴミ箱を空にしてもよいですか ?この操作は元に戻すことができません。";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "メールアドレスなしで送信してもよろしいですか ?返信は送信されないことになります。";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "本当に実行しますか ?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "ファイルの添付";
+/* User Authenticated */
+"Authenticated" = "認証済み";
+
+/* Title of Back button for Markdown preview */
+"Back" = "戻る";
+
+/* The Simplenote blog */
+"Blog" = "ブログ";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "アカウントを作成すると次に合意したものとみなされます";
@@ -477,17 +106,54 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* No comment provided by engineer. */
 "Can't Access." = "アクセスできません。";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "キャンセル";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "写真を選択";
 
 /* No comment provided by engineer. */
 "Close" = "閉じる";
 
+/* Verb - work with others on a note */
+"Collaborate" = "共同編集";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "コラボレーションは移動しました";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "共同編集者";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "要約ノート一覧";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "連絡";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "参加";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "不満がある";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "入力されたメールアドレスとパスワードではアカウントを作成できませんでした。";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "入力されたメールアドレスとパスワードではログインできませんでした。";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "改善方法についてご意見いただけますか ?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "ログインできません";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "新規ノートを作成";
+
+/* No comment provided by engineer. */
+"Create a new note" = "新規ノートを作成";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "作成日 :最新";
@@ -495,29 +161,97 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "作成日 :最も古い";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "現在の共同編集者";
+
 /* Theme: Dark */
 "Dark" = "ダーク";
 
-/* Message for alert when user tries to send feedback without an email address */
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "デバッグ";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "削除";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "ノートを削除";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Markdown フォーマットを無効化";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "キーボードを閉じる";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "完了";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "編集";
+
+/* Email TextField Placeholder */
+"Email" = "メールアドレス";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "メールアドレス";
 
 /* Email Taken Alert Title */
 "Email in use" = "使用中のメールアドレス";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "空にする";
+
+/* Remove all notes from the trash */
+"Empty trash" = "ゴミ箱を空にする";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Markdown フォーマットを有効化";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "待機状態";
+
+/* No comment provided by engineer. */
+"Error" = "エラー";
+
 /* No comment provided by engineer. */
 "Error uploading." = "アップロードの際にエラーが発生しました。";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "パスワードを忘れましたか ?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "ありがとうございます。レビューを書いてもらえると、とても助かります。";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "弊社の分析ツールに使用データを提供し、Simplenote の品質向上にご協力ください。";
+
+/* Noun - the version history of a note */
+"History" = "履歴";
+
+/* Action - view the version history of a note */
+"History..." = "履歴…";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "どのようなサポートをお求めですか ?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "満足している";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "無効なメールアドレス。";
 
+/* Last Message timestamp */
+"LastSeen" = "LastSeen";
+
 /* Learn More Action */
 "Learn more" = "さらに詳しく";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "レビューを書く";
 
 /* Theme: Light */
 "Light" = "ライト";
@@ -525,17 +259,41 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "タイムアウトをロック";
 
-/* Sign in error message */
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
 "Log In" = "ログイン";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "メールアドレスでログイン";
+/* Log out of the active account in the app */
+"Log Out" = "ログアウト";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "WordPress.com アカウントでログイン";
 
-/* Log out of the active account in the app */
-"Log Out" = "ログアウト";
+/* Presents the regular Email signin flow */
+"Log in with email" = "メールアドレスでログイン";
+
+/* Month and day date formatter */
+"MMM d" = "M月d日";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "M月d日 h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "yyyy年M月d日";
+
+/* Month and year date formatter */
+"MMM yyyy" = "yyyy年M月";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown 切り替え";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "メニュー";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "更新日 :最新";
@@ -543,8 +301,15 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "更新日 :最も古い";
 
+/* Label to create a new note */
+"New note" = "新規ノート";
+
 /* Empty Note Placeholder */
 "New note..." = "新規ノート…";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "いいえ";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "メールアドレスがありません。";
@@ -555,17 +320,74 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "メッセージがありません。";
 
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "ノートがありません";
+
+/* Message shown when no notes match a search string */
+"No Results" = "一致する結果がありません";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "いいえ";
+
+/* No comment provided by engineer. */
+"Note not published" = "非公開ノート";
+
+/* Plural form of notes */
+"Notes" = "メモ";
+
+/* Dismisses an AlertController */
+"OK" = "OK";
+
+/* Instant passcode lock timeout */
+"Off" = "オフ";
+
+/* No comment provided by engineer. */
+"On" = "オン";
+
 /* Siri Suggestion to open a specific Note */
-"Open "(preview)"" = "「(プレビュー)」を開く";
+"Open \"(preview)\"" = "「(プレビュー)」を開く";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Simplenote を開く";
 
+/* Select a note to view in the note editor */
+"Open note" = "ノートを開く";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "更新によってノートの表示順が変更された可能性があります。並べ替えの設定を確認しますか ?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "パスコード";
+
+/* Password TextField Placeholder */
+"Password" = "パスワード";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "パスワードは4文字以上にしてください";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "パスワードは6文字以上にしてください。";
+
+/* Number of changes pending to be sent */
+"Pendings" = "保留中";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "ピン";
+
+/* Action to mark a note as pinned */
+"Pin note" = "ノートを上部固定";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "上部に固定";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "固定切り替え";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "上部固定中";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "メールから WordPress.com アカウントを有効にして、もう一度試してください。";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "メールアドレスが無効のようです。ご確認ください。";
@@ -573,11 +395,57 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "メッセージを入力してください。";
 
+/* Title of Markdown preview screen */
+"Preview" = "プレビュー";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "個人情報保護方針";
 
 /* Privacy Settings */
 "Privacy Settings" = "プライバシー設定";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "公開";
+
+/* Action which published a note to a web page */
+"Publish note" = "ノートを公開";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "公開の切り替え";
+
+/* No comment provided by engineer. */
+"Published" = "公開済み";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "公開中";
+
+/* Reachs Internet */
+"Reachability" = "到達の可能性";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "ゴミ箱からノートを完全消去";
+
+/* Rename a tag */
+"Rename" = "タイトル変更";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "復元";
+
+/* Restore a note to a previous version */
+"Restore Note" = "ノートを復元";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "検索";
+
+/* No comment provided by engineer. */
+"Security" = "セキュリティ";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "送信";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "意見を送る";
 
 /* For debugging use */
 "Send a Test Crash" = "テストクラッシュを送信";
@@ -585,7 +453,33 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "送信中...";
 
+/* Title of options screen */
+"Settings" = "設定";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "共有";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "分析を共有";
+
+/* No comment provided by engineer. */
+"Share note" = "ノートを共有";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "ノートの共有はツールバーのアクションメニューからアクセスできます。";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "サイドバー";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "登録";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "ログアウトすると、同期されていないメモはすべて削除されます。同期したメモを確認するには、Web アプリにログインします。";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -594,8 +488,15 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "アルファベット順に並べ替え";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "ソート順";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "システムの初期設定";
+
+/* No comment provided by engineer. */
+"Tags" = "タグ";
 
 /* No comment provided by engineer. */
 "Take Photo" = "写真を撮影";
@@ -603,10 +504,10 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue */
 "Terms and Conditions" = "利用規約";
 
-/* Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue */
+/* Simplenote terms of service */
 "Terms of Service" = "利用規約";
 
-/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+/* No comment provided by engineer. */
 "Thanks" = "ありがとうございます。";
 
 /* Error when address is in use */
@@ -616,16 +517,49 @@ It really helps." = "ありがとうございます。レビューを書いて�
 "The simplest way to keep notes." = "最も手軽にメモを残せる方法です。";
 
 /* Option to enable the dark app theme. */
+"Theme" = "テーマ";
+
+/* Simplenote Themes */
 "Themes" = "テーマ";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "フィードバックを送信する際にエラーが発生しました。もう一度お試しください。";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "今日";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "タグサイドバーを切り替え";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "ゴミ箱";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "ゴミ箱に移動";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "ピンを外す";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "固定表示を解除";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "ノートを非公開";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "非公開設定中…";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "同期されていないメモが検出されました";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "タグなし";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "タグがつけられていないメモ";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "最新の写真を使う";
@@ -633,8 +567,14 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* A user's Simplenote account */
 "Username" = "ユーザー名";
 
+/* Represents a snapshot in time for a note */
+"Version" = "バージョン";
+
 /* App version number */
 "Version %@" = "バージョン %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Web アプリにアクセス";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "写真にアクセスできませんでした。「設定」でこのアプリケーションにアクセス権が与えられていることをご確認ください。";
@@ -648,15 +588,76 @@ It really helps." = "ありがとうございます。レビューを書いて�
 /* Generic error */
 "We're having problems. Please try again soon." = "問題が発生しました。すぐにもう一度実行してください。";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Simplenote アプリに満足していますか ?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "WordPress についてのご意見をお聞かせください。";
 
 /* Work at Automattic */
 "Work With Us" = "求人情報";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "はい";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "昨日";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "メールアドレス:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "無効なメールアドレスです。";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "メッセージは失われます。";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "パスワードは4文字以上にしてください";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "ファイルの添付";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "ノートの共同編集を有効化";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "ノートを共同編集したい人のメールアドレスを入力してください。その人も編集できるようになります。";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "このノートは他のデバイスから削除されました。";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "以前のバージョンにノートを復元";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "ノートのオプションを表示";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "現在のノートを閉じる";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "現在のノートのコンテンツを共有";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "現在のノートにタグを追加";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "現在のノートからタグを削除";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "現在のノートをゴミ箱へ移動";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "以前のバージョンにアクセスするにはインターネットに接続してください。";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "このバージョンにスイッチ";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "バージョンを取得中";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Simplenote for iOS へようこそ !\n\nノートを新規作成するには、「＋」ボタンをタップしてください。\n\n一覧を使ってノートをブラウズできます。ノートの内容を表示するにはタイトルをタップしてください。次の画面で本文をタップすると編集できます。\n\nノートを検索するには、ノート一覧の上に検索キーワードを入力してください。\n\n左上の矢印ボタンをタップするか、ノート一覧画面で左から右にスワイプするとタグを表示できます。タグを追加するには、エディタの一番下をタップして入力してください。\n\nノートには他にもオプションがあります。共同編集者を追加したり、ノートを Web ページとして公開したりできます。\n\nhttp:\/\/simplenote.com で Mac・Android アプリやブラウザからのアクセス方法をご覧いただけます。ノートはすべてのデバイスで自動的に更新されます。";
 

--- a/Simplenote/ko.lproj/Localizable.strings
+++ b/Simplenote/ko.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: ko_KR */
 
-/* Number of found search results */
-"%d Result" = "결과 %d개";
+/* Number of Characters in a note */
+"%@ Character" = "%@자";
 
-/* Number of found search results */
-"%d Results" = "결과 %d개";
+/* Number of Characters in a note */
+"%@ Characters" = "%@자";
 
 /* Number of words in a note */
 "%@ Word" = "단어 %@개";
@@ -15,415 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "단어 %@개";
 
-   Label of accept button on alert dialog */
-"Accept" = "수락";
-
-/* No comment provided by engineer. */
-"Account" = "계정";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "새 공동 작업자 추가...";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "태그 추가";
-
-/* Title: No filters applied */
-"All Notes" = "모든 메모";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "취소";
-
-/* Verb - work with others on a note */
-"Collaborate" = "협업";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "다른 사람과 협업할 수 있습니다.";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "공동 작업자";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "이 메모를 다른 사람과 공유하려면 이메일 주소를 추가하세요. 그러면 두 사람 모두 메모를 수정할 수 있습니다.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "메모 요약 목록";
-
-/* Siri Suggestion to create a New Note */
-"Create a new note" = "새 메모 만들기";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "현재 공동 작업자";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "이 메모는 다른 장치에서 삭제됐습니다.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "키보드 비활성화";
-
-   Verb: Close current view */
-"Done" = "완료";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "비우기";
-
-/* Remove all notes from the trash */
-"Empty trash" = "휴지통 비우기";
-
-/* Noun - the version history of a note */
-"History" = "내역";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "이전 버전에 메모 복원";
-
-/* Action - view the version history of a note */
-"History..." = "내역...";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "메뉴";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "메모 옵션 표시";
-
-/* Siri Suggestion to create a New Note */
-"New note" = "새 메모";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "메모 없음";
-
-/* Message shown when no notes match a search string */
-"No Results" = "결과 없음";
-
-/* No comment provided by engineer. */
-"Note not published" = "메모 게시 안 됨";
-
-/* Title: No filters applied */
-"Notes" = "메모";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "현재 메모 닫기";
-
-/* Instant passcode lock timeout */
-"Off" = "끔";
-
-/* Dismisses an AlertController */
-"OK" = "확인";
-
-/* No comment provided by engineer. */
-"On" = "켬";
-
-/* Select a note to view in the note editor */
-"Open note" = "메모 열기";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "패스코드";
-
-/* Action to mark a note as pinned */
-"Pin note" = "메모 고정";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "상단에 고정";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "핀 토클";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "고정됨";
-
-/* No comment provided by engineer. */
-"Publish" = "게시";
-
-/* No comment provided by engineer. */
-"Publish note" = "메모 게시";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "게시 상태 전환";
-
-/* No comment provided by engineer. */
-"Published" = "게시됨";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "게시 중...";
-
-/* Remove all notes from the trash */
-"Remove all notes from trash" = "휴지통 비우기";
-
-/* Rename a tag */
-"Rename" = "이름 변경";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "복구";
-
-/* Restore a note to a previous version */
-"Restore Note" = "메모 복구";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "보내기";
-
-/* AlertController's Payload for the broken Sort Options Fix */
-"Settings" = "설정";
-
-/* No comment provided by engineer. */
-"Share note" = "메모 공유";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "현재 메모 내용 공유";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "사이드바";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "현재 메모에 태그 추가";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "현재 메모에서 태그 제거";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "오늘";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "태그 사이드바 토글";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "휴지통으로 현재 메모 이동";
-
-/* Empty Trash Warning */
-"Trash-noun" = "휴지통";
-
-/* Empty Trash Warning */
-"Trash-verb" = "휴지통";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "메모 고정 취소";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "메모 게시 취소";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "게시 취소 중...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "버전";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "이전 버전을 사용하려면 인터넷에 연결해야 합니다.";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "이 버전으로 전환";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "버전 패치";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "어제";
-
-"welcomeNote-iOS" = "iOS용 Simplenote 시작하기
-
-메모를 추가하려면 더하기 버튼을 누르세요.
-
-메모를 탐색하려면 목록을 누르세요 메모를 보려면 제목을 누르고 메모를 수정하려면 메모 내용을 누르세요.
-
-메모 목록 상단의 검색 필드에 검색어를 입력해서 모든 메모를 검색할 수 있습니다.
-
-태그를 보려면 왼쪽 상단의 화살표 버튼을 누르거나 메모 목록을 옆으로 쓸어 넘기세요. 메모 에디터 하단에서 메모에 태그를 추가하고 사이드바를 사용해서 메모를 정리할 수 있습니다.
-
-필요한 경우 더욱 다양한 메모 옵션을 사용할 수 있습니다. 다른 사용자를 메모 공유자로 추가하거나 메모를 웹 페이지로 게시할 수 있습니다.
-
-Mac, Android 장치나 웹 브라우저(http://simplenote.com)에서 Simplenote를 사용할 수 있습니다. 어디에 있든 메모 내용이 자동으로 업데이트됩니다.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "입력하신 이메일 주소와 비밀번호로 계정을 만들지 못했습니다.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "입력하신 이메일 주소와 비밀번호로 로그인하지 못했습니다.";
-
-/* Error for bad email or password */
-"Password" = "비밀번호";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "비밀번호에는 최소 6개의 문자가 포함되어야 합니다.";
-
-   SignUp Interface Title */
-"Sign Up" = "가입";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "이메일 주소가 올바르지 않습니다.";
-
-/* User Authenticated */
-"Authenticated" = "인증됨";
-
-   Display internal debug status */
-"Debug" = "디버그";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "활성화됨";
-
-/* Last Message timestamp */
-"LastSeen" = "LastSeen";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "yyyy MMM d";
-
-/* Month, day, and year date formatter */
-"MMM yyyy" = "yyyy MMM";
-
-/* Number of changes pending to be sent */
-"Pendings" = "대기 중";
-
-/* Reachs Internet */
-"Reachability" = "연결";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "보안";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Simplenote를 어떻게 생각하시나요?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "좋아요";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "별로";
-
-"Great! Could you leave us a nice review?
-It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\n\n많은 도움이 될 겁니다.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "리뷰를 남겨주세요.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "괜찮습니다.";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "개선 방안을 말해 주시겠어요?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "의견 보내기";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "문의";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "귀하의 이메일:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "어떻게 도와드릴까요?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "로그인하는 중에 오류가 발생했습니다.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "휴지통을 비우시겠습니까? 이 작업은 되돌릴 수 없습니다.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "뒤로";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "협업이 이동됨";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "로그인할 수 없음";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "삭제";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "메모 삭제";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "마크다운 형식 사용 안 함";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "편집";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "마크다운 형식 사용";
-
-
-"Face ID" = "Face ID";
-
-/* No comment provided by engineer. */
-"Markdown" = "마크다운";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "토글 마크다운";
-
-   Cancels Empty Trash Action */
-"No" = "아니요";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "이메일을 통해 워드프레스닷컴 계정을 활성화하고 다시 시도하세요.";
-
-/* Siri Suggestion to open a specific Note */
-"Preview" = "미리보기";
-
-   Using Search instead of Back if user is searching */
-"Search" = "검색";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "이제 도구 모음에서 작업 메뉴를 통해 메모 공유에 액세스할 수 있습니다.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "로그아웃하면 동기화되지 않은 모든 메모가 삭제됩니다. 웹 앱에 로그인하여 동기화된 메모를 확인할 수 있습니다.";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tags" = "태그";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "동기화되지 않은 메모 감지됨";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "웹 앱 방문";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "예";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "태그...";
-
-/* Privacy Details */
-"Share" = "공유";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "태그 없는 메모";
-
-   Sort Order for the Notes List */
-"Sort Order" = "정렬 순서";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "분석 공유";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Email" = "이메일";
-
-/* Option to enable the dark app theme. */
-"Theme" = "테마";
-
-/* The Simplenote blog */
-"Blog" = "블로그";
-
-/* Sign in error message */
-"Error" = "오류";
-
-/* No comment provided by engineer. */
-"Appearance" = "모양";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@자";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@자";
+/* Number of found search results */
+"%d Result" = "결과 %d개";
+
+/* Number of found search results */
+"%d Results" = "결과 %d개";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1분";
@@ -449,11 +45,36 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Display app about screen */
 "About" = "정보";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "수락";
+
+/* No comment provided by engineer. */
+"Account" = "계정";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "새 공동 작업자 추가...";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "태그...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "태그 추가";
+
+/* Title: No filters applied */
+"All Notes" = "모든 메모";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "알파벳순: A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "알파벳순: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "로그인하는 중에 오류가 발생했습니다.";
+
+/* No comment provided by engineer. */
+"Appearance" = "모양";
 
 /* Other Simplenote apps */
 "Apps" = "앱";
@@ -461,14 +82,23 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "개발자이십니까? Automattic에서 채용 모집 중입니다.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "휴지통을 비우시겠습니까? 이 작업은 되돌릴 수 없습니다.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "이메일 없이 보내고 싶으십니까? 회원님께 회신할 수 없습니다.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "계속할까요?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "파일 첨부";
+/* User Authenticated */
+"Authenticated" = "인증됨";
+
+/* Title of Back button for Markdown preview */
+"Back" = "뒤로";
+
+/* The Simplenote blog */
+"Blog" = "블로그";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "계정을 만들면 다음에 동의하는 것입니다.";
@@ -476,17 +106,54 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* No comment provided by engineer. */
 "Can't Access." = "액세스를 할 수 없습니다.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "취소";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "사진 선택";
 
 /* No comment provided by engineer. */
 "Close" = "닫기";
 
+/* Verb - work with others on a note */
+"Collaborate" = "협업";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "협업이 이동됨";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "공동 작업자";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "메모 요약 목록";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "문의";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "참여";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "별로";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "입력하신 이메일 주소와 비밀번호로 계정을 만들지 못했습니다.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "입력하신 이메일 주소와 비밀번호로 로그인하지 못했습니다.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "개선 방안을 말해 주시겠어요?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "로그인할 수 없음";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "새 메모 만들기";
+
+/* No comment provided by engineer. */
+"Create a new note" = "새 메모 만들기";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "생성됨: 최신순";
@@ -494,29 +161,97 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "생성됨: 오래된 항목";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "현재 공동 작업자";
+
 /* Theme: Dark */
 "Dark" = "검정";
 
-/* Error for bad email or password */
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "디버그";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "삭제";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "메모 삭제";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "마크다운 형식 사용 안 함";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "키보드 비활성화";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "완료";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "편집";
+
+/* Email TextField Placeholder */
+"Email" = "이메일";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "이메일 주소";
 
 /* Email Taken Alert Title */
 "Email in use" = "사용 중인 이메일";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "비우기";
+
+/* Remove all notes from the trash */
+"Empty trash" = "휴지통 비우기";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "마크다운 형식 사용";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "활성화됨";
+
+/* No comment provided by engineer. */
+"Error" = "오류";
+
 /* No comment provided by engineer. */
 "Error uploading." = "업로드하는 중 오류가 발생했습니다.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "비밀번호를 잊으셨나요?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\\n\\n\\n많은 도움이 될 겁니다.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "사용 데이터를 분석 도구와 공유하여 Simplenote를 개선하도록 도와주세요.";
+
+/* Noun - the version history of a note */
+"History" = "내역";
+
+/* Action - view the version history of a note */
+"History..." = "내역...";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "어떻게 도와드릴까요?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "좋아요";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "잘못된 이메일 주소입니다.";
 
+/* Last Message timestamp */
+"LastSeen" = "LastSeen";
+
 /* Learn More Action */
 "Learn more" = "더 알아보기";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "리뷰를 남겨주세요.";
 
 /* Theme: Light */
 "Light" = "밝음";
@@ -524,17 +259,41 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "잠금 타임아웃";
 
-/* Sign in error message */
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
 "Log In" = "로그인";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "이메일로 로그인";
+/* Log out of the active account in the app */
+"Log Out" = "로그아웃";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "워드프레스닷컴으로 로그인";
 
-/* Log out of the active account in the app */
-"Log Out" = "로그아웃";
+/* Presents the regular Email signin flow */
+"Log in with email" = "이메일로 로그인";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "yyyy MMM d";
+
+/* Month and year date formatter */
+"MMM yyyy" = "yyyy MMM";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "마크다운";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "토글 마크다운";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "메뉴";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "수정됨: 최신순";
@@ -542,8 +301,15 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "수정됨: 오래된 항목";
 
+/* Label to create a new note */
+"New note" = "새 메모";
+
 /* Empty Note Placeholder */
 "New note..." = "새 메모...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "아니요";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "이메일이 없습니다.";
@@ -554,17 +320,74 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "메시지 없음";
 
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "메모 없음";
+
+/* Message shown when no notes match a search string */
+"No Results" = "결과 없음";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "괜찮습니다.";
+
+/* No comment provided by engineer. */
+"Note not published" = "메모 게시 안 됨";
+
+/* Plural form of notes */
+"Notes" = "메모";
+
+/* Dismisses an AlertController */
+"OK" = "확인";
+
+/* Instant passcode lock timeout */
+"Off" = "끔";
+
+/* No comment provided by engineer. */
+"On" = "켬";
+
 /* Siri Suggestion to open a specific Note */
-"Open "(preview)"" = "“(미리보기)” 열기";
+"Open \"(preview)\"" = "“(미리보기)” 열기";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Simplenote 열기";
 
+/* Select a note to view in the note editor */
+"Open note" = "메모 열기";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "업데이트로 메모가 표시되는 순서가 변경되었을 수 있습니다. 정렬 설정을 검토하시겠어요?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "패스코드";
+
+/* Password TextField Placeholder */
+"Password" = "비밀번호";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "암호는 4자 이상이어야 합니다.";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "비밀번호에는 최소 6개의 문자가 포함되어야 합니다.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "대기 중";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "고정";
+
+/* Action to mark a note as pinned */
+"Pin note" = "메모 고정";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "상단에 고정";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "핀 토클";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "고정됨";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "이메일을 통해 워드프레스닷컴 계정을 활성화하고 다시 시도하세요.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "이메일 주소를 확인하세요. 잘못된 주소인 것 같습니다.";
@@ -572,11 +395,57 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "메시지를 입력하세요.";
 
+/* Title of Markdown preview screen */
+"Preview" = "미리보기";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "개인정보 취급방침";
 
 /* Privacy Settings */
 "Privacy Settings" = "개인 정보 설정";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "게시";
+
+/* Action which published a note to a web page */
+"Publish note" = "메모 게시";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "게시 상태 전환";
+
+/* No comment provided by engineer. */
+"Published" = "게시됨";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "게시 중...";
+
+/* Reachs Internet */
+"Reachability" = "연결";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "휴지통 비우기";
+
+/* Rename a tag */
+"Rename" = "이름 변경";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "복구";
+
+/* Restore a note to a previous version */
+"Restore Note" = "메모 복구";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "검색";
+
+/* No comment provided by engineer. */
+"Security" = "보안";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "보내기";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "의견 보내기";
 
 /* For debugging use */
 "Send a Test Crash" = "테스트 충돌 보내기";
@@ -584,7 +453,33 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "전송 중...";
 
+/* Title of options screen */
+"Settings" = "설정";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "공유";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "분석 공유";
+
+/* No comment provided by engineer. */
+"Share note" = "메모 공유";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "이제 도구 모음에서 작업 메뉴를 통해 메모 공유에 액세스할 수 있습니다.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "사이드바";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "가입";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "로그아웃하면 동기화되지 않은 모든 메모가 삭제됩니다. 웹 앱에 로그인하여 동기화된 메모를 확인할 수 있습니다.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -593,8 +488,15 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "알파벳순으로 정렬";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "정렬 순서";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "시스템 기본값";
+
+/* No comment provided by engineer. */
+"Tags" = "태그";
 
 /* No comment provided by engineer. */
 "Take Photo" = "사진 촬영";
@@ -615,16 +517,49 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 "The simplest way to keep notes." = "메모를 보관하는 가장 간단한 방법입니다.";
 
 /* Option to enable the dark app theme. */
+"Theme" = "테마";
+
+/* Simplenote Themes */
 "Themes" = "테마";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "피드백을 보내는 과정에서 오류가 발생했습니다. 다시 시도하세요.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "오늘";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "태그 사이드바 토글";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "휴지통";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "휴지통";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "고정 해제";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "메모 고정 취소";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "메모 게시 취소";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "게시 취소 중...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "동기화되지 않은 메모 감지됨";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "태그 없음";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "태그 없는 메모";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "최신 사진 사용";
@@ -632,8 +567,14 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* A user's Simplenote account */
 "Username" = "사용자명";
 
+/* Represents a snapshot in time for a note */
+"Version" = "버전";
+
 /* App version number */
 "Version %@" = "버전 %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "웹 앱 방문";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "회원님의 사진에 액세스할 수 없습니다. 이 앱을 설정에서 액세스할 수 있도록 하세요.";
@@ -647,15 +588,76 @@ It really helps." = "훌륭합니다! 좋은 리뷰를 남겨주시겠어요?\n\
 /* Generic error */
 "We're having problems. Please try again soon." = "문제가 있습니다. 나중에 다시 시도하세요.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Simplenote를 어떻게 생각하시나요?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "워드프레스를 어떻게 생각하시나요?";
 
 /* Work at Automattic */
 "Work With Us" = "채용 공고";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "예";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "어제";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "귀하의 이메일:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "이메일 주소가 올바르지 않습니다.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "메시지가 손실됩니다.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "암호는 4자 이상이어야 합니다.";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "파일 첨부";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "다른 사람과 협업할 수 있습니다.";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "이 메모를 다른 사람과 공유하려면 이메일 주소를 추가하세요. 그러면 두 사람 모두 메모를 수정할 수 있습니다.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "이 메모는 다른 장치에서 삭제됐습니다.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "이전 버전에 메모 복원";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "메모 옵션 표시";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "현재 메모 닫기";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "현재 메모 내용 공유";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "현재 메모에 태그 추가";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "현재 메모에서 태그 제거";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "휴지통으로 현재 메모 이동";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "이전 버전을 사용하려면 인터넷에 연결해야 합니다.";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "이 버전으로 전환";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "버전 패치";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "iOS용 Simplenote 시작하기\n\n메모를 추가하려면 더하기 버튼을 누르세요.\n\n메모를 탐색하려면 목록을 누르세요 메모를 보려면 제목을 누르고 메모를 수정하려면 메모 내용을 누르세요.\n\n메모 목록 상단의 검색 필드에 검색어를 입력해서 모든 메모를 검색할 수 있습니다.\n\n태그를 보려면 왼쪽 상단의 화살표 버튼을 누르거나 메모 목록을 옆으로 쓸어 넘기세요. 메모 에디터 하단에서 메모에 태그를 추가하고 사이드바를 사용해서 메모를 정리할 수 있습니다.\n\n필요한 경우 더욱 다양한 메모 옵션을 사용할 수 있습니다. 다른 사용자를 메모 공유자로 추가하거나 메모를 웹 페이지로 게시할 수 있습니다.\n\nMac, Android 장치나 웹 브라우저(http:\/\/simplenote.com)에서 Simplenote를 사용할 수 있습니다. 어디에 있든 메모 내용이 자동으로 업데이트됩니다.";
 

--- a/Simplenote/nl.lproj/Localizable.strings
+++ b/Simplenote/nl.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: nl */
 
-/* Number of found search results */
-"%d Result" = "%d resultaat";
+/* Number of Characters in a note */
+"%@ Character" = "%@ teken";
 
-/* Number of found search results */
-"%d Results" = "%d resultaten";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ tekens";
 
 /* Number of words in a note */
 "%@ Word" = "%@ woord";
@@ -15,410 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ woorden";
 
-   Label of accept button on alert dialog */
-"Accept" = "Accepteren";
-
-/* No comment provided by engineer. */
-"Account" = "Account";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Een nieuwe samenwerker toevoegen...";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Tag toevoegen";
-
-/* Title: No filters applied */
-"All Notes" = "Alle notities";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "Annuleren";
-
-/* Verb - work with others on a note */
-"Collaborate" = "Samenwerken";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Samenwerking met anderen inschakelen";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Samenwerkers";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "Voeg een e-mailadres toe om deze notitie met iemand te delen. Dan kunnen jullie hem beide wijzigen.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Beknopte notitielijst";
-
-/* Siri Suggestion to create a New Note */
-"Create a new note" = "Een nieuwe notitie maken";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Huidige samenwerkers";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Deze notitie is verwijderd op een ander apparaat.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Toetsenbord sluiten";
-
-   Verb: Close current view */
-"Done" = "Klaar";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "Leegmaken";
-
-/* Remove all notes from the trash */
-"Empty trash" = "Prullenbak leegmaken";
-
-/* Noun - the version history of a note */
-"History" = "Geschiedenis";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Notitie herstellen naar eerdere versie";
-
-/* Action - view the version history of a note */
-"History..." = "Geschiedenis...";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "Menu";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Opties tonen voor notitie";
-
-/* Label to create a new note */
-"New note" = "Nieuwe notitie";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "Geen notities";
-
-/* Message shown when no notes match a search string */
-"No Results" = "Geen resultaten";
-
-/* No comment provided by engineer. */
-"Note not published" = "Notitie niet gepubliceerd";
-
-/* Verb: Delete notes and log out of the app */
-"Notes" = "Notities";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Huidige notitie sluiten";
-
-/* Log out of the active account in the app */
-"Off" = "Uit";
-
-/* Dismisses an AlertController */
-"OK" = "OK";
-
-/* Alert dialog title displayed on sign in error */
-"On" = "Aan";
-
-/* Select a note to view in the note editor */
-"Open note" = "Notitie openen";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Wachtwoordcode";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Notitie vastmaken";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "Vastmaken aan bovenzijde";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "Knop Vastmaken";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Vastgemaakt";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Publiceren";
-
-/* Action which published a note to a web page */
-"Publish note" = "Notitie publiceren";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "Knop Publiceren";
-
-/* No comment provided by engineer. */
-"Published" = "Gepubliceerd";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Publiceren...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Alle notities verwijderen uit prullenbak";
-
-/* Rename a tag */
-"Rename" = "Hernoemen";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Herstellen";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Notitie herstellen";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "Verzenden";
-
-/* Title of options screen */
-"Settings" = "Instellingen";
-
-/* No comment provided by engineer. */
-"Share note" = "Notitie delen";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "De inhoud van de huidige notitie delen";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Sidebar";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Een tag toevoegen aan de huidige notitie";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Tag verwijderen uit de huidige notitie";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Vandaag";
-
-"Toggle tag sidebar" = "Tag-sidebar tonen/verbergen";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "De huidige notitie verplaatsen naar de prullenbak";
-
-/* Remove all notes from the trash */
-"Trash-noun" = "Prullenbak";
-
-/* Trash (verb) - the action of deleting a note */
-"Trash-verb" = "Naar prullenbak";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Notitie losmaken";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Notitie verwijderen";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Verwijderen ...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Versie";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Maak verbinding met internet voor toegang tot eerdere versies";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Overschakelen naar deze versie";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Versie ophalen";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Gisteren";
-
-"welcomeNote-iOS" = "Welkom bij Simplenote voor iOS!
-
-Om een notitie toe te voegen, tik je op de plusknop.
-
-Veeg door de lijst om te bladeren in je notities. Tik op een titel om een notitie te bekijken en tik dan op de inhoud om hem te wijzigen.
-
-Je kunt in al je notities zoeken door te typen in het zoekveld boven aan de notitielijst.
-
-Tik op de pijlknop linksboven of veeg over je notitielijst om je tags te bekijken. Je kunt tags toevoegen aan een notitie onder aan de notitie-editor en vervolgens de sidebar gebruiken om overzicht te houden.
-
-Desgewenst zijn er nog meer notitie-opties. Je kunt anderen toevoegen aan een notitie als samenwerker of een notitie publiceren als webpagina.
-
-Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://simplenote.com. Je notities worden overal automatisch bijgewerkt.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Kan geen account maken met het opgegeven e-mailadres en wachtwoord.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Kan niet inloggen met het opgegeven e-mailadres en wachtwoord.";
-
-/* Password Reset Action */
-"Password" = "Wachtwoord";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Wachtwoord moet ten minste 6 tekens bevatten.";
-
-   SignUp Interface Title */
-"Sign Up" = "Registreren";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Je e-mailadres is niet geldig.";
-
-/* User Authenticated */
-"Authenticated" = "Geverifieerd";
-
-
-"Debug" = "Debug";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "Aantal in wachtrij";
-
-/* Last Message timestamp */
-"LastSeen" = "Laatst bekeken om";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, u:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM jjjj";
-
-/* Month, day, and year date formatter */
-"MMM yyyy" = "MMM jjjj";
-
-/* Number of changes pending to be sent */
-"Pendings" = "Aantal in behandeling";
-
-/* Reachs Internet */
-"Reachability" = "Bereikbaarheid";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Beveiliging";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Wat vind je van Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Ik vind het leuk";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Kan beter";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Laat een beoordeling achter";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Nee, liever niet";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Kun je ons vertellen wat we kunnen verbeteren?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Stuur feedback";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Contact";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "Je e-mailadres:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Hoe kunnen we helpen?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "Er is een aanmeldfout opgetreden.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "Weet je zeker dat je de prullenbak wilt leegmaken? Deze actie kan niet ongedaan worden gemaakt.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Terug";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "Samenwerking is verplaatst";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "Aanmelden mislukt";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Verwijderen";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Notities verwijderen";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Markdown-opmaak uitschakelen";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "Bewerken";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Markdown-opmaak inschakelen";
-
-/* Offer to enable Face ID support if available and passcode is on. */
-"Face ID" = "Gezichts-ID";
-
-/* Special formatting that can be turned on for notes */
-"Markdown" = "Snelle stijl";
-
-"Markdown toggle" = "Markdown in-/uitschakelen";
-
-   Cancels Empty Trash Action */
-"No" = "Nee";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Activeer je WordPress.com-account via e-mail en probeer het nogmaals.";
-
-/* Title of Markdown preview screen */
-"Preview" = "Voorbeeld bekijken";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Zoeken";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Je kunt vanaf nu notities delen via het actiemenu vanuit de werkbalk.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Door je af te melden worden gesynchroniseerde notities verwijderd. Je kunt je gesynchroniseerde notities verifiëren door je aan te melden via de web-app.";
-
-
-"Tags" = "Tags";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Ongesynchroniseerde notities gedetecteerd";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Web-app bezoeken";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "Ja";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Tag...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Delen";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Niet-getagde notities";
-
-   Sort Order for the Notes List */
-"Sort Order" = "Sorteervolgorde";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Analyses delen";
-
-/* Email TextField Placeholder */
-"Email" = "E-mailen";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Thema";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
-
-/* No comment provided by engineer. */
-"Error" = "Fout";
-
-/* No comment provided by engineer. */
-"Appearance" = "Weergave";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ teken";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ tekens";
+/* Number of found search results */
+"%d Result" = "%d resultaat";
+
+/* Number of found search results */
+"%d Results" = "%d resultaten";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 minuut";
@@ -444,11 +45,36 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Display app about screen */
 "About" = "Over";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Accepteren";
+
+/* No comment provided by engineer. */
+"Account" = "Account";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Een nieuwe samenwerker toevoegen...";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Tag...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Tag toevoegen";
+
+/* Title: No filters applied */
+"All Notes" = "Alle notities";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "Alfabetisch: A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "Alfabetisch: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "Er is een aanmeldfout opgetreden.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Weergave";
 
 /* Other Simplenote apps */
 "Apps" = "Apps";
@@ -456,14 +82,23 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "Ben je ontwikkelaar? Automattic is op zoek naar nieuwe collega's.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Weet je zeker dat je de prullenbak wilt leegmaken? Deze actie kan niet ongedaan worden gemaakt.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "Weet je zeker dat je wilt versturen zonder je e-mailadres? We kunnen je dan geen antwoord sturen.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "Weet je het zeker?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "voeg een bestand bij";
+/* User Authenticated */
+"Authenticated" = "Geverifieerd";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Terug";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "Door een account aan te maken, ga je akkoord met onze";
@@ -471,17 +106,54 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* No comment provided by engineer. */
 "Can't Access." = "Geen toegang.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "Annuleren";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Kies een foto";
 
 /* No comment provided by engineer. */
 "Close" = "Sluiten";
 
+/* Verb - work with others on a note */
+"Collaborate" = "Samenwerken";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Samenwerking is verplaatst";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Samenwerkers";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Beknopte notitielijst";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Contact";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Bijdragen";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Kan beter";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Kan geen account maken met het opgegeven e-mailadres en wachtwoord.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Kan niet inloggen met het opgegeven e-mailadres en wachtwoord.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Kun je ons vertellen wat we kunnen verbeteren?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Aanmelden mislukt";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Een nieuwe notitie maken";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Een nieuwe notitie maken";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Aangemaakt op: Nieuwste";
@@ -489,8 +161,37 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Aangemaakt op: Oudste";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Huidige samenwerkers";
+
 /* Theme: Dark */
 "Dark" = "Donker";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Debug";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Verwijderen";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Notities verwijderen";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Markdown-opmaak uitschakelen";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Toetsenbord sluiten";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Klaar";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Bewerken";
+
+/* Email TextField Placeholder */
+"Email" = "E-mailen";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "E-mailadres";
@@ -498,20 +199,59 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Email Taken Alert Title */
 "Email in use" = "E-mail in gebruik";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Leegmaken";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Prullenbak leegmaken";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Markdown-opmaak inschakelen";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Aantal in wachtrij";
+
+/* No comment provided by engineer. */
+"Error" = "Fout";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Uploadfout.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Gezichts-ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "Wachtwoord vergeten?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Great! Could you leave us a nice review?\nIt really helps.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Help ons Simplenote te verbeteren door gebruiksgegevens te delen met onze analysetool.";
+
+/* Noun - the version history of a note */
+"History" = "Geschiedenis";
+
+/* Action - view the version history of a note */
+"History..." = "Geschiedenis...";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Hoe kunnen we helpen?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Ik vind het leuk";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Ongeldig e-mailadres";
 
+/* Last Message timestamp */
+"LastSeen" = "Laatst bekeken om";
+
 /* Learn More Action */
 "Learn more" = "Meer informatie";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Laat een beoordeling achter";
 
 /* Theme: Light */
 "Light" = "Licht";
@@ -519,17 +259,41 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Time-out voor vergrendeling";
 
+/* Log In Action
+   Login Action
+   LogIn Action
    LogIn Interface Title */
 "Log In" = "Inloggen";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "Inloggen met e-mail";
+/* Log out of the active account in the app */
+"Log Out" = "Uitloggen";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "Inloggen met WordPress.com";
 
-/* Log out of the active account in the app */
-"Log Out" = "Uitloggen";
+/* Presents the regular Email signin flow */
+"Log in with email" = "Inloggen met e-mail";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, u:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM jjjj";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM jjjj";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Snelle stijl";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown in-\/uitschakelen";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Menu";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Aangepast op: Nieuwste";
@@ -537,8 +301,15 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Aangepast op: Oudste";
 
+/* Label to create a new note */
+"New note" = "Nieuwe notitie";
+
 /* Empty Note Placeholder */
 "New note..." = "Nieuwe notitie …";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "Nee";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "Geen e-mail.";
@@ -549,17 +320,74 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Geen bericht.";
 
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "Geen notities";
+
+/* Message shown when no notes match a search string */
+"No Results" = "Geen resultaten";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Nee, liever niet";
+
+/* No comment provided by engineer. */
+"Note not published" = "Notitie niet gepubliceerd";
+
+/* Plural form of notes */
+"Notes" = "Notities";
+
+/* Dismisses an AlertController */
+"OK" = "OK";
+
+/* Instant passcode lock timeout */
+"Off" = "Uit";
+
+/* No comment provided by engineer. */
+"On" = "Aan";
+
 /* Siri Suggestion to open a specific Note */
-"Open "(preview)"" = "Open '(voorbeeldweergave)'";
+"Open \"(preview)\"" = "Open '(voorbeeldweergave)'";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Open Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "Notitie openen";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "De volgorde waarin je notities worden weergegeven, kan na onze update gewijzigd zijn. Wil je de sorteerinstellingen controleren?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Wachtwoordcode";
+
+/* Password TextField Placeholder */
+"Password" = "Wachtwoord";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Wachtwoord moet minstens 4 tekens bevatten";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Wachtwoord moet ten minste 6 tekens bevatten.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Aantal in behandeling";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Vastmaken";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Notitie vastmaken";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "Vastmaken aan bovenzijde";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "Knop Vastmaken";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Vastgemaakt";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Activeer je WordPress.com-account via e-mail en probeer het nogmaals.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "Controleer je e-mailadres, het lijkt ongeldig te zijn.";
@@ -567,11 +395,57 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Voer een bericht in.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Voorbeeld bekijken";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Privacybeleid";
 
 /* Privacy Settings */
 "Privacy Settings" = "Privacy instellingen";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Publiceren";
+
+/* Action which published a note to a web page */
+"Publish note" = "Notitie publiceren";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Knop Publiceren";
+
+/* No comment provided by engineer. */
+"Published" = "Gepubliceerd";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Publiceren...";
+
+/* Reachs Internet */
+"Reachability" = "Bereikbaarheid";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Alle notities verwijderen uit prullenbak";
+
+/* Rename a tag */
+"Rename" = "Hernoemen";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Herstellen";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Notitie herstellen";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Zoeken";
+
+/* No comment provided by engineer. */
+"Security" = "Beveiliging";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Verzenden";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Stuur feedback";
 
 /* For debugging use */
 "Send a Test Crash" = "Een testcrash verzenden";
@@ -579,7 +453,33 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Versturen...";
 
+/* Title of options screen */
+"Settings" = "Instellingen";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Delen";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Analyses delen";
+
+/* No comment provided by engineer. */
+"Share note" = "Notitie delen";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Je kunt vanaf nu notities delen via het actiemenu vanuit de werkbalk.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Sidebar";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Registreren";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Door je af te melden worden gesynchroniseerde notities verwijderd. Je kunt je gesynchroniseerde notities verifiëren door je aan te melden via de web-app.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -588,8 +488,15 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Alfabetische volgorde";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Sorteervolgorde";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Systeemstandaard";
+
+/* No comment provided by engineer. */
+"Tags" = "Tags";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Neem een foto";
@@ -609,17 +516,50 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "De eenvoudigste manier om notities bij te houden.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "Thema";
+
 /* Simplenote Themes */
 "Themes" = "Thema's";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "Er is een fout opgetreden bij het versturen van je feedback, probeer het nog een keer.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Vandaag";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Tag-sidebar tonen\/verbergen";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Prullenbak";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Naar prullenbak";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Losgemaakt";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "Notitie losmaken";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Notitie verwijderen";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Verwijderen ...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Ongesynchroniseerde notities gedetecteerd";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Tag verwijderd";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Niet-getagde notities";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "Gebruik de nieuwste foto";
@@ -627,8 +567,14 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* A user's Simplenote account */
 "Username" = "Gebruikersnaam";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Versie";
+
 /* App version number */
 "Version %@" = "Versie %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Web-app bezoeken";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "We hebben geen toegang tot je foto’s. Controleer in de instellingen of deze applicatie toegang heeft.";
@@ -642,15 +588,76 @@ Gebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http://sim
 /* Generic error */
 "We're having problems. Please try again soon." = "We ondervinden wat problemen. Probeer het later opnieuw.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Wat vind je van Simplenote?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "Wat vind je van WordPress?";
 
 /* Work at Automattic */
 "Work With Us" = "Met ons samenwerken";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Ja";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Gisteren";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Je e-mailadres:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Je e-mailadres is niet geldig.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Je bericht gaat verloren.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "Wachtwoord moet minstens 4 tekens bevatten";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "voeg een bestand bij";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Samenwerking met anderen inschakelen";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Voeg een e-mailadres toe om deze notitie met iemand te delen. Dan kunnen jullie hem beide wijzigen.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Deze notitie is verwijderd op een ander apparaat.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Notitie herstellen naar eerdere versie";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Opties tonen voor notitie";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Huidige notitie sluiten";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "De inhoud van de huidige notitie delen";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Een tag toevoegen aan de huidige notitie";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Tag verwijderen uit de huidige notitie";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "De huidige notitie verplaatsen naar de prullenbak";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Maak verbinding met internet voor toegang tot eerdere versies";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Overschakelen naar deze versie";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Versie ophalen";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Welkom bij Simplenote voor iOS!\n\nOm een notitie toe te voegen, tik je op de plusknop.\n\nVeeg door de lijst om te bladeren in je notities. Tik op een titel om een notitie te bekijken en tik dan op de inhoud om hem te wijzigen.\n\nJe kunt in al je notities zoeken door te typen in het zoekveld boven aan de notitielijst.\n\nTik op de pijlknop linksboven of veeg over je notitielijst om je tags te bekijken. Je kunt tags toevoegen aan een notitie onder aan de notitie-editor en vervolgens de sidebar gebruiken om overzicht te houden.\n\nDesgewenst zijn er nog meer notitie-opties. Je kunt anderen toevoegen aan een notitie als samenwerker of een notitie publiceren als webpagina.\n\nGebruik Simplenote op je Mac, Android-apparaat of in je webbrowser op http:\/\/simplenote.com. Je notities worden overal automatisch bijgewerkt.";
 

--- a/Simplenote/pt-BR.lproj/Localizable.strings
+++ b/Simplenote/pt-BR.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: pt_BR */
 
-/* Number of found search results */
-"%d Result" = "%d resultado";
+/* Number of Characters in a note */
+"%@ Character" = "%@ caractere";
 
-/* Number of found search results */
-"%d Results" = "%d resultados";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ caracteres";
 
 /* Number of words in a note */
 "%@ Word" = "%@ palavra";
@@ -15,417 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ palavras";
 
-   Label of accept button on alert dialog */
-"Accept" = "Aceitar";
-
-/* No comment provided by engineer. */
-"Account" = "Conta";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Adicionar novo colaborador";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Adicionar tag";
-
-/* Title: No filters applied */
-"All Notes" = "Todas as anotações";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "Cancelar";
-
-/* Verb - work with others on a note */
-"Collaborate" = "Colaborar";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Habilitar outros a colaborar";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Colaboradores";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "Adicione um endereço de email para compartilhar esta anotação com alguém. Em seguida, ambos poderão fazer alterações.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Lista condensada de anotações";
-
-/* No comment provided by engineer. */
-"Create a new note" = "Criar uma nova anotação";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Colaboradores atuais";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Esta anotação foi excluída em outro dispositivo.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Dispensar teclado";
-
-   Verb: Close current view */
-"Done" = "Concluído";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "Vazio";
-
-/* Remove all notes from the trash */
-"Empty trash" = "Esvaziar a lixeira";
-
-/* Noun - the version history of a note */
-"History" = "Histórico";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Restaurar anotação para versão anterior";
-
-/* Noun - the version history of a note */
-"History..." = "Histórico";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "Menu";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Mostrar opções para anotação";
-
-/* Label to create a new note */
-"New note" = "Nova anotação";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "Nenhuma anotação";
-
-/* Message shown when no notes match a search string */
-"No Results" = "Nenhum resultado";
-
-/* No comment provided by engineer. */
-"Note not published" = "Anotação não publicada";
-
-/* Plural form of notes */
-"Notes" = "Anotações";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Fechar anotação atual";
-
-/* Instant passcode lock timeout */
-"Off" = "Desativado";
-
-/* Dismisses an AlertController */
-"OK" = "OK";
-
-/* No comment provided by engineer. */
-"On" = "Ativado";
-
-/* Select a note to view in the note editor */
-"Open note" = "Anotação em aberto";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Senha";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Marcar anotação";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "Marcar no topo";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "Opção Marcar";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Marcada";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Publicar";
-
-/* Action which published a note to a web page */
-"Publish note" = "Publicar anotação";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "Opção Publicar";
-
-/* No comment provided by engineer. */
-"Published" = "Publicado";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Publicando...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Remover todas as anotações da lixeira";
-
-/* Rename a tag */
-"Rename" = "Renomear";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Restaurar";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Restaurar anotação";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "Enviar";
-
-/* Privacy Settings */
-"Settings" = "Configurações";
-
-/* No comment provided by engineer. */
-"Share note" = "Compartilhar anotação";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Compartilhar o conteúdo da anotação atual";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Barra lateral";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Adicionar uma tag à anotação atual";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Remover tag da anotação atual";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Hoje";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Exibir a barra lateral de tags";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Mover a anotação atual para a lixeira";
-
-/* Title: Trash Tag is selected */
-"Trash-noun" = "Lixeira";
-
-/* Title: Trash Tag is selected */
-"Trash-verb" = "Lixeira";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Desmarcar anotação";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Desfazer publicação";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Cancelando publicação...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Versão";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Conecte-se à Internet para acessar as versões anteriores";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Alternar para essa versão";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Obtendo a versão";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Ontem";
-
-"welcomeNote-iOS" = "Bem-vindo ao Simplenote para iOS!
-
-Para adicionar uma anotação, toque no botão de adição.
-
-Mexa na lista para procurar suas anotações. Toque em um título para visualizar uma anotação e no conteúdo para alterá-lo.
-
-Você pode pesquisar todas as suas anotações tocando no campo de pesquisa no topo da lista de anotações.
-
-Toque no botão de seta na parte superior à esquerda ou deslize os dedos pela lista de anotações para visualizar suas tags. Você pode adicionar tags a uma anotação na parte inferior do editor de anotações e usar a barra lateral para ajudá-lo com a organização.
-
-Há mais opções de anotação, se necessário. Você pode adicionar outras pessoas como colaboradores a uma anotação ou publicá-la como uma página na web.
-
-Use o Simplenote no seu dispositivo Mac, Android ou no navegador em http://simplenote.com. Suas anotações serão atualizadas automaticamente em qualquer lugar.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Não foi possível criar uma conta com o endereço de email e senha fornecidos.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Não foi possível fazer login com o endereço de email e senha fornecidos.";
-
-/* A 4-digit code to lock the app when it is closed */
-"Password" = "Senha";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "A senha deve ter 6 caracteres no mínimo.";
-
-   SignUp Interface Title */
-"Sign Up" = "Registrar-se";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Seu endereço de email é inválido.";
-
-/* User Authenticated */
-"Authenticated" = "Autenticado";
-
-   Display internal debug status */
-"Debug" = "Depurar";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "Enfileirado";
-
-/* Last Message timestamp */
-"LastSeen" = "Visto pela última vez";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "Pendentes";
-
-/* Reachs Internet */
-"Reachability" = "Acessibilidade";
-
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Identificação por toque";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Segurança";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "O que você acha do Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Curti";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Poderia ser melhor";
-
-"Great! Could you leave us a nice review?
-It really helps." = "Legal! Que tal deixar suas impressoes sobre o aplicativo?
-
-Isso realmente ajudará!";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Faça uma avaliação";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Não, obrigado!";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Poderia nos dizer o que podemos fazer para melhorar?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Enviar feedback";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Contato";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "Seu email:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Como podemos ajudar?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "Foi encontrado um erro ao fazer login.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "Tem certeza de que deseja esvaziar a lixeira? Essa ação não pode ser desfeita.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Voltar";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "A colaboração mudou";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "Não foi possível entrar";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Excluir";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Apagar notas";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Desativar formatação Markdown";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "Editar";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Ativar formatação Markdown";
-
-/* Offer to enable Face ID support if available and passcode is on. */
-"Face ID" = "ID do rosto";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Opção Markdown";
-
-/* Message for alert when user tries to send feedback without an email address */
-"No" = "Não";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Ative sua conta do WordPress.com por e-mail e tente novamente.";
-
-/* Title of Markdown preview screen */
-"Preview" = "Visualizar";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Pesquisar";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Agora, o compartilhamento de notas é acessado através do menu de ação da barra de ferramentas.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Sair resultará na exclusão de quaisquer anotações não sincronizadas. Para verificar suas anotações sincronizadas, entre no Aplicativo para Web.";
-
-
-"Tags" = "Tags";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Anotações não sincronizadas detectadas";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Acessar o aplicativo para Web";
-
-
-"Yes" = "Sim";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "tag...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Compartilhar";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Anotações sem tags";
-
-   Sort Order for the Notes List */
-"Sort Order" = "Organizar";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Compartilhar dados analíticos";
-
-
-"Email" = "Email";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Tema";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
-
-
-"Error" = "Erro";
-
-/* No comment provided by engineer. */
-"Appearance" = "Aparência";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ caractere";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ caracteres";
+/* Number of found search results */
+"%d Result" = "%d resultado";
+
+/* Number of found search results */
+"%d Results" = "%d resultados";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 minuto";
@@ -451,11 +45,36 @@ Isso realmente ajudará!";
 /* Display app about screen */
 "About" = "Sobre";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Aceitar";
+
+/* No comment provided by engineer. */
+"Account" = "Conta";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Adicionar novo colaborador";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "tag...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Adicionar tag";
+
+/* Title: No filters applied */
+"All Notes" = "Todas as anotações";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "Ordem alfabética: A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "Ordem alfabética: Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "Foi encontrado um erro ao fazer login.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Aparência";
 
 /* Other Simplenote apps */
 "Apps" = "Aplicativos";
@@ -463,14 +82,23 @@ Isso realmente ajudará!";
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "Você é um desenvolvedor? A Automattic está contratando.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Tem certeza de que deseja esvaziar a lixeira? Essa ação não pode ser desfeita.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "Tem certeza de que deseja enviar sem seu e-mail? Não poderemos lhe responder.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "Tem certeza?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "anexar um arquivo";
+/* User Authenticated */
+"Authenticated" = "Autenticado";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Voltar";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "Ao criar uma conta, você concorda com os";
@@ -478,17 +106,54 @@ Isso realmente ajudará!";
 /* No comment provided by engineer. */
 "Can't Access." = "Não é possível acessar.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "Cancelar";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Escolher foto";
 
 /* No comment provided by engineer. */
 "Close" = "Fechar";
 
+/* Verb - work with others on a note */
+"Collaborate" = "Colaborar";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "A colaboração mudou";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Colaboradores";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Lista condensada de anotações";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Contato";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Contribuir";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Poderia ser melhor";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Não foi possível criar uma conta com o endereço de email e senha fornecidos.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Não foi possível fazer login com o endereço de email e senha fornecidos.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Poderia nos dizer o que podemos fazer para melhorar?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Não foi possível entrar";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Criar uma nova nota";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Criar uma nova anotação";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Criado: mais recente";
@@ -496,8 +161,37 @@ Isso realmente ajudará!";
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Criado: mais antiga";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Colaboradores atuais";
+
 /* Theme: Dark */
 "Dark" = "Escuro";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Depurar";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Excluir";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Apagar notas";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Desativar formatação Markdown";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Dispensar teclado";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Concluído";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Editar";
+
+/* Email TextField Placeholder */
+"Email" = "Email";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "Endereço de e-mail";
@@ -505,20 +199,59 @@ Isso realmente ajudará!";
 /* Email Taken Alert Title */
 "Email in use" = "E-mail em uso";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Vazio";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Esvaziar a lixeira";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Ativar formatação Markdown";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Enfileirado";
+
+/* No comment provided by engineer. */
+"Error" = "Erro";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Erro ao fazer upload.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "ID do rosto";
 
 /* Password Reset Action */
 "Forgotten password?" = "Esqueceu a senha?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Legal! Que tal deixar suas impressoes sobre o aplicativo?\n\nIsso realmente ajudará!";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Ajude-nos a aprimorar o Simplenote compartilhando o uso de dados com nossa ferramenta de dados analíticos.";
+
+/* Noun - the version history of a note */
+"History" = "Histórico";
+
+/* Action - view the version history of a note */
+"History..." = "Histórico";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Como podemos ajudar?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Curti";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Endereço de e-mail inválido.";
 
+/* Last Message timestamp */
+"LastSeen" = "Visto pela última vez";
+
 /* Learn More Action */
 "Learn more" = "Saiba mais";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Faça uma avaliação";
 
 /* Theme: Light */
 "Light" = "Claro";
@@ -526,17 +259,41 @@ Isso realmente ajudará!";
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Tempo limite de bloqueio";
 
+/* Log In Action
+   Login Action
+   LogIn Action
    LogIn Interface Title */
 "Log In" = "Fazer login";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "Fazer login com o e-mail";
+/* Log out of the active account in the app */
+"Log Out" = "Fazer logout";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "Fazer login com o WordPress.com";
 
-/* Log out of the active account in the app */
-"Log Out" = "Fazer logout";
+/* Presents the regular Email signin flow */
+"Log in with email" = "Fazer login com o e-mail";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Opção Markdown";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Menu";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Modificado: mais recente";
@@ -544,8 +301,15 @@ Isso realmente ajudará!";
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Modificado: mais antiga";
 
+/* Label to create a new note */
+"New note" = "Nova anotação";
+
 /* Empty Note Placeholder */
 "New note..." = "Nova nota...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "Não";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "Sem e-mail.";
@@ -556,16 +320,74 @@ Isso realmente ajudará!";
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Sem mensagem.";
 
-"Open "(preview)"" = "Abrir "(visualização)"";
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "Nenhuma anotação";
+
+/* Message shown when no notes match a search string */
+"No Results" = "Nenhum resultado";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Não, obrigado!";
+
+/* No comment provided by engineer. */
+"Note not published" = "Anotação não publicada";
+
+/* Plural form of notes */
+"Notes" = "Anotações";
+
+/* Dismisses an AlertController */
+"OK" = "OK";
+
+/* Instant passcode lock timeout */
+"Off" = "Desativado";
+
+/* No comment provided by engineer. */
+"On" = "Ativado";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "Abrir \"(visualização)\"";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Abrir Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "Anotação em aberto";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Nossa atualização pode ter alterado a ordem em que suas notas aparecem. Deseja revisar as configurações de classificação?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Senha";
+
+/* Password TextField Placeholder */
+"Password" = "Senha";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "A senha deve ter no mínimo 4 caracteres";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "A senha deve ter 6 caracteres no mínimo.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Pendentes";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Fixar";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Marcar anotação";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "Marcar no topo";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "Opção Marcar";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Marcada";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Ative sua conta do WordPress.com por e-mail e tente novamente.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "Verifique seu endereço de e-mail, ele parece ser inválido.";
@@ -573,11 +395,57 @@ Isso realmente ajudará!";
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Insira uma mensagem.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Visualizar";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Política de privacidade";
 
 /* Privacy Settings */
 "Privacy Settings" = "Configurações de privacidade";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Publicar";
+
+/* Action which published a note to a web page */
+"Publish note" = "Publicar anotação";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Opção Publicar";
+
+/* No comment provided by engineer. */
+"Published" = "Publicado";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Publicando...";
+
+/* Reachs Internet */
+"Reachability" = "Acessibilidade";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Remover todas as anotações da lixeira";
+
+/* Rename a tag */
+"Rename" = "Renomear";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Restaurar";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Restaurar anotação";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Pesquisar";
+
+/* No comment provided by engineer. */
+"Security" = "Segurança";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Enviar";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Enviar feedback";
 
 /* For debugging use */
 "Send a Test Crash" = "Enviar uma falha de teste";
@@ -585,7 +453,33 @@ Isso realmente ajudará!";
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Enviando...";
 
+/* Title of options screen */
+"Settings" = "Configurações";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Compartilhar";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Compartilhar dados analíticos";
+
+/* No comment provided by engineer. */
+"Share note" = "Compartilhar anotação";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Agora, o compartilhamento de notas é acessado através do menu de ação da barra de ferramentas.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Barra lateral";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Registrar-se";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Sair resultará na exclusão de quaisquer anotações não sincronizadas. Para verificar suas anotações sincronizadas, entre no Aplicativo para Web.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -594,8 +488,15 @@ Isso realmente ajudará!";
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Classificar em ordem alfabética";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Organizar";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Sistema padrão";
+
+/* No comment provided by engineer. */
+"Tags" = "Tags";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Fotografar";
@@ -615,17 +516,50 @@ Isso realmente ajudará!";
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "A melhor forma de manter notas.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "Tema";
+
 /* Simplenote Themes */
 "Themes" = "Temas";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "Houve um erro ao enviar seu feedback. Tente novamente.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Hoje";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Exibir a barra lateral de tags";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Identificação por toque";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Lixeira";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Lixeira";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Desmarcar";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "Desmarcar anotação";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Desfazer publicação";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Cancelando publicação...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Anotações não sincronizadas detectadas";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Sem tags";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Anotações sem tags";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "Usar a foto mais recente";
@@ -633,8 +567,14 @@ Isso realmente ajudará!";
 /* A user's Simplenote account */
 "Username" = "Nome de usuário";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Versão";
+
 /* App version number */
 "Version %@" = "Versão %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Acessar o aplicativo para Web";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "Não conseguimos acessar suas fotos. Verifique se este aplicativo tem acesso a elas nas Configurações.";
@@ -648,15 +588,76 @@ Isso realmente ajudará!";
 /* Generic error */
 "We're having problems. Please try again soon." = "Estamos com problemas. Tente novamente mais tarde.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "O que você acha do Simplenote?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "O que você acha do WordPress?";
 
 /* Work at Automattic */
 "Work With Us" = "Trabalhe conosco";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Sim";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Ontem";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Seu email:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Seu endereço de email é inválido.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Sua mensagem será perdida.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "A senha deve ter no mínimo 4 caracteres";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "anexar um arquivo";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Habilitar outros a colaborar";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Adicione um endereço de email para compartilhar esta anotação com alguém. Em seguida, ambos poderão fazer alterações.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Esta anotação foi excluída em outro dispositivo.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Restaurar anotação para versão anterior";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Mostrar opções para anotação";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Fechar anotação atual";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Compartilhar o conteúdo da anotação atual";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Adicionar uma tag à anotação atual";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Remover tag da anotação atual";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Mover a anotação atual para a lixeira";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Conecte-se à Internet para acessar as versões anteriores";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Alternar para essa versão";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Obtendo a versão";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Bem-vindo ao Simplenote para iOS!\n\nPara adicionar uma anotação, toque no botão de adição.\n\nMexa na lista para procurar suas anotações. Toque em um título para visualizar uma anotação e no conteúdo para alterá-lo.\n\nVocê pode pesquisar todas as suas anotações tocando no campo de pesquisa no topo da lista de anotações.\n\nToque no botão de seta na parte superior à esquerda ou deslize os dedos pela lista de anotações para visualizar suas tags. Você pode adicionar tags a uma anotação na parte inferior do editor de anotações e usar a barra lateral para ajudá-lo com a organização.\n\nHá mais opções de anotação, se necessário. Você pode adicionar outras pessoas como colaboradores a uma anotação ou publicá-la como uma página na web.\n\nUse o Simplenote no seu dispositivo Mac, Android ou no navegador em http:\/\/simplenote.com. Suas anotações serão atualizadas automaticamente em qualquer lugar.";
 

--- a/Simplenote/ru.lproj/Localizable.strings
+++ b/Simplenote/ru.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: ru */
 
-/* Number of found search results */
-"%d Result" = "%d Найдено";
+/* Number of Characters in a note */
+"%@ Character" = "%@ знак";
 
-/* Number of found search results */
-"%d Results" = "%d результатов";
+/* Number of Characters in a note */
+"%@ Characters" = "Знаков: %@";
 
 /* Number of words in a note */
 "%@ Word" = "%@ слово";
@@ -15,417 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ слов";
 
-   Label of accept button on alert dialog */
-"Accept" = "Согласен";
-
-/* No comment provided by engineer. */
-"Account" = "Учетная запись";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Добавить нового партнера";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Добавить тег";
-
-/* Title: No filters applied */
-"All Notes" = "Все заметки";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "Отмена";
-
-/* Verb - work with others on a note */
-"Collaborate" = "Партнер";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Разрешить другим сотрудничать";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Партнеры";
-
-"collaborators-description" = "Добавьте адрес электронной почто, чтобы делиться этой заметкой с кем-нибудь.
-Позже вы сможете изменить его. ";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Сократить список заметок";
-
-/* No comment provided by engineer. */
-"Create a new note" = "Создать новую заметку";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Текущие партнеры";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Эта заметка была удалена на другом устройстве";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Скрыть клавиатуру";
-
-   Verb: Close current view */
-"Done" = "Готово";
-
-/* Empty Trash Warning */
-"Empty" = "Очистить";
-
-/* Empty Trash Warning */
-"Empty trash" = "Очистить корзину";
-
-/* Noun - the version history of a note */
-"History" = "История";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Восстановить предыдущую версию заметки";
-
-/* Action - view the version history of a note */
-"History..." = "История…";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "Меню";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Показать опции заметки";
-
-/* Label to create a new note */
-"New note" = "Новая заметка";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "Нет заметок";
-
-/* Message shown when no notes match a search string */
-"No Results" = "Нет результатов";
-
-/* No comment provided by engineer. */
-"Note not published" = "Заметка не опубликована";
-
-/* Plural form of notes */
-"Notes" = "Заметки";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Закрыть текущую заметку";
-
-/* No comment provided by engineer. */
-"Off" = "Выключить";
-
-/* Dismisses an AlertController */
-"OK" = "Хорошо";
-
-/* No comment provided by engineer. */
-"On" = "Включить";
-
-/* Select a note to view in the note editor */
-"Open note" = "Открыть заметку";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Пароль";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Закрепить заметку";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "В топ";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "Переключатель закрепления";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Закреплено";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Публикация";
-
-/* Action which published a note to a web page */
-"Publish note" = "Публикация заметки";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "Переключатель публикации";
-
-/* No comment provided by engineer. */
-"Published" = "Опубликовать";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Публикация…";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Удалить все заметки из корзины";
-
-/* Rename a tag */
-"Rename" = "Переименовать";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Восстановить";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Восстановить заметку";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Send" = "Отправить";
-
-/* Privacy Settings */
-"Settings" = "Настройки";
-
-/* No comment provided by engineer. */
-"Share note" = "Поделиться заметкой";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Поделится содержанием данной заметки";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Боковая панель";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Добавить тег к текущей заметке";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Удалить тег в текущей заметке";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Сегодня";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "Боковая панель переключения меток";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Отправить текущую заметку в корзину";
-
-/* Title: Trash Tag is selected */
-"Trash-noun" = "Корзина";
-
-/* Trash (verb) - the action of deleting a note */
-"Trash-verb" = "Удалить";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Открепить заметку";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Не публиковать заметку";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Отмена публикации…";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Версия";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Подключитесь к интернету доя доступа к предыдущим вариантам";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Оставить этот вариант";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Извлечение версии";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Вчера";
-
-"welcomeNote-iOS" = "Добро пожаловать в Simplenote для iOS!
-
-Добавьте заметку, тапнув на кнопку с плюсом. 
-
-Пролистайте список, чтобы просмотреть ваши заметки. Нажмите на название для просмотра заметки, затем нажмите на его содержание, чтобы изменить его.
-
-Вы можете искать ваши заметки: для этого пролестните вверх ваш список с заметки и нажмите на строку поиска. 
-
-Нажмите на кнопку в левом верхнем углу или смахните слева на право, чтобы посмотреть ваши теги. Вы можете добавить тег к заметке, нажав на кнопку при изменении заметки, и используйте боковую панель - она поможет оставаться Вам быть организованным. 
-
-Но у заметок есть больше опций, если они вам нужны. Например, вы можете пригласить партнеры или соавтора для общего ведения заметки, либо опубликовать запись в виде веб-страницы. 
-
-Пользуйтесь Simplenote на вашем компьютере Mac, Android устройствах или в вашем веб-браузере на сайте http://simplenote.com. Ваши заметки всегда останутся обновленными везде. ";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Невозможно создать учетную запись с указанными адресом email и паролем.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Невозможно авторизоваться с указанными адресом email и паролем.";
-
-/* A 4-digit code to lock the app when it is closed */
-"Password" = "Пароль";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Пароль должен содержать не менее 6 символов.";
-
-   SignUp Interface Title */
-"Sign Up" = "Зарегистрироваться";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Ваш адрес электронной почты не действителен.";
-
-/* User Authenticated */
-"Authenticated" = "Прошедший проверку";
-
-   Display internal debug status */
-"Debug" = "Отладка";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "Требуется";
-
-/* Last Message timestamp */
-"LastSeen" = "Последнее прочитанное";
-
-/* Month and day date formatter */
-"MMM d" = "Д ммм";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "Д ммм, чч:мм";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "Д ммм гггг";
-
-/* Month and year date formatter */
-"MMM yyyy" = "МММ гггг";
-
-/* Number of changes pending to be sent */
-"Pendings" = "На утверждении";
-
-/* Reachs Internet */
-"Reachability" = "Удобный доступ";
-
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "Идентификатор прикосновения";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Безопасность";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Каково ваше мнение о Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Мне нравится";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Нужно доработать";
-
-"Great! Could you leave us a nice review?
-It really helps." = "Замечательно! Не могли бы вы оставить нам хороший отзыв?
-
-Заранее благодарим.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Оставить отзыв";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Нет, спасибо";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Посоветуйте, как нам стать лучше.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Отправить отзыв";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Обратная связь";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "Ваш электронный адрес:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Чем вам помочь?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "Во время входа произошла ошибка.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "Очистить корзину? Это действие нельзя отменить.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Назад";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "Раздел совместной работы перенесен";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "Не удалось войти";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Удалить";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Удалить заметки";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Выключить форматирование Markdown";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "Редактирование";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Включить форматирование Markdown";
-
-
-"Face ID" = "Face ID";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Переключатель Markdown";
-
-/* No comment provided by engineer. */
-"No" = "Нет";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Активируйте учетную запись WordPress.com через эл. почту или повторите попытку.";
-
-/* Title of Markdown preview screen */
-"Preview" = "Предварительный просмотр";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Поиск";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Функция отправки заметок теперь находится в меню действий на панели инструментов.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "При выходе из учётной записи все несинхронизированные заметки будут удалены. Чтобы убедиться, что заметки синхронизированы, войдите в веб-приложение.";
-
-/* No comment provided by engineer. */
-"Tags" = "Метки";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Обнаружены несинхронизированные заметки";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Перейти в веб-приложение";
-
-/* Sort Mode: Creation Date, descending */
-"Yes" = "Да";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Метка...";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Поделиться";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Заметки без меток";
-
-   Sort Order for the Notes List */
-"Sort Order" = "Порядок сортировки";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Поделиться аналитическими данными";
-
-/* Email TextField Placeholder */
-"Email" = "Отправить email";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Тема оформления";
-
-/* The Simplenote blog */
-"Blog" = "Блог";
-
-/* No comment provided by engineer. */
-"Error" = "Ошибка";
-
-/* No comment provided by engineer. */
-"Appearance" = "Внешний вид";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ знак";
-
-/* Number of Characters in a note */
-"%@ Characters" = "Знаков: %@";
+/* Number of found search results */
+"%d Result" = "%d Найдено";
+
+/* Number of found search results */
+"%d Results" = "%d результатов";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 минута";
@@ -451,11 +45,36 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Display app about screen */
 "About" = "О нас";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Согласен";
+
+/* No comment provided by engineer. */
+"Account" = "Учетная запись";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Добавить нового партнера";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Метка...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Добавить тег";
+
+/* Title: No filters applied */
+"All Notes" = "Все заметки";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "По алфавиту: А–Я";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "По алфавиту: Я–А";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "Во время входа произошла ошибка.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Внешний вид";
 
 /* Other Simplenote apps */
 "Apps" = "Приложения";
@@ -463,14 +82,23 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "Вы разработчик? Automattic расширяет штат.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Очистить корзину? Это действие нельзя отменить.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "Отправить без вашего адреса эл. почты? В этом случае мы не сможем вам ответить.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "Продолжить?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "Добавить файл";
+/* User Authenticated */
+"Authenticated" = "Прошедший проверку";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Назад";
+
+/* The Simplenote blog */
+"Blog" = "Блог";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "Создавая учетную запись, вы принимаете наши";
@@ -478,17 +106,54 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* No comment provided by engineer. */
 "Can't Access." = "Нет доступа.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "Отмена";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Выбрать фото";
 
 /* No comment provided by engineer. */
 "Close" = "Закрыть";
 
+/* Verb - work with others on a note */
+"Collaborate" = "Партнер";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Раздел совместной работы перенесен";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Партнеры";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Сократить список заметок";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Обратная связь";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Принять участие";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Нужно доработать";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Невозможно создать учетную запись с указанными адресом email и паролем.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Невозможно авторизоваться с указанными адресом email и паролем.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Посоветуйте, как нам стать лучше.";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Не удалось войти";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Создай новую заметку";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Создать новую заметку";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Дата создания: сначала новые";
@@ -496,8 +161,37 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Дата создания: сначала старые";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Текущие партнеры";
+
 /* Theme: Dark */
 "Dark" = "Тёмная";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Отладка";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Удалить";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Удалить заметки";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Выключить форматирование Markdown";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Скрыть клавиатуру";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Готово";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Редактирование";
+
+/* Email TextField Placeholder */
+"Email" = "Отправить email";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "Адрес эл. почты";
@@ -505,20 +199,59 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Email Taken Alert Title */
 "Email in use" = "Используемый адрес эл. почты";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Очистить";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Очистить корзину";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Включить форматирование Markdown";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Требуется";
+
+/* No comment provided by engineer. */
+"Error" = "Ошибка";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Ошибка загрузки";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "Забыли пароль?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Замечательно! Не могли бы вы оставить нам хороший отзыв?\n\nЗаранее благодарим.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Помогите нам улучшить Simplenote — предоставьте данные об использовании нашему средству аналитики.";
+
+/* Noun - the version history of a note */
+"History" = "История";
+
+/* Action - view the version history of a note */
+"History..." = "История…";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Чем вам помочь?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Мне нравится";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Неверный адрес эл. почты";
 
+/* Last Message timestamp */
+"LastSeen" = "Последнее прочитанное";
+
 /* Learn More Action */
 "Learn more" = "Подробнее";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Оставить отзыв";
 
 /* Theme: Light */
 "Light" = "Светлая";
@@ -526,17 +259,41 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Время до блокировки";
 
+/* Log In Action
+   Login Action
+   LogIn Action
    LogIn Interface Title */
 "Log In" = "Войти";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "Войти с помощью эл. почты";
+/* Log out of the active account in the app */
+"Log Out" = "Выйти";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "Войти через WordPress.com";
 
-/* Log out of the active account in the app */
-"Log Out" = "Выйти";
+/* Presents the regular Email signin flow */
+"Log in with email" = "Войти с помощью эл. почты";
+
+/* Month and day date formatter */
+"MMM d" = "Д ммм";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "Д ммм, чч:мм";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "Д ммм гггг";
+
+/* Month and year date formatter */
+"MMM yyyy" = "МММ гггг";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Переключатель Markdown";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Меню";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Дата изменения: сначала новые";
@@ -544,8 +301,15 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Дата изменения: сначала старые";
 
+/* Label to create a new note */
+"New note" = "Новая заметка";
+
 /* Empty Note Placeholder */
 "New note..." = "Новая заметка...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "Нет";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "Не указан эл. адрес.";
@@ -556,17 +320,74 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Нет сообщения.";
 
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "Нет заметок";
+
+/* Message shown when no notes match a search string */
+"No Results" = "Нет результатов";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Нет, спасибо";
+
+/* No comment provided by engineer. */
+"Note not published" = "Заметка не опубликована";
+
+/* Plural form of notes */
+"Notes" = "Заметки";
+
+/* Dismisses an AlertController */
+"OK" = "Хорошо";
+
+/* Instant passcode lock timeout */
+"Off" = "Выключить";
+
+/* No comment provided by engineer. */
+"On" = "Включить";
+
 /* Siri Suggestion to open a specific Note */
-"Open "(preview)"" = "Открой «(предварительный просмотр)»";
+"Open \"(preview)\"" = "Открой «(предварительный просмотр)»";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Открой Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "Открыть заметку";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Из-за обновления мог измениться порядок заметок. Изменить настройки сортировки?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Пароль";
+
+/* Password TextField Placeholder */
+"Password" = "Пароль";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Пароль должен содержать не меньше 4 знаков";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Пароль должен содержать не менее 6 символов.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "На утверждении";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Закрепить";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Закрепить заметку";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "В топ";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "Переключатель закрепления";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Закреплено";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Активируйте учетную запись WordPress.com через эл. почту или повторите попытку.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "Проверьте адрес эл. почты, возможно, он неверный.";
@@ -574,11 +395,57 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Введите сообщение.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Предварительный просмотр";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Политика конфиденциальности";
 
 /* Privacy Settings */
 "Privacy Settings" = "Настройки конфиденциальности";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Публикация";
+
+/* Action which published a note to a web page */
+"Publish note" = "Публикация заметки";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Переключатель публикации";
+
+/* No comment provided by engineer. */
+"Published" = "Опубликовать";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Публикация…";
+
+/* Reachs Internet */
+"Reachability" = "Удобный доступ";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Удалить все заметки из корзины";
+
+/* Rename a tag */
+"Rename" = "Переименовать";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Восстановить";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Восстановить заметку";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Поиск";
+
+/* No comment provided by engineer. */
+"Security" = "Безопасность";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Отправить";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Отправить отзыв";
 
 /* For debugging use */
 "Send a Test Crash" = "Отправить данные о сбое";
@@ -586,7 +453,33 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Отправка…";
 
+/* Title of options screen */
+"Settings" = "Настройки";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Поделиться";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Поделиться аналитическими данными";
+
+/* No comment provided by engineer. */
+"Share note" = "Поделиться заметкой";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Функция отправки заметок теперь находится в меню действий на панели инструментов.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Боковая панель";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Зарегистрироваться";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "При выходе из учётной записи все несинхронизированные заметки будут удалены. Чтобы убедиться, что заметки синхронизированы, войдите в веб-приложение.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -595,8 +488,15 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Сортировать по алфавиту";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Порядок сортировки";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Настройки системы по умолчанию";
+
+/* No comment provided by engineer. */
+"Tags" = "Метки";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Сделать фотографию";
@@ -616,17 +516,50 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "Простой способ хранить заметки.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "Тема оформления";
+
 /* Simplenote Themes */
 "Themes" = "Темы";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "При отправке вашего отзыва произошла ошибка, попробуйте еще раз.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Сегодня";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Боковая панель переключения меток";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Идентификатор прикосновения";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Корзина";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Удалить";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Открепить";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "Открепить заметку";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Не публиковать заметку";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Отмена публикации…";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Обнаружены несинхронизированные заметки";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Без меток";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Заметки без меток";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "Использовать самую новую фотографию";
@@ -634,8 +567,14 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* A user's Simplenote account */
 "Username" = "Имя пользователя";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Версия";
+
 /* App version number */
 "Version %@" = "Версия %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Перейти в веб-приложение";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "Не удалось получить доступ к вашим фотографиям. Убедитесь, что этому приложению разрешен доступ к фотографиям в разделе «Настройки».";
@@ -649,15 +588,76 @@ It really helps." = "Замечательно! Не могли бы вы ост�
 /* Generic error */
 "We're having problems. Please try again soon." = "Произошла ошибка. Повторите попытку позже.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Каково ваше мнение о Simplenote?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "Что вы думаете о WordPress?";
 
 /* Work at Automattic */
 "Work With Us" = "Сотрудничество";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Да";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Вчера";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Ваш электронный адрес:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Ваш адрес электронной почты не действителен.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Это приведет к удалению сообщения.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "Пароль должен содержать не меньше 4 знаков";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "Добавить файл";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Разрешить другим сотрудничать";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Добавьте адрес электронной почто, чтобы делиться этой заметкой с кем-нибудь.\nПозже вы сможете изменить его. ";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Эта заметка была удалена на другом устройстве";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Восстановить предыдущую версию заметки";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Показать опции заметки";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Закрыть текущую заметку";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Поделится содержанием данной заметки";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Добавить тег к текущей заметке";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Удалить тег в текущей заметке";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Отправить текущую заметку в корзину";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Подключитесь к интернету доя доступа к предыдущим вариантам";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Оставить этот вариант";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Извлечение версии";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Добро пожаловать в Simplenote для iOS!\n\nДобавьте заметку, тапнув на кнопку с плюсом. \n\nПролистайте список, чтобы просмотреть ваши заметки. Нажмите на название для просмотра заметки, затем нажмите на его содержание, чтобы изменить его.\n\nВы можете искать ваши заметки: для этого пролестните вверх ваш список с заметки и нажмите на строку поиска. \n\nНажмите на кнопку в левом верхнем углу или смахните слева на право, чтобы посмотреть ваши теги. Вы можете добавить тег к заметке, нажав на кнопку при изменении заметки, и используйте боковую панель - она поможет оставаться Вам быть организованным. \n\nНо у заметок есть больше опций, если они вам нужны. Например, вы можете пригласить партнеры или соавтора для общего ведения заметки, либо опубликовать запись в виде веб-страницы. \n\nПользуйтесь Simplenote на вашем компьютере Mac, Android устройствах или в вашем веб-браузере на сайте http:\/\/simplenote.com. Ваши заметки всегда останутся обновленными везде. ";
 

--- a/Simplenote/sv.lproj/Localizable.strings
+++ b/Simplenote/sv.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: sv_SE */
 
-/* Number of found search results */
-"%d Result" = "%d sökresultat";
+/* Number of Characters in a note */
+"%@ Character" = "%@ tecken";
 
-/* Number of found search results */
-"%d Results" = "%d sökresultat";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ tecken";
 
 /* Number of words in a note */
 "%@ Word" = "%@ ord";
@@ -15,414 +15,13 @@
 /* Number of words in a note */
 "%@ Words" = "%@ ord";
 
-   Label of accept button on alert dialog */
-"Accept" = "Godkänn";
+/* Number of found search results */
+"%d Result" = "%d sökresultat";
 
-/* No comment provided by engineer. */
-"Account" = "Konto";
+/* Number of found search results */
+"%d Results" = "%d sökresultat";
 
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Lägg till ny redigerare...";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Lägg till etikett";
-
-/* Title: No filters applied */
-"All Notes" = "Alla anteckningar";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "Avbryt";
-
-/* Verb - work with others on a note */
-"Collaborate" = "Samarbeta";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Gör så att andra kan hjälpa till och redigera";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Redigerare";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "Lägg till en e-postadress för att dela denna anteckning med någon, då kan ni båda göra ändringar.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Komprimerad anteckningslista";
-
-/* Siri Suggestion to create a New Note */
-"Create a new note" = "Skapa ny anteckning";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Nuvarande redigerare";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Denna anteckning har blivit borttagen på en annan enhet.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Göm tangentbord";
-
-   Verb: Close current view */
-"Done" = "Klar";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "Töm";
-
-/* Remove all notes from the trash */
-"Empty trash" = "Töm papperskorgen";
-
-/* Noun - the version history of a note */
-"History" = "Historik";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Återställ anteckning till tidigare version";
-
-/* Action - view the version history of a note */
-"History..." = "Historik...";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "Meny";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Visa alternativ för anteckning";
-
-/* Label to create a new note */
-"New note" = "Ny anteckning";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "Inga anteckningar";
-
-/* Message shown when no notes match a search string */
-"No Results" = "Inga sökresultat";
-
-/* No comment provided by engineer. */
-"Note not published" = "Anteckning inte publicerad";
-
-/* Plural form of notes */
-"Notes" = "Anteckningar";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Stäng nuvarande anteckning";
-
-   Verb, cancel an alert dialog */
-"Off" = "Av";
-
-/* Dismisses an AlertController */
-"OK" = "OK";
-
-/* No comment provided by engineer. */
-"On" = "På";
-
-/* Select a note to view in the note editor */
-"Open note" = "Öppna anteckning";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Lösenkod";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Nåla fast anteckning";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "Nåla fast högst upp";
-
-"Pin toggle" = "Slå på/av fastnålning";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "Fastnålad";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Publicera";
-
-/* Action which published a note to a web page */
-"Publish note" = "Publicera anteckning";
-
-"Publish toggle" = "Publicera på/av";
-
-/* No comment provided by engineer. */
-"Published" = "Publicerad";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Publicerar...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Ta bort alla anteckningar från papperskorgen";
-
-/* Rename a tag */
-"Rename" = "Ändra namn";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Återställ";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Återställ anteckning";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "Skicka";
-
-/* Privacy Settings */
-"Settings" = "Inställningar";
-
-/* No comment provided by engineer. */
-"Share note" = "Dela anteckning";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Dela innehåll i nuvarande anteckning";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Sidopanel";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Lägg till en etikett för anteckningen";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Ta bort etikett från den nuvarande anteckningen";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Idag";
-
-"Toggle tag sidebar" = "Slå på/av etiketter i sidopanelen";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Kasta anteckningen i papperskorgen";
-
-/* Title: Trash Tag is selected */
-"Trash-noun" = "Papperskorgen";
-
-/* Trash (verb) - the action of deleting a note */
-"Trash-verb" = "Kasta bort";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Ta bort nål";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Sluta publicera anteckning";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Slutar publicera...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Version";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Anslut till ett nätverk för att se tidigare versioner";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Välj denna version";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Hämtar version";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Igår";
-
-"welcomeNote-iOS" = "Välkommen till Simplenote för iOS!
-
-För att skapa en anteckning, tryck på plus-knappen.
-
-Scrolla i listan för att se dina anteckningar. Tryck på en rubrik för att visa en anteckning, sedan på dess innehåll för att ändra det.
-
-Du kan söka bland dina anteckningar genom att skriva i sökfältet högst upp i anteckningslistan.
-
-Tryck på pilen eller dra från vänster för att visa sidopanelen och dina etiketter. Du kan lägga till etiketter för en anteckning längst ner i redigeraren och sedan använda sidopanelen för att filtrera anteckningar.
-
-Det finns fler inställningar för dina anteckningar om du behöver dem. Du kan bjuda in andra att redigera en anteckning, publicera en anteckning som en webbsida, med mera.
-
-Använd Simplenote på din Mac, din Android-platta eller -telefon och direkt i din webbläsare på http://simplenote.com. Dina anteckningar synkroniseras automatiskt mellan alla dina enheter.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Kunde inte skapa ett konto med den e-postadressen och det lösenordet.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Kunde inte logga in med den e-postadressen och det lösenordet.";
-
-/* Password TextField Placeholder */
-"Password" = "Lösenord";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Lösenord måste innehålla minst 6 tecken.";
-
-   SignUp Interface Title */
-"Sign Up" = "Skapa konto";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "Din e-postadress är inte giltig.";
-
-/* User Authenticated */
-"Authenticated" = "Autentiserad";
-
-   Display internal debug status */
-"Debug" = "Felsök";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "I kö";
-
-/* Last Message timestamp */
-"LastSeen" = "LastSeen";
-
-/* Month and day date formatter */
-"MMM d" = "d MMM";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "d MMM, h:mm";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "d MMM, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "Väntande";
-
-/* Reachs Internet */
-"Reachability" = "Nåbarhet";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Säkerhet";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Vad tycker du om Simplenote?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Jag gillar den";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Kunde vara bättre";
-
-"Great! Could you leave us a nice review?
-It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\nDet skulle verkligen uppskattas.";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Skriv en recension";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Nej, tack";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Kan du berätta för oss vad vi kan förbättra?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Skicka feedback";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "Kontakt";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "Din e-post:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Hur kan vi hjälpa till?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "Ett fel uppstod vid inloggningen.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "Är du säker på att du vill tömma papperskorgen? Det här går inte att ångra.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Tillbaka";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "Samarbetet har flyttats";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "Det gick inte att logga in";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Ta bort";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Radera anteckningar";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Inaktivera Markdown-formatering";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Edit" = "Redigera";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Aktivera Markdown-formatering";
-
-/* Offer to enable Face ID support if available and passcode is on. */
-"Face ID" = "Ansiktsidentifiering";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Markdown-växling";
-
-   Cancels Empty Trash Action */
-"No" = "Nej";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Aktivera ditt WordPress.com-konto via e-post och försök igen.";
-
-/* Title of Markdown preview screen */
-"Preview" = "Förhandsgranska";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Sök";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Det går nu att dela anteckningar via åtgärdsmenyn i verktygsfältet.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Utloggning kommer att radera alla osynkroniserade anteckningar. Du kan verifiera dina synkroniserade anteckningar genom att logga in på webbappen.";
-
-/* No comment provided by engineer. */
-"Tags" = "Etiketter";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Osynkroniserade anteckningar upptäckta";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Besök webbappen";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Yes" = "Ja";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Etikett…";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "Dela";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Omärkta anteckningar";
-
-   Sort Order for the Notes List */
-"Sort Order" = "Sortering";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Dela analys";
-
-/* Email TextField Placeholder */
-"Email" = "E-post";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Tema";
-
-/* The Simplenote blog */
-"Blog" = "Blogg";
-
-   Display internal debug status */
-"Error" = "Fel";
-
-/* No comment provided by engineer. */
-"Appearance" = "Utseende";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ tecken";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ tecken";
-
-
+/* 1 minute passcode lock timeout */
 "1 Minute" = "1 minut";
 
 /* 15 seconds passcode lock timeout */
@@ -446,11 +45,36 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Display app about screen */
 "About" = "Om";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Godkänn";
+
+/* No comment provided by engineer. */
+"Account" = "Konto";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Lägg till ny redigerare...";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Etikett…";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Lägg till etikett";
+
+/* Title: No filters applied */
+"All Notes" = "Alla anteckningar";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "Alfabetiskt: A-Ö";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "Alfabetiskt: Ö-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "Ett fel uppstod vid inloggningen.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Utseende";
 
 /* Other Simplenote apps */
 "Apps" = "Appar";
@@ -458,14 +82,23 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "Är du en utvecklare? Automattic söker personal.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Är du säker på att du vill tömma papperskorgen? Det här går inte att ångra.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "Vill du skicka meddelandet utan att ange din e-postadress? Om du gör det kan vi inte svara dig.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "Är du säker?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "bifoga fil";
+/* User Authenticated */
+"Authenticated" = "Autentiserad";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Tillbaka";
+
+/* The Simplenote blog */
+"Blog" = "Blogg";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "Genom att skapa ett konto godkänner du våra";
@@ -473,17 +106,54 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* No comment provided by engineer. */
 "Can't Access." = "Ingen åtkomst.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "Avbryt";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Välj bild";
 
 /* No comment provided by engineer. */
 "Close" = "Stäng";
 
+/* Verb - work with others on a note */
+"Collaborate" = "Samarbeta";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "Samarbetet har flyttats";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Redigerare";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Komprimerad anteckningslista";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "Kontakt";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Bidra";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Kunde vara bättre";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Kunde inte skapa ett konto med den e-postadressen och det lösenordet.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Kunde inte logga in med den e-postadressen och det lösenordet.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Kan du berätta för oss vad vi kan förbättra?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Det gick inte att logga in";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Skapa ny anteckning";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Skapa ny anteckning";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Skapad: Senaste";
@@ -491,8 +161,37 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Skapad: Äldsta";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Nuvarande redigerare";
+
 /* Theme: Dark */
 "Dark" = "Mörkt";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Felsök";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Ta bort";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Radera anteckningar";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Inaktivera Markdown-formatering";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Göm tangentbord";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Klar";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Redigera";
+
+/* Email TextField Placeholder */
+"Email" = "E-post";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "E-postadress";
@@ -500,20 +199,59 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Email Taken Alert Title */
 "Email in use" = "E-postadressen används redan";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Töm";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Töm papperskorgen";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Aktivera Markdown-formatering";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "I kö";
+
+/* No comment provided by engineer. */
+"Error" = "Fel";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Fel vid uppladdning.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Ansiktsidentifiering";
 
 /* Password Reset Action */
 "Forgotten password?" = "Har du glömt lösenordet?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\\n\\nDet skulle verkligen uppskattas.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Hjälp oss att förbättra Simplenote genom att dela användningsdata med vårt analysverktyg.";
+
+/* Noun - the version history of a note */
+"History" = "Historik";
+
+/* Action - view the version history of a note */
+"History..." = "Historik...";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Hur kan vi hjälpa till?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Jag gillar den";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Ogiltig e-postadress.";
 
+/* Last Message timestamp */
+"LastSeen" = "LastSeen";
+
 /* Learn More Action */
 "Learn more" = "Läs mer";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Skriv en recension";
 
 /* Theme: Light */
 "Light" = "Ljust";
@@ -521,17 +259,41 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Timeout för lås";
 
+/* Log In Action
+   Login Action
+   LogIn Action
    LogIn Interface Title */
 "Log In" = "Logga in";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "Logga in med e-post";
+/* Log out of the active account in the app */
+"Log Out" = "Logga ut";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "Logga in med WordPress.com";
 
-/* Log out of the active account in the app */
-"Log Out" = "Logga ut";
+/* Presents the regular Email signin flow */
+"Log in with email" = "Logga in med e-post";
+
+/* Month and day date formatter */
+"MMM d" = "d MMM";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "d MMM, h:mm";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "d MMM, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown-växling";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Meny";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Modifierad: Senaste";
@@ -539,8 +301,15 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Modifierad: Äldsta";
 
+/* Label to create a new note */
+"New note" = "Ny anteckning";
+
 /* Empty Note Placeholder */
 "New note..." = "Ny anteckning ...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "Nej";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "Ingen e-postadress.";
@@ -551,16 +320,74 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Ingen text.";
 
-"Open "(preview)"" = "Öppna "(förhandsgranskning)"";
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "Inga anteckningar";
+
+/* Message shown when no notes match a search string */
+"No Results" = "Inga sökresultat";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Nej, tack";
+
+/* No comment provided by engineer. */
+"Note not published" = "Anteckning inte publicerad";
+
+/* Plural form of notes */
+"Notes" = "Anteckningar";
+
+/* Dismisses an AlertController */
+"OK" = "OK";
+
+/* Instant passcode lock timeout */
+"Off" = "Av";
+
+/* No comment provided by engineer. */
+"On" = "På";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "Öppna \"(förhandsgranskning)\"";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Öppna Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "Öppna anteckning";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Vår uppdatering kan ha ändrat i vilken ordning dina anteckningar visas. Vill du granska sorteringsinställningarna?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Lösenkod";
+
+/* Password TextField Placeholder */
+"Password" = "Lösenord";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Lösenord måste innehålla minst 4 tecken";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Lösenord måste innehålla minst 6 tecken.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Väntande";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Fäst";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Nåla fast anteckning";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "Nåla fast högst upp";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "Slå på\/av fastnålning";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "Fastnålad";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Aktivera ditt WordPress.com-konto via e-post och försök igen.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "Kontrollera e-postadressen. Den verkar inte vara giltig.";
@@ -568,11 +395,57 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Du måste skriva något.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Förhandsgranska";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Integritetspolicy";
 
 /* Privacy Settings */
 "Privacy Settings" = "Inställningar för integritet";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Publicera";
+
+/* Action which published a note to a web page */
+"Publish note" = "Publicera anteckning";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Publicera på\/av";
+
+/* No comment provided by engineer. */
+"Published" = "Publicerad";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Publicerar...";
+
+/* Reachs Internet */
+"Reachability" = "Nåbarhet";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Ta bort alla anteckningar från papperskorgen";
+
+/* Rename a tag */
+"Rename" = "Ändra namn";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Återställ";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Återställ anteckning";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Sök";
+
+/* No comment provided by engineer. */
+"Security" = "Säkerhet";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Skicka";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Skicka feedback";
 
 /* For debugging use */
 "Send a Test Crash" = "Skicka en testkrasch";
@@ -580,7 +453,33 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Skickar ...";
 
+/* Title of options screen */
+"Settings" = "Inställningar";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Dela";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Dela analys";
+
+/* No comment provided by engineer. */
+"Share note" = "Dela anteckning";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Det går nu att dela anteckningar via åtgärdsmenyn i verktygsfältet.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Sidopanel";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Skapa konto";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Utloggning kommer att radera alla osynkroniserade anteckningar. Du kan verifiera dina synkroniserade anteckningar genom att logga in på webbappen.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -589,8 +488,15 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Sortera alfabetiskt";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Sortering";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Systemstandard";
+
+/* No comment provided by engineer. */
+"Tags" = "Etiketter";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Ta bild";
@@ -610,17 +516,50 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "Det enklaste sättet att anteckna på.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "Tema";
+
 /* Simplenote Themes */
 "Themes" = "Teman";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "Ett fel inträffade när din feedback skulle skickas. Försök igen.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Idag";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Slå på\/av etiketter i sidopanelen";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Papperskorgen";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Kasta bort";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Lossa";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "Ta bort nål";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Sluta publicera anteckning";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Slutar publicera...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Osynkroniserade anteckningar upptäckta";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Utan etikett";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Omärkta anteckningar";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "Använd den senaste bilden";
@@ -628,8 +567,14 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* A user's Simplenote account */
 "Username" = "Användarnamn:";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Version";
+
 /* App version number */
 "Version %@" = "Version %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Besök webbappen";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "Vi kommer inte åt dina bilder. Kontrollera i inställningarna att du har ställt in åtkomst för den här appen.";
@@ -643,15 +588,76 @@ It really helps." = "Vad kul! Kan du tänka dig att ge oss en bra recension?\n\n
 /* Generic error */
 "We're having problems. Please try again soon." = "Vi har problem. Försök igen om en stund.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Vad tycker du om Simplenote?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "Vad tycker du om WordPress?";
 
 /* Work at Automattic */
 "Work With Us" = "Jobba med oss";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Ja";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Igår";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "Din e-post:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "Din e-postadress är inte giltig.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Ditt meddelande kommer att försvinna.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "Lösenord måste innehålla minst 4 tecken";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "bifoga fil";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Gör så att andra kan hjälpa till och redigera";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Lägg till en e-postadress för att dela denna anteckning med någon, då kan ni båda göra ändringar.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Denna anteckning har blivit borttagen på en annan enhet.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Återställ anteckning till tidigare version";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Visa alternativ för anteckning";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Stäng nuvarande anteckning";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Dela innehåll i nuvarande anteckning";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Lägg till en etikett för anteckningen";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Ta bort etikett från den nuvarande anteckningen";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Kasta anteckningen i papperskorgen";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Anslut till ett nätverk för att se tidigare versioner";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Välj denna version";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Hämtar version";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "Välkommen till Simplenote för iOS!\n\nFör att skapa en anteckning, tryck på plus-knappen.\n\nScrolla i listan för att se dina anteckningar. Tryck på en rubrik för att visa en anteckning, sedan på dess innehåll för att ändra det.\n\nDu kan söka bland dina anteckningar genom att skriva i sökfältet högst upp i anteckningslistan.\n\nTryck på pilen eller dra från vänster för att visa sidopanelen och dina etiketter. Du kan lägga till etiketter för en anteckning längst ner i redigeraren och sedan använda sidopanelen för att filtrera anteckningar.\n\nDet finns fler inställningar för dina anteckningar om du behöver dem. Du kan bjuda in andra att redigera en anteckning, publicera en anteckning som en webbsida, med mera.\n\nAnvänd Simplenote på din Mac, din Android-platta eller -telefon och direkt i din webbläsare på http:\/\/simplenote.com. Dina anteckningar synkroniseras automatiskt mellan alla dina enheter.";
 

--- a/Simplenote/tr.lproj/Localizable.strings
+++ b/Simplenote/tr.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: tr */
 
-/* Number of found search results */
-"%d Result" = "%d Sonuç";
+/* Number of Characters in a note */
+"%@ Character" = "%@ Karakter";
 
-/* Number of found search results */
-"%d Results" = "%d Sonuç";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ Karakter";
 
 /* Number of words in a note */
 "%@ Word" = "%@ Sözcük";
@@ -15,409 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ Sözcük";
 
-   Label of accept button on alert dialog */
-"Accept" = "Kabul";
-
-/* No comment provided by engineer. */
-"Account" = "Hesap";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "Yeni çalışma arkadaşı ekle...";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "Etiket ekle";
-
-/* Title: No filters applied */
-"All Notes" = "Tüm Notlar";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "İptal";
-
-/* Verb - work with others on a note */
-"Collaborate" = "İşbirliği Yap";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "Diğer kişilerin iş birliği kurmasını sağlayın";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "Çalışma Arkadaşları";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "Bu notu bir başka kişinin görebilmesi için o kişinin e-posta adresini ekleyin. Bunun ardından her ikiniz de not üzerinde değişiklik yapabilirsiniz.";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "Sıkıştırılmış Not Listesi";
-
-/* No comment provided by engineer. */
-"Create a new note" = "Yeni not oluştur";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "Şu Anki Çalışma Arkadaşları";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "Bu not bir başka aygıtta silindi.";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "Klavyeyi kapat";
-
-   Verb: Close current view */
-"Done" = "Bitti";
-
-/* Verb - empty causes all notes to be removed permenently from the trash */
-"Empty" = "Boş";
-
-/* Remove all notes from the trash */
-"Empty trash" = "Çöpü boşalt";
-
-/* Noun - the version history of a note */
-"History" = "Geçmiş";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "Notu önceki sürüme geri yükle";
-
-/* Action - view the version history of a note */
-"History..." = "Geçmiş…";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "Menü";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "Not seçeneklerini göster";
-
-/* No comment provided by engineer. */
-"New note" = "Yeni not";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "Not Yok";
-
-/* Message shown when no notes match a search string */
-"No Results" = "Sonuç Yok";
-
-/* No comment provided by engineer. */
-"Note not published" = "Not yayınlanmadı";
-
-/* Title: No filters applied */
-"Notes" = "Notlar";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "Geçerli notu kapat";
-
-/* Instant passcode lock timeout */
-"Off" = "Kapalı";
-
-/* Dismisses an AlertController */
-"OK" = "Tamam";
-
-/* Theme: Light */
-"On" = "Açık";
-
-/* Select a note to view in the note editor */
-"Open note" = "Notu aç";
-
-/* A 4-digit code to lock the app when it is closed */
-"Passcode" = "Geçiş kodu";
-
-/* Action to mark a note as pinned */
-"Pin note" = "Notu iğnele";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "Üste İğnele";
-
-"Pin toggle" = "İğneyi aç/kapat";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "İğnelendi";
-
-/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
-"Publish" = "Yayınla";
-
-/* Action which published a note to a web page */
-"Publish note" = "Notu yayınla";
-
-"Publish toggle" = "Yayınlamayı aç/kapat";
-
-/* No comment provided by engineer. */
-"Published" = "Yayınlandı";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "Yayınlanıyor…";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "Çöp kutusundaki tüm notları kaldır";
-
-/* Rename a tag */
-"Rename" = "Yeniden Adlandır";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "Geri Yükle";
-
-/* Restore a note to a previous version */
-"Restore Note" = "Notu Geri Yükle";
-
-/* Verb - send the content of the note by email, message, etc */
-"Send" = "Gönder";
-
-/* Privacy Settings */
-"Settings" = "Ayarlar";
-
-/* No comment provided by engineer. */
-"Share note" = "Notu paylaş";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "Geçerli notun içeriğini paylaş";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "Kenar çubuğu";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "Geçerli nota etiket ekle";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "Geçerli nottan etiket kaldır";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "Bugün";
-
-"Toggle tag sidebar" = "Etiket kenar çubuğunu aç/kapat";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "Geçerli notu çöp kutusuna taşı";
-
-/* Title: Trash Tag is selected */
-"Trash-noun" = "Çöpe At";
-
-/* Title: Trash Tag is selected */
-"Trash-verb" = "Çöpe At";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "Notu kaldır";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "Notu yayından kaldır";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "Yayından kaldırılıyor...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "Sürüm";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "Önceki Sürümlere Erişmek için İnternet'e bağlanın";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "Bu sürümü değiştir";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "Sürüm alınıyor";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "Dün";
-
-"welcomeNote-iOS" = "iOS için Simplenote’a hoş geldiniz!
-
-Yeni bir not eklemek için artı düğmesine dokunun.
-
-Notlarınıza göz atmak için listeye hafifçe vurun. Bir notu görmek için başlığa dokunun; ardından değiştirmek için notun içeriklerine dokunun.
-
-Not listesinin üst kısmında bulunan arama alanına yazarak tüm notlarınızda arama yapabilirsiniz.
-
-Sol üst kısımdaki ok düğmesine dokunarak veya not listenizi kaydırarak etiketlerinizi görebilirsiniz. Not düzenleyicinin alt kısmında bir nota etiket ekleyebilir, ardından kenar çubuğunu kullanarak notları düzenli şekilde saklayabilirsiniz.
-
-Gerek duyduğunuzda diğer not seçeneklerini de kullanabilirsiniz. Bir nota iş birliği kurduğunuz kişiler olarak başka insanlar ekleyebilir veya notu web sayfası olarak yayınlayabilirsiniz.
-
-Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com adresini yazarak internet tarayıcınızda kullanabilirsiniz. Notlarınız her yerde otomatik olarak güncellenecek.";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "Verilen e-posta adresi ve parolayla hesap oluşturulamadı.";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "Verilen e-posta adresi ve parolayla oturum açılamadı.";
-
-/* Password Reset Action */
-"Password" = "Parola";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "Parola en az 6 karakter olmalıdır.";
-
-   SignUp Interface Title */
-"Sign Up" = "Kaydol";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "E-posta adresiniz geçerli değil.";
-
-/* User Authenticated */
-"Authenticated" = "Kimliği Doğrulandı";
-
-   Display internal debug status */
-"Debug" = "Hata ayıklama";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "Sıraya Alındı";
-
-/* Last Message timestamp */
-"LastSeen" = "Son Görülen";
-
-/* Month and day date formatter */
-"MMM d" = "AAA g";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "g, AAA, sa:dkdk sn";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "g, AAA, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "AAA yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "Bekleyenler";
-
-/* Reachs Internet */
-"Reachability" = "Erişilebilirlik";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "Güvenlik";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "Simplenote hakkında ne düşünüyorsunuz?";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "Beğendim";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "Daha İyi Olabilir";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "Görüşünüzü Paylaşın";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "Hayır, teşekkürler";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "Bize nasıl daha iyi olabileceğimizi belirtir misiniz?";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "Geri Bildirim Gönder";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "İletişim";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "E-posta adresiniz:";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "Nasıl yardımcı olabiliriz?";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "Oturum açılırken bir hata oluştu.";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "Çöp kutusunu boşaltmak istediğinizden emin misiniz? Bu işlem geri alınamaz.";
-
-/* Title of Back button for Markdown preview */
-"Back" = "Geri";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "İşbirliği taşındı";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "Oturum Açılamadı";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "Sil";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "Notları Sil";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "Markdown biçimlendirmesini devre dışı bırak";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "Düzenle";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "Markdown biçimlendirmesini etkinleştir";
-
-/* Offer to enable Face ID support if available and passcode is on. */
-"Face ID" = "Yüz Kimliği";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Markdown düğmesi";
-
-   Cancels Empty Trash Action */
-"No" = "Hayır";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "Lütfen WordPress.com hesabınızı e-posta aracılığıyla etkinleştirin ve tekrar deneyin.";
-
-/* Title of Markdown preview screen */
-"Preview" = "Önizleme";
-
-   Using Search instead of Back if user is searching */
-"Search" = "Ara";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "Notların paylaşılmasına şimdi araç çubuğundaki işlem menüsünden erişilebilir.";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Oturumu kapattığınızda, senkronize edilmemiş tüm notlar silinir. Senkronize edilmiş notlarınızı Web Uygulamasında oturum açarak doğrulayabilirsiniz.";
-
-/* No comment provided by engineer. */
-"Tags" = "Etiketler";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "Senkronize Edilmemiş Notlar Tespit Edildi";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "Web Uygulamasını Ziyaret Et";
-
-   Proceeds with the Empty Trash OP */
-"Yes" = "Evet";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Etiketle…";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Share" = "Paylaş";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "Etiketsiz Notlar";
-
-/* AlertController's Payload for the broken Sort Options Fix */
-"Sort Order" = "Sıralama";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "Analizleri paylaş";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Email" = "E-posta";
-
-/* Option to enable the dark app theme. */
-"Theme" = "Tema";
-
-/* The Simplenote blog */
-"Blog" = "Blog";
-
-   Display internal debug status */
-"Error" = "Hata";
-
-/* No comment provided by engineer. */
-"Appearance" = "Görünüm";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ Karakter";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ Karakter";
+/* Number of found search results */
+"%d Result" = "%d Sonuç";
+
+/* Number of found search results */
+"%d Results" = "%d Sonuç";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 Dakika";
@@ -443,11 +45,36 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Display app about screen */
 "About" = "Hakkında";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "Kabul";
+
+/* No comment provided by engineer. */
+"Account" = "Hesap";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "Yeni çalışma arkadaşı ekle...";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Etiketle…";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "Etiket ekle";
+
+/* Title: No filters applied */
+"All Notes" = "Tüm Notlar";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "Alfabetik: A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "Alfabetik: Z'den A'ya";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "Oturum açılırken bir hata oluştu.";
+
+/* No comment provided by engineer. */
+"Appearance" = "Görünüm";
 
 /* Other Simplenote apps */
 "Apps" = "Uygulamalar";
@@ -455,14 +82,23 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "Bir geliştirici misiniz? Automattic yeni çalışanlarını arıyor.";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "Çöp kutusunu boşaltmak istediğinizden emin misiniz? Bu işlem geri alınamaz.";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "E-posta adresiniz olmadan göndermek istediğinizden emin misiniz? Sizi yanıtlayamayız.";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "Emin misiniz?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "dosya ekle";
+/* User Authenticated */
+"Authenticated" = "Kimliği Doğrulandı";
+
+/* Title of Back button for Markdown preview */
+"Back" = "Geri";
+
+/* The Simplenote blog */
+"Blog" = "Blog";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "Hesap oluşturarak şunları kabul etmiş olursunuz:";
@@ -470,17 +106,54 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* No comment provided by engineer. */
 "Can't Access." = "Erişilemiyor.";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "İptal";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "Fotoğraf Seç";
 
 /* No comment provided by engineer. */
 "Close" = "Kapat";
 
+/* Verb - work with others on a note */
+"Collaborate" = "İşbirliği Yap";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "İşbirliği taşındı";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "Çalışma Arkadaşları";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "Sıkıştırılmış Not Listesi";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "İletişim";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "Katılımda Bulunun";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "Daha İyi Olabilir";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "Verilen e-posta adresi ve parolayla hesap oluşturulamadı.";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "Verilen e-posta adresi ve parolayla oturum açılamadı.";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "Bize nasıl daha iyi olabileceğimizi belirtir misiniz?";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "Oturum Açılamadı";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "Yeni Not Oluştur";
+
+/* No comment provided by engineer. */
+"Create a new note" = "Yeni not oluştur";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "Oluşturma Tarihi: En yeni";
@@ -488,8 +161,37 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "Oluşturma Tarihi: Eski";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "Şu Anki Çalışma Arkadaşları";
+
 /* Theme: Dark */
 "Dark" = "Koyu";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "Hata ayıklama";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Sil";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "Notları Sil";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "Markdown biçimlendirmesini devre dışı bırak";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "Klavyeyi kapat";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "Bitti";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "Düzenle";
+
+/* Email TextField Placeholder */
+"Email" = "E-posta";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "E-posta Adresi";
@@ -497,20 +199,59 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Email Taken Alert Title */
 "Email in use" = "E-posta kullanılıyor";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "Boş";
+
+/* Remove all notes from the trash */
+"Empty trash" = "Çöpü boşalt";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "Markdown biçimlendirmesini etkinleştir";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "Sıraya Alındı";
+
+/* No comment provided by engineer. */
+"Error" = "Hata";
+
 /* No comment provided by engineer. */
 "Error uploading." = "Yükleme hatası.";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Yüz Kimliği";
 
 /* Password Reset Action */
 "Forgotten password?" = "Parolayı mı unuttunuz?";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Great! Could you leave us a nice review?\nIt really helps.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "Analiz aracımızla kullanım verilerini paylaşarak Simplenote'u iyileştirmemize yardımcı olun.";
+
+/* Noun - the version history of a note */
+"History" = "Geçmiş";
+
+/* Action - view the version history of a note */
+"History..." = "Geçmiş…";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "Nasıl yardımcı olabiliriz?";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "Beğendim";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "Geçersiz E-posta Adresi";
 
+/* Last Message timestamp */
+"LastSeen" = "Son Görülen";
+
 /* Learn More Action */
 "Learn more" = "Daha fazlasını öğrenin";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "Görüşünüzü Paylaşın";
 
 /* Theme: Light */
 "Light" = "Açık";
@@ -518,17 +259,41 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "Kilitlenme Zaman Aşımı";
 
+/* Log In Action
+   Login Action
+   LogIn Action
    LogIn Interface Title */
 "Log In" = "Giriş yap";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "E-postayla oturum aç";
+/* Log out of the active account in the app */
+"Log Out" = "Çıkış yap";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "WordPress.com ile oturum aç";
 
-/* Log out of the active account in the app */
-"Log Out" = "Çıkış yap";
+/* Presents the regular Email signin flow */
+"Log in with email" = "E-postayla oturum aç";
+
+/* Month and day date formatter */
+"MMM d" = "AAA g";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "g, AAA, sa:dkdk sn";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "g, AAA, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "AAA yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown düğmesi";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "Menü";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "Değiştirme Tarihi: En yeni";
@@ -536,8 +301,15 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "Değiştirme Tarihi: Eski";
 
+/* Label to create a new note */
+"New note" = "Yeni not";
+
 /* Empty Note Placeholder */
 "New note..." = "Yeni not...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "Hayır";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "E-posta Yok.";
@@ -548,16 +320,74 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "Mesaj Yok.";
 
-"Open "(preview)"" = ""(önizleme)" Öğesini Aç";
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "Not Yok";
+
+/* Message shown when no notes match a search string */
+"No Results" = "Sonuç Yok";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "Hayır, teşekkürler";
+
+/* No comment provided by engineer. */
+"Note not published" = "Not yayınlanmadı";
+
+/* Plural form of notes */
+"Notes" = "Notlar";
+
+/* Dismisses an AlertController */
+"OK" = "Tamam";
+
+/* Instant passcode lock timeout */
+"Off" = "Kapalı";
+
+/* No comment provided by engineer. */
+"On" = "Açık";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "\"(önizleme)\" Öğesini Aç";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "Simplenote'u Aç";
 
+/* Select a note to view in the note editor */
+"Open note" = "Notu aç";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "Güncellememiz, notlarınızın görünme sırasını değiştirmiş olabilir. Sıralama ayarlarını gözden geçirmek ister misiniz?";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "Geçiş kodu";
+
+/* Password TextField Placeholder */
+"Password" = "Parola";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "Parola en az 4 karakter içermelidir.";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "Parola en az 6 karakter olmalıdır.";
+
+/* Number of changes pending to be sent */
+"Pendings" = "Bekleyenler";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "Sabitle";
+
+/* Action to mark a note as pinned */
+"Pin note" = "Notu iğnele";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "Üste İğnele";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "İğneyi aç\/kapat";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "İğnelendi";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "Lütfen WordPress.com hesabınızı e-posta aracılığıyla etkinleştirin ve tekrar deneyin.";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "E-posta adresiniz geçersiz gibi görünüyor. Lütfen e-posta adresinizi kontrol edin.";
@@ -565,11 +395,57 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "Lütfen bir mesaj girin.";
 
+/* Title of Markdown preview screen */
+"Preview" = "Önizleme";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "Gizlilik Politikası";
 
 /* Privacy Settings */
 "Privacy Settings" = "Gizlilik Ayarları";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "Yayınla";
+
+/* Action which published a note to a web page */
+"Publish note" = "Notu yayınla";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "Yayınlamayı aç\/kapat";
+
+/* No comment provided by engineer. */
+"Published" = "Yayınlandı";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "Yayınlanıyor…";
+
+/* Reachs Internet */
+"Reachability" = "Erişilebilirlik";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "Çöp kutusundaki tüm notları kaldır";
+
+/* Rename a tag */
+"Rename" = "Yeniden Adlandır";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "Geri Yükle";
+
+/* Restore a note to a previous version */
+"Restore Note" = "Notu Geri Yükle";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "Ara";
+
+/* No comment provided by engineer. */
+"Security" = "Güvenlik";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "Gönder";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "Geri Bildirim Gönder";
 
 /* For debugging use */
 "Send a Test Crash" = "Yanıt Vermeyen Test İletisi Gönder";
@@ -577,7 +453,33 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "Gönderiliyor...";
 
+/* Title of options screen */
+"Settings" = "Ayarlar";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "Paylaş";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "Analizleri paylaş";
+
+/* No comment provided by engineer. */
+"Share note" = "Notu paylaş";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "Notların paylaşılmasına şimdi araç çubuğundaki işlem menüsünden erişilebilir.";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "Kenar çubuğu";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "Kaydol";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "Oturumu kapattığınızda, senkronize edilmemiş tüm notlar silinir. Senkronize edilmiş notlarınızı Web Uygulamasında oturum açarak doğrulayabilirsiniz.";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -586,8 +488,15 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "Alfabetik Olarak Sırala";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "Sıralama";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "Sistem Varsayılanı";
+
+/* No comment provided by engineer. */
+"Tags" = "Etiketler";
 
 /* No comment provided by engineer. */
 "Take Photo" = "Fotoğraf Çek";
@@ -607,17 +516,50 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Onboarding Header Text */
 "The simplest way to keep notes." = "Not tutmanın en basit yolu.";
 
+/* Option to enable the dark app theme. */
+"Theme" = "Tema";
+
 /* Simplenote Themes */
 "Themes" = "Temalar";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "Geri bildiriminiz gönderilirken bir hata oluştu, lütfen tekrar deneyin.";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "Bugün";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "Etiket kenar çubuğunu aç\/kapat";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "Çöpe At";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "Çöpe At";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "Sabitlemeyi kaldır";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "Notu kaldır";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "Notu yayından kaldır";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "Yayından kaldırılıyor...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "Senkronize Edilmemiş Notlar Tespit Edildi";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "Etiketlenmemiş";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "Etiketsiz Notlar";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "En Son Fotoğrafı Kullan";
@@ -625,8 +567,14 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* A user's Simplenote account */
 "Username" = "Kullanıcı adı";
 
+/* Represents a snapshot in time for a note */
+"Version" = "Sürüm";
+
 /* App version number */
 "Version %@" = "Sürüm %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "Web Uygulamasını Ziyaret Et";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "Fotoğraflarınıza erişemiyoruz. Lütfen Ayarlar'da bu uygulamanın erişimi olduğundan emin olun.";
@@ -640,15 +588,76 @@ Simplenote’u Mac’inizde, Android aygıtınızda veya http://simplenote.com a
 /* Generic error */
 "We're having problems. Please try again soon." = "Sorun yaşanıyor. Lütfen kısa bir süre sonra tekrar deneyin.";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "Simplenote hakkında ne düşünüyorsunuz?";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "WordPress hakkında ne düşünüyorsunuz?";
 
 /* Work at Automattic */
 "Work With Us" = "Bizimle Çalışın";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "Evet";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "Dün";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "E-posta adresiniz:";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "E-posta adresiniz geçerli değil.";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "Mesajınız kaybolacak.";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "Parola en az 4 karakter içermelidir.";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "dosya ekle";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "Diğer kişilerin iş birliği kurmasını sağlayın";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Bu notu bir başka kişinin görebilmesi için o kişinin e-posta adresini ekleyin. Bunun ardından her ikiniz de not üzerinde değişiklik yapabilirsiniz.";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "Bu not bir başka aygıtta silindi.";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "Notu önceki sürüme geri yükle";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "Not seçeneklerini göster";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "Geçerli notu kapat";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "Geçerli notun içeriğini paylaş";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Geçerli nota etiket ekle";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "Geçerli nottan etiket kaldır";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "Geçerli notu çöp kutusuna taşı";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "Önceki Sürümlere Erişmek için İnternet'e bağlanın";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "Bu sürümü değiştir";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "Sürüm alınıyor";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "iOS için Simplenote’a hoş geldiniz!\n\nYeni bir not eklemek için artı düğmesine dokunun.\n\nNotlarınıza göz atmak için listeye hafifçe vurun. Bir notu görmek için başlığa dokunun; ardından değiştirmek için notun içeriklerine dokunun.\n\nNot listesinin üst kısmında bulunan arama alanına yazarak tüm notlarınızda arama yapabilirsiniz.\n\nSol üst kısımdaki ok düğmesine dokunarak veya not listenizi kaydırarak etiketlerinizi görebilirsiniz. Not düzenleyicinin alt kısmında bir nota etiket ekleyebilir, ardından kenar çubuğunu kullanarak notları düzenli şekilde saklayabilirsiniz.\n\nGerek duyduğunuzda diğer not seçeneklerini de kullanabilirsiniz. Bir nota iş birliği kurduğunuz kişiler olarak başka insanlar ekleyebilir veya notu web sayfası olarak yayınlayabilirsiniz.\n\nSimplenote’u Mac’inizde, Android aygıtınızda veya http:\/\/simplenote.com adresini yazarak internet tarayıcınızda kullanabilirsiniz. Notlarınız her yerde otomatik olarak güncellenecek.";
 

--- a/Simplenote/zh-Hans-CN.lproj/Localizable.strings
+++ b/Simplenote/zh-Hans-CN.lproj/Localizable.strings
@@ -3,415 +3,23 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: zh_CN */
 
-/* Number of found search results */
-"%d Result" = "%d 个结果";
-
-/* Number of found search results */
-"%d Results" = "%d 个结果";
-
-/* Number of Characters in a note */
-"%@ Word" = "%@ 个字";
-
-/* Number of Characters in a note */
-"%@ Words" = "%@ 个字";
-
-   Label of accept button on alert dialog */
-"Accept" = "接受";
-
-/* No comment provided by engineer. */
-"Account" = "帐户";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "添加新协作者...";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "添加标签";
-
-/* Title: No filters applied */
-"All Notes" = "全部笔记";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "取消";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborate" = "协作";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "同意他人进行协作";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "协作者";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "添加电子邮件地址即可与他人分享此笔记。而且，您与协作者均可对笔记作出更改。";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "压缩的笔记列表";
-
-/* Siri Suggestion to create a New Note */
-"Create a new note" = "创建新笔记";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "当前协作者";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "此笔记已从其他设备上删除。";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "关闭键盘";
-
-   Verb: Close current view */
-"Done" = "完成";
-
-/* Empty Trash Warning */
-"Empty" = "清空";
-
-/* Empty Trash Warning */
-"Empty trash" = "清空回收站";
-
-/* Noun - the version history of a note */
-"History" = "历史";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "将笔记恢复至之前版本";
-
-/* Action - view the version history of a note */
-"History..." = "历史…";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "菜单";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "显示笔记选项";
-
-/* Label to create a new note */
-"New note" = "新建笔记";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "无笔记";
-
-/* Message shown when no notes match a search string */
-"No Results" = "无结果";
-
-/* No comment provided by engineer. */
-"Note not published" = "笔记尚未发布";
-
-/* Title: No filters applied */
-"Notes" = "笔记";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "关闭当前笔记";
-
-/* No comment provided by engineer. */
-"Off" = "关闭";
-
-/* Empty Trash Warning */
-"OK" = "确定";
-
-/* No comment provided by engineer. */
-"On" = "打开";
-
-/* Select a note to view in the note editor */
-"Open note" = "打开笔记";
-
-/* Error for bad email or password */
-"Passcode" = "密码";
-
-/* Action to mark a note as pinned */
-"Pin note" = "固定笔记";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "固定至顶部";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "固定切换";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "已固定";
-
-/* No comment provided by engineer. */
-"Publish" = "发布";
-
-/* Action which published a note to a web page */
-"Publish note" = "发布笔记";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "发布切换";
-
-/* No comment provided by engineer. */
-"Published" = "已发布";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "正在发布...";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "从回收站中移除所有笔记";
-
-/* Rename a tag */
-"Rename" = "重命名";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "恢复";
-
-/* Restore a note to a previous version */
-"Restore Note" = "恢复笔记";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Send" = "发送";
-
-/* AlertController's Payload for the broken Sort Options Fix */
-"Settings" = "设置";
-
-/* No comment provided by engineer. */
-"Share note" = "分享笔记";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "分享当前笔记的内容";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "侧边栏";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "向当前笔记中添加标签";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "将标签从当前笔记中删除";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "今天";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "切换标签侧边栏";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "将当前笔记移至回收站";
-
-/* Title: Trash Tag is selected */
-"Trash-noun" = "移到回收站";
-
-/* Title: Trash Tag is selected */
-"Trash-verb" = "移到回收站";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "取消固定笔记";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "取消发布笔记";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "正在取消发布...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "版本";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "连接至互联网，访问之前版本";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "切换至此版本";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "正在获取版本";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "昨天";
-
-"welcomeNote-iOS" = "欢迎使用 iOS 版 Simplenote！
-
-要添加笔记，请轻点“加号”按钮。
-
-弹出列表即可浏览笔记。轻点标题即可查看笔记；轻点笔记内容即可对其进行更改。
-
-您可以通过在笔记列表顶部的搜索字段中输入相关内容来搜索笔记。
-
-要查看标签，请轻点左上方的“箭头”按钮或滑动笔记列表。您可以在笔记编辑器底部向笔记添加标签，并借助侧边栏来整理笔记。
-
-您可以根据需要选择其他笔记选项。您可以将其他人添加为笔记的协作者，或将笔记作为网页发布。
-
-您可以通过 Mac、Android 设备或网络浏览器 (http://simplenote.com) 使用 Simplenote。您的笔记可随时随地自动更新。";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "无法使用所提供的电子邮件地址和密码创建帐户。";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "无法使用所提供的电子邮件地址和密码登录。";
-
-/* Error for bad email or password */
-"Password" = "密码";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "密码中必须至少包含 6 个字符。";
-
-   SignUp Interface Title */
-"Sign Up" = "注册";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "您输入的电子邮件地址无效。";
-
-/* User Authenticated */
-"Authenticated" = "已验证";
-
-   Display internal debug status */
-"Debug" = "调试";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "已排入队列数";
-
-/* Last Message timestamp */
-"LastSeen" = "上一次查看时间";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "yyyy MMM d";
-
-/* Month, day, and year date formatter */
-"MMM yyyy" = "yyyy MMM";
-
-/* Number of changes pending to be sent */
-"Pendings" = "待处理数";
-
-/* Reachs Internet */
-"Reachability" = "可访问性";
-
-/* Offer to enable Touch ID support if available and passcode is on. */
-"Touch ID" = "触摸 ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "安全";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "您觉得 Simplenote 怎么样？";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "我喜欢";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "还可以更好";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "留下评价";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "不用了，谢谢";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "您可以告诉我们如何改进吗？";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "发送反馈";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "联系";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "您的电子邮件：";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "您希望我们如何为您提供帮助？";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "登录时出错。";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "是否确定要清空回收站？此操作无法撤消。";
-
-/* Title of Back button for Markdown preview */
-"Back" = "返回";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "已移动协作功能";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "无法登录";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "删除笔记";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "禁用 Markdown 格式";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "编辑";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "启用 Markdown 格式";
-
-/* Offer to enable Face ID support if available and passcode is on. */
-"Face ID" = "面容 ID";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Markdown 功能开关";
-
-/* Empty Trash Warning */
-"No" = "否";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "请通过电子邮件激活您的 WordPress.com 帐户，然后重试。";
-
-   Using Search instead of Back if user is searching */
-"Search" = "搜索";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "现在可通过工具栏上的操作菜单访问共享笔记。";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "注销会删除所有未同步的备注。您可以通过登录 Web 应用程序以确认您已同步的备注。";
-
-/* Label on button to add a new tag to a note */
-"Tags" = "标签";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "检测到未同步的备注";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "访问 Web 应用程序";
-
-/* Automattic hiring description */
-"Yes" = "是";
-
-/* Share (verb) - the action of Sharing a note */
-"Share" = "共享";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "未标记备注";
-
-/* AlertController's Payload for the broken Sort Options Fix */
-"Sort Order" = "排序";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "共享分析数据";
-
-/* Error for bad email or password */
-"Email" = "电子邮件";
-
-/* Option to enable the dark app theme. */
-"Theme" = "主题";
-
-/* The Simplenote blog */
-"Blog" = "博客";
-
-/* No comment provided by engineer. */
-"Error" = "错误";
-
-/* No comment provided by engineer. */
-"Appearance" = "外观";
-
 /* Number of Characters in a note */
 "%@ Character" = "%@ 个字符";
 
 /* Number of Characters in a note */
 "%@ Characters" = "%@ 个字符";
+
+/* Number of words in a note */
+"%@ Word" = "%@ 个字";
+
+/* Number of words in a note */
+"%@ Words" = "%@ 个字";
+
+/* Number of found search results */
+"%d Result" = "%d 个结果";
+
+/* Number of found search results */
+"%d Results" = "%d 个结果";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 分钟";
@@ -437,11 +45,36 @@
 /* Display app about screen */
 "About" = "关于";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "接受";
+
+/* No comment provided by engineer. */
+"Account" = "帐户";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "添加新协作者...";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "Tag...";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "添加标签";
+
+/* Title: No filters applied */
+"All Notes" = "全部笔记";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "按字母顺序：A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "按字母顺序：Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "登录时出错。";
+
+/* No comment provided by engineer. */
+"Appearance" = "外观";
 
 /* Other Simplenote apps */
 "Apps" = "应用程序";
@@ -449,14 +82,23 @@
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "您是开发人员吗？Automattic 正在招聘。";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "是否确定要清空回收站？此操作无法撤消。";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "是否确定要匿名发送？我们将无法回复您。";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "是否确定?";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "附上文件";
+/* User Authenticated */
+"Authenticated" = "已验证";
+
+/* Title of Back button for Markdown preview */
+"Back" = "返回";
+
+/* The Simplenote blog */
+"Blog" = "博客";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "创建帐户即表示，您同意我们的";
@@ -464,17 +106,54 @@
 /* No comment provided by engineer. */
 "Can't Access." = "无法访问。";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "取消";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "选择照片";
 
 /* No comment provided by engineer. */
 "Close" = "关闭";
 
+/* Verb - work with others on a note */
+"Collaborate" = "协作";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "已移动协作功能";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "协作者";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "压缩的笔记列表";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "联系";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "贡献";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "还可以更好";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "无法使用所提供的电子邮件地址和密码创建帐户。";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "无法使用所提供的电子邮件地址和密码登录。";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "您可以告诉我们如何改进吗？";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "无法登录";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "创建新笔记";
+
+/* No comment provided by engineer. */
+"Create a new note" = "创建新笔记";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "创建时间：最新";
@@ -482,29 +161,97 @@
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "创建时间：最旧";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "当前协作者";
+
 /* Theme: Dark */
 "Dark" = "深色";
 
-/* Error for bad email or password */
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "调试";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "Delete";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "删除笔记";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "禁用 Markdown 格式";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "关闭键盘";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "完成";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "编辑";
+
+/* Email TextField Placeholder */
+"Email" = "电子邮件";
+
+/* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "电子邮件地址";
 
 /* Email Taken Alert Title */
 "Email in use" = "电子邮件在使用中";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "清空";
+
+/* Remove all notes from the trash */
+"Empty trash" = "清空回收站";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "启用 Markdown 格式";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "已排入队列数";
+
+/* No comment provided by engineer. */
+"Error" = "错误";
+
 /* No comment provided by engineer. */
 "Error uploading." = "上传时出错。";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "面容 ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "忘记密码？";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "Great! Could you leave us a nice review?\nIt really helps.";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "与分析工具分享使用数据，帮助我们改善 Simplenote。";
+
+/* Noun - the version history of a note */
+"History" = "历史";
+
+/* Action - view the version history of a note */
+"History..." = "历史…";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "您希望我们如何为您提供帮助？";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "我喜欢";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "电子邮件地址无效。";
 
+/* Last Message timestamp */
+"LastSeen" = "上一次查看时间";
+
 /* Learn More Action */
 "Learn more" = "了解更多";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "留下评价";
 
 /* Theme: Light */
 "Light" = "浅色";
@@ -512,17 +259,41 @@
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "锁定超时";
 
-/* Sign in error message */
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
 "Log In" = "登录";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "使用电子邮件登录";
+/* Log out of the active account in the app */
+"Log Out" = "注销";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "使用 WordPress.com 帐户登录";
 
-/* Log out of the active account in the app */
-"Log Out" = "注销";
+/* Presents the regular Email signin flow */
+"Log in with email" = "使用电子邮件登录";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "yyyy MMM d";
+
+/* Month and year date formatter */
+"MMM yyyy" = "yyyy MMM";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown 功能开关";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "菜单";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "修改时间：最新";
@@ -530,8 +301,15 @@
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "修改时间：最旧";
 
+/* Label to create a new note */
+"New note" = "新建笔记";
+
 /* Empty Note Placeholder */
 "New note..." = "新建笔记...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "否";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "没有电子邮件。";
@@ -542,17 +320,74 @@
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "没有消息。";
 
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "无笔记";
+
+/* Message shown when no notes match a search string */
+"No Results" = "无结果";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "不用了，谢谢";
+
+/* No comment provided by engineer. */
+"Note not published" = "笔记尚未发布";
+
+/* Plural form of notes */
+"Notes" = "笔记";
+
+/* Dismisses an AlertController */
+"OK" = "确定";
+
+/* Instant passcode lock timeout */
+"Off" = "关闭";
+
+/* No comment provided by engineer. */
+"On" = "打开";
+
 /* Siri Suggestion to open a specific Note */
-"Open "(preview)"" = "打开“(预览)”";
+"Open \"(preview)\"" = "打开“(预览)”";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "打开 Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "打开笔记";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "我们的更新可能改变了您笔记的显示顺序。您想要查看排序设置吗？";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "密码";
+
+/* Password TextField Placeholder */
+"Password" = "密码";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "密码必须包含至少 4 个字符";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "密码中必须至少包含 6 个字符。";
+
+/* Number of changes pending to be sent */
+"Pendings" = "待处理数";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "钉选";
+
+/* Action to mark a note as pinned */
+"Pin note" = "固定笔记";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "固定至顶部";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "固定切换";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "已固定";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "请通过电子邮件激活您的 WordPress.com 帐户，然后重试。";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "请检查您的电子邮件地址，该地址好像无效。";
@@ -560,11 +395,57 @@
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "请输入消息。";
 
+/* Title of Markdown preview screen */
+"Preview" = "Preview";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "隐私政策";
 
 /* Privacy Settings */
 "Privacy Settings" = "隐私设置";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "发布";
+
+/* Action which published a note to a web page */
+"Publish note" = "发布笔记";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "发布切换";
+
+/* No comment provided by engineer. */
+"Published" = "已发布";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "正在发布...";
+
+/* Reachs Internet */
+"Reachability" = "可访问性";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "从回收站中移除所有笔记";
+
+/* Rename a tag */
+"Rename" = "重命名";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "恢复";
+
+/* Restore a note to a previous version */
+"Restore Note" = "恢复笔记";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "搜索";
+
+/* No comment provided by engineer. */
+"Security" = "安全";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "发送";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "发送反馈";
 
 /* For debugging use */
 "Send a Test Crash" = "发送测试崩溃";
@@ -572,7 +453,33 @@
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "正在发送...";
 
+/* Title of options screen */
+"Settings" = "设置";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "共享";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "共享分析数据";
+
+/* No comment provided by engineer. */
+"Share note" = "分享笔记";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "现在可通过工具栏上的操作菜单访问共享笔记。";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "侧边栏";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "注册";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "注销会删除所有未同步的备注。您可以通过登录 Web 应用程序以确认您已同步的备注。";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
@@ -581,8 +488,15 @@
 /* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "按字母顺序排列";
 
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "排序";
+
 /* Theme: Matches iOS Settings */
 "System Default" = "系统默认";
+
+/* No comment provided by engineer. */
+"Tags" = "标签";
 
 /* No comment provided by engineer. */
 "Take Photo" = "拍照";
@@ -593,7 +507,7 @@
 /* Simplenote terms of service */
 "Terms of Service" = "服务条款";
 
-/* This is one of the buttons we display when prompting the user for a review */
+/* No comment provided by engineer. */
 "Thanks" = "谢谢";
 
 /* Error when address is in use */
@@ -603,16 +517,49 @@
 "The simplest way to keep notes." = "记录笔记最简单的方法。";
 
 /* Option to enable the dark app theme. */
+"Theme" = "主题";
+
+/* Simplenote Themes */
 "Themes" = "主题";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "发送您的反馈时出错，请重试。";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "今天";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "切换标签侧边栏";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "触摸 ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "移到回收站";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "移到回收站";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "取消钉选";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "取消固定笔记";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "取消发布笔记";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "正在取消发布...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "检测到未同步的备注";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "已取消标记";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "未标记备注";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "使用最新照片";
@@ -620,8 +567,14 @@
 /* A user's Simplenote account */
 "Username" = "用户名";
 
+/* Represents a snapshot in time for a note */
+"Version" = "版本";
+
 /* App version number */
 "Version %@" = "版本 %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "访问 Web 应用程序";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "我们无法访问您的照片，请在“设置”中确保此应用程序拥有访问权限。";
@@ -635,15 +588,76 @@
 /* Generic error */
 "We're having problems. Please try again soon." = "我们遇到了问题。请稍后重试。";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "您觉得 Simplenote 怎么样？";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "您认为 WordPress 怎么样？";
 
 /* Work at Automattic */
 "Work With Us" = "与我们合作";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "是";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "昨天";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "您的电子邮件：";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "您输入的电子邮件地址无效。";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "您的消息将会丢失。";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "密码必须包含至少 4 个字符";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "附上文件";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "同意他人进行协作";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "添加电子邮件地址即可与他人分享此笔记。而且，您与协作者均可对笔记作出更改。";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "此笔记已从其他设备上删除。";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "将笔记恢复至之前版本";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "显示笔记选项";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "关闭当前笔记";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "分享当前笔记的内容";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "向当前笔记中添加标签";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "将标签从当前笔记中删除";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "将当前笔记移至回收站";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "连接至互联网，访问之前版本";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "切换至此版本";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "正在获取版本";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "欢迎使用 iOS 版 Simplenote！\n\n要添加笔记，请轻点“加号”按钮。\n\n弹出列表即可浏览笔记。轻点标题即可查看笔记；轻点笔记内容即可对其进行更改。\n\n您可以通过在笔记列表顶部的搜索字段中输入相关内容来搜索笔记。\n\n要查看标签，请轻点左上方的“箭头”按钮或滑动笔记列表。您可以在笔记编辑器底部向笔记添加标签，并借助侧边栏来整理笔记。\n\n您可以根据需要选择其他笔记选项。您可以将其他人添加为笔记的协作者，或将笔记作为网页发布。\n\n您可以通过 Mac、Android 设备或网络浏览器 (http:\/\/simplenote.com) 使用 Simplenote。您的笔记可随时随地自动更新。";
 

--- a/Simplenote/zh-Hant-TW.lproj/Localizable.strings
+++ b/Simplenote/zh-Hant-TW.lproj/Localizable.strings
@@ -3,11 +3,11 @@
 /* Generator: GlotPress/2.4.0-alpha */
 /* Language: zh_TW */
 
-/* Number of found search results */
-"%d Result" = "%d 個搜尋結果";
+/* Number of Characters in a note */
+"%@ Character" = "%@ 個字元";
 
-/* Number of found search results */
-"%d Results" = "%d 個搜尋結果";
+/* Number of Characters in a note */
+"%@ Characters" = "%@ 個字元";
 
 /* Number of words in a note */
 "%@ Word" = "%@ 字";
@@ -15,418 +15,11 @@
 /* Number of words in a note */
 "%@ Words" = "%@ 字";
 
-   Label of accept button on alert dialog */
-"Accept" = "接受";
-
-/* No comment provided by engineer. */
-"Account" = "帳號";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Add a new collaborator..." = "新增協作者…";
-
-/* Label on button to add a new tag to a note */
-"Add tag" = "新增標籤";
-
-/* Title: No filters applied */
-"All Notes" = "所有筆記";
-
-   Verb, cancel an alert dialog */
-"Cancel" = "取消";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborate" = "協作";
-
-/* Accessibility hint on button which shows the current collaborators on a note */
-"collaborate-accessibility-hint" = "將其他人加入協作";
-
-/* Noun - collaborators are other Simplenote users who you chose to share a note with */
-"Collaborators" = "協作者";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "新增電子郵件地址，將此筆記與他人分享。這樣雙方都能變更筆記內容。";
-
-/* Option to make the note list show only 1 line of text. The default is 3. */
-"Condensed Note List" = "精簡版筆記清單";
-
-/* Siri Suggestion to create a New Note */
-"Create a new note" = "建立新筆記";
-
-/* No comment provided by engineer. */
-"Current Collaborators" = "目前協作者";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "此筆記已在另一部裝置上刪除。";
-
-/* No comment provided by engineer. */
-"Dismiss keyboard" = "收起鍵盤";
-
-   Verb: Close current view */
-"Done" = "完成";
-
-/* Empty Trash Warning */
-"Empty" = "清空";
-
-/* Empty Trash Warning */
-"Empty trash" = "清空垃圾桶";
-
-/* Noun - the version history of a note */
-"History" = "歷史紀錄";
-
-/* Accessibility hint on button which shows the history of a note */
-"history-accessibility-hint" = "將筆記還原至先前版本";
-
-/* Action - view the version history of a note */
-"History..." = "歷史紀錄…";
-
-/* Terminoligy used for sidebar UI element where tags are displayed */
-"Menu" = "選單";
-
-/* VoiceOver accessibiliity hint on button which shows or hides the menu */
-"menu-accessibility-hint" = "顯示筆記選項";
-
-/* Label to create a new note */
-"New note" = "新增筆記";
-
-/* Message shown in note list when no notes are in the current view */
-"No Notes" = "沒有筆記";
-
-/* Message shown when no notes match a search string */
-"No Results" = "沒有任何搜尋結果";
-
-/* No comment provided by engineer. */
-"Note not published" = "筆記未發表";
-
-/* Title: No filters applied */
-"Notes" = "筆記";
-
-/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
-"notes-accessibility-hint" = "關閉目前筆記";
-
-/* No comment provided by engineer. */
-"Off" = "關閉";
-
-/* Empty Trash Warning */
-"OK" = "確定";
-
-/* No comment provided by engineer. */
-"On" = "開啟";
-
-/* Select a note to view in the note editor */
-"Open note" = "開啟筆記";
-
-/* Error for bad email or password */
-"Passcode" = "密碼";
-
-/* Action to mark a note as pinned */
-"Pin note" = "釘選筆記";
-
-/* Denotes when note is pinned to the top of the note list */
-"Pin to Top" = "釘選至最上方";
-
-/* Switch which marks a note as pinned or unpinned */
-"Pin toggle" = "釘選開關";
-
-/* Pinned notes are stuck to the note of the note list */
-"Pinned" = "已釘選";
-
-/* No comment provided by engineer. */
-"Publish" = "發表";
-
-/* Action which published a note to a web page */
-"Publish note" = "發表筆記";
-
-/* Switch which marks a note as published or unpublished */
-"Publish toggle" = "發表開關";
-
-/* No comment provided by engineer. */
-"Published" = "已發表";
-
-/* Message shown when a note is in the processes of being published */
-"Publishing..." = "正在發表…";
-
-/* No comment provided by engineer. */
-"Remove all notes from trash" = "移除垃圾桶的所有筆記";
-
-/* Rename a tag */
-"Rename" = "重新命名";
-
-/* Restore a note from the trash, markking it as undeleted */
-"Restore" = "還原";
-
-/* Restore a note to a previous version */
-"Restore Note" = "還原筆記";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Send" = "傳送";
-
-/* AlertController's Payload for the broken Sort Options Fix */
-"Settings" = "設定";
-
-/* No comment provided by engineer. */
-"Share note" = "分享筆記";
-
-/* Accessibility hint on share button */
-"share-accessibility-hint" = "分享目前筆記的內容";
-
-/* UI region to the left of the note list which shows all of a users tags */
-"Sidebar" = "側選單";
-
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "將標籤新增至目前筆記";
-
-/* No comment provided by engineer. */
-"tag-delete-accessibility-hint" = "移除目前筆記的標籤";
-
-/* Displayed as a date in the case where a note was modified today, for example */
-"Today" = "今天";
-
-/* Accessibility hint used to show or hide the sidebar */
-"Toggle tag sidebar" = "切換標籤側選單";
-
-/* Accessibility hint on button which moves a note to the trash */
-"trash-accessibility-hint" = "將目前筆記移至垃圾桶";
-
-/* Empty Trash Warning */
-"Trash-noun" = "垃圾桶";
-
-/* Trash (verb) - the action of deleting a note */
-"Trash-verb" = "移至垃圾桶";
-
-/* Action to mark a note as unpinned */
-"Unpin note" = "取消釘選筆記";
-
-/* Action which unpublishes a note */
-"Unpublish note" = "取消發表筆記";
-
-/* Message shown when a note is in the processes of being unpublished */
-"Unpublishing..." = "正在取消發表...";
-
-/* Represents a snapshot in time for a note */
-"Version" = "版本";
-
-/* Error alert message shown when trying to view history of a note without an internet connection */
-"version-alert-message" = "連線至網際網路以存取先前版本";
-
-/* Accessiblity hint describing how to reset the current note to a previous version */
-"version-cell-accessibility-hint" = "切換至此版本";
-
-/* Accessibility hint used when previous versions of a note are being fetched */
-"version-cell-fetching-accessibility-hint" = "正在擷取此版本";
-
-/* Displayed as a date in the case where a note was modified yesterday, for example */
-"Yesterday" = "昨天";
-
-"welcomeNote-iOS" = "歡迎使用 Simplenote iOS 版！
-
-若要新增筆記，請點選加號按鈕。
-
-撥動清單即可瀏覽你的筆記。點選標題可瀏覽筆記，然後點選內容則可進行變更。
-
-你可以在筆記清單頂端的搜尋欄位內輸入關鍵字搜尋你全部的筆記。
-
-點選左上方的箭號按鈕或撥動筆記清單可檢視標籤。在筆記編輯器底部可將標籤新增至筆記，然後使用側選單可協助你妥善整理筆記。
-
-若有需要，還有更多筆記選項可供使用。你可以將其他人新增為筆記的協作者，或是將筆記發表至網頁。
-
-前往 http://simplenote.com 將 Simplenote 下載至你的 Mac、Android 裝置或在網頁瀏覽器中使用。你的筆記將會隨時隨地保持更新。";
-
-/* Error for bad email or password */
-"Could not create an account with the provided email address and password." = "無法使用提供的電子郵件地址和密碼建立帳號。";
-
-/* Message displayed when login fails */
-"Could not login with the provided email address and password." = "無法使用提供的電子郵件地址和密碼登入。";
-
-/* Error for bad email or password */
-"Password" = "密碼";
-
-/* Message displayed when password is invalid (Signup) */
-"Password must contain at least 6 characters" = "密碼必須包含至少 6 個字元。";
-
-   SignUp Interface Title */
-"Sign Up" = "註冊";
-
-/* Message displayed when email address is invalid */
-"Your email address is not valid" = "你的電子郵件地址無效。";
-
-/* User Authenticated */
-"Authenticated" = "已驗證";
-
-   Display internal debug status */
-"Debug" = "偵錯";
-
-/* Number of objects enqueued for processing */
-"Enqueued" = "加入佇列";
-
-/* Last Message timestamp */
-"LastSeen" = "上次上線";
-
-/* Month and day date formatter */
-"MMM d" = "MMM d";
-
-/* Month, day, and time date formatter */
-"MMM d, h:mm a" = "MMM d, h:mm a";
-
-/* Month, day, and year date formatter */
-"MMM d, yyyy" = "MMM d, yyyy";
-
-/* Month and year date formatter */
-"MMM yyyy" = "MMM yyyy";
-
-/* Number of changes pending to be sent */
-"Pendings" = "待確認";
-
-/* Reachs Internet */
-"Reachability" = "可達性";
-
-
-"Touch ID" = "Touch ID";
-
-
-"WebSocket" = "WebSocket";
-
-/* No comment provided by engineer. */
-"Security" = "安全性";
-
-/* This is the string we display when prompting the user to review the app */
-"What do you think about Simplenote?" = "你覺得 Simplenote 如何？";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"I Like It" = "我喜歡";
-
-/* This is one of the buttons we display inside of the prompt to review the app */
-"Could Be Better" = "可以再好一點";
-
-"Great! Could you leave us a nice review?
-It really helps." = "太棒了！你可以給我們一些回饋嗎？
-
-
-您的回饋會使我們更好";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Leave a Review" = "留下評語";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"No Thanks" = "不用了，謝謝";
-
-/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
-"Could you tell us how we could improve?" = "你可以告訴我們哪裡該改進嗎？";
-
-/* This is one of the buttons we display when prompting the user for a review */
-"Send Feedback" = "傳送回饋意見";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"Contact" = "聯絡";
-
-/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
-"Your Email:" = "你的電子郵件：";
-
-/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
-"How can we help?" = "需要什麼協助？";
-
-/* Sign in error message */
-"An error was encountered while signing in." = "登入時發生錯誤。";
-
-/* Empty Trash Warning */
-"Are you sure you want to empty the trash? This cannot be undone." = "確定要清空垃圾桶？此動作無法復原。";
-
-/* Title of Back button for Markdown preview */
-"Back" = "上一步";
-
-/* No comment provided by engineer. */
-"Collaboration has moved" = "協作已移動";
-
-/* Alert dialog title displayed on sign in error */
-"Couldn't Sign In" = "無法登入";
-
-/* Trash (verb) - the action of deleting a note */
-"Delete" = "刪除";
-
-/* Verb: Delete notes and log out of the app */
-"Delete Notes" = "刪除筆記";
-
-/* No comment provided by engineer. */
-"Disable Markdown formatting" = "停用 Markdown 格式";
-
-/* Edit Tags Action: Visible in the Tags List */
-"Edit" = "編輯";
-
-/* No comment provided by engineer. */
-"Enable Markdown formatting" = "啟用 Markdown 格式";
-
-
-"Face ID" = "Face ID";
-
-
-"Markdown" = "Markdown";
-
-/* Switch which marks a note as using Markdown formatting or not */
-"Markdown toggle" = "Markdown 切換開關";
-
-   Cancels Empty Trash Action */
-"No" = "否";
-
-/* Error message displayed when user has not verified their WordPress.com account */
-"Please activate your WordPress.com account via email and try again." = "請透過電子郵件啟用你的 WordPress.com 帳號，並再試一次。";
-
-/* Title of Markdown preview screen */
-"Preview" = "預覽";
+/* Number of found search results */
+"%d Result" = "%d 個搜尋結果";
 
 /* Number of found search results */
-"Search" = "搜尋";
-
-/* No comment provided by engineer. */
-"Sharing notes is now accessed through the action menu from the toolbar." = "你現可從工具列的動作選單存取分享筆記。";
-
-/* Alert message displayed when an account has unsynced notes */
-"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "登出將會刪除任何尚未同步的備註。登入網頁應用程式即可驗證已同步的備註。";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Tags" = "標籤";
-
-/* Alert title displayed in settings when an account has unsynced notes */
-"Unsynced Notes Detected" = "偵測到尚未同步的備註";
-
-/* Visit app.simplenote.com in the browser */
-"Visit Web App" = "前往網頁應用程式";
-
-/* Automattic hiring description */
-"Yes" = "是";
-
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "標籤…";
-
-/* Privacy Details */
-"Share" = "分享";
-
-/* Allows selecting notes with no tags */
-"Untagged Notes" = "取消標籤備註";
-
-/* Sort Mode: Alphabetically, ascending */
-"Sort Order" = "排序";
-
-/* Option to disable Analytics. */
-"Share Analytics" = "分享分析資料";
-
-/* Message for alert when user tries to send feedback without an email address */
-"Email" = "電子郵件";
-
-/* Option to enable the dark app theme. */
-"Theme" = "佈景主題";
-
-/* The Simplenote blog */
-"Blog" = "網誌";
-
-/* Sign in error message */
-"Error" = "錯誤";
-
-/* No comment provided by engineer. */
-"Appearance" = "外觀";
-
-/* Number of Characters in a note */
-"%@ Character" = "%@ 個字元";
-
-/* Number of Characters in a note */
-"%@ Characters" = "%@ 個字元";
+"%d Results" = "%d 個搜尋結果";
 
 /* 1 minute passcode lock timeout */
 "1 Minute" = "1 分鐘";
@@ -452,11 +45,36 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Display app about screen */
 "About" = "關於";
 
+/* Accept Action
+   Label of accept button on alert dialog */
+"Accept" = "接受";
+
+/* No comment provided by engineer. */
+"Account" = "帳號";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Add a new collaborator..." = "新增協作者…";
+
+/* Placeholder test in textfield when adding a new tag to a note */
+"Tag..." = "標籤…";
+
+/* Label on button to add a new tag to a note */
+"Add tag" = "新增標籤";
+
+/* Title: No filters applied */
+"All Notes" = "所有筆記";
+
 /* Sort Mode: Alphabetically, ascending */
 "Alphabetically: A-Z" = "依英文字母排序：A-Z";
 
 /* Sort Mode: Alphabetically, descending */
 "Alphabetically: Z-A" = "依英文字母排序：Z-A";
+
+/* Sign in error message */
+"An error was encountered while signing in." = "登入時發生錯誤。";
+
+/* No comment provided by engineer. */
+"Appearance" = "外觀";
 
 /* Other Simplenote apps */
 "Apps" = "應用程式";
@@ -464,14 +82,23 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Automattic hiring description */
 "Are you a developer? Automattic is hiring." = "你是開發人員嗎？Automattic 正在招募人才。";
 
+/* Empty Trash Warning */
+"Are you sure you want to empty the trash? This cannot be undone." = "確定要清空垃圾桶？此動作無法復原。";
+
 /* Message for alert when user tries to send feedback without an email address */
 "Are you sure you want to send without your email? We won't be able reply to you." = "確定不留下電子郵件地址而傳送？我們將無法回覆你。";
 
 /* Title for prompt when user tries to close the feedback view */
 "Are you sure?" = "你確定嗎？";
 
-/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
-"attach a file" = "附加檔案";
+/* User Authenticated */
+"Authenticated" = "已驗證";
+
+/* Title of Back button for Markdown preview */
+"Back" = "上一步";
+
+/* The Simplenote blog */
+"Blog" = "網誌";
 
 /* Terms of Service Legend *PREFIX*: printed in dark color */
 "By creating an account you agree to our" = "建立帳號即表示你同意我們的";
@@ -479,17 +106,54 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* No comment provided by engineer. */
 "Can't Access." = "無法存取。";
 
+/* Cancel Action
+   Verb, cancel an alert dialog */
+"Cancel" = "取消";
+
 /* No comment provided by engineer. */
 "Choose Photo" = "選擇照片";
 
 /* No comment provided by engineer. */
 "Close" = "關閉";
 
+/* Verb - work with others on a note */
+"Collaborate" = "協作";
+
+/* No comment provided by engineer. */
+"Collaboration has moved" = "協作已移動";
+
+/* Noun - collaborators are other Simplenote users who you chose to share a note with */
+"Collaborators" = "協作者";
+
+/* Option to make the note list show only 1 line of text. The default is 3. */
+"Condensed Note List" = "精簡版筆記清單";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"Contact" = "聯絡";
+
 /* Contribute to the Simplenote apps on github */
 "Contribute" = "參與";
 
+/* This is one of the buttons we display inside of the prompt to review the app */
+"Could Be Better" = "可以再好一點";
+
+/* Error for bad email or password */
+"Could not create an account with the provided email address and password." = "無法使用提供的電子郵件地址和密碼建立帳號。";
+
+/* Message displayed when login fails */
+"Could not login with the provided email address and password." = "無法使用提供的電子郵件地址和密碼登入。";
+
+/* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
+"Could you tell us how we could improve?" = "你可以告訴我們哪裡該改進嗎？";
+
+/* Alert dialog title displayed on sign in error */
+"Couldn't Sign In" = "無法登入";
+
 /* Siri Suggestion to create a New Note */
 "Create a New Note" = "建立新筆記";
+
+/* No comment provided by engineer. */
+"Create a new note" = "建立新筆記";
 
 /* Sort Mode: Creation Date, descending */
 "Created: Newest" = "建立時間：最新";
@@ -497,8 +161,37 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Sort Mode: Creation Date, ascending */
 "Created: Oldest" = "建立時間：最舊";
 
+/* No comment provided by engineer. */
+"Current Collaborators" = "目前協作者";
+
 /* Theme: Dark */
 "Dark" = "深色系";
+
+/* Debug Screen Title
+   Display internal debug status */
+"Debug" = "偵錯";
+
+/* Trash (verb) - the action of deleting a note */
+"Delete" = "刪除";
+
+/* Verb: Delete notes and log out of the app */
+"Delete Notes" = "刪除筆記";
+
+/* No comment provided by engineer. */
+"Disable Markdown formatting" = "停用 Markdown 格式";
+
+/* No comment provided by engineer. */
+"Dismiss keyboard" = "收起鍵盤";
+
+/* Done toolbar button
+   Verb: Close current view */
+"Done" = "完成";
+
+/* Edit Tags Action: Visible in the Tags List */
+"Edit" = "編輯";
+
+/* Email TextField Placeholder */
+"Email" = "電子郵件";
 
 /* Placeholder text we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
 "Email Address" = "電子郵件地址：";
@@ -506,20 +199,59 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Email Taken Alert Title */
 "Email in use" = "電子郵件地址已有人使用";
 
+/* Verb - empty causes all notes to be removed permenently from the trash */
+"Empty" = "清空";
+
+/* Remove all notes from the trash */
+"Empty trash" = "清空垃圾桶";
+
+/* No comment provided by engineer. */
+"Enable Markdown formatting" = "啟用 Markdown 格式";
+
+/* Number of objects enqueued for processing */
+"Enqueued" = "加入佇列";
+
+/* No comment provided by engineer. */
+"Error" = "錯誤";
+
 /* No comment provided by engineer. */
 "Error uploading." = "上傳時發生錯誤。";
+
+/* Offer to enable Face ID support if available and passcode is on. */
+"Face ID" = "Face ID";
 
 /* Password Reset Action */
 "Forgotten password?" = "忘記密碼了嗎？";
 
+/* This is the text we display to the user when we ask them for a review and they've indicated they like the app */
+"Great! Could you leave us a nice review?\nIt really helps." = "太棒了！你可以給我們一些回饋嗎？\n\n\n您的回饋會使我們更好";
+
 /* Privacy Details */
 "Help us improve Simplenote by sharing usage data with our analytics tool." = "請透過我們的分析工具分享使用情形資料，協助我們改善 Simplenote。";
+
+/* Noun - the version history of a note */
+"History" = "歷史紀錄";
+
+/* Action - view the version history of a note */
+"History..." = "歷史紀錄…";
+
+/* This is text that appears in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback */
+"How can we help?" = "需要什麼協助？";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"I Like It" = "我喜歡";
 
 /* Title for alert that a user has entered an invalid email address */
 "Invalid Email Address." = "無效的電子郵件地址。";
 
+/* Last Message timestamp */
+"LastSeen" = "上次上線";
+
 /* Learn More Action */
 "Learn more" = "瞭解更多";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Leave a Review" = "留下評語";
 
 /* Theme: Light */
 "Light" = "淡色系";
@@ -527,17 +259,41 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Setting for when the passcode lock should enable */
 "Lock Timeout" = "鎖定逾時";
 
-/* Sign in error message */
+/* Log In Action
+   Login Action
+   LogIn Action
+   LogIn Interface Title */
 "Log In" = "登入";
 
-/* Presents the regular Email signin flow */
-"Log in with email" = "透過電子郵件登入";
+/* Log out of the active account in the app */
+"Log Out" = "登出";
 
 /* Allows the user to SignIn using their WPCOM Account */
 "Log in with WordPress.com" = "透過 WordPress.com 登入";
 
-/* Log out of the active account in the app */
-"Log Out" = "登出";
+/* Presents the regular Email signin flow */
+"Log in with email" = "透過電子郵件登入";
+
+/* Month and day date formatter */
+"MMM d" = "MMM d";
+
+/* Month, day, and time date formatter */
+"MMM d, h:mm a" = "MMM d, h:mm a";
+
+/* Month, day, and year date formatter */
+"MMM d, yyyy" = "MMM d, yyyy";
+
+/* Month and year date formatter */
+"MMM yyyy" = "MMM yyyy";
+
+/* Special formatting that can be turned on for notes */
+"Markdown" = "Markdown";
+
+/* Switch which marks a note as using Markdown formatting or not */
+"Markdown toggle" = "Markdown 切換開關";
+
+/* Terminoligy used for sidebar UI element where tags are displayed */
+"Menu" = "選單";
 
 /* Sort Mode: Modified Date, descending */
 "Modified: Newest" = "修改時間：最新";
@@ -545,8 +301,15 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Sort Mode: Creation Date, ascending */
 "Modified: Oldest" = "修改時間：最舊";
 
+/* Label to create a new note */
+"New note" = "新增筆記";
+
 /* Empty Note Placeholder */
 "New note..." = "新筆記...";
+
+/* Alert's Cancel Action
+   Cancels Empty Trash Action */
+"No" = "否";
 
 /* Title for alert when user tires to send feedback without an email address */
 "No Email." = "無電子郵件。";
@@ -557,16 +320,74 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Title for message when user tries to send feedback without any text */
 "No Message." = "無訊息。";
 
-"Open "(preview)"" = "開啟 "(preview)"";
+/* Message shown in note list when no notes are in the current view */
+"No Notes" = "沒有筆記";
+
+/* Message shown when no notes match a search string */
+"No Results" = "沒有任何搜尋結果";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"No Thanks" = "不用了，謝謝";
+
+/* No comment provided by engineer. */
+"Note not published" = "筆記未發表";
+
+/* Plural form of notes */
+"Notes" = "筆記";
+
+/* Dismisses an AlertController */
+"OK" = "確定";
+
+/* Instant passcode lock timeout */
+"Off" = "關閉";
+
+/* No comment provided by engineer. */
+"On" = "開啟";
+
+/* Siri Suggestion to open a specific Note */
+"Open \"(preview)\"" = "開啟 \"(preview)\"";
 
 /* Siri Suggestion to open our app */
 "Open Simplenote" = "開啟 Simplenote";
 
+/* Select a note to view in the note editor */
+"Open note" = "開啟筆記";
+
 /* AlertController's Payload for the broken Sort Options Fix */
 "Our update may have changed the order in which your notes appear. Would you like to review sort settings?" = "我們的更新可能已調整筆記的顯示順序。是否要檢視排序設定？";
 
+/* A 4-digit code to lock the app when it is closed */
+"Passcode" = "密碼";
+
+/* Password TextField Placeholder */
+"Password" = "密碼";
+
+/* Message displayed when password is invalid (Login) */
+"Password must contain at least 4 characters" = "密碼必須包含至少 4 個字元";
+
+/* Message displayed when password is invalid (Signup) */
+"Password must contain at least 6 characters" = "密碼必須包含至少 6 個字元。";
+
+/* Number of changes pending to be sent */
+"Pendings" = "待確認";
+
 /* Pin (verb) - the action of Pinning a note */
 "Pin" = "釘選";
+
+/* Action to mark a note as pinned */
+"Pin note" = "釘選筆記";
+
+/* Denotes when note is pinned to the top of the note list */
+"Pin to Top" = "釘選至最上方";
+
+/* Switch which marks a note as pinned or unpinned */
+"Pin toggle" = "釘選開關";
+
+/* Pinned notes are stuck to the note of the note list */
+"Pinned" = "已釘選";
+
+/* Error message displayed when user has not verified their WordPress.com account */
+"Please activate your WordPress.com account via email and try again." = "請透過電子郵件啟用你的 WordPress.com 帳號，並再試一次。";
 
 /* Message for alert that user has entered an invalid email address */
 "Please check your email address, it appears to be invalid." = "請檢查你的電子郵件地址，這似乎是無效的地址。";
@@ -574,11 +395,57 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Message for alert when user tires to send feedback without any text */
 "Please enter a message." = "請輸入訊息。";
 
+/* Title of Markdown preview screen */
+"Preview" = "預覽";
+
 /* Simplenote privacy policy */
 "Privacy Policy" = "隱私權政策";
 
 /* Privacy Settings */
 "Privacy Settings" = "隱私權設定";
+
+/* Verb - Publishing a note creates  URL and for any note in a user's account, making it viewable to others */
+"Publish" = "發表";
+
+/* Action which published a note to a web page */
+"Publish note" = "發表筆記";
+
+/* Switch which marks a note as published or unpublished */
+"Publish toggle" = "發表開關";
+
+/* No comment provided by engineer. */
+"Published" = "已發表";
+
+/* Message shown when a note is in the processes of being published */
+"Publishing..." = "正在發表…";
+
+/* Reachs Internet */
+"Reachability" = "可達性";
+
+/* No comment provided by engineer. */
+"Remove all notes from trash" = "移除垃圾桶的所有筆記";
+
+/* Rename a tag */
+"Rename" = "重新命名";
+
+/* Restore a note from the trash, markking it as undeleted */
+"Restore" = "還原";
+
+/* Restore a note to a previous version */
+"Restore Note" = "還原筆記";
+
+/* Search Placeholder
+   Using Search instead of Back if user is searching */
+"Search" = "搜尋";
+
+/* No comment provided by engineer. */
+"Security" = "安全性";
+
+/* Verb - send the content of the note by email, message, etc */
+"Send" = "傳送";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"Send Feedback" = "傳送回饋意見";
 
 /* For debugging use */
 "Send a Test Crash" = "傳送故障測試";
@@ -586,17 +453,50 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Label that is shown when feedback from the user is sending */
 "Sending..." = "正在傳送...";
 
+/* Title of options screen */
+"Settings" = "設定";
 
+/* Share (verb) - the action of Sharing a note */
+"Share" = "分享";
+
+/* Option to disable Analytics. */
+"Share Analytics" = "分享分析資料";
+
+/* No comment provided by engineer. */
+"Share note" = "分享筆記";
+
+/* No comment provided by engineer. */
+"Sharing notes is now accessed through the action menu from the toolbar." = "你現可從工具列的動作選單存取分享筆記。";
+
+/* UI region to the left of the note list which shows all of a users tags */
+"Sidebar" = "側選單";
+
+/* Signup Action
+   SignUp Action
+   SignUp Interface Title */
+"Sign Up" = "註冊";
+
+/* Alert message displayed when an account has unsynced notes */
+"Signing out will delete any unsynced notes. You can verify your synced notes by signing in to the Web App." = "登出將會刪除任何尚未同步的備註。登入網頁應用程式即可驗證已同步的備註。";
+
+/* Our mighty brand! */
 "Simplenote" = "Simplenote";
 
 /* Authentication Error Alert Title */
 "Sorry!" = "很抱歉！";
 
-/* Sort Mode: Alphabetically, ascending */
+/* Option to sort tags alphabetically. The default is by manual ordering. */
 "Sort Alphabetically" = "依英文字母排序";
+
+/* Option to sort notes in the note list alphabetically. The default is by modification date
+   Sort Order for the Notes List */
+"Sort Order" = "排序";
 
 /* Theme: Matches iOS Settings */
 "System Default" = "系統預設";
+
+/* No comment provided by engineer. */
+"Tags" = "標籤";
 
 /* No comment provided by engineer. */
 "Take Photo" = "拍攝照片";
@@ -607,7 +507,7 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Simplenote terms of service */
 "Terms of Service" = "服務條款";
 
-/* This is one of the buttons we display when prompting the user for a review */
+/* No comment provided by engineer. */
 "Thanks" = "謝謝";
 
 /* Error when address is in use */
@@ -617,16 +517,49 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 "The simplest way to keep notes." = "輕鬆作筆記的最佳方式。";
 
 /* Option to enable the dark app theme. */
+"Theme" = "佈景主題";
+
+/* Simplenote Themes */
 "Themes" = "佈景主題";
 
 /* No comment provided by engineer. */
 "There was an error sending your feedback, please try again." = "傳送你的回饋意見時發生錯誤，請再試一次。";
 
+/* Displayed as a date in the case where a note was modified today, for example */
+"Today" = "今天";
+
+/* Accessibility hint used to show or hide the sidebar */
+"Toggle tag sidebar" = "切換標籤側選單";
+
+/* Offer to enable Touch ID support if available and passcode is on. */
+"Touch ID" = "Touch ID";
+
+/* Title: Trash Tag is selected */
+"Trash" = "垃圾桶";
+
+/* Trash (verb) - the action of deleting a note */
+"Trash" = "移至垃圾桶";
+
 /* Unpin (verb) - the action of Unpinning a note */
 "Unpin" = "取消釘選";
 
+/* Action to mark a note as unpinned */
+"Unpin note" = "取消釘選筆記";
+
+/* Action which unpublishes a note */
+"Unpublish note" = "取消發表筆記";
+
+/* Message shown when a note is in the processes of being unpublished */
+"Unpublishing..." = "正在取消發表...";
+
+/* Alert title displayed in settings when an account has unsynced notes */
+"Unsynced Notes Detected" = "偵測到尚未同步的備註";
+
 /* Title: Untagged Notes are onscreen */
 "Untagged" = "取消標籤";
+
+/* Allows selecting notes with no tags */
+"Untagged Notes" = "取消標籤備註";
 
 /* No comment provided by engineer. */
 "Use Latest Photo" = "使用最新照片";
@@ -634,8 +567,14 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* A user's Simplenote account */
 "Username" = "使用者名稱";
 
+/* Represents a snapshot in time for a note */
+"Version" = "版本";
+
 /* App version number */
 "Version %@" = "版本 %@";
+
+/* Visit app.simplenote.com in the browser */
+"Visit Web App" = "前往網頁應用程式";
 
 /* No comment provided by engineer. */
 "We can't access your photos, please ensure this application has access in Settings." = "我們無法存取你的照片，請確定此應用程式在「設定」中有存取權。";
@@ -649,15 +588,76 @@ It really helps." = "太棒了！你可以給我們一些回饋嗎？
 /* Generic error */
 "We're having problems. Please try again soon." = "發生問題，請再試一次。";
 
+/* WebSocket Status */
+"WebSocket" = "WebSocket";
+
+/* This is the string we display when prompting the user to review the app */
+"What do you think about Simplenote?" = "你覺得 Simplenote 如何？";
+
 /* This is the string we display when prompting the user to review the app */
 "What do you think about WordPress?" = "你覺得 WordPress 如何？";
 
 /* Work at Automattic */
 "Work With Us" = "與我們合作";
 
+/* Alert's Accept Action
+   Proceeds with the Empty Trash OP */
+"Yes" = "是";
+
+/* Displayed as a date in the case where a note was modified yesterday, for example */
+"Yesterday" = "昨天";
+
+/* The label we display in the feedback view that is brought up when the user doesn't like our app and they've indicated they want to give feedback */
+"Your Email:" = "你的電子郵件：";
+
+/* Message displayed when email address is invalid */
+"Your email address is not valid" = "你的電子郵件地址無效。";
+
 /* Message for prompt when user tries to close feedback view after having entered text */
 "Your message will be lost." = "你的訊息將會遺失。";
 
-/* Message displayed when password is invalid (Login) */
-"Password must contain at least 4 characters" = "密碼必須包含至少 4 個字元";
+/* This is text we display in the feedback view that we display when we prompt the user for an app review and they've indicated they don't like it and want to give us feedback. Tapping on this 'button' will pull up the photo browser so they can attach a photo */
+"attach a file" = "附加檔案";
+
+/* Accessibility hint on button which shows the current collaborators on a note */
+"Enable others to collaborate" = "將其他人加入協作";
+
+/* No comment provided by engineer. */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "新增電子郵件地址，將此筆記與他人分享。這樣雙方都能變更筆記內容。";
+
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device." = "此筆記已在另一部裝置上刪除。";
+
+/* Accessibility hint on button which shows the history of a note */
+"Restore note to previous version" = "將筆記還原至先前版本";
+
+/* VoiceOver accessibiliity hint on button which shows or hides the menu */
+"Show options for note" = "顯示筆記選項";
+
+/* VoiceOver accessibiliity hint on the button that closes the notes editor and navigates back to the note list */
+"Close current note" = "關閉目前筆記";
+
+/* Accessibility hint on share button */
+"Share the content of the current note" = "分享目前筆記的內容";
+
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "將標籤新增至目前筆記";
+
+/* No comment provided by engineer. */
+"Remove tag from the current note" = "移除目前筆記的標籤";
+
+/* Accessibility hint on button which moves a note to the trash */
+"Move the current note to trash" = "將目前筆記移至垃圾桶";
+
+/* Error alert message shown when trying to view history of a note without an internet connection */
+"Connect to the Internet to Access Previous Versions" = "連線至網際網路以存取先前版本";
+
+/* Accessiblity hint describing how to reset the current note to a previous version */
+"Switch to this version" = "切換至此版本";
+
+/* Accessibility hint used when previous versions of a note are being fetched */
+"Fetching version" = "正在擷取此版本";
+
+/* A welcome note for new iOS users */
+"Welcome to Simplenote for iOS!\n\nTo add a note, tap the plus button.\n\nFlick the list to browse your notes. Tap a title to view a note, then tap its contents to change it.\n\nYou can search all your notes by typing in the search field at the top of the note list.\n\nTap the arrow button at the top left or swipe across your note list to view your tags. You can add tags to a note at the bottom of the note editor, and then use the sidebar to help you stay organized.\n\nThere are more note options if you need them. You can add others as collaborators to a note, or publish a note as a web page.\n\nUse Simplenote on your Mac, Android device, or in your web browser at http:\/\/simplenote.com. Your notes will stay updated everywhere automatically." = "歡迎使用 Simplenote iOS 版！\n\n若要新增筆記，請點選加號按鈕。\n\n撥動清單即可瀏覽你的筆記。點選標題可瀏覽筆記，然後點選內容則可進行變更。\n\n你可以在筆記清單頂端的搜尋欄位內輸入關鍵字搜尋你全部的筆記。\n\n點選左上方的箭號按鈕或撥動筆記清單可檢視標籤。在筆記編輯器底部可將標籤新增至筆記，然後使用側選單可協助你妥善整理筆記。\n\n若有需要，還有更多筆記選項可供使用。你可以將其他人新增為筆記的協作者，或是將筆記發表至網頁。\n\n前往 http:\/\/simplenote.com 將 Simplenote 下載至你的 Mac、Android 裝置或在網頁瀏覽器中使用。你的筆記將會隨時隨地保持更新。";
 


### PR DESCRIPTION
### Fix
In this PR we're replicating WPiOS's [Update Translations](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/Scripts/update-translations.rb) script.

Instead of downloading the JSON + Strings translation, we snap everything in a single shot (which is what we do in WordPress).

The current mechanism has a couple issues, and it's producing malformed strings / comments. [More here!](https://github.com/Automattic/simplenote-ios/pull/544).

Gentlemen, may I bug you with this PR?
cc @loremattei or @jkmassel

Thanks in advance!!

 
### Test
1. Run `./Scripts/update-translations.rb`
2. Verify Simplenote builds correctly
3. (OR) simply verify that the CI is happy

**Note:** Since I was in the neighborhood, I've also squeezed in the fixed `.strings` files!!

### Review
These changes do not require release notes.
