### PR TITLE
Implements NotesListController: Part II

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -124,6 +124,9 @@
 		74F6637F22BADB5000FA147E /* ExtensionPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6637E22BADB5000FA147E /* ExtensionPresentationController.swift */; };
 		74F6638122BADBD200FA147E /* ExtensionPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638022BADBD200FA147E /* ExtensionPresentationAnimator.swift */; };
 		74F6638322BADD0300FA147E /* SharePresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638222BADD0300FA147E /* SharePresentationController.swift */; };
+		B504D4DE23D2014200AEED27 /* IndexPath+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504D4DD23D2014200AEED27 /* IndexPath+Simplenote.swift */; };
+		B504D4E023D2018800AEED27 /* ResultsObjectChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504D4DF23D2018800AEED27 /* ResultsObjectChange.swift */; };
+		B504D4E223D201C300AEED27 /* ResultsSectionChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504D4E123D201C300AEED27 /* ResultsSectionChange.swift */; };
 		B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17C421CE1BE0BAB100752B56 /* SPInteractivePushPopAnimationController.m */; };
 		B50789FF1C1F5592009F097A /* markdown-default.css in Resources */ = {isa = PBXBuildFile; fileRef = 1748382E1BC1CC2D00E834AF /* markdown-default.css */; };
 		B5078A001C1F5595009F097A /* markdown-dark.css in Resources */ = {isa = PBXBuildFile; fileRef = 17BC3D461BC46BA800535DF3 /* markdown-dark.css */; };
@@ -424,6 +427,9 @@
 		A774E3E4F5041D36FBE400BD /* Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig"; sourceTree = "<group>"; };
 		AE066B9C23C9166D41F1A732 /* Pods-SimplenoteTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B303123B163A5C7805D10DC7 /* Pods-Automattic-Simplenote.distribution adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution adhoc.xcconfig"; sourceTree = "<group>"; };
+		B504D4DD23D2014200AEED27 /* IndexPath+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "IndexPath+Simplenote.swift"; path = "Classes/IndexPath+Simplenote.swift"; sourceTree = "<group>"; };
+		B504D4DF23D2018800AEED27 /* ResultsObjectChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ResultsObjectChange.swift; path = Classes/ResultsObjectChange.swift; sourceTree = "<group>"; };
+		B504D4E123D201C300AEED27 /* ResultsSectionChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ResultsSectionChange.swift; path = Classes/ResultsSectionChange.swift; sourceTree = "<group>"; };
 		B50E99F3234242130092F274 /* UISearchBar+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UISearchBar+Simplenote.swift"; path = "Classes/UISearchBar+Simplenote.swift"; sourceTree = "<group>"; };
 		B50F479E1D1D77FC00822748 /* UIAlertController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIAlertController+Helpers.swift"; path = "Classes/UIAlertController+Helpers.swift"; sourceTree = "<group>"; };
 		B50F47A21D1D78EA00822748 /* SPRatingsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPRatingsHelper.h; path = Classes/SPRatingsHelper.h; sourceTree = "<group>"; };
@@ -932,6 +938,26 @@
 			path = config;
 			sourceTree = "<group>";
 		};
+		B504D4DB23D1FBB400AEED27 /* ResultsController */ = {
+			isa = PBXGroup;
+			children = (
+				B504D4DC23D1FBD200AEED27 /* Internal */,
+				B5421F3723CE79F6004DDC19 /* ResultsController.swift */,
+				B504D4DF23D2018800AEED27 /* ResultsObjectChange.swift */,
+				B504D4E123D201C300AEED27 /* ResultsSectionChange.swift */,
+				B5421F3923CE7A02004DDC19 /* UITableView+ResultsController.swift */,
+			);
+			name = ResultsController;
+			sourceTree = "<group>";
+		};
+		B504D4DC23D1FBD200AEED27 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				B5421F3323CE79D7004DDC19 /* FetchedResultsControllerDelegateWrapper.swift */,
+			);
+			name = Internal;
+			sourceTree = "<group>";
+		};
 		B512AF8F1C209DE800FE76D8 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -1051,6 +1077,7 @@
 				B5CBEF4122D3B419009DBE67 /* Bundle+Simplenote.swift */,
 				F52A2FD01DE8B1FB002DEB0E /* CSSearchable+Helpers.swift */,
 				B52BB74922CFC0670042C162 /* FileManager+Simplenote.swift */,
+				B504D4DD23D2014200AEED27 /* IndexPath+Simplenote.swift */,
 				B5421F3523CE79E4004DDC19 /* NSManagedObject+Simplenote.swift */,
 				B56A696822F9D57200B90398 /* NSMutableAttributedString+Simplenote.swift */,
 				74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */,
@@ -1183,7 +1210,7 @@
 		B5BE053E1AB751FD002417BF /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				B5421F3323CE79D7004DDC19 /* FetchedResultsControllerDelegateWrapper.swift */,
+				B504D4DB23D1FBB400AEED27 /* ResultsController */,
 				B5CBEF3F22D3AD92009DBE67 /* MigrationsHandler.swift */,
 				B5D3FCCF201F96AC00A813B7 /* StatusChecker.h */,
 				B5D3FCCE201F96AC00A813B7 /* StatusChecker.m */,
@@ -1198,8 +1225,6 @@
 				F9E197D32283D05C0092B3E1 /* CrashLogging.swift */,
 				F920265A2294661C0061B1DE /* BuildConfiguration.swift */,
 				74F454EC22DD4BC0000C66DB /* KeyboardObservable.swift */,
-				B5421F3723CE79F6004DDC19 /* ResultsController.swift */,
-				B5421F3923CE7A02004DDC19 /* UITableView+ResultsController.swift */,
 				B5185CFA23427F2F0060145A /* SearchDisplayController.swift */,
 				B531090723D0B685002B0998 /* SPSimpleTextPrintFormatter.swift */,
 			);
@@ -1923,6 +1948,7 @@
 			files = (
 				B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */,
 				E215C793180B115C00AD36B5 /* SPNavigationController.m in Sources */,
+				B504D4E023D2018800AEED27 /* ResultsObjectChange.swift in Sources */,
 				B5DF734422A56E2800602CE7 /* UserDefaults+Simplenote.swift in Sources */,
 				46A3C96217DFA81A002865AE /* SPTagListViewCell.m in Sources */,
 				B52B8A231BAAF80B002CC55D /* UIViewController+Extensions.m in Sources */,
@@ -1938,6 +1964,7 @@
 				B5BE05461AB7522F002417BF /* JSONKit+Simplenote.m in Sources */,
 				B56E763422BD394C00C5AA47 /* UIImage+Simplenote.swift in Sources */,
 				B543C7E323CF76EA00003A80 /* NotesListFilter.swift in Sources */,
+				B504D4E223D201C300AEED27 /* ResultsSectionChange.swift in Sources */,
 				46A3C96717DFA81A002865AE /* NSManagedObjectContext+CoreDataExtensions.m in Sources */,
 				B59314D81A486B3800B651ED /* SPConstants.m in Sources */,
 				375D24B421E01131007AB25A /* escape.c in Sources */,
@@ -2098,6 +2125,7 @@
 				B584DA36236722D400B2844A /* SPBlurEffectView.swift in Sources */,
 				B521A1961BC8446900E1CF2A /* SPAutomatticTracker.m in Sources */,
 				375D24B121E01131007AB25A /* html5_blocks.c in Sources */,
+				B504D4DE23D2014200AEED27 /* IndexPath+Simplenote.swift in Sources */,
 				B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */,
 				46A3C9AF17DFA81A002865AE /* NSString+Condensing.m in Sources */,
 				B50F47A41D1D78EA00822748 /* SPRatingsHelper.m in Sources */,

--- a/Simplenote/Classes/IndexPath+Simplenote.swift
+++ b/Simplenote/Classes/IndexPath+Simplenote.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+
+// MARK: - IndexPath
+//
+extension IndexPath {
+
+    func transpose(toSection newSection: Int) -> IndexPath {
+        IndexPath(row: row, section: newSection)
+    }
+}

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -11,15 +11,15 @@ class NotesListController: NSObject {
 
     /// Notes Controller
     ///
-    private lazy var notesController: ResultsController<Note> = {
-        ResultsController<Note>(viewContext: viewContext, matching: state.predicateForNotes(filter: filter), sortedBy: sortMode.descriptorsForNotes)
-    }()
+    private lazy var notesController = ResultsController<Note>(viewContext: viewContext,
+                                                               matching: state.predicateForNotes(filter: filter),
+                                                               sortedBy: sortMode.descriptorsForNotes)
 
     /// Tags Controller
     ///
-    private lazy var tagsController: ResultsController<Tag> = {
-        ResultsController<Tag>(viewContext: viewContext, matching: state.predicateForTags(), sortedBy: sortMode.descriptorsForTags)
-    }()
+    private lazy var tagsController = ResultsController<Tag>(viewContext: viewContext,
+                                                             matching: state.predicateForTags(),
+                                                             sortedBy: sortMode.descriptorsForTags)
 
     /// Notes Changes: We group all of the Sections + Object changes, and notify our listeners in batch.
     ///

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -191,10 +191,6 @@ extension NotesListController {
     ///
     @objc
     func refreshSearchResults(keyword: String) {
-        guard !keyword.isEmpty else {
-            return
-        }
-
         state = .searching(keyword: keyword)
     }
 

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -161,7 +161,6 @@ extension NotesListController {
     ///
     @objc
     func performFetch() {
-// TODO: Does refetching cause changes?
         removePendingTagChanges()
         removePendingNoteChanges()
 

--- a/Simplenote/Classes/NotesListState.swift
+++ b/Simplenote/Classes/NotesListState.swift
@@ -30,6 +30,33 @@ extension NotesListState {
         return true
     }
 
+    /// Returns the SectionIndex for Notes, in the current state
+    ///
+    var sectionIndexForNotes: Int {
+        switch self {
+        case .searching:
+            return 1
+        default:
+            return .zero
+        }
+    }
+
+    /// Returns the SectionIndex for Tags, in the current state
+    ///
+    var sectionIndexForTags: Int {
+        return .zero
+    }
+
+    /// Indicates if we should adjust SectionIndexes for ResultsController Changes entities
+    ///
+    var requiresNoteSectionIndexAdjustments: Bool {
+        guard case .searching = self else {
+            return false
+        }
+
+        return true
+    }
+
     /// Returns a NSPredicate to filter out Notes in the current state, with the specified Filter
     ///
     func predicateForNotes(filter: NotesListFilter) -> NSPredicate? {

--- a/Simplenote/Classes/ResultsController.swift
+++ b/Simplenote/Classes/ResultsController.swift
@@ -7,21 +7,6 @@ import CoreData
 typealias ResultsSectionInfo = NSFetchedResultsSectionInfo
 
 
-// MARK: - Result Changes: Encapsulate Change Events Metadata
-//
-enum ResultsObjectChange {
-    case delete(indexPath: IndexPath)
-    case insert(indexPath: IndexPath)
-    case move(oldIndexPath: IndexPath, newIndexPath: IndexPath)
-    case update(indexPath: IndexPath)
-}
-
-enum ResultsSectionChange {
-    case delete(sectionIndex: Int)
-    case insert(sectionIndex: Int)
-}
-
-
 // MARK: - ResultsController
 //
 class ResultsController<T: NSManagedObject> {

--- a/Simplenote/Classes/ResultsObjectChange.swift
+++ b/Simplenote/Classes/ResultsObjectChange.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+
+// MARK: - ResultsObjectChange
+//
+enum ResultsObjectChange {
+    case delete(indexPath: IndexPath)
+    case insert(indexPath: IndexPath)
+    case move(oldIndexPath: IndexPath, newIndexPath: IndexPath)
+    case update(indexPath: IndexPath)
+}
+
+
+// MARK: - ResultsObjectChange: Transposing
+//
+extension ResultsObjectChange {
+
+    /// Why? Because displaying data coming from multiple ResultsController onScreen... just requires us to adjust sectionIndexes
+    ///
+    func transpose(toSection section: Int) -> ResultsObjectChange {
+        switch self {
+        case .delete(let path):
+            return .delete(indexPath: path.transpose(toSection: section))
+
+        case .insert(let path):
+            return .insert(indexPath: path.transpose(toSection: section))
+
+        case .move(let oldPath, let newPath):
+            return .move(oldIndexPath: oldPath.transpose(toSection: section),
+                         newIndexPath: newPath.transpose(toSection: section))
+
+        case .update(let path):
+            return .update(indexPath: path.transpose(toSection: section))
+        }
+    }
+}

--- a/Simplenote/Classes/ResultsObjectChange.swift
+++ b/Simplenote/Classes/ResultsObjectChange.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - ResultsObjectChange
 //
-enum ResultsObjectChange {
+enum ResultsObjectChange: Equatable {
     case delete(indexPath: IndexPath)
     case insert(indexPath: IndexPath)
     case move(oldIndexPath: IndexPath, newIndexPath: IndexPath)
@@ -32,5 +32,23 @@ extension ResultsObjectChange {
         case .update(let path):
             return .update(indexPath: path.transpose(toSection: section))
         }
+    }
+}
+
+
+// MARK: - Equality
+//
+func ==(lhs: ResultsObjectChange, rhs: ResultsObjectChange) -> Bool {
+    switch (lhs, rhs) {
+    case (.delete(let lPath), .delete(let rPath)):
+        return lPath == rPath
+    case (.insert(let lPath), .insert(let rPath)):
+        return lPath == rPath
+    case (.move(let lOldPath, let lNewPath), .move(let rOldPath, let rNewPath)):
+        return lOldPath == rOldPath && lNewPath == rNewPath
+    case (.update(let lPath), .update(let rPath)):
+        return lPath == rPath
+    default:
+        return false
     }
 }

--- a/Simplenote/Classes/ResultsSectionChange.swift
+++ b/Simplenote/Classes/ResultsSectionChange.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - ResultsSectionChange
 //
-enum ResultsSectionChange {
+enum ResultsSectionChange: Equatable {
     case delete(sectionIndex: Int)
     case insert(sectionIndex: Int)
 }
@@ -22,5 +22,19 @@ extension ResultsSectionChange {
         case .insert:
             return .insert(sectionIndex: section)
         }
+    }
+}
+
+
+// MARK: - Equality
+//
+func ==(lhs: ResultsSectionChange, rhs: ResultsSectionChange) -> Bool {
+    switch (lhs, rhs) {
+    case (.delete(let lSection), .delete(let rSection)):
+        return lSection == rSection
+    case (.insert(let lSection), .insert(let rSection)):
+        return lSection == rSection
+    default:
+        return false
     }
 }

--- a/Simplenote/Classes/ResultsSectionChange.swift
+++ b/Simplenote/Classes/ResultsSectionChange.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+
+// MARK: - ResultsSectionChange
+//
+enum ResultsSectionChange {
+    case delete(sectionIndex: Int)
+    case insert(sectionIndex: Int)
+}
+
+
+// MARK: - ResultsSectionChange: Transposing
+//
+extension ResultsSectionChange {
+
+    /// Why? Because displaying data coming from multiple ResultsController onScreen... just requires us to adjust sectionIndexes
+    ///
+    func transpose(toSection section: Int) -> ResultsSectionChange {
+        switch self {
+        case .delete:
+            return .delete(sectionIndex: section)
+        case .insert:
+            return .insert(sectionIndex: section)
+        }
+    }
+}

--- a/SimplenoteTests/MockupStorage.swift
+++ b/SimplenoteTests/MockupStorage.swift
@@ -31,6 +31,11 @@ class MockupStorageManager {
         return container
     }()
 
+    /// Nukes the specified Object
+    ///
+    func delete(_ object: NSManagedObject) {
+        viewContext.delete(object)
+    }
 
     /// This method effectively destroys all of the stored data, and generates a blank Persistent Store from scratch.
     ///

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -320,6 +320,26 @@ class NotesListControllerTests: XCTestCase {
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
     }
 
+    /// Verifies that `onBatchChanges` runs for **Notes** in the following scenarios
+    ///
+    ///     - Mode: Results
+    ///     - OP: Update
+    ///
+    func testOnBatchChangesDoesRunForNoteUpdateWhenInResultsModeAndRelaysMoveOperations() {
+        let firstNote = storage.insertSampleNote(contents: "A")
+        storage.insertSampleNote(contents: "B")
+        storage.save()
+
+        expectBatchChanges(objectChanges: [
+            .move(oldIndexPath: IndexPath(row: 0, section: 0), newIndexPath: IndexPath(row: 1, section: 0))
+        ])
+
+        firstNote.content = "C"
+        storage.save()
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
     /// Verifies that `onBatchChanges` runs for **Tag** in the following scenarios
     ///
     ///     - Mode: Search
@@ -454,7 +474,6 @@ class NotesListControllerTests: XCTestCase {
         storage.save()
 
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
-
     }
 }
 

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -136,7 +136,24 @@ class NotesListControllerTests: XCTestCase {
 
         noteListController.endSearch()
         XCTAssertEqual(noteListController.numberOfObjects, notes.count)
+    }
 
+    /// Verifies that the SearchMode disregards active Filters
+    ///
+    func testSearchModeYieldsGlobalResultsDisregardingActiveFilter() {
+        let note = storage.insertSampleNote(contents: "Something Here")
+        storage.save()
+
+        noteListController.filter = .deleted
+        noteListController.performFetch()
+
+        XCTAssertEqual(noteListController.numberOfObjects, 0)
+
+        noteListController.beginSearch()
+        noteListController.refreshSearchResults(keyword: "Here")
+
+        let retrievedNote = noteListController.object(at: IndexPath(row: 0, section: 1)) as! Note
+        XCTAssertEqual(retrievedNote, note)
     }
 
 
@@ -421,6 +438,23 @@ class NotesListControllerTests: XCTestCase {
         storage.save()
 
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    /// Verifies that `onBatchChanges` does not relay duplicated Changesets
+    ///
+    func testOnBatchChangesDoesNotRelayDuplicatedEvents() {
+        storage.insertSampleNote(contents: "A")
+        storage.save()
+
+        expectBatchChanges(objectChanges: [
+            .insert(indexPath: IndexPath(row: 1, section: 0))
+        ])
+
+        storage.insertSampleNote(contents: "B")
+        storage.save()
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+
     }
 }
 


### PR DESCRIPTION
### Details:
In this PR we're enhancing **NotesListController** by adding a callback, to be known as **onBatchChanges**.

Such closure is to be executed whenever the entities onScreen (either Tags or Notes) get updated. The trick here is: we're mixing results from **two** *NSFetchedResultsController(s)*, and rendering them in a single UITableView.

Because of this, we're adjusting IndexPaths, accordingly:

- Results Mode: *single* section, **only** Notes onscreen
- Search Mode: **two** sections. Section zero displays Tags, section One displays Notes

cc @bummytime (Thank you sir!!)

Ref. #507 

### Test
The changes in this PR haven't been wired just yet. Please:

- [x] Verify all of the new Unit Tests are green
- [x] Verify that the code makes sense!

### Release
These changes do not require release notes.
