### PR TITLE
Implements ResultsController

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -614,7 +614,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     SPNoteListViewController *listController = [[SPAppDelegate sharedDelegate] noteListViewController];
     if (_currentNote) {
         
-        NSIndexPath *notePath = [listController.fetchedResultsController indexPathForObject:_currentNote];
+        NSIndexPath *notePath = [listController.resultsController indexPathForObject:_currentNote];
         
         if (![[listController.tableView indexPathsForVisibleRows] containsObject:notePath])
             [listController.tableView scrollToRowAtIndexPath:notePath

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -12,7 +12,10 @@ extension SPNoteListViewController {
     func configureResultsController() {
         assert(resultsController == nil, "resultsController is already initialized!")
 
-        let viewContext = SPAppDelegate.shared().simperium.managedObjectContext()!
+        guard let viewContext = SPAppDelegate.shared().simperium.managedObjectContext() else {
+            fatalError("MainMOC should be already available")
+        }
+
         resultsController = SPSearchResultsController(viewContext: viewContext)
         try? resultsController.performFetch()
     }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -116,19 +116,26 @@ extension SPNoteListViewController {
     @objc
     func refreshResultsController() {
         // TODO: Consolidate this into a single property!!
-        var selectedTag: String?
+
+        let filter: ResultsFilter
+
         switch SPAppDelegate.shared().selectedTag {
         case kSimplenoteTrashKey:
+            filter = .deleted
             tagFilterType = .deleted
         case kSimplenoteUntaggedKey:
+            filter = .untagged
             tagFilterType = .untagged
         case let tag:
+            if let tag = tag {
+                filter = .tag(name: tag)
+            } else {
+                filter = .all
+            }
             tagFilterType = .userTag
-            selectedTag = tag
         }
 
-        resultsController.filter = tagFilterType
-        resultsController.selectedTag = selectedTag
+        resultsController.filter = filter
         resultsController.keyword = searchText
         resultsController.sortMode = Options.shared.listSortMode
         try? resultsController.performFetch()

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -2,6 +2,23 @@ import Foundation
 import UIKit
 
 
+// MARK: - Components Initialization
+//
+extension SPNoteListViewController {
+
+    /// Sets up the Results Controller
+    ///
+    @objc
+    func configureResultsController() {
+        assert(resultsController == nil, "resultsController is already initialized!")
+
+        let viewContext = SPAppDelegate.shared().simperium.managedObjectContext()!
+        resultsController = SPSearchResultsController(viewContext: viewContext)
+        try? resultsController.performFetch()
+    }
+}
+
+
 // MARK: - Interface Initialization
 //
 extension SPNoteListViewController {
@@ -89,6 +106,30 @@ extension SPNoteListViewController {
             title = selectedTag
         }
     }
+
+    /// Refreshes the ResultsController Filters
+    ///
+    @objc
+    func refreshResultsController() {
+        var selectedTag: String?
+        switch SPAppDelegate.shared().selectedTag {
+        case kSimplenoteTrashKey:
+            tagFilterType = .deleted
+        case kSimplenoteUntaggedKey:
+            tagFilterType = .untagged
+        case let tag:
+            tagFilterType = .userTag
+            selectedTag = tag
+        }
+
+        resultsController.filter = tagFilterType
+        resultsController.selectedTag = selectedTag
+        resultsController.keyword = searchText
+        resultsController.sortMode = Options.shared.listSortMode
+        try? resultsController.performFetch()
+
+        tableView.reloadData()
+    }
 }
 
 
@@ -111,7 +152,7 @@ extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
         previewingContext.sourceRect = tableView.rectForRow(at: indexPath)
 
         /// Setup the Editor
-        let note = fetchedResultsController.object(at: indexPath)
+        let note = resultsController.object(at: indexPath)
         let editorViewController = SPAppDelegate.shared().noteEditorViewController
         editorViewController.update(note)
         editorViewController.isPreviewing = true

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -115,24 +115,17 @@ extension SPNoteListViewController {
     ///
     @objc
     func refreshResultsController() {
-        // TODO: Consolidate this into a single property!!
-
         let filter: ResultsFilter
 
         switch SPAppDelegate.shared().selectedTag {
         case kSimplenoteTrashKey:
             filter = .deleted
-            tagFilterType = .deleted
         case kSimplenoteUntaggedKey:
             filter = .untagged
-            tagFilterType = .untagged
-        case let tag:
-            if let tag = tag {
-                filter = .tag(name: tag)
-            } else {
-                filter = .all
-            }
-            tagFilterType = .userTag
+        case .some(let tag) where tag.count > 0:
+            filter = .tag(name: tag)
+        default:
+            filter = .all
         }
 
         resultsController.filter = filter
@@ -141,6 +134,13 @@ extension SPNoteListViewController {
         try? resultsController.performFetch()
 
         tableView.reloadData()
+    }
+
+    /// Indicates if the Deleted Notes are onScreen
+    ///
+    @objc
+    var isDeletedFilterActive: Bool {
+        return resultsController.filter == .deleted
     }
 }
 
@@ -151,7 +151,7 @@ extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
 
     public func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
         guard tableView.isUserInteractionEnabled,
-            tagFilterType != .deleted,
+            isDeletedFilterActive == false,
             let indexPath = tableView.indexPathForRow(at: location)
             else {
                 return nil

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -16,6 +16,7 @@ extension SPNoteListViewController {
             fatalError("MainMOC should be already available")
         }
 
+        // TODO: Link between FRC <> TableView (FRC Delegate Methods)
         resultsController = SPSearchResultsController(viewContext: viewContext)
         try? resultsController.performFetch()
     }
@@ -114,6 +115,7 @@ extension SPNoteListViewController {
     ///
     @objc
     func refreshResultsController() {
+        // TODO: Consolidate this into a single property!!
         var selectedTag: String?
         switch SPAppDelegate.shared().selectedTag {
         case kSimplenoteTrashKey:

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -9,10 +9,7 @@
 typedef NS_ENUM(NSInteger, SPTagFilterType) {
 	SPTagFilterTypeUserTag = 0,
 	SPTagFilterTypeDeleted = 1,
-	SPTagFilterTypeShared = 2,
-    SPTagFilterTypePinned = 3,
-    SPTagFilterTypeUnread = 4,
-    SPTagFilterTypeUntagged = 5
+    SPTagFilterTypeUntagged = 2
 };
 
 @interface SPNoteListViewController : UIViewController<SPSidebarContainerDelegate> {

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -7,12 +7,6 @@
 @class SPBlurEffectView;
 @class SPSearchResultsController;
 
-typedef NS_ENUM(NSInteger, SPTagFilterType) {
-	SPTagFilterTypeUserTag = 0,
-	SPTagFilterTypeDeleted = 1,
-    SPTagFilterTypeUntagged = 2
-};
-
 @interface SPNoteListViewController : UIViewController<SPSidebarContainerDelegate> {
 
     NSTimer *searchTimer;
@@ -30,7 +24,6 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
 
 @property (nonatomic, strong, readonly) SPBlurEffectView                    *navigationBarBackground;
 @property (nonatomic, strong, readonly) UISearchBar                         *searchBar;
-@property (nonatomic, assign) SPTagFilterType                               tagFilterType;
 @property (nonatomic, strong, readonly) SPEmptyListView                     *emptyListView;
 @property (nonatomic, strong, readonly) UITableView                         *tableView;
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -5,6 +5,7 @@
 
 @class SPEmptyListView;
 @class SPBlurEffectView;
+@class SPSearchResultsController;
 
 typedef NS_ENUM(NSInteger, SPTagFilterType) {
 	SPTagFilterTypeUserTag = 0,
@@ -23,13 +24,13 @@ typedef NS_ENUM(NSInteger, SPTagFilterType) {
     BOOL bShouldShowSidePanel;
 }
 
-@property (nonatomic, strong, readonly) NSFetchedResultsController<Note *>  *fetchedResultsController;
+@property (nonatomic, strong) SPSearchResultsController                     *resultsController;
 @property (nonatomic, strong) NSString                                      *searchText;
 @property (nonatomic) BOOL                                                  firstLaunch;
 
 @property (nonatomic, strong, readonly) SPBlurEffectView                    *navigationBarBackground;
 @property (nonatomic, strong, readonly) UISearchBar                         *searchBar;
-@property (nonatomic, assign, readonly) SPTagFilterType                     tagFilterType;
+@property (nonatomic, assign) SPTagFilterType                               tagFilterType;
 @property (nonatomic, strong, readonly) SPEmptyListView                     *emptyListView;
 @property (nonatomic, strong, readonly) UITableView                         *tableView;
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -794,15 +794,6 @@
     [predicateList addObject: [NSPredicate predicateForNotesWithDeletedStatus:(self.tagFilterType == SPTagFilterTypeDeleted)]];
 
     switch (self.tagFilterType) {
-        case SPTagFilterTypeShared:
-            [predicateList addObject:[NSPredicate predicateForSystemTagWith:kSimplenoteSystemTagShared]];
-            break;
-        case SPTagFilterTypePinned:
-            [predicateList addObject:[NSPredicate predicateForSystemTagWith:kSimplenoteSystemTagPinned]];
-            break;
-        case SPTagFilterTypeUnread:
-            [predicateList addObject:[NSPredicate predicateForSystemTagWith:kSimplenoteSystemTagUnread]];
-            break;
         case SPTagFilterTypeUntagged:
             [predicateList addObject:[NSPredicate predicateForUntaggedNotes]];
             break;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -238,7 +238,7 @@
 }
 
 - (void)updateNavigationBar {
-    UIBarButtonItem *rightButton = (self.tagFilterType == SPTagFilterTypeDeleted) ? self.emptyTrashButton : self.addButton;
+    UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : self.addButton;
 
     [self.navigationItem setRightBarButtonItem:rightButton animated:YES];
     [self.navigationItem setLeftBarButtonItem:self.sidebarButton animated:YES];
@@ -507,7 +507,7 @@
 - (NSArray *)tableView:(UITableView*)tableView editActionsForRowAtIndexPath:(nonnull NSIndexPath *)indexPath{
     
     Note *note = [self.resultsController objectAtIndexPath:indexPath];
-    if (self.tagFilterType == SPTagFilterTypeDeleted) {
+    if (self.isDeletedFilterActive) {
         return [self rowActionsForDeletedNote:note];
     }
 
@@ -704,7 +704,7 @@
     [self refreshResultsController];
     [self refreshTitle];
 
-    BOOL isTrashOnScreen = self.tagFilterType == SPTagFilterTypeDeleted;
+    BOOL isTrashOnScreen = self.isDeletedFilterActive;
     self.emptyTrashButton.enabled = isTrashOnScreen && self.numNotes > 0;
     self.tableView.allowsSelection = !isTrashOnScreen;
     
@@ -832,7 +832,7 @@
 - (void)setWaitingForIndex:(BOOL)waiting {
     
     // if the current tag is the deleted tag, do not show the activity spinner
-    if (self.tagFilterType == SPTagFilterTypeDeleted && waiting) {
+    if (self.isDeletedFilterActive && waiting) {
         return;
     }
 

--- a/Simplenote/Classes/SPSearchResultsController.swift
+++ b/Simplenote/Classes/SPSearchResultsController.swift
@@ -33,7 +33,7 @@ class SPSearchResultsController: NSObject {
 
     /// Keyword we should be filtering by
     ///
-    var keyword = String() {
+    var keyword: String? {
         didSet {
             guard oldValue != keyword else {
                 return
@@ -75,8 +75,13 @@ extension SPSearchResultsController {
         try resultsController.performFetch()
     }
 
+    @objc(objectAtIndexPath:)
     func object(at indexPath: IndexPath) -> Note {
         return resultsController.object(at: indexPath)
+    }
+
+    func indexPath(forObject object: Note) -> IndexPath? {
+        return resultsController.indexPath(forObject: object)
     }
 
     /// Returns the number of fetched objects.
@@ -105,7 +110,7 @@ private extension SPSearchResultsController {
 
     /// Refreshes the ResultsController's Predicate
     ///
-    func updatePredicateAndFetch(keyword: String) {
+    func updatePredicateAndFetch(keyword: String?) {
         resultsController.fetchRequest.predicate = predicate(keyword: keyword)
         try? resultsController.performFetch()
     }
@@ -119,12 +124,12 @@ private extension SPSearchResultsController {
 
     /// Returns a NSPredicate which will filter notes by a given keyword.
     ///
-    func predicate(keyword: String) -> NSPredicate {
+    func predicate(keyword: String?) -> NSPredicate {
         var predicates = [
             NSPredicate.predicateForNotesWithStatus(deleted: false)
         ]
 
-        if keyword.count > 0 {
+        if let keyword = keyword, keyword.count > 0 {
             predicates.append( NSPredicate.predicateForSearchText(searchText: keyword) )
         }
 

--- a/Simplenote/Classes/SPSearchResultsController.swift
+++ b/Simplenote/Classes/SPSearchResultsController.swift
@@ -23,7 +23,7 @@ class SPSearchResultsController: NSObject {
 
     /// Results Controller
     ///
-    private lazy var resultsController: NSFetchedResultsController<Note> = {
+    private(set) lazy var resultsController: NSFetchedResultsController<Note> = {
         NSFetchedResultsController<Note>(fetchRequest: request, managedObjectContext: viewContext, sectionNameKeyPath: nil, cacheName: nil)
     }()
 
@@ -35,7 +35,7 @@ class SPSearchResultsController: NSObject {
     ///
     var filter: SPTagFilterType = .userTag {
         didSet {
-            guard oldValue == filter else {
+            guard oldValue != filter else {
                 return
             }
 
@@ -57,7 +57,15 @@ class SPSearchResultsController: NSObject {
 
     /// Selected Tag
     ///
-    var selectedTag: String?
+    var selectedTag: String? {
+        didSet {
+            guard oldValue != selectedTag else {
+                return
+            }
+
+            refreshFetchRequest()
+        }
+    }
 
     /// Sorting Mode
     ///

--- a/Simplenote/Classes/SPSearchResultsController.swift
+++ b/Simplenote/Classes/SPSearchResultsController.swift
@@ -4,31 +4,32 @@ import CoreData
 
 // MARK: - SPSearchResultsController
 //
-class SPSearchResultsController {
+@objcMembers
+class SPSearchResultsController: NSObject {
 
     /// Batch Size for the FRC's Request
     ///
     private let resultsBatchSize = 20
 
-    /// Fetch Request: Note
+    /// Fetch Request
     ///
     private lazy var request: NSFetchRequest<Note> = {
         let request = NSFetchRequest<Note>()
-        request.entity = NSEntityDescription.entity(forEntityName: Note.classNameWithoutNamespaces, in: mainContext)
+        request.entity = NSEntityDescription.entity(forEntityName: Note.classNameWithoutNamespaces, in: viewContext)
         request.fetchBatchSize = resultsBatchSize
         request.sortDescriptors = sortDescriptors(sortMode: sortMode)
         return request
     }()
 
-    /// Results Controller: Note Entity
+    /// Results Controller
     ///
     private lazy var resultsController: NSFetchedResultsController<Note> = {
-        NSFetchedResultsController<Note>(fetchRequest: request, managedObjectContext: mainContext, sectionNameKeyPath: nil, cacheName: nil)
+        NSFetchedResultsController<Note>(fetchRequest: request, managedObjectContext: viewContext, sectionNameKeyPath: nil, cacheName: nil)
     }()
 
-    /// Main MOC
+    /// View Context MOC: Main Thread!
     ///
-    private let mainContext: NSManagedObjectContext
+    private let viewContext: NSManagedObjectContext
 
     /// Keyword we should be filtering by
     ///
@@ -55,12 +56,11 @@ class SPSearchResultsController {
      }
 
     /// Designated Initializer
-    ///
     ///  - mainContext: Main Thread's MOC
     ///
-    init(mainContext: NSManagedObjectContext = SPAppDelegate.shared().managedObjectContext) {
-        assert(mainContext.concurrencyType == .mainQueueConcurrencyType)
-        self.mainContext = mainContext
+    init(viewContext: NSManagedObjectContext) {
+        assert(viewContext.concurrencyType == .mainQueueConcurrencyType)
+        self.viewContext = viewContext
     }
 }
 

--- a/Simplenote/Classes/SPSearchResultsController.swift
+++ b/Simplenote/Classes/SPSearchResultsController.swift
@@ -39,21 +39,22 @@ class SPSearchResultsController: NSObject {
                 return
             }
 
-            updatePredicateAndFetch(keyword: keyword)
+            refreshFetchRequest()
         }
     }
 
     /// Sorting Mode
-     ///
-     var sortMode: SortMode = .alphabeticallyAscending {
+    ///
+    var sortMode: SortMode = .alphabeticallyAscending {
          didSet {
              guard oldValue != sortMode else {
                  return
              }
 
-             refreshSortDescriptors(sortMode: sortMode)
+            refreshFetchRequest()
          }
-     }
+    }
+
 
     /// Designated Initializer
     ///  - mainContext: Main Thread's MOC
@@ -108,18 +109,12 @@ extension SPSearchResultsController {
 //
 private extension SPSearchResultsController {
 
-    /// Refreshes the ResultsController's Predicate
+    /// Refreshes the ResultsController's Fetch Request
     ///
-    func updatePredicateAndFetch(keyword: String?) {
-        resultsController.fetchRequest.predicate = predicate(keyword: keyword)
-        try? resultsController.performFetch()
-    }
-
-    /// Refreshes the ResultsController's Sort Descriptors
-    ///
-    func refreshSortDescriptors(sortMode: SortMode) {
-        resultsController.fetchRequest.sortDescriptors = sortDescriptors(sortMode: sortMode)
-        try? resultsController.performFetch()
+    func refreshFetchRequest() {
+        let request = resultsController.fetchRequest
+        request.predicate = predicate(keyword: keyword)
+        request.sortDescriptors = sortDescriptors(sortMode: sortMode)
     }
 
     /// Returns a NSPredicate which will filter notes by a given keyword.

--- a/Simplenote/Classes/SPSearchResultsViewController.swift
+++ b/Simplenote/Classes/SPSearchResultsViewController.swift
@@ -19,7 +19,7 @@ class SPSearchResultsViewController: UIViewController {
     /// Results Controller
     ///
     private lazy var resultsController: SPSearchResultsController = {
-        SPSearchResultsController(mainContext: mainContext)
+        SPSearchResultsController(viewContext: mainContext)
     }()
 
     // MARK: - View Lifecycle
@@ -175,11 +175,11 @@ private extension SPSearchResultsViewController {
         cell.titleText = note.titlePreview
         cell.bodyText = note.bodyPreview
 
-        guard resultsController.keyword.count > 0 else {
+        guard let keyword = resultsController.keyword else {
             return
         }
 
-        cell.highlightSubstrings(matching: resultsController.keyword, color: .simplenoteTintColor)
+        cell.highlightSubstrings(matching: keyword, color: .simplenoteTintColor)
     }
 
     /// Returns the Note at a given IndexPath
@@ -188,7 +188,7 @@ private extension SPSearchResultsViewController {
         resultsController.object(at: indexPath)
     }
 
-    func presentEditor(note: Note, keyword: String) {
+    func presentEditor(note: Note, keyword: String?) {
         let editorViewController = SPNoteEditorViewController()
         editorViewController.update(note)
         editorViewController.searchString = keyword

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -426,7 +426,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
         
         
         // get selected path
-        _selectedPath = [listController.fetchedResultsController indexPathForObject:editorController.currentNote];
+        _selectedPath = [listController.resultsController indexPathForObject:editorController.currentNote];
         
         
         // get snapshots of the final editor text


### PR DESCRIPTION
### Details:
In this PR we're encapsulating (nearly all) of the NSFetchedResultsController interactions within a single class, to be named **ResultsController**.

This is one of many PR(s). Since the AdvancedSearch feature requires to mix results from multiple Entities, we're likely to use a **DataSource**, which will interact with **ResultsController**.

cc @bummytime (Thanks in advance Bummy!!)
Ref. #507

### Notes:
Live refresh of remote changes coming up in #573!

### Test: List Filters
1. Fresh install the app
2. Log into your account

- [ ] Verify that while your notes are downloading, there's a spinner on top
- [ ] Verify **All Notes** effectively display all of your notes
- [ ] Verify **Trash** renders the trashed notes
- [ ] Verify **Untagged Notes** filters out just the notes that don't have a valid tag
- [ ] Verify the App's title is updated in each one of the above scenarios
- [ ] Verify that the Trash shows a button that reads `Empty` on the top right corner
- [ ] Verify the Sort Mode setting is also always respected

### Test: List Actions
1. Log into your account

- [ ] Verify that 3d Touch is available for every note (except Trashed Notes)
- [ ] Verify that Swipeable actions work correctly (for Deleted and non Deleted notes)
- [ ] Verify that pressing over any Note cell pushes the Editor

### Test: Searching
1. Log into your account
2. Press the Search Bar
3. Type any random keyword

- [ ] Verify that searching by any given keyword filters out the related notes
- [ ] Verify that any matching keywords are highlighted
- [ ] Verify that pressing over any of the results row pushes the Editor in search mode (a bar should show up at the bottom)

### Release:
These changes do not require release notes.
