### PR TITLE
Updates Simperium to Mark 0.8.26

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ abstract_target 'Automattic' do
 		#
 		pod 'Automattic-Tracks-iOS', '~> 0.4'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
-		pod 'Simperium', '~> 0.8.25'
+		pod 'Simperium', '~> 0.8.26'
 		pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :tag => '1.0.7'
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,17 +24,17 @@ PODS:
   - Sentry (4.4.0):
     - Sentry/Core (= 4.4.0)
   - Sentry/Core (4.4.0)
-  - Simperium (0.8.25):
-    - Simperium/DiffMatchPach (= 0.8.25)
-    - Simperium/JRSwizzle (= 0.8.25)
-    - Simperium/SocketTrust (= 0.8.25)
-    - Simperium/SPReachability (= 0.8.25)
-    - Simperium/SSKeychain (= 0.8.25)
-  - Simperium/DiffMatchPach (0.8.25)
-  - Simperium/JRSwizzle (0.8.25)
-  - Simperium/SocketTrust (0.8.25)
-  - Simperium/SPReachability (0.8.25)
-  - Simperium/SSKeychain (0.8.25)
+  - Simperium (0.8.26):
+    - Simperium/DiffMatchPach (= 0.8.26)
+    - Simperium/JRSwizzle (= 0.8.26)
+    - Simperium/SocketTrust (= 0.8.26)
+    - Simperium/SPReachability (= 0.8.26)
+    - Simperium/SSKeychain (= 0.8.26)
+  - Simperium/DiffMatchPach (0.8.26)
+  - Simperium/JRSwizzle (0.8.26)
+  - Simperium/SocketTrust (0.8.26)
+  - Simperium/SPReachability (0.8.26)
+  - Simperium/SSKeychain (0.8.26)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
   - WordPress-AppbotX (1.0.7)
@@ -48,7 +48,7 @@ DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.4)
   - Gridicons (~> 0.18)
   - SAMKeychain (= 1.5.2)
-  - Simperium (~> 0.8.25)
+  - Simperium (~> 0.8.26)
   - SVProgressHUD (= 2.2.5)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, tag `1.0.7`)
   - WordPress-Ratings-iOS (= 0.0.2)
@@ -89,13 +89,13 @@ SPEC CHECKSUMS:
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SAMKeychain: 1865333198217411f35327e8da61b43de79b635b
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
-  Simperium: 3264e16fee1e66124700f2e09d74da96d3cb2ecc
+  Simperium: a3afa88e53e30b1d4aa3f7c0131cd9abfb8dc6d5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-AppbotX: 624387ac980fc0663cbb9425e22bf514329be96f
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 81510cefce5ec71f975ba273c25d9b4733983456
+PODFILE CHECKSUM: 5e7cdf39a3afcee0e3bc7fa2e07f3098c1205e64
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
### Fix
We're updating Simperium to Mk 0.8.26, which contains an improved error handling mechanism, aiming at preventing crashes caused by malformed diffs.

### Test
1. Map the Simperium dependency to 0.8.23
2. Clean + Rebuild
3. Log into your account
4. Add a new note
5. Insert the following emojis: ☺️🖖🏿
6. Insert the following emoji in between: 😃
7. Re-map to Simperium 0.8.26
8. Clean + Rebuild

- [x] Verify the app doesn't crash anymore

### Release
These changes do not require release notes.
