### PR TITLE
Fixing warnings

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -125,7 +125,6 @@
 		74F6637F22BADB5000FA147E /* ExtensionPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6637E22BADB5000FA147E /* ExtensionPresentationController.swift */; };
 		74F6638122BADBD200FA147E /* ExtensionPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638022BADBD200FA147E /* ExtensionPresentationAnimator.swift */; };
 		74F6638322BADD0300FA147E /* SharePresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638222BADD0300FA147E /* SharePresentationController.swift */; };
-		8C573B0E22CD1AD6005BC6F5 /* Version.Public.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8C573B0D22CD1AD6005BC6F5 /* Version.Public.xcconfig */; };
 		B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17C421CE1BE0BAB100752B56 /* SPInteractivePushPopAnimationController.m */; };
 		B50789FF1C1F5592009F097A /* markdown-default.css in Resources */ = {isa = PBXBuildFile; fileRef = 1748382E1BC1CC2D00E834AF /* markdown-default.css */; };
 		B5078A001C1F5595009F097A /* markdown-dark.css in Resources */ = {isa = PBXBuildFile; fileRef = 17BC3D461BC46BA800535DF3 /* markdown-dark.css */; };
@@ -1601,7 +1600,7 @@
 			attributes = {
 				CLASSPREFIX = SP;
 				LastSwiftUpdateCheck = 0910;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = Automattic;
 				TargetAttributes = {
 					46A3C96017DFA81A002865AE = {
@@ -1704,7 +1703,6 @@
 				E280453C180DAE0200670073 /* Localizable.strings in Resources */,
 				B5AB169A22FA128000B4EBA5 /* SPSheetController.xib in Resources */,
 				B546BE97234E64F200A126DA /* SPTagListViewCell.xib in Resources */,
-				8C573B0E22CD1AD6005BC6F5 /* Version.Public.xcconfig in Resources */,
 				B56C8CA2234CEAF100FE55F4 /* SPTagsListViewController.xib in Resources */,
 				B50789FF1C1F5592009F097A /* markdown-default.css in Resources */,
 			);

--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Simplenote/Classes/Note.h
+++ b/Simplenote/Classes/Note.h
@@ -48,7 +48,27 @@
 @property (nonatomic,   copy) NSString          *preview;
 @property (nonatomic,   copy) NSString          *titlePreview;
 @property (nonatomic,   copy) NSString          *bodyPreview;
+
+// What's going on:
+//
+//  -   Since Simplenote's inception, logic deletion flag was a simple boolean called `deleted`
+//  -   Collision with NSManagedObject's `deleted` flag wasn't picked up
+//  -   Eventually CLANG enhanced checks allowed us to notice there's a collision
+//
+//  Proper fix involves a heavy modification in Simperium, which would allow us to keep the `deleted` "internal"
+//  property name, while exposing a different property setter / getter, and thus, avoiding the collision.
+//
+// In This thermonuclear massive super workaround, we're simply silencing the warning.
+//
+// Proper course of action should be taken as soon as the next steps for Simperium are outlined.
+//
+// TODO: JLP Dec.3.2019.
+//
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wproperty-attribute-mismatch"
 @property BOOL deleted;
+#pragma clang diagnostic pop
+
 @property (nonatomic, assign) int               lastPosition;
 @property (nonatomic, assign) BOOL              pinned;
 @property (nonatomic, assign) BOOL              markdown;

--- a/Simplenote/Preferences.m
+++ b/Simplenote/Preferences.m
@@ -9,6 +9,7 @@
 @dynamic ghostData;
 @dynamic simperiumKey;
 
+@dynamic recent_searches;
 @dynamic analytics_enabled;
 
 - (void) didChangeValueForKey:(NSString *)key


### PR DESCRIPTION
### Fix
In this PR we're fixing a number of Xcode build warnings.

Proper fix for the `Note.h` warning will come... hopefully as soon as Simperium's next steps are outlined.

cc @bummytime (Thanks in advance sir!!)

### Test
- [x] Verify the app builds correctly

### Release
These changes do not require release notes.
