### PR TITLE
Search: Tag Operator

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.16
 -----
 -   Search results now display matching tags!
+-   We're now supporting the `tag:keyword` search operator. Simplenote will yield Notes whose tag names contain such *keyword*.
 
 4.15
 -----

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		B518899E1E0D5EF800E71B83 /* SPContactsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */; };
 		B51889A01E0D5F2200E71B83 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B518899F1E0D5F2200E71B83 /* Contacts.framework */; };
 		B51889A41E0DB01E00E71B83 /* ContactsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B51889A31E0DB01E00E71B83 /* ContactsUI.framework */; };
+		B51D7C7923D9CFA4005D4B77 /* StringSimplenoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51D7C7823D9CFA4005D4B77 /* StringSimplenoteTests.swift */; };
 		B521A1961BC8446900E1CF2A /* SPAutomatticTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = B521A1941BC8446900E1CF2A /* SPAutomatticTracker.m */; };
 		B524AE0F2352BE9200EA11D4 /* UITableView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B524AE0E2352BE9200EA11D4 /* UITableView+Simplenote.swift */; };
 		B524AE112352CC7900EA11D4 /* UIScreen+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B524AE102352CC7900EA11D4 /* UIScreen+Simplenote.swift */; };
@@ -192,6 +193,7 @@
 		B5476BBB23D89B66000E7723 /* SPSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5476BBA23D89B66000E7723 /* SPSectionHeaderView.xib */; };
 		B5476BBD23D8A71D000E7723 /* UIFont+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BBC23D8A71D000E7723 /* UIFont+Simplenote.swift */; };
 		B5476BBF23D8B686000E7723 /* NotesListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BBE23D8B686000E7723 /* NotesListSection.swift */; };
+		B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */; };
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B550F93122BA65CD00091939 /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93022BA65CD00091939 /* ActivityType.swift */; };
 		B550F93322BA6A3300091939 /* ShortcutsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93222BA6A3300091939 /* ShortcutsHandler.swift */; };
@@ -453,6 +455,7 @@
 		B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SPContactsManager.swift; path = Classes/SPContactsManager.swift; sourceTree = "<group>"; };
 		B518899F1E0D5F2200E71B83 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
 		B51889A31E0DB01E00E71B83 /* ContactsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ContactsUI.framework; path = System/Library/Frameworks/ContactsUI.framework; sourceTree = SDKROOT; };
+		B51D7C7823D9CFA4005D4B77 /* StringSimplenoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringSimplenoteTests.swift; sourceTree = "<group>"; };
 		B521A1931BC8446900E1CF2A /* SPAutomatticTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPAutomatticTracker.h; path = Classes/SPAutomatticTracker.h; sourceTree = "<group>"; };
 		B521A1941BC8446900E1CF2A /* SPAutomatticTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPAutomatticTracker.m; path = Classes/SPAutomatticTracker.m; sourceTree = "<group>"; };
 		B524AE0E2352BE9200EA11D4 /* UITableView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITableView+Simplenote.swift"; path = "Classes/UITableView+Simplenote.swift"; sourceTree = "<group>"; };
@@ -501,6 +504,7 @@
 		B5476BBA23D89B66000E7723 /* SPSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSectionHeaderView.xib; path = Classes/SPSectionHeaderView.xib; sourceTree = "<group>"; };
 		B5476BBC23D8A71D000E7723 /* UIFont+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIFont+Simplenote.swift"; path = "Classes/UIFont+Simplenote.swift"; sourceTree = "<group>"; };
 		B5476BBE23D8B686000E7723 /* NotesListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotesListSection.swift; path = Classes/NotesListSection.swift; sourceTree = "<group>"; };
+		B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "String+Simplenote.swift"; path = "Classes/String+Simplenote.swift"; sourceTree = "<group>"; };
 		B55051811A4328B9002A1093 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		B550F93022BA65CD00091939 /* ActivityType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ActivityType.swift; path = Classes/ActivityType.swift; sourceTree = "<group>"; };
 		B550F93222BA6A3300091939 /* ShortcutsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShortcutsHandler.swift; path = Classes/ShortcutsHandler.swift; sourceTree = "<group>"; };
@@ -1033,6 +1037,7 @@
 			isa = PBXGroup;
 			children = (
 				B5B85BA4235173BF00AD5221 /* NSPredicateSimplenoteTests.swift */,
+				B51D7C7823D9CFA4005D4B77 /* StringSimplenoteTests.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1113,6 +1118,7 @@
 				B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */,
 				B5CDE61D2150834C00C3FED4 /* Simperium+Simplenote.h */,
 				B5CDE61E2150834C00C3FED4 /* Simperium+Simplenote.m */,
+				B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */,
 				B50F479E1D1D77FC00822748 /* UIAlertController+Helpers.swift */,
 				B5757367232BED0700443C2E /* UIBezierPath+Simplenote.swift */,
 				B570D2D82360F16F006E1C85 /* UIBlurEffect+Simplenote.swift */,
@@ -2034,6 +2040,7 @@
 				46A3C97417DFA81A002865AE /* SPTransitionSnapshot.m in Sources */,
 				46A3C97717DFA81A002865AE /* SPTagView.m in Sources */,
 				B5AB169822FA124F00B4EBA5 /* SPSheetController.swift in Sources */,
+				B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */,
 				B5DF734222A565DA00602CE7 /* Options.swift in Sources */,
 				B550F93122BA65CD00091939 /* ActivityType.swift in Sources */,
 				46A3C97817DFA81A002865AE /* PersonTag.m in Sources */,
@@ -2188,6 +2195,7 @@
 				B5421F4023CE7A1C004DDC19 /* MockupStorage+Sample.swift in Sources */,
 				B5421F4223CE7A25004DDC19 /* ResultsControllerTests.swift in Sources */,
 				B5B85BA5235173BF00AD5221 /* NSPredicateSimplenoteTests.swift in Sources */,
+				B51D7C7923D9CFA4005D4B77 /* StringSimplenoteTests.swift in Sources */,
 				B5421F4623CE7DEB004DDC19 /* ResultsControllerUIKitTests.swift in Sources */,
 				B5421F3C23CE7A14004DDC19 /* Constants.swift in Sources */,
 				B5421F3F23CE7A1C004DDC19 /* MockupStorage.swift in Sources */,

--- a/Simplenote/Classes/NSPredicate+Simplenote.swift
+++ b/Simplenote/Classes/NSPredicate+Simplenote.swift
@@ -5,12 +5,29 @@ import Foundation
 //
 extension NSPredicate {
 
+    /// `tag:123`: Tag Predicate should ignore this keyword
+    /// Tags should support partial matches
+    ///
+
     /// Returns a collection of NSPredicates that will match, as a compound, a given Search Text
     ///
     @objc(predicateForSearchText:)
     static func predicateForNotes(searchText: String) -> NSPredicate {
-        let words = searchText.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
-        let output = words.map { NSPredicate(format: "content CONTAINS[c] %@", $0) }
+        let keywords = searchText.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
+        var output = [NSPredicate]()
+
+        for keyword in keywords {
+            guard let tag = keyword.lowercased().suffix(afterPrefix: .searchOperatorForTags) else {
+                output.append( NSPredicate(format: "content CONTAINS[c] %@", keyword) )
+                continue
+            }
+
+            guard !tag.isEmpty else {
+                continue
+            }
+
+            output.append( NSPredicate(format: "tags CONTAINS[c] %@", tag) )
+        }
 
         return NSCompoundPredicate(andPredicateWithSubpredicates: output)
     }
@@ -56,10 +73,15 @@ extension NSPredicate {
     }
 
     /// Returns a NSPredicate that will match Tags with a given name
+    /// We'll completely ignore the `tag:` Search Operator, since we're already matching tag names.
     ///
     @objc
     static func predicateForTag(name: String) -> NSPredicate {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = name
+                        .lowercased()
+                        .replacingOccurrences(of: String.searchOperatorForTags, with: " ")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+
         return NSPredicate(format: "name CONTAINS[c] %@", trimmed)
     }
 }

--- a/Simplenote/Classes/NSPredicate+Simplenote.swift
+++ b/Simplenote/Classes/NSPredicate+Simplenote.swift
@@ -5,10 +5,6 @@ import Foundation
 //
 extension NSPredicate {
 
-    /// `tag:123`: Tag Predicate should ignore this keyword
-    /// Tags should support partial matches
-    ///
-
     /// Returns a collection of NSPredicates that will match, as a compound, a given Search Text
     ///
     @objc(predicateForSearchText:)

--- a/Simplenote/Classes/NSPredicate+Simplenote.swift
+++ b/Simplenote/Classes/NSPredicate+Simplenote.swift
@@ -25,6 +25,10 @@ extension NSPredicate {
             output.append( NSPredicate(format: "tags CONTAINS[c] %@", tag) )
         }
 
+        guard !output.isEmpty else {
+            return NSPredicate(value: true)
+        }
+
         return NSCompoundPredicate(andPredicateWithSubpredicates: output)
     }
 

--- a/Simplenote/Classes/NSPredicate+Simplenote.swift
+++ b/Simplenote/Classes/NSPredicate+Simplenote.swift
@@ -12,7 +12,7 @@ extension NSPredicate {
         let keywords = searchText.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
         var output = [NSPredicate]()
 
-        for keyword in keywords {
+        for keyword in keywords where keyword.isEmpty == false {
             guard let tag = keyword.lowercased().suffix(afterPrefix: .searchOperatorForTags) else {
                 output.append( NSPredicate(format: "content CONTAINS[c] %@", keyword) )
                 continue

--- a/Simplenote/Classes/NotesListState.swift
+++ b/Simplenote/Classes/NotesListState.swift
@@ -113,7 +113,7 @@ extension NotesListState {
             return nil
         }
 
-        return NSPredicate.predicateForTag(name: keyword)
+        return NSPredicate.predicateForTag(keyword: keyword)
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -119,6 +119,15 @@ extension SPNoteListViewController {
         title = notesListController.filter.title
     }
 
+    /// Refreshes the SearchBar's Text (and backfires the NoteListController filtering mechanisms!)
+    ///
+    func refreshSearchText(appendFilterFor tag: Tag) {
+        let keyword = String.searchOperatorForTags + tag.name
+        let updated = searchBar.text?.replaceLastWord(with: keyword) ?? keyword
+
+        searchController.updateSearchText(searchText: updated + .space)
+    }
+
     /// Indicates if the Deleted Notes are onScreen
     ///
     @objc
@@ -286,8 +295,8 @@ extension SPNoteListViewController: UITableViewDelegate {
         case let note as Note:
             SPRatingsHelper.sharedInstance()?.incrementSignificantEvent()
             open(note, from: indexPath, animated: true)
-        case _ as Tag:
-            break
+        case let tag as Tag:
+            refreshSearchText(appendFilterFor: tag)
         default:
             break
         }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -329,7 +329,7 @@ private extension SPNoteListViewController {
     ///
     func dequeueAndConfigureCell(for tag: Tag, in tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(ofType: SPTagTableViewCell.self, for: indexPath)
-        cell.titleText = "tag:" + tag.name
+        cell.titleText = String.searchOperatorForTags + tag.name
         return cell
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -6,6 +6,7 @@
 @class SPEmptyListView;
 @class SPBlurEffectView;
 @class NotesListController;
+@class SearchDisplayController;
 
 @interface SPNoteListViewController : UIViewController<SPSidebarContainerDelegate>
 
@@ -13,6 +14,7 @@
 @property (nonatomic, strong, readonly) UISearchBar                         *searchBar;
 @property (nonatomic, strong, readonly) SPEmptyListView                     *emptyListView;
 @property (nonatomic, strong, readonly) UITableView                         *tableView;
+@property (nonatomic, strong, readonly) SearchDisplayController             *searchController;
 @property (nonatomic, strong) NotesListController                           *notesListController;
 @property (nonatomic) CGFloat                                               noteRowHeight;
 @property (nonatomic) CGFloat                                               tagRowHeight;

--- a/Simplenote/Classes/SearchDisplayController.swift
+++ b/Simplenote/Classes/SearchDisplayController.swift
@@ -57,6 +57,13 @@ class SearchDisplayController: NSObject {
         searchBar.resignFirstResponder()
         updateStatus(active: false)
     }
+
+    /// Updates the SearchBar's Text, and notifies the Delegate
+    ///
+    func updateSearchText(searchText: String) {
+        searchBar.text = searchText
+        delegate?.searchDisplayController(self, updateSearchResults: searchText)
+    }
 }
 
 

--- a/Simplenote/Classes/SearchDisplayController.swift
+++ b/Simplenote/Classes/SearchDisplayController.swift
@@ -75,6 +75,7 @@ private extension SearchDisplayController {
         searchBar.delegate = self
         searchBar.placeholder = NSLocalizedString("Search", comment: "Search Placeholder")
         searchBar.searchBarStyle = .minimal
+        searchBar.autocapitalizationType = .none
         searchBar.sizeToFit()
     }
 

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -7,7 +7,7 @@ extension String {
 
     /// Returns the Search Operator we should recognize, when filtering out entities with a given Tag
     ///
-    static let searchOperatorForTags = "tag:"
+    static let searchOperatorForTags = NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!")
 
 
     /// Returns the Suffix string after a given `prefix` (if any!)

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -9,6 +9,10 @@ extension String {
     ///
     static let searchOperatorForTags = NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!")
 
+    /// String containing a Space
+    ///
+    static let space = " "
+
 
     /// Returns the Suffix string after a given `prefix` (if any!)
     ///
@@ -18,5 +22,14 @@ extension String {
         }
 
         return String(dropFirst(prefix.count))
+    }
+
+    /// Replaces the last word in the receiver (tokens are separated by whitespaces)
+    ///
+    func replaceLastWord(with word: String) -> String {
+        var words = components(separatedBy: .whitespaces).dropLast()
+        words.append(word)
+
+        return words.joined(separator: .space)
     }
 }

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+
+// MARK: - String
+//
+extension String {
+
+    /// Returns the Search Operator we should recognize, when filtering out entities with a given Tag
+    ///
+    static let searchOperatorForTags = "tag:"
+
+
+    /// Returns the Suffix string after a given `prefix` (if any!)
+    ///
+    func suffix(afterPrefix prefix: String) -> String? {
+        guard hasPrefix(prefix), count > prefix.count else {
+            return nil
+        }
+
+        return String(dropFirst(prefix.count))
+    }
+}

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -13,7 +13,7 @@ extension String {
     /// Returns the Suffix string after a given `prefix` (if any!)
     ///
     func suffix(afterPrefix prefix: String) -> String? {
-        guard hasPrefix(prefix), count > prefix.count else {
+        guard hasPrefix(prefix), count >= prefix.count else {
             return nil
         }
 

--- a/SimplenoteTests/NSPredicateSimplenoteTests.swift
+++ b/SimplenoteTests/NSPredicateSimplenoteTests.swift
@@ -212,33 +212,61 @@ class NSPredicateSimplenoteTests: XCTestCase {
         XCTAssertFalse(NSPredicate.predicateForUntaggedNotes().evaluate(with: entity))
     }
 
-    /// Verifies that `NSPredicate.predicateForTag(name:)` matches Tags with names containing the specified name (partially or fully)
+    /// Verifies that `NSPredicate.predicateForTag(keyword:)` matches Tags with names containing the specified name (Partially)
     ///
-    func testPredicateForTagWithNameMatchesEntitiesWithTheTargetName() {
+    func testPredicateForTagWithKeywordPerformsPartialMatches() {
         let entity = MockupTag()
         entity.name = "123456789"
-        XCTAssertTrue(NSPredicate.predicateForTag(name: entity.name!).evaluate(with: entity))
-        XCTAssertTrue(NSPredicate.predicateForTag(name: "45").evaluate(with: entity))
-        XCTAssertTrue(NSPredicate.predicateForTag(name: "tag:45").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "45").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:45").evaluate(with: entity))
     }
 
-    /// Verifies that `NSPredicate.predicateForTag(name:)` will match Tags that contain a given string
+    /// Verifies that `NSPredicate.predicateForTag(keyword:)` will ignore exact matches
     ///
-    func testPredicateForTagWithNameCompletelyIgnoresSearchTagOperator() {
+    func testPredicateForTagWithKeywordCompletelyIgnoresExactTagMatches() {
         let entity = MockupTag()
         entity.name = "123456789"
-        XCTAssertTrue(NSPredicate.predicateForTag(name: "tag:123456789").evaluate(with: entity))
-        XCTAssertTrue(NSPredicate.predicateForTag(name: "TAG:123456789").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "tag:123456789").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "TAG:123456789").evaluate(with: entity))
     }
 
-    /// Verifies that `NSPredicate.predicateForTag(name:)` won't match Tags that don't contain a given string
+    /// Verifies that `NSPredicate.predicateForTag(keyword:)` won't match Tags that don't contain a given string
     ///
-    func testPredicateForTagWithNameWontMatcheEntitiesWithoutTheTargetName() {
+    func testPredicateForTagWithNameWontMatchEntitiesWithoutTheTargetName() {
         let entity = MockupTag()
         entity.name = "123456789"
-        XCTAssertFalse(NSPredicate.predicateForTag(name: "0").evaluate(with: entity))
-        XCTAssertFalse(NSPredicate.predicateForTag(name: "tag:0").evaluate(with: entity))
-        XCTAssertFalse(NSPredicate.predicateForTag(name: "TaG:0").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "0").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "tag:0").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "TaG:0").evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForTag(keyword:)` only performs lookup OPs over the last keyword
+    ///
+    func testPredicateForTagWithKeywordIsOnlyInterestedInTheLastKeyword() {
+        let entity = MockupTag()
+        entity.name = "123456789"
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: entity.name!).evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "ignored alsoIgnored 45").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "ignored alsoIgnored tag:45").evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForTag(keyword:)` matches Tags with names containing the full keyword (whenever there is no Tag Operator)
+    ///
+    func testPredicateForTagWithKeywordPerformsFullMatchesWhenThereIsNoTagOperator() {
+        let entity = MockupTag()
+        entity.name = "123456789"
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "123456789").evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForTag(keyword:)` matches *everything* whenever the `tag:` operator has no payload
+    ///
+    func testPredicateForTagWithKeywordMatchesEverythingWheneverSearchTagOperatorHasNoPayload() {
+        let entity = MockupTag()
+        entity.name = nil
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:").evaluate(with: entity))
+
+        entity.name = "whatever"
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:").evaluate(with: entity))
     }
 }
 

--- a/SimplenoteTests/NSPredicateSimplenoteTests.swift
+++ b/SimplenoteTests/NSPredicateSimplenoteTests.swift
@@ -17,6 +17,16 @@ class NSPredicateSimplenoteTests: XCTestCase {
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` ignores spaces between keywords
+    ///
+    func testPredicateForNotesWithSearchTextIgnoresEmptySpacesInBetweenKeywords() {
+        let entity = MockupNote()
+        entity.content = "first second"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "    first       second")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` produces one subpredicate per word, and disregards newlines and spaces
     ///
     func testPredicateForNotesWithSearchTextProducesOnePredicatePerWordAndDisregardNewlinesAndSpaces() {

--- a/SimplenoteTests/NSPredicateSimplenoteTests.swift
+++ b/SimplenoteTests/NSPredicateSimplenoteTests.swift
@@ -9,7 +9,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
 
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` match entities that contain a single specified keyword
     ///
-    func testPredicatesForNotesWithSearchTextMatchesNotesContainingTheSpecifiedKeyword() {
+    func testPredicateForNotesWithSearchTextMatchesNotesContainingTheSpecifiedKeyword() {
         let entity = MockupNote()
         entity.content = "some content here and maybe a keyword"
 
@@ -19,7 +19,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
 
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` produces one subpredicate per word, and disregards newlines and spaces
     ///
-    func testPredicatesForNotesWithSearchTextProducesOnePredicatePerWordAndDisregardNewlinesAndSpaces() {
+    func testPredicateForNotesWithSearchTextProducesOnePredicatePerWordAndDisregardNewlinesAndSpaces() {
         let keyword = "     lots of empty spaces   \n   \n  "
         let numberOfWords = 4
         let predicate = NSPredicate.predicateForNotes(searchText: keyword) as! NSCompoundPredicate
@@ -29,7 +29,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
 
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` match entities that contain multiple specified keywords
     ///
-    func testPredicatesForNotesWithSearchTextMatchesNotesContainingMultipleSpecifiedKeywords() {
+    func testPredicateForNotesWithSearchTextMatchesNotesContainingMultipleSpecifiedKeywords() {
         let entity = MockupNote()
         entity.content = "some keyword1 here and maybe another keyword2 there"
 
@@ -39,12 +39,74 @@ class NSPredicateSimplenoteTests: XCTestCase {
 
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` won't match entities that dont contain a given searchText
     ///
-    func testPredicatesForNotesWithSearchTextWontMatchNotesContainingTheSpecifiedKeywords() {
+    func testPredicateForNotesWithSearchTextWontMatchNotesContainingTheSpecifiedKeywords() {
         let entity = MockupNote()
         entity.content = "some content here and maybe a keyword"
 
         let predicate = NSPredicate.predicateForNotes(searchText: "missing")
         XCTAssertFalse(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` will not match entities that lack a given `tag:`
+    ///
+    func testPredicateForNotesWithSearchTextDoesntMatchNoteWithoutSpecifiedTag() {
+        let entity = MockupNote()
+        entity.content = "keyword"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword")
+        XCTAssertFalse(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` will  match entities whenever the `tag:` operator has no actual payload
+    ///
+    func testPredicateForNotesWithSearchTextMatchesNoteWheneverTagPayloadIsEmpty() {
+        let entity = MockupNote()
+        entity.tags = "[ 'keyword' ]"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` will  match entities that contain a given `tag:`
+    ///
+    func testPredicateForNotesWithSearchTextMatchesNoteWithSpecifiedTag() {
+        let entity = MockupNote()
+        entity.tags = "[ 'keyword' ]"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` will  match entities that contain a partial match with the `tag:` operator
+    ///
+    func testPredicateForNotesWithSearchTextMatchesNoteWithSpecifiedPartialTag() {
+        let entity = MockupNote()
+        entity.tags = "[ 'keyword' ]"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:word")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` will not match entities that do contain a given `tag:`, but lack the target content
+    ///
+    func testPredicateForNotesWithSearchTextWillNotMatchEntityWithoutTargetContentEvenWhenTheSpecifiedTagIsThere() {
+        let entity = MockupNote()
+        entity.content = "unmatched"
+        entity.tags = "[ 'keyword' ]"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword else")
+        XCTAssertFalse(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForNotes(searchText:)` will match entities that do contain a given `tag:` and a given content
+    ///
+    func testPredicateForNotesWithSearchTextWillMatchEntityWithTargetContentAndTag() {
+        let entity = MockupNote()
+        entity.content = "something else"
+        entity.tags = "[ 'keyword' ]"
+
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword else something")
+        XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForNotes(deleted:)` matches notes with a Deleted status
@@ -157,6 +219,16 @@ class NSPredicateSimplenoteTests: XCTestCase {
         entity.name = "123456789"
         XCTAssertTrue(NSPredicate.predicateForTag(name: entity.name!).evaluate(with: entity))
         XCTAssertTrue(NSPredicate.predicateForTag(name: "45").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(name: "tag:45").evaluate(with: entity))
+    }
+
+    /// Verifies that `NSPredicate.predicateForTag(name:)` will match Tags that contain a given string
+    ///
+    func testPredicateForTagWithNameCompletelyIgnoresSearchTagOperator() {
+        let entity = MockupTag()
+        entity.name = "123456789"
+        XCTAssertTrue(NSPredicate.predicateForTag(name: "tag:123456789").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(name: "TAG:123456789").evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForTag(name:)` won't match Tags that don't contain a given string
@@ -165,6 +237,8 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupTag()
         entity.name = "123456789"
         XCTAssertFalse(NSPredicate.predicateForTag(name: "0").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(name: "tag:0").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(name: "TaG:0").evaluate(with: entity))
     }
 }
 

--- a/SimplenoteTests/StringSimplenoteTests.swift
+++ b/SimplenoteTests/StringSimplenoteTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Simplenote
+
+
+// MARK: - String Simplenote Unit Tests
+//
+class StringSimplenoteTests: XCTestCase {
+
+    /// Verifies that Suffix after Prefix returns nil, whenever such prefix isn't to be found
+    ///
+    func testSuffixAfterPrefixReturnsNilWheneverTheInputStringLacksSuchPrefix() {
+        let sample = "This is a sample of some random string without the tag operator"
+        XCTAssertNil(sample.suffix(afterPrefix: .searchOperatorForTags))
+    }
+
+    /// Verifies that Suffix after Prefix returns an empty string, whenever there is no actual Payload
+    ///
+    func testSuffixAfterPrefixReturnsNilWheneverTheTagSearchOperatorHasAnEmptyKeyword() {
+        let sample = String.searchOperatorForTags
+        XCTAssertNil(sample.suffix(afterPrefix: .searchOperatorForTags))
+    }
+
+    /// Verifies that Suffix after Prefix returns the payload right after the first occurrence of such suffix
+    ///
+    func testSuffixAfterPrefixReturnsTheRightHandSideStringAfterTheTagSearchOperator() {
+        let expected = "somenameforatag"
+        let sample = String.searchOperatorForTags + expected
+
+        XCTAssertEqual(sample.suffix(afterPrefix: .searchOperatorForTags), expected)
+    }
+}

--- a/SimplenoteTests/StringSimplenoteTests.swift
+++ b/SimplenoteTests/StringSimplenoteTests.swift
@@ -28,4 +28,29 @@ class StringSimplenoteTests: XCTestCase {
 
         XCTAssertEqual(sample.suffix(afterPrefix: .searchOperatorForTags), expected)
     }
+
+    /// Verifies that `replaceLastWord(:)` returns the new word, whenever the receiver was empty
+    ///
+    func testReplaceLastWordReturnsJustTheNewWordWheneverTheReceiverWasEmpty() {
+        let expected = "something"
+        XCTAssertEqual("".replaceLastWord(with: expected), expected)
+    }
+
+    /// Verifies that `replaceLastWord(:)` effectively swaps the last word in the receiver
+    ///
+    func testReplaceLastWordEffectivelySwapsTheLastWordInTheReceiver() {
+        let text = "one two"
+        let word = "something"
+        let expected = "one something"
+        XCTAssertEqual(text.replaceLastWord(with: word), expected)
+    }
+
+    /// Verifies that `replaceLastWord(:)` appends the new word whenever the receiver ends up in a space
+    ///
+    func testReplaceLastWordAppendsNewKeywordWheneverTheReceiverEndsInSpace() {
+        let text = "one "
+        let word = "something"
+        let expected = "one something"
+        XCTAssertEqual(text.replaceLastWord(with: word), expected)
+    }
 }

--- a/SimplenoteTests/StringSimplenoteTests.swift
+++ b/SimplenoteTests/StringSimplenoteTests.swift
@@ -17,7 +17,7 @@ class StringSimplenoteTests: XCTestCase {
     ///
     func testSuffixAfterPrefixReturnsNilWheneverTheTagSearchOperatorHasAnEmptyKeyword() {
         let sample = String.searchOperatorForTags
-        XCTAssertNil(sample.suffix(afterPrefix: .searchOperatorForTags))
+        XCTAssertEqual(sample.suffix(afterPrefix: .searchOperatorForTags), "")
     }
 
     /// Verifies that Suffix after Prefix returns the payload right after the first occurrence of such suffix


### PR DESCRIPTION
### Details:
This PR is all about supporting the **tag:** operator:

- Whenever the Search Text contains the `tag:keyword`, we'll filter out notes with tags whose names contain `keyword`
- Pressing Tag Results now updates the Search Text. We're always replacing the last word, with whatever **tag** the user entered
- And we definitely added **a ton** of new Unit Tests added

@bummytime incoming FUN pr!!!

Ref. #507 
Closes #57

### Scenario: Tag Filtering
1. Log into your account
2. Make sure you've got at least 3 tags
3. Press over the Search Bar
4. Enter `something else [VALID_TAG_SUBSTRING]` (Where only the last word is a partial match of a valid tag name)

- [x] Verify that Tags whose names match the last word do show up onScreen
- [x] Repeat the same test, but in (4) enter `one two tag:[VALID_TAG_SUBSTRING]`

### Scenario: Excluding Exact Matches
1. Log into your account
2. Make sure you've got at least one tag
3. Press over the Search Bar
4. Enter `tag:VALID_TAG_NAME` (with **VALID_TAG_NAME** being a full tag name)

- [x] Verify that such tag (VALID_TAG_NAME_ is excluded from the results

### Scenario: Pressing Tag Results (No Spaces)
1. Log into your account
2. Make sure you've got at least one tag
3. Press over the Search Bar
4. Enter a keyword that yields multiple Tag Results
5. Make sure there is no space after the keyword

- [x] Verify that pressing over any of the Tag Results replaces the `keyword` with the `tag:xxx` you've pressed in (5)
- [x] Verify that the Search Results are updated accordingly!

### Scenario: Pressing Tag Results (Space!)
1. Log into your account
2. Make sure you've got at least one tag
3. Press over the Search Bar
4. Enter a keyword that yields multiple Tag Results
5. Make sure to leave a space right after the keyword

- [x] Verify that pressing over any of the Tag Results simply gets the `tag:xxx` appended to the search text
- [x] Verify that the Search Results are updated accordingly!

### Release
`RELEASE-NOTES.txt` was updated in 73f9924 with:

> We're now supporting the `tag:keyword` search operator. Simplenote will yield Notes whose tag names contain such *keyword*.