### PR TITLE
Search: Limits the number of Tag Results

### DIFF
--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -34,6 +34,9 @@ class NotesListController: NSObject {
 
     /// Indicates the maximum number of Tag results we'll yield
     ///
+    ///     -  Known Issues: If new Tags are added in a second device, and sync'ed while we're in Search Mode,
+    ///        ResultsController won't respect the limit.
+    ///
     let limitForTagResults = 5
 
     /// FSM Current State

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -19,7 +19,8 @@ class NotesListController: NSObject {
     ///
     private lazy var tagsController = ResultsController<Tag>(viewContext: viewContext,
                                                              matching: state.predicateForTags(),
-                                                             sortedBy: sortMode.descriptorsForTags)
+                                                             sortedBy: sortMode.descriptorsForTags,
+                                                             limit: Settings.limitForTagResults)
 
     /// Notes Changes: We group all of the Sections + Object changes, and notify our listeners in batch.
     ///
@@ -308,4 +309,14 @@ private extension NotesListController {
 
         return (transposedObjectChanges, transposedSectionChanges)
     }
+}
+
+
+// MARK: - Settings
+//
+private struct Settings {
+
+    /// Indicates the maximum number of Tags to retrieve (when in search mode!)
+    ///
+    static let limitForTagResults = 5
 }

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -20,7 +20,7 @@ class NotesListController: NSObject {
     private lazy var tagsController = ResultsController<Tag>(viewContext: viewContext,
                                                              matching: state.predicateForTags(),
                                                              sortedBy: sortMode.descriptorsForTags,
-                                                             limit: Settings.limitForTagResults)
+                                                             limit: limitForTagResults)
 
     /// Notes Changes: We group all of the Sections + Object changes, and notify our listeners in batch.
     ///
@@ -31,6 +31,10 @@ class NotesListController: NSObject {
     ///
     private var tagObjectChanges = [ResultsObjectChange]()
     private var tagSectionChanges = [ResultsSectionChange]()
+
+    /// Indicates the maximum number of Tag results we'll yield
+    ///
+    let limitForTagResults = 5
 
     /// FSM Current State
     ///
@@ -309,14 +313,4 @@ private extension NotesListController {
 
         return (transposedObjectChanges, transposedSectionChanges)
     }
-}
-
-
-// MARK: - Settings
-//
-private struct Settings {
-
-    /// Indicates the maximum number of Tags to retrieve (when in search mode!)
-    ///
-    static let limitForTagResults = 5
 }

--- a/Simplenote/Classes/ResultsController.swift
+++ b/Simplenote/Classes/ResultsController.swift
@@ -25,6 +25,17 @@ class ResultsController<T: NSManagedObject> {
         resultsController.fetchRequest
     }
 
+    /// Limits the number of entries to retrieve
+    ///
+    var limit: Int? {
+        get {
+            fetchRequest.fetchLimit
+        }
+        set {
+            fetchRequest.fetchLimit = newValue ?? .zero
+        }
+    }
+
     /// Filtering Predicate to be applied to the Results.
     ///
     var predicate: NSPredicate? {
@@ -74,7 +85,8 @@ class ResultsController<T: NSManagedObject> {
     init(viewContext: NSManagedObjectContext,
          sectionNameKeyPath: String? = nil,
          matching predicate: NSPredicate? = nil,
-         sortedBy sortDescriptors: [NSSortDescriptor]) {
+         sortedBy sortDescriptors: [NSSortDescriptor],
+         limit: Int = .zero) {
 
         assert(viewContext.concurrencyType == .mainQueueConcurrencyType)
 
@@ -82,6 +94,7 @@ class ResultsController<T: NSManagedObject> {
             let request = NSFetchRequest<T>(entityName: T.entityName)
             request.predicate = predicate
             request.sortDescriptors = sortDescriptors
+            request.fetchLimit = limit
 
             return NSFetchedResultsController<T>(fetchRequest: request,
                                                  managedObjectContext: viewContext,

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -156,7 +156,7 @@ class NotesListControllerTests: XCTestCase {
         XCTAssertEqual(retrievedNote, note)
     }
 
-    /// Verifis that the SEarchMode yields a limited number of Tags
+    /// Verifies that the SearchMode yields a limited number of Tags
     ///
     func testSearchModeReturnsLimitedNumberOfTags() {
         insertSampleEntities(count: 100)

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -156,6 +156,18 @@ class NotesListControllerTests: XCTestCase {
         XCTAssertEqual(retrievedNote, note)
     }
 
+    /// Verifis that the SEarchMode yields a limited number of Tags
+    ///
+    func testSearchModeReturnsLimitedNumberOfTags() {
+        insertSampleEntities(count: 100)
+        storage.save()
+
+        noteListController.beginSearch()
+        noteListController.refreshSearchResults(keyword: "0")
+
+        XCTAssert(noteListController.sections[0].numberOfObjects <= noteListController.limitForTagResults)
+    }
+
 
     // MARK: - Tests: `object(at:)`
 

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -125,14 +125,14 @@ class NotesListControllerTests: XCTestCase {
     /// Verifies that the `endSearch` switches the NotesList back to a single section
     ///
     func testEndSearchSwitchesBackToSingleSectionMode() {
-        let (notes, tags, _) = insertSampleEntities(count: 100)
+        let (notes, _, _) = insertSampleEntities(count: 100)
         storage.save()
 
         XCTAssertEqual(noteListController.numberOfObjects, notes.count)
 
         noteListController.beginSearch()
         noteListController.refreshSearchResults(keyword: "0")
-        XCTAssertEqual(noteListController.numberOfObjects, notes.count + tags.count)
+        XCTAssertEqual(noteListController.numberOfObjects, notes.count + noteListController.limitForTagResults)
 
         noteListController.endSearch()
         XCTAssertEqual(noteListController.numberOfObjects, notes.count)
@@ -184,9 +184,13 @@ class NotesListControllerTests: XCTestCase {
         noteListController.refreshSearchResults(keyword: "0")
 
         for (index, payload) in expected.enumerated() {
-            let tag = noteListController.object(at: IndexPath(row: index, section: 0)) as! Tag
             let note = noteListController.object(at: IndexPath(row: index, section: 1)) as! Note
             XCTAssertEqual(note.content, payload)
+        }
+
+        // We're capping the number of Tags to 5!
+        for (index, payload) in expected.enumerated() where index < noteListController.limitForTagResults {
+            let tag = noteListController.object(at: IndexPath(row: index, section: 0)) as! Tag
             XCTAssertEqual(tag.name, payload)
         }
     }
@@ -234,7 +238,7 @@ class NotesListControllerTests: XCTestCase {
         // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
         noteListController.refreshSearchResults(keyword: "0")
 
-        for (row, tag) in tags.enumerated() {
+        for (row, tag) in tags.enumerated() where row < noteListController.limitForTagResults {
             XCTAssertEqual(noteListController.indexPath(forObject: tag), IndexPath(row: row, section: 0))
         }
 


### PR DESCRIPTION
### Details:
In this PR we're capping the number of Tag results to 5, when in Search Mode.

cc @aerych (Thaaanks!!!)

### Test
1. Log into your account
2. Enter a keyword that yields +5 Tag Results

- [x] Verify that **only** 5 Tag results show up onScreen
- [x] Verify that the (new) Unit Test is green!

### Release
These changes do not require release notes.
