### PR TITLE
Fixes Localized Strings not translating "Trash" in note settings

### DIFF
--- a/Simplenote/ar.lproj/Localizable.strings
+++ b/Simplenote/ar.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "إصلاح الخطأ";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "حذف";
+"Trash-verb" = "حذف";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Delete Notes";

--- a/Simplenote/cy.lproj/Localizable.strings
+++ b/Simplenote/cy.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Dadfygio";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Dileu";
+"Trash-verb" = "Dileu";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Delete Notes";

--- a/Simplenote/de.lproj/Localizable.strings
+++ b/Simplenote/de.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Debuggen";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Delete";
+"Trash-verb" = "Löschen";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Notizen löschen";

--- a/Simplenote/el.lproj/Localizable.strings
+++ b/Simplenote/el.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Debug";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Delete";
+"Trash-verb" = "Delete";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Delete Notes";

--- a/Simplenote/es.lproj/Localizable.strings
+++ b/Simplenote/es.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Debug";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Eliminar";
+"Trash-verb" = "Eliminar";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Eliminar notas";

--- a/Simplenote/fr.lproj/Localizable.strings
+++ b/Simplenote/fr.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Débogage";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Supprimer";
+"Trash-verb" = "Supprimer";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Supprimer les notes";

--- a/Simplenote/he.lproj/Localizable.strings
+++ b/Simplenote/he.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "איתור באגים";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "מחיקה";
+"Trash-verb" = "מחיקה";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "למחוק את הפתקים";

--- a/Simplenote/id.lproj/Localizable.strings
+++ b/Simplenote/id.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Debug";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Hapus";
+"Trash-verb" = "Hapus";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Hapus Catatan";

--- a/Simplenote/it.lproj/Localizable.strings
+++ b/Simplenote/it.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Debug";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Elimina";
+"Trash-verb" = "Elimina";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Delete Notes";

--- a/Simplenote/ja.lproj/Localizable.strings
+++ b/Simplenote/ja.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "デバッグ";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "削除";
+"Trash-verb" = "削除";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "ノートを削除";

--- a/Simplenote/ko.lproj/Localizable.strings
+++ b/Simplenote/ko.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "디버그";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "삭제";
+"Trash-verb" = "삭제";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "메모 삭제";

--- a/Simplenote/nl.lproj/Localizable.strings
+++ b/Simplenote/nl.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Debug";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Verwijderen";
+"Trash-verb" = "Verwijderen";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Notities verwijderen";

--- a/Simplenote/pt-BR.lproj/Localizable.strings
+++ b/Simplenote/pt-BR.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Depurar";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Excluir";
+"Trash-verb" = "Excluir";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Apagar notas";

--- a/Simplenote/ru.lproj/Localizable.strings
+++ b/Simplenote/ru.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Отладка";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Удалить";
+"Trash-verb" = "Удалить";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Удалить заметки";

--- a/Simplenote/sv.lproj/Localizable.strings
+++ b/Simplenote/sv.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Felsök";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Ta bort";
+"Trash-verb" = "Ta bort";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Radera anteckningar";

--- a/Simplenote/tr.lproj/Localizable.strings
+++ b/Simplenote/tr.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "Hata ayıklama";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Sil";
+"Trash-verb" = "Sil";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Notları Sil";

--- a/Simplenote/zh-Hans-CN.lproj/Localizable.strings
+++ b/Simplenote/zh-Hans-CN.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "调试";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "Delete";
+"Trash-verb" = "Delete";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "删除笔记";

--- a/Simplenote/zh-Hant-TW.lproj/Localizable.strings
+++ b/Simplenote/zh-Hant-TW.lproj/Localizable.strings
@@ -172,7 +172,7 @@
 "Debug" = "偵錯";
 
 /* Trash (verb) - the action of deleting a note */
-"Delete" = "刪除";
+"Trash-verb" = "刪除";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "刪除筆記";


### PR DESCRIPTION
In all of the localized string files (except for English) the identifier for the label "Trash" in the note settings was set to "Delete" 
In SPNoteEditorViewController the identifier was set to "Trash-verb"

### Fix
This PR fixes the problem of the label Trash not localizing correctly.  This fixes https://github.com/Automattic/simplenote-ios/issues/564

Also note, that the translation for delete in German was incorrect as noted by this issue https://github.com/Automattic/simplenote-ios/issues/566  I updated that to the correct translation "Löschen"

### Test
1.Set Simplenote to a language other than English
2. Go to a Note > Note Settings
3. Under the Trash icon the label should be localized to the language you chose.
4. Check a few languages
5.  Check English to make sure it still works correctly (no changes were made, but just in case)

### Review

- [ ] Confirm the trash label is changing for several of the languages
- [ ] Confirm English is unaffected

### Release
"Fixed a few localization errors to make using Simplenote easy in any language"