### PR TITLE
Fixes Print Share Printing White in Darkmode

### DIFF
--- a/Simplenote/SPSimpleTextPrintFormatter.swift
+++ b/Simplenote/SPSimpleTextPrintFormatter.swift
@@ -1,17 +1,11 @@
-//
-//  SimplenoteSimpleTextPrintFormatter.swift
-//  Simplenote
-//
-//  Created by Charlie Scheer on 1/10/20.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
-
 import UIKit
 
 class SPSimpleTextPrintFormatter: UISimpleTextPrintFormatter {
     override init(text: String) {
         super.init(text: text)
         
+        //Check for darkmode
+        //If dark mode is enabled change the text color to black before printing
         if #available(iOS 12.0, *) {
             if SPUserInterface.isDark {
                 self.color = UIColor.black

--- a/Simplenote/SPSimpleTextPrintFormatter.swift
+++ b/Simplenote/SPSimpleTextPrintFormatter.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class SimplenoteSimpleTextPrintFormatter: UISimpleTextPrintFormatter {
+class SPSimpleTextPrintFormatter: UISimpleTextPrintFormatter {
     override init(text: String) {
         super.init(text: text)
         

--- a/Simplenote/SimplenoteSimpleTextPrintFormatter.swift
+++ b/Simplenote/SimplenoteSimpleTextPrintFormatter.swift
@@ -1,0 +1,21 @@
+//
+//  SimplenoteSimpleTextPrintFormatter.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 1/10/20.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class SimplenoteSimpleTextPrintFormatter: UISimpleTextPrintFormatter {
+    override init(text: String) {
+        super.init(text: text)
+        
+        if #available(iOS 12.0, *) {
+            if UIScreen.main.traitCollection.userInterfaceStyle == .dark {
+                self.color = UIColor.black
+            }
+        }
+    }
+}

--- a/Simplenote/SimplenoteSimpleTextPrintFormatter.swift
+++ b/Simplenote/SimplenoteSimpleTextPrintFormatter.swift
@@ -13,7 +13,7 @@ class SimplenoteSimpleTextPrintFormatter: UISimpleTextPrintFormatter {
         super.init(text: text)
         
         if #available(iOS 12.0, *) {
-            if UIScreen.main.traitCollection.userInterfaceStyle == .dark {
+            if SPUserInterface.isDark {
                 self.color = UIColor.black
             }
         }

--- a/Simplenote/UIActivityViewController+Simplenote.swift
+++ b/Simplenote/UIActivityViewController+Simplenote.swift
@@ -14,7 +14,7 @@ extension UIActivityViewController {
             return nil
         }
 
-        let print = UISimpleTextPrintFormatter(text: content)
+        let print = SimplenoteSimpleTextPrintFormatter(text: content)
         let source = SimplenoteActivityItemSource(note: note)
 
         self.init(activityItems: [print, source], applicationActivities: nil)

--- a/Simplenote/UIActivityViewController+Simplenote.swift
+++ b/Simplenote/UIActivityViewController+Simplenote.swift
@@ -14,7 +14,7 @@ extension UIActivityViewController {
             return nil
         }
 
-        let print = SimplenoteSimpleTextPrintFormatter(text: content)
+        let print = SPSimpleTextPrintFormatter(text: content)
         let source = SimplenoteActivityItemSource(note: note)
 
         self.init(activityItems: [print, source], applicationActivities: nil)


### PR DESCRIPTION
### Fix
This PR fixes [issue 447](https://github.com/Automattic/simplenote-ios/issues/447)
If the device running Simplenote is set to Dark Mode, and the user goes to the Note Settings > Share > Print, the text would be formatted in white, so it would appear that what was printed was blank.

Added a check when the SimpleTextPrintFormatter is initialized to see if the device is in Dark mode, and switch the text in the print formatter to black before printing.

### Test
1. Set device to Dark Mode
2. Open a note and go to the sharing options
3. Choose Print.  The preview should display a white background with black text.

### Review
- [ ] Check and make sure the preview text is appearing in black
- [ ] Make sure the text is still formatted correctly when device is in light mode
- [ ] Check sharing to other apps to confirm only the print text is being reformatted
