### PR TITLE
Renaming SearchController > SearchDisplayController

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -137,7 +137,7 @@
 		B513F2B82319A9A40021CFA4 /* UITableViewCell+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513F2B72319A9A40021CFA4 /* UITableViewCell+Simplenote.swift */; };
 		B513FB2422EF6A4B00B178AC /* SPUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513FB2322EF6A4B00B178AC /* SPUserInterface.swift */; };
 		B513FB2622EF6A7400B178AC /* VSTheme+Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513FB2522EF6A7300B178AC /* VSTheme+Keys.swift */; };
-		B5185CFB23427F2F0060145A /* SPSearchDisplayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5185CFA23427F2F0060145A /* SPSearchDisplayController.swift */; };
+		B5185CFB23427F2F0060145A /* SearchDisplayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5185CFA23427F2F0060145A /* SearchDisplayController.swift */; };
 		B518899E1E0D5EF800E71B83 /* SPContactsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */; };
 		B51889A01E0D5F2200E71B83 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B518899F1E0D5F2200E71B83 /* Contacts.framework */; };
 		B51889A41E0DB01E00E71B83 /* ContactsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B51889A31E0DB01E00E71B83 /* ContactsUI.framework */; };
@@ -423,7 +423,7 @@
 		B513F2B72319A9A40021CFA4 /* UITableViewCell+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITableViewCell+Simplenote.swift"; path = "Classes/UITableViewCell+Simplenote.swift"; sourceTree = "<group>"; };
 		B513FB2322EF6A4B00B178AC /* SPUserInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPUserInterface.swift; path = Classes/SPUserInterface.swift; sourceTree = "<group>"; };
 		B513FB2522EF6A7300B178AC /* VSTheme+Keys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VSTheme+Keys.swift"; path = "Classes/VSTheme+Keys.swift"; sourceTree = "<group>"; };
-		B5185CFA23427F2F0060145A /* SPSearchDisplayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSearchDisplayController.swift; path = Classes/SPSearchDisplayController.swift; sourceTree = "<group>"; };
+		B5185CFA23427F2F0060145A /* SearchDisplayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchDisplayController.swift; path = Classes/SearchDisplayController.swift; sourceTree = "<group>"; };
 		B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SPContactsManager.swift; path = Classes/SPContactsManager.swift; sourceTree = "<group>"; };
 		B518899F1E0D5F2200E71B83 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
 		B51889A31E0DB01E00E71B83 /* ContactsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ContactsUI.framework; path = System/Library/Frameworks/ContactsUI.framework; sourceTree = SDKROOT; };
@@ -1154,7 +1154,7 @@
 				F9E197D32283D05C0092B3E1 /* CrashLogging.swift */,
 				F920265A2294661C0061B1DE /* BuildConfiguration.swift */,
 				74F454EC22DD4BC0000C66DB /* KeyboardObservable.swift */,
-				B5185CFA23427F2F0060145A /* SPSearchDisplayController.swift */,
+				B5185CFA23427F2F0060145A /* SearchDisplayController.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1974,7 +1974,7 @@
 				B5C57A4122E78F4D009166EA /* UIColorName.swift in Sources */,
 				B518899E1E0D5EF800E71B83 /* SPContactsManager.swift in Sources */,
 				46A3C98917DFA81A002865AE /* SPAppDelegate.m in Sources */,
-				B5185CFB23427F2F0060145A /* SPSearchDisplayController.swift in Sources */,
+				B5185CFB23427F2F0060145A /* SearchDisplayController.swift in Sources */,
 				B524AE0F2352BE9200EA11D4 /* UITableView+Simplenote.swift in Sources */,
 				B5D982D022F8643300C37C29 /* SPTextInputView.swift in Sources */,
 				B52BB75022CFD18F0042C162 /* UIActivity+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -137,7 +137,7 @@
 		B513F2B82319A9A40021CFA4 /* UITableViewCell+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513F2B72319A9A40021CFA4 /* UITableViewCell+Simplenote.swift */; };
 		B513FB2422EF6A4B00B178AC /* SPUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513FB2322EF6A4B00B178AC /* SPUserInterface.swift */; };
 		B513FB2622EF6A7400B178AC /* VSTheme+Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513FB2522EF6A7300B178AC /* VSTheme+Keys.swift */; };
-		B5185CFB23427F2F0060145A /* SPSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5185CFA23427F2F0060145A /* SPSearchController.swift */; };
+		B5185CFB23427F2F0060145A /* SPSearchDisplayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5185CFA23427F2F0060145A /* SPSearchDisplayController.swift */; };
 		B518899E1E0D5EF800E71B83 /* SPContactsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */; };
 		B51889A01E0D5F2200E71B83 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B518899F1E0D5F2200E71B83 /* Contacts.framework */; };
 		B51889A41E0DB01E00E71B83 /* ContactsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B51889A31E0DB01E00E71B83 /* ContactsUI.framework */; };
@@ -423,7 +423,7 @@
 		B513F2B72319A9A40021CFA4 /* UITableViewCell+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITableViewCell+Simplenote.swift"; path = "Classes/UITableViewCell+Simplenote.swift"; sourceTree = "<group>"; };
 		B513FB2322EF6A4B00B178AC /* SPUserInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPUserInterface.swift; path = Classes/SPUserInterface.swift; sourceTree = "<group>"; };
 		B513FB2522EF6A7300B178AC /* VSTheme+Keys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "VSTheme+Keys.swift"; path = "Classes/VSTheme+Keys.swift"; sourceTree = "<group>"; };
-		B5185CFA23427F2F0060145A /* SPSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSearchController.swift; path = Classes/SPSearchController.swift; sourceTree = "<group>"; };
+		B5185CFA23427F2F0060145A /* SPSearchDisplayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSearchDisplayController.swift; path = Classes/SPSearchDisplayController.swift; sourceTree = "<group>"; };
 		B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SPContactsManager.swift; path = Classes/SPContactsManager.swift; sourceTree = "<group>"; };
 		B518899F1E0D5F2200E71B83 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
 		B51889A31E0DB01E00E71B83 /* ContactsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ContactsUI.framework; path = System/Library/Frameworks/ContactsUI.framework; sourceTree = SDKROOT; };
@@ -1154,7 +1154,7 @@
 				F9E197D32283D05C0092B3E1 /* CrashLogging.swift */,
 				F920265A2294661C0061B1DE /* BuildConfiguration.swift */,
 				74F454EC22DD4BC0000C66DB /* KeyboardObservable.swift */,
-				B5185CFA23427F2F0060145A /* SPSearchController.swift */,
+				B5185CFA23427F2F0060145A /* SPSearchDisplayController.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1974,7 +1974,7 @@
 				B5C57A4122E78F4D009166EA /* UIColorName.swift in Sources */,
 				B518899E1E0D5EF800E71B83 /* SPContactsManager.swift in Sources */,
 				46A3C98917DFA81A002865AE /* SPAppDelegate.m in Sources */,
-				B5185CFB23427F2F0060145A /* SPSearchController.swift in Sources */,
+				B5185CFB23427F2F0060145A /* SPSearchDisplayController.swift in Sources */,
 				B524AE0F2352BE9200EA11D4 /* UITableView+Simplenote.swift in Sources */,
 				B5D982D022F8643300C37C29 /* SPTextInputView.swift in Sources */,
 				B52BB75022CFD18F0042C162 /* UIActivity+Simplenote.swift in Sources */,

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -32,8 +32,8 @@
                                         UITableViewDelegate,
                                         NSFetchedResultsControllerDelegate,
                                         UITextFieldDelegate,
-                                        SPSearchDisplayControllerDelegate,
-                                        SPSearchControllerPresentationContextProvider,
+                                        SearchDisplayControllerDelegate,
+                                        SearchControllerPresentationContextProvider,
                                         SPTransitionControllerDelegate,
                                         SPRatingsPromptDelegate>
 
@@ -47,7 +47,7 @@
 
 @property (nonatomic, strong) UITableView                           *tableView;
 
-@property (nonatomic, strong) SPSearchDisplayController             *searchController;
+@property (nonatomic, strong) SearchDisplayController               *searchController;
 @property (nonatomic, strong) UIActivityIndicatorView               *activityIndicator;
 
 @property (nonatomic, strong) SPTransitionController                *transitionController;
@@ -318,7 +318,7 @@
     // Note: For performance reasons, we'll keep the Results always prebuilt. Same mechanism seen in UISearchController
     self.resultsViewController = [SPSearchResultsViewController new];
 
-    self.searchController = [[SPSearchDisplayController alloc] initWithResultsViewController:self.resultsViewController];
+    self.searchController = [[SearchDisplayController alloc] initWithResultsViewController:self.resultsViewController];
     self.searchController.delegate = self;
     self.searchController.presenter = self;
 
@@ -349,7 +349,7 @@
 
 #pragma mark - SPSearchControllerDelegate methods
 
-- (BOOL)searchDisplayControllerShouldBeginSearch:(SPSearchDisplayController *)controller
+- (BOOL)searchDisplayControllerShouldBeginSearch:(SearchDisplayController *)controller
 {
     if (bListViewIsEmpty) {
         return NO;
@@ -365,7 +365,7 @@
     return bSearching;
 }
 
-- (void)searchDisplayController:(SPSearchDisplayController *)controller updateSearchResults:(NSString *)keyword
+- (void)searchDisplayController:(SearchDisplayController *)controller updateSearchResults:(NSString *)keyword
 {
     if (FeatureManager.advancedSearchEnabled) {
         [self.resultsViewController updateSearchResultsWithKeyword:keyword];
@@ -387,7 +387,7 @@
                                                   repeats:NO];
 }
 
-- (void)searchDisplayControllerWillBeginSearch:(SPSearchDisplayController *)controller
+- (void)searchDisplayControllerWillBeginSearch:(SearchDisplayController *)controller
 {
     // Ensure our custom NavigationBar + SearchBar are always on top (!)
     [self.view bringSubviewToFront:self.navigationBarBackground];
@@ -397,7 +397,7 @@
     [self.navigationBarBackground fadeIn];
 }
 
-- (void)searchDisplayControllerDidEndSearch:(SPSearchDisplayController *)controller
+- (void)searchDisplayControllerDidEndSearch:(SearchDisplayController *)controller
 {
     [self endSearching];
 }
@@ -405,12 +405,12 @@
 
 #pragma mark - SPSearchControllerPresenter methods
 
-- (UINavigationController *)navigationControllerForSearchDisplayController:(SPSearchDisplayController *)controller
+- (UINavigationController *)navigationControllerForSearchDisplayController:(SearchDisplayController *)controller
 {
     return self.navigationController;
 }
 
-- (UIViewController *)resultsParentControllerForSearchDisplayController:(SPSearchDisplayController *)controller
+- (UIViewController *)resultsParentControllerForSearchDisplayController:(SearchDisplayController *)controller
 {
     return self;
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -32,7 +32,7 @@
                                         UITableViewDelegate,
                                         NSFetchedResultsControllerDelegate,
                                         UITextFieldDelegate,
-                                        SPSearchControllerDelegate,
+                                        SPSearchDisplayControllerDelegate,
                                         SPSearchControllerPresentationContextProvider,
                                         SPTransitionControllerDelegate,
                                         SPRatingsPromptDelegate>
@@ -349,7 +349,7 @@
 
 #pragma mark - SPSearchControllerDelegate methods
 
-- (BOOL)searchControllerShouldBeginSearch:(SPSearchDisplayController *)controller
+- (BOOL)searchDisplayControllerShouldBeginSearch:(SPSearchDisplayController *)controller
 {
     if (bListViewIsEmpty) {
         return NO;
@@ -365,7 +365,7 @@
     return bSearching;
 }
 
-- (void)searchController:(SPSearchDisplayController *)controller updateSearchResults:(NSString *)keyword
+- (void)searchDisplayController:(SPSearchDisplayController *)controller updateSearchResults:(NSString *)keyword
 {
     if (FeatureManager.advancedSearchEnabled) {
         [self.resultsViewController updateSearchResultsWithKeyword:keyword];
@@ -387,7 +387,7 @@
                                                   repeats:NO];
 }
 
-- (void)searchControllerWillBeginSearch:(SPSearchDisplayController *)controller
+- (void)searchDisplayControllerWillBeginSearch:(SPSearchDisplayController *)controller
 {
     // Ensure our custom NavigationBar + SearchBar are always on top (!)
     [self.view bringSubviewToFront:self.navigationBarBackground];
@@ -397,7 +397,7 @@
     [self.navigationBarBackground fadeIn];
 }
 
-- (void)searchControllerDidEndSearch:(SPSearchDisplayController *)controller
+- (void)searchDisplayControllerDidEndSearch:(SPSearchDisplayController *)controller
 {
     [self endSearching];
 }
@@ -405,12 +405,12 @@
 
 #pragma mark - SPSearchControllerPresenter methods
 
-- (UINavigationController *)navigationControllerForSearchController:(SPSearchDisplayController *)controller
+- (UINavigationController *)navigationControllerForSearchDisplayController:(SPSearchDisplayController *)controller
 {
     return self.navigationController;
 }
 
-- (UIViewController *)resultsParentControllerForSearchController:(SPSearchDisplayController *)controller
+- (UIViewController *)resultsParentControllerForSearchDisplayController:(SPSearchDisplayController *)controller
 {
     return self;
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -47,7 +47,7 @@
 
 @property (nonatomic, strong) UITableView                           *tableView;
 
-@property (nonatomic, strong) SPSearchController                    *searchController;
+@property (nonatomic, strong) SPSearchDisplayController             *searchDisplayController;
 @property (nonatomic, strong) UIActivityIndicatorView               *activityIndicator;
 
 @property (nonatomic, strong) SPTransitionController                *transitionController;
@@ -68,7 +68,7 @@
         [self configureNavigationButtons];
         [self configureNavigationBarBackground];
         [self configureTableView];
-        [self configureSearchController];
+        [self configureSearchDisplayController];
         [self configureRootView];
         [self updateRowHeight];
         [self startListeningToNotifications];
@@ -173,7 +173,7 @@
 #pragma mark - Dynamic Properties
 
 - (UISearchBar *)searchBar {
-    return _searchController.searchBar;
+    return _searchDisplayController.searchBar;
 }
 
 - (UIActivityIndicatorView *)activityIndicator {
@@ -311,16 +311,16 @@
     [self.tableView registerNib:[SPNoteTableViewCell loadNib] forCellReuseIdentifier:[SPNoteTableViewCell reuseIdentifier]];
 }
 
-- (void)configureSearchController {
-    NSAssert(_searchController == nil, @"_searchController is already initialized!");
+- (void)configureSearchDisplayController {
+    NSAssert(_searchDisplayController == nil, @"_searchDisplayController is already initialized!");
     NSAssert(_resultsViewController == nil, @"_resultsController is already initialized!");
 
     // Note: For performance reasons, we'll keep the Results always prebuilt. Same mechanism seen in UISearchController
     self.resultsViewController = [SPSearchResultsViewController new];
 
-    self.searchController = [[SPSearchController alloc] initWithResultsViewController:self.resultsViewController];
-    self.searchController.delegate = self;
-    self.searchController.presenter = self;
+    self.searchDisplayController = [[SPSearchDisplayController alloc] initWithResultsViewController:self.resultsViewController];
+    self.searchDisplayController.delegate = self;
+    self.searchDisplayController.presenter = self;
 
     [self.searchBar applySimplenoteStyle];
 }
@@ -349,7 +349,7 @@
 
 #pragma mark - SPSearchControllerDelegate methods
 
-- (BOOL)searchControllerShouldBeginSearch:(SPSearchController *)controller
+- (BOOL)searchControllerShouldBeginSearch:(SPSearchDisplayController *)controller
 {
     if (bListViewIsEmpty) {
         return NO;
@@ -365,7 +365,7 @@
     return bSearching;
 }
 
-- (void)searchController:(SPSearchController *)controller updateSearchResults:(NSString *)keyword
+- (void)searchController:(SPSearchDisplayController *)controller updateSearchResults:(NSString *)keyword
 {
     if (FeatureManager.advancedSearchEnabled) {
         [self.resultsViewController updateSearchResultsWithKeyword:keyword];
@@ -387,7 +387,7 @@
                                                   repeats:NO];
 }
 
-- (void)searchControllerWillBeginSearch:(SPSearchController *)controller
+- (void)searchControllerWillBeginSearch:(SPSearchDisplayController *)controller
 {
     // Ensure our custom NavigationBar + SearchBar are always on top (!)
     [self.view bringSubviewToFront:self.navigationBarBackground];
@@ -397,7 +397,7 @@
     [self.navigationBarBackground fadeIn];
 }
 
-- (void)searchControllerDidEndSearch:(SPSearchController *)controller
+- (void)searchControllerDidEndSearch:(SPSearchDisplayController *)controller
 {
     [self endSearching];
 }
@@ -405,12 +405,12 @@
 
 #pragma mark - SPSearchControllerPresenter methods
 
-- (UINavigationController *)navigationControllerForSearchController:(SPSearchController *)controller
+- (UINavigationController *)navigationControllerForSearchController:(SPSearchDisplayController *)controller
 {
     return self.navigationController;
 }
 
-- (UIViewController *)resultsParentControllerForSearchController:(SPSearchController *)controller
+- (UIViewController *)resultsParentControllerForSearchController:(SPSearchDisplayController *)controller
 {
     return self;
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -47,7 +47,7 @@
 
 @property (nonatomic, strong) UITableView                           *tableView;
 
-@property (nonatomic, strong) SPSearchDisplayController             *searchDisplayController;
+@property (nonatomic, strong) SPSearchDisplayController             *searchController;
 @property (nonatomic, strong) UIActivityIndicatorView               *activityIndicator;
 
 @property (nonatomic, strong) SPTransitionController                *transitionController;
@@ -68,7 +68,7 @@
         [self configureNavigationButtons];
         [self configureNavigationBarBackground];
         [self configureTableView];
-        [self configureSearchDisplayController];
+        [self configureSearchController];
         [self configureRootView];
         [self updateRowHeight];
         [self startListeningToNotifications];
@@ -173,7 +173,7 @@
 #pragma mark - Dynamic Properties
 
 - (UISearchBar *)searchBar {
-    return _searchDisplayController.searchBar;
+    return _searchController.searchBar;
 }
 
 - (UIActivityIndicatorView *)activityIndicator {
@@ -311,16 +311,16 @@
     [self.tableView registerNib:[SPNoteTableViewCell loadNib] forCellReuseIdentifier:[SPNoteTableViewCell reuseIdentifier]];
 }
 
-- (void)configureSearchDisplayController {
-    NSAssert(_searchDisplayController == nil, @"_searchDisplayController is already initialized!");
+- (void)configureSearchController {
+    NSAssert(_searchController == nil, @"_searchController is already initialized!");
     NSAssert(_resultsViewController == nil, @"_resultsController is already initialized!");
 
     // Note: For performance reasons, we'll keep the Results always prebuilt. Same mechanism seen in UISearchController
     self.resultsViewController = [SPSearchResultsViewController new];
 
-    self.searchDisplayController = [[SPSearchDisplayController alloc] initWithResultsViewController:self.resultsViewController];
-    self.searchDisplayController.delegate = self;
-    self.searchDisplayController.presenter = self;
+    self.searchController = [[SPSearchDisplayController alloc] initWithResultsViewController:self.resultsViewController];
+    self.searchController.delegate = self;
+    self.searchController.presenter = self;
 
     [self.searchBar applySimplenoteStyle];
 }

--- a/Simplenote/Classes/SPSearchDisplayController.swift
+++ b/Simplenote/Classes/SPSearchDisplayController.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 
-// MARK: - UISearchController Delegate Methods
+// MARK: - SPSearchDisplayController Delegate Methods
 //
 @objc
 protocol SPSearchDisplayControllerDelegate: NSObjectProtocol {

--- a/Simplenote/Classes/SPSearchDisplayController.swift
+++ b/Simplenote/Classes/SPSearchDisplayController.swift
@@ -5,11 +5,11 @@ import UIKit
 // MARK: - UISearchController Delegate Methods
 //
 @objc
-protocol SPSearchControllerDelegate: NSObjectProtocol {
-    func searchControllerShouldBeginSearch(_ controller: SPSearchDisplayController) -> Bool
-    func searchController(_ controller: SPSearchDisplayController, updateSearchResults keyword: String)
-    func searchControllerWillBeginSearch(_ controller: SPSearchDisplayController)
-    func searchControllerDidEndSearch(_ controller: SPSearchDisplayController)
+protocol SPSearchDisplayControllerDelegate: NSObjectProtocol {
+    func searchDisplayControllerShouldBeginSearch(_ controller: SPSearchDisplayController) -> Bool
+    func searchDisplayController(_ controller: SPSearchDisplayController, updateSearchResults keyword: String)
+    func searchDisplayControllerWillBeginSearch(_ controller: SPSearchDisplayController)
+    func searchDisplayControllerDidEndSearch(_ controller: SPSearchDisplayController)
 }
 
 
@@ -17,8 +17,8 @@ protocol SPSearchControllerDelegate: NSObjectProtocol {
 //
 @objc
 protocol SPSearchControllerPresentationContextProvider: NSObjectProtocol {
-    func navigationControllerForSearchController(_ controller: SPSearchDisplayController) -> UINavigationController
-    func resultsParentControllerForSearchController(_ controller: SPSearchDisplayController) -> UIViewController
+    func navigationControllerForSearchDisplayController(_ controller: SPSearchDisplayController) -> UINavigationController
+    func resultsParentControllerForSearchDisplayController(_ controller: SPSearchDisplayController) -> UIViewController
 }
 
 
@@ -48,7 +48,7 @@ class SPSearchDisplayController: NSObject {
 
     /// SearchController's Delegate
     ///
-    weak var delegate: SPSearchControllerDelegate?
+    weak var delegate: SPSearchDisplayControllerDelegate?
 
     /// SearchController's Presentation Context Provider
     ///
@@ -105,7 +105,7 @@ private extension SPSearchDisplayController {
     }
 
     func updateNavigationBar(hidden: Bool) {
-        guard let navigationController = presenter?.navigationControllerForSearchController(self),
+        guard let navigationController = presenter?.navigationControllerForSearchDisplayController(self),
             navigationController.isNavigationBarHidden != hidden
             else {
                 return
@@ -141,9 +141,9 @@ private extension SPSearchDisplayController {
 
     func notifyStatusChanged(active: Bool) {
         if active {
-            delegate?.searchControllerWillBeginSearch(self)
+            delegate?.searchDisplayControllerWillBeginSearch(self)
         } else {
-            delegate?.searchControllerDidEndSearch(self)
+            delegate?.searchDisplayControllerDidEndSearch(self)
         }
     }
 }
@@ -157,7 +157,7 @@ private extension SPSearchDisplayController {
     ///
     func displayResultsViewController() {
         guard resultsViewController.parent == nil,
-            let parentViewController = presenter?.resultsParentControllerForSearchController(self) else {
+            let parentViewController = presenter?.resultsParentControllerForSearchDisplayController(self) else {
                 return
         }
 
@@ -204,7 +204,7 @@ private extension SPSearchDisplayController {
 extension SPSearchDisplayController: UISearchBarDelegate {
 
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
-        guard let shouldBeginEditing = delegate?.searchControllerShouldBeginSearch(self) else {
+        guard let shouldBeginEditing = delegate?.searchDisplayControllerShouldBeginSearch(self) else {
             return false
         }
 
@@ -214,7 +214,7 @@ extension SPSearchDisplayController: UISearchBarDelegate {
     }
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        delegate?.searchController(self, updateSearchResults: searchText)
+        delegate?.searchDisplayController(self, updateSearchResults: searchText)
     }
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {

--- a/Simplenote/Classes/SPSearchDisplayController.swift
+++ b/Simplenote/Classes/SPSearchDisplayController.swift
@@ -6,10 +6,10 @@ import UIKit
 //
 @objc
 protocol SPSearchControllerDelegate: NSObjectProtocol {
-    func searchControllerShouldBeginSearch(_ controller: SPSearchController) -> Bool
-    func searchController(_ controller: SPSearchController, updateSearchResults keyword: String)
-    func searchControllerWillBeginSearch(_ controller: SPSearchController)
-    func searchControllerDidEndSearch(_ controller: SPSearchController)
+    func searchControllerShouldBeginSearch(_ controller: SPSearchDisplayController) -> Bool
+    func searchController(_ controller: SPSearchDisplayController, updateSearchResults keyword: String)
+    func searchControllerWillBeginSearch(_ controller: SPSearchDisplayController)
+    func searchControllerDidEndSearch(_ controller: SPSearchDisplayController)
 }
 
 
@@ -17,22 +17,22 @@ protocol SPSearchControllerDelegate: NSObjectProtocol {
 //
 @objc
 protocol SPSearchControllerPresentationContextProvider: NSObjectProtocol {
-    func navigationControllerForSearchController(_ controller: SPSearchController) -> UINavigationController
-    func resultsParentControllerForSearchController(_ controller: SPSearchController) -> UIViewController
+    func navigationControllerForSearchController(_ controller: SPSearchDisplayController) -> UINavigationController
+    func resultsParentControllerForSearchController(_ controller: SPSearchDisplayController) -> UIViewController
 }
 
 
 // MARK: - SPSearchControllerResults: To be (optionally) implemented by specialized ResultsViewController(s)
 //
 protocol SPSearchControllerResults: NSObjectProtocol {
-    var searchController: SPSearchController? { get set }
+    var searchController: SPSearchDisplayController? { get set }
 }
 
 
 // MARK: - Simplenote's Search Controller: Because UIKit's Search Controller is simply unusable
 //
 @objcMembers
-class SPSearchController: NSObject {
+class SPSearchDisplayController: NSObject {
 
     /// Indicates if the SearchController is active (or not!)
     ///
@@ -76,7 +76,7 @@ class SPSearchController: NSObject {
 
 // MARK: - Private Methods
 //
-private extension SPSearchController {
+private extension SPSearchDisplayController {
 
     func setupResultsViewController() {
         // Analog to the old school `self.searchDisplayController` UIViewController property, we'll set our own
@@ -151,7 +151,7 @@ private extension SPSearchController {
 
 // MARK: - ResultsViewController Methods
 //
-private extension SPSearchController {
+private extension SPSearchDisplayController {
 
     /// Displays the SearchResultsController onScreen
     ///
@@ -201,7 +201,7 @@ private extension SPSearchController {
 
 // MARK: - UISearchBar Delegate Methods
 //
-extension SPSearchController: UISearchBarDelegate {
+extension SPSearchDisplayController: UISearchBarDelegate {
 
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
         guard let shouldBeginEditing = delegate?.searchControllerShouldBeginSearch(self) else {

--- a/Simplenote/Classes/SPSearchResultsViewController.swift
+++ b/Simplenote/Classes/SPSearchResultsViewController.swift
@@ -24,7 +24,7 @@ class SPSearchResultsViewController: UIViewController, SPSearchControllerResults
 
     /// SearchController: Expected to be set externally
     ///
-    weak var searchController: SPSearchDisplayController?
+    weak var searchController: SearchDisplayController?
 
     // MARK: - View Lifecycle
 

--- a/Simplenote/Classes/SPSearchResultsViewController.swift
+++ b/Simplenote/Classes/SPSearchResultsViewController.swift
@@ -24,7 +24,7 @@ class SPSearchResultsViewController: UIViewController, SPSearchControllerResults
 
     /// SearchController: Expected to be set externally
     ///
-    weak var searchController: SPSearchController?
+    weak var searchController: SPSearchDisplayController?
 
     // MARK: - View Lifecycle
 

--- a/Simplenote/Classes/SearchDisplayController.swift
+++ b/Simplenote/Classes/SearchDisplayController.swift
@@ -2,37 +2,37 @@ import Foundation
 import UIKit
 
 
-// MARK: - SPSearchDisplayController Delegate Methods
+// MARK: - SearchDisplayController Delegate Methods
 //
 @objc
-protocol SPSearchDisplayControllerDelegate: NSObjectProtocol {
-    func searchDisplayControllerShouldBeginSearch(_ controller: SPSearchDisplayController) -> Bool
-    func searchDisplayController(_ controller: SPSearchDisplayController, updateSearchResults keyword: String)
-    func searchDisplayControllerWillBeginSearch(_ controller: SPSearchDisplayController)
-    func searchDisplayControllerDidEndSearch(_ controller: SPSearchDisplayController)
+protocol SearchDisplayControllerDelegate: NSObjectProtocol {
+    func searchDisplayControllerShouldBeginSearch(_ controller: SearchDisplayController) -> Bool
+    func searchDisplayController(_ controller: SearchDisplayController, updateSearchResults keyword: String)
+    func searchDisplayControllerWillBeginSearch(_ controller: SearchDisplayController)
+    func searchDisplayControllerDidEndSearch(_ controller: SearchDisplayController)
 }
 
 
-// MARK: - SPSearchControllerPresenter Delegate Methods
+// MARK: - SearchControllerPresentationContextProvider Methods
 //
 @objc
-protocol SPSearchControllerPresentationContextProvider: NSObjectProtocol {
-    func navigationControllerForSearchDisplayController(_ controller: SPSearchDisplayController) -> UINavigationController
-    func resultsParentControllerForSearchDisplayController(_ controller: SPSearchDisplayController) -> UIViewController
+protocol SearchControllerPresentationContextProvider: NSObjectProtocol {
+    func navigationControllerForSearchDisplayController(_ controller: SearchDisplayController) -> UINavigationController
+    func resultsParentControllerForSearchDisplayController(_ controller: SearchDisplayController) -> UIViewController
 }
 
 
 // MARK: - SPSearchControllerResults: To be (optionally) implemented by specialized ResultsViewController(s)
 //
 protocol SPSearchControllerResults: NSObjectProtocol {
-    var searchController: SPSearchDisplayController? { get set }
+    var searchController: SearchDisplayController? { get set }
 }
 
 
 // MARK: - Simplenote's Search Controller: Because UIKit's Search Controller is simply unusable
 //
 @objcMembers
-class SPSearchDisplayController: NSObject {
+class SearchDisplayController: NSObject {
 
     /// Indicates if the SearchController is active (or not!)
     ///
@@ -48,11 +48,11 @@ class SPSearchDisplayController: NSObject {
 
     /// SearchController's Delegate
     ///
-    weak var delegate: SPSearchDisplayControllerDelegate?
+    weak var delegate: SearchDisplayControllerDelegate?
 
     /// SearchController's Presentation Context Provider
     ///
-    weak var presenter: SPSearchControllerPresentationContextProvider?
+    weak var presenter: SearchControllerPresentationContextProvider?
 
 
     /// Designated Initializer
@@ -76,7 +76,7 @@ class SPSearchDisplayController: NSObject {
 
 // MARK: - Private Methods
 //
-private extension SPSearchDisplayController {
+private extension SearchDisplayController {
 
     func setupResultsViewController() {
         // Analog to the old school `self.searchDisplayController` UIViewController property, we'll set our own
@@ -151,7 +151,7 @@ private extension SPSearchDisplayController {
 
 // MARK: - ResultsViewController Methods
 //
-private extension SPSearchDisplayController {
+private extension SearchDisplayController {
 
     /// Displays the SearchResultsController onScreen
     ///
@@ -201,7 +201,7 @@ private extension SPSearchDisplayController {
 
 // MARK: - UISearchBar Delegate Methods
 //
-extension SPSearchDisplayController: UISearchBarDelegate {
+extension SearchDisplayController: UISearchBarDelegate {
 
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
         guard let shouldBeginEditing = delegate?.searchDisplayControllerShouldBeginSearch(self) else {


### PR DESCRIPTION
### Details:
As of now, we've got the following classes:

- **SPSearchController:** In charge of handling UI interactions / UISearchBar
- **SPSearchResultsController:** (CoreData bridge)
- **SPSearchResultsViewController:** Renders Search Results

For readability and clarity purposes, in this PR we're renaming **SPSearchController** as **SearchDisplayController**.

Plus, in upcoming PR's, we'll consolidate both Search and Notes List rendering in a single ViewController.

Ref. #507

@bummytime Thanks in advance!!

### Test
- [x] Verify the code looks sound
- [x] Verify the app builds correctly

### Release
These changes do not require release notes.
