### PR TITLE
Fixing Add Collaborators UI

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 4.15
 -----
- 
+
+4.14.1
+======
+-   Fixed a bug that made rendered the Add Collaborators button not visible.
+
 4.14
 ====
 -   Fixed a bug that prevented users from repositioning the caret in the Email field (Login / SignUp)

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.m
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.m
@@ -40,7 +40,9 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
+
+    self.edgesForExtendedLayout = UIRectEdgeNone;
+
     [self setupNavigationItem];
     [self setupTextFields];
 


### PR DESCRIPTION
### Fix
In this PR we're disabling Extended Edges, for the Add Collaborator UI. This is causing the `Add Collaborator` button to be rendered below the navigationBar (and thus, not visible / accessible).

Closes #549

@aerych Sir!! May I bug you with a fun PR?
Thanks in advance!!

### Test
1. Log into your account
2. Open any note
3. Press over the top right **( i )** icon
4. Press over the **Collaborate** button

- [x] Verify the **Add Collaborator** row shows up at the top
- [x] Verify that pressing **Add Collaborator** causes the Contacts Picker to show up

### Release
`RELEASE-NOTES.txt` was updated in 0028cd1 with:

> Fixed a bug that made rendered the Add Collaborators button not visible.
