### PR TITLE
Fix: Surrogate Pairs (Mark II)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ abstract_target 'Automattic' do
 		#
 		pod 'Automattic-Tracks-iOS', '~> 0.4'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
-		pod 'Simperium', '~> 0.8.24'
+		pod 'Simperium', '~> 0.8.25'
 		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :tag => '1.0.7'
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,17 +24,17 @@ PODS:
   - Sentry (4.4.0):
     - Sentry/Core (= 4.4.0)
   - Sentry/Core (4.4.0)
-  - Simperium (0.8.24):
-    - Simperium/DiffMatchPach (= 0.8.24)
-    - Simperium/JRSwizzle (= 0.8.24)
-    - Simperium/SocketTrust (= 0.8.24)
-    - Simperium/SPReachability (= 0.8.24)
-    - Simperium/SSKeychain (= 0.8.24)
-  - Simperium/DiffMatchPach (0.8.24)
-  - Simperium/JRSwizzle (0.8.24)
-  - Simperium/SocketTrust (0.8.24)
-  - Simperium/SPReachability (0.8.24)
-  - Simperium/SSKeychain (0.8.24)
+  - Simperium (0.8.25):
+    - Simperium/DiffMatchPach (= 0.8.25)
+    - Simperium/JRSwizzle (= 0.8.25)
+    - Simperium/SocketTrust (= 0.8.25)
+    - Simperium/SPReachability (= 0.8.25)
+    - Simperium/SSKeychain (= 0.8.25)
+  - Simperium/DiffMatchPach (0.8.25)
+  - Simperium/JRSwizzle (0.8.25)
+  - Simperium/SocketTrust (0.8.25)
+  - Simperium/SPReachability (0.8.25)
+  - Simperium/SSKeychain (0.8.25)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
   - WordPress-AppbotX (1.0.7)
@@ -48,7 +48,7 @@ DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.4)
   - Gridicons (~> 0.18)
   - SAMKeychain (= 1.5.2)
-  - Simperium (~> 0.8.24)
+  - Simperium (~> 0.8.25)
   - SVProgressHUD (= 2.2.5)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, tag `1.0.7`)
   - WordPress-Ratings-iOS (= 0.0.2)
@@ -89,13 +89,13 @@ SPEC CHECKSUMS:
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SAMKeychain: 1865333198217411f35327e8da61b43de79b635b
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
-  Simperium: aeaf03461d8f75fd90d0cb199a5c8a1e9095ef15
+  Simperium: 3264e16fee1e66124700f2e09d74da96d3cb2ecc
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-AppbotX: 624387ac980fc0663cbb9425e22bf514329be96f
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 1dff08b8f6b531e2143e06a34d2499cf2a248d3c
+PODFILE CHECKSUM: 81510cefce5ec71f975ba273c25d9b4733983456
 
 COCOAPODS: 1.7.5

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 4.15
 -----
 
+4.14.2
+======
+-   Fixed a bug that caused notes with specific emoji sequences to crash the app.
+
 4.14.1
 ======
 -   Fixed a bug that made rendered the Add Collaborators button not visible.


### PR DESCRIPTION
### Fix
In this PR we're updating the Simperium dependency to Mark 0.8.25, which contains a second Surrogate Pairs fix.

Closes #524
Closes #556

### Test: Regression!
1. Add a new note
2. Enter the following emojis: ☺️🖖🏿
3. Insert the following emoji in between: 😃

- [x] Verify the app doesn't break!

### Test: New Crash!
1. Add a new note
2. Enter the following string

```
😃🖖🏻🖖🏻🖖🏿
🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉

.👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽s👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿.
🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉
.👉🏽👈🏿👈🏿👈🏿🥶🥶🥶🥶🥶👈🏼🖖🏻👈🏼s🖖🏻👈🏼😋

dasdas
dasvafksdldasfadsxc vzx
```

3. Replace with the following string

```
😃🖖🏻🖖🏻🖖🏿
🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉
fds
.👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽👉🏽s👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿👈🏿.
🥶🥶🥶👈🏼🖖🏻😉🖖🏽🖖🏿😉fdsvadsfewdsfdsafsdafsd
```

- [x] Verify Simplenote doesn't crash



### Release
`RELEASE-NOTES.txt` was updated in 61d7082 with:

> Fixed a bug that caused notes with specific emoji sequences to crash the app.
