### PR TITLE
Disabling custom transitions: Part 1

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -439,7 +439,6 @@
 
     BOOL disableCustomTransition = UIAccessibilityIsVoiceOverRunning() || self.isSearchActive;
     self.navigationController.delegate = disableCustomTransition ? nil : self.transitionController;
-    editor.transitioningDelegate = disableCustomTransition ? nil : self.transitionController;
 
     [editor updateNote:note];
 
@@ -641,11 +640,7 @@
 - (void)didReceiveVoiceoverNotification:(NSNotification *)notification {
     
     BOOL isVoiceOverRunning = UIAccessibilityIsVoiceOverRunning();
-    self.navigationController.delegate = isVoiceOverRunning ? nil : self.transitionController;
-	
-	SPNoteEditorViewController *editor = [[SPAppDelegate sharedDelegate] noteEditorViewController];
-    editor.transitioningDelegate = isVoiceOverRunning ? nil : self.transitionController;
-    
+    self.navigationController.delegate = isVoiceOverRunning ? nil : self.transitionController;    
 }
 
 #pragma mark - SPTransitionDelegate

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -135,11 +135,8 @@
         return;
     }
 
-    NSAssert(self.tableView != nil, @"tableView should be initialized before this method runs");
     NSAssert(self.navigationController != nil, @"we should be already living within a navigationController before this method can be called");
-
-    self.transitionController = [[SPTransitionController alloc] initWithTableView:self.tableView navigationController:self.navigationController];
-    self.transitionController.delegate = self;
+    self.transitionController = [[SPTransitionController alloc] initWithNavigationController:self.navigationController];
 }
 
 - (void)updateRowHeight
@@ -640,7 +637,7 @@
 - (void)didReceiveVoiceoverNotification:(NSNotification *)notification {
     
     BOOL isVoiceOverRunning = UIAccessibilityIsVoiceOverRunning();
-    self.navigationController.delegate = isVoiceOverRunning ? nil : self.transitionController;    
+    self.navigationController.delegate = isVoiceOverRunning ? nil : self.transitionController;
 }
 
 #pragma mark - SPTransitionDelegate

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -28,8 +28,7 @@
 #import "Simplenote-Swift.h"
 
 
-@interface SPNoteListViewController () <UITableViewDelegate,
-                                        UITextFieldDelegate,
+@interface SPNoteListViewController () <UITextFieldDelegate,
                                         SearchDisplayControllerDelegate,
                                         SearchControllerPresentationContextProvider,
                                         SPRatingsPromptDelegate>
@@ -441,7 +440,7 @@
     if (self.isSearchActive) {
         [editor setSearchString:self.searchText];
     }
-    
+
     // Failsafe:
     // We were getting (a whole lot!) of crash reports with the exception
     // 'Pushing the same view controller instance more than once is not supported'. This is intended to act

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -442,8 +442,6 @@
         [editor setSearchString:self.searchText];
     }
     
-    self.transitionController.selectedPath = indexPath;
-    
     // Failsafe:
     // We were getting (a whole lot!) of crash reports with the exception
     // 'Pushing the same view controller instance more than once is not supported'. This is intended to act

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -32,7 +32,6 @@
                                         UITextFieldDelegate,
                                         SearchDisplayControllerDelegate,
                                         SearchControllerPresentationContextProvider,
-                                        SPTransitionControllerDelegate,
                                         SPRatingsPromptDelegate>
 
 @property (nonatomic, strong) NSTimer                               *searchTimer;
@@ -640,12 +639,6 @@
     self.navigationController.delegate = isVoiceOverRunning ? nil : self.transitionController;
 }
 
-#pragma mark - SPTransitionDelegate
-
-- (void)interactionBegan {
-    
-    [self.navigationController popViewControllerAnimated:YES];
-}
 
 #pragma mark - Keyboard
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -135,6 +135,7 @@
 
     NSAssert(self.navigationController != nil, @"we should be already living within a navigationController before this method can be called");
     self.transitionController = [[SPTransitionController alloc] initWithNavigationController:self.navigationController];
+    self.navigationController.delegate = self.transitionController;
 }
 
 - (void)updateRowHeight

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -193,9 +193,6 @@
     [nc addObserver:self selector:@selector(condensedPreferenceWasUpdated:) name:SPCondensedNoteListPreferenceChangedNotification object:nil];
     [nc addObserver:self selector:@selector(sortOrderPreferenceWasUpdated:) name:SPNotesListSortModeChangedNotification object:nil];
 
-    // Voiceover status is tracked because the custom animated transition is not used when enabled
-    [nc addObserver:self selector:@selector(didReceiveVoiceoverNotification:) name:UIAccessibilityVoiceOverStatusDidChangeNotification object:nil];
-
     // Register for keyboard notifications
     [nc addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [nc addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
@@ -432,9 +429,6 @@
 
     SPNoteEditorViewController *editor = [[SPAppDelegate sharedDelegate] noteEditorViewController];
 
-    BOOL disableCustomTransition = UIAccessibilityIsVoiceOverRunning() || self.isSearchActive;
-    self.navigationController.delegate = disableCustomTransition ? nil : self.transitionController;
-
     [editor updateNote:note];
 
     if (self.isSearchActive) {
@@ -625,15 +619,6 @@
         self.bResetTitleView = NO;
         [self.activityIndicator stopAnimating];
     }];
-}
-
-
-#pragma mark - VoiceOver
-
-- (void)didReceiveVoiceoverNotification:(NSNotification *)notification {
-    
-    BOOL isVoiceOverRunning = UIAccessibilityIsVoiceOverRunning();
-    self.navigationController.delegate = isVoiceOverRunning ? nil : self.transitionController;
 }
 
 

--- a/Simplenote/Classes/SPTransitionController.h
+++ b/Simplenote/Classes/SPTransitionController.h
@@ -7,7 +7,7 @@ extern NSString *const SPTransitionControllerPopGestureTriggeredNotificationName
 - (void)interactionBegan;
 @end
 
-@interface SPTransitionController : NSObject <UIViewControllerTransitioningDelegate, UINavigationControllerDelegate>
+@interface SPTransitionController : NSObject <UINavigationControllerDelegate>
 
 @property (nonatomic) id <SPTransitionControllerDelegate> delegate;
 @property (nonatomic) BOOL transitioning;

--- a/Simplenote/Classes/SPTransitionController.h
+++ b/Simplenote/Classes/SPTransitionController.h
@@ -17,7 +17,6 @@ extern NSString *const SPTransitionControllerPopGestureTriggeredNotificationName
 
 @property (nonatomic) NSIndexPath *selectedPath;
 
-- (instancetype)initWithTableView:(UITableView *)tableView
-             navigationController:(UINavigationController *)navigationController;
+- (instancetype)initWithNavigationController:(UINavigationController *)navigationController;
 
 @end

--- a/Simplenote/Classes/SPTransitionController.h
+++ b/Simplenote/Classes/SPTransitionController.h
@@ -6,13 +6,6 @@ extern NSString *const SPTransitionControllerPopGestureTriggeredNotificationName
 
 @interface SPTransitionController : NSObject <UINavigationControllerDelegate>
 
-@property (nonatomic) BOOL transitioning;
-@property (nonatomic) BOOL hasActiveInteraction;
-@property (nonatomic) UINavigationControllerOperation navigationOperation;
-@property (nonatomic) UITableView *tableView;
-
-@property (nonatomic) NSIndexPath *selectedPath;
-
 - (instancetype)initWithNavigationController:(UINavigationController *)navigationController;
 
 @end

--- a/Simplenote/Classes/SPTransitionController.h
+++ b/Simplenote/Classes/SPTransitionController.h
@@ -3,13 +3,9 @@
 
 extern NSString *const SPTransitionControllerPopGestureTriggeredNotificationName;
 
-@protocol SPTransitionControllerDelegate <NSObject>
-- (void)interactionBegan;
-@end
 
 @interface SPTransitionController : NSObject <UINavigationControllerDelegate>
 
-@property (nonatomic) id <SPTransitionControllerDelegate> delegate;
 @property (nonatomic) BOOL transitioning;
 @property (nonatomic) BOOL hasActiveInteraction;
 @property (nonatomic) UINavigationControllerOperation navigationOperation;

--- a/Simplenote/Classes/SPTransitionController.h
+++ b/Simplenote/Classes/SPTransitionController.h
@@ -7,7 +7,7 @@ extern NSString *const SPTransitionControllerPopGestureTriggeredNotificationName
 - (void)interactionBegan;
 @end
 
-@interface SPTransitionController : NSObject <UIViewControllerAnimatedTransitioning, UIViewControllerInteractiveTransitioning, UIViewControllerTransitioningDelegate, UINavigationControllerDelegate>
+@interface SPTransitionController : NSObject <UIViewControllerTransitioningDelegate, UINavigationControllerDelegate>
 
 @property (nonatomic) id <SPTransitionControllerDelegate> delegate;
 @property (nonatomic) BOOL transitioning;

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -55,7 +55,6 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 
 @interface SPTransitionController () <UIGestureRecognizerDelegate>
 
-@property (nonatomic, strong) SnapshotRenderer                          *renderer;
 @property (nonatomic, strong) SPInteractivePushPopAnimationController   *pushPopAnimationController;
 @property (nonatomic, weak) UINavigationController                      *navigationController;
 @property (nonatomic, strong) NSMutableArray                            *temporaryTransitionViews;
@@ -71,7 +70,6 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     self = [super init];
     if (self) {
         self.tableView = tableView;
-        self.renderer = [SnapshotRenderer new];
         self.useCount = 0;
         
         if ([UIDevice isPad]) {

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -730,12 +730,9 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     // We only want to handle the Editor > List transition with a custom transition, so if
     // there's anything other than the List view on the top of the stack, we'll let the OS handle it.
     BOOL isTransitioningToList = [self.navigationController.topViewController isKindOfClass:[SPNoteListViewController class]];
-    
     if (isTransitioningToList && sender.state == UIGestureRecognizerStateBegan) {
         [self postPopGestureNotification];
     }
-    
-    return;
 }
 
 - (void)handlePinch:(UIPinchGestureRecognizer*)sender
@@ -746,8 +743,6 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 
         [self postPopGestureNotification];
     }
-    
-    return;
 }
 
 - (void)postPopGestureNotification

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -38,24 +38,17 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 #pragma mark - Private Properties
 
 @interface SPTransitionController () <UIGestureRecognizerDelegate>
-
 @property (nonatomic, strong) SPInteractivePushPopAnimationController   *pushPopAnimationController;
 @property (nonatomic, weak) UINavigationController                      *navigationController;
-@property (nonatomic, strong) NSMutableArray                            *temporaryTransitionViews;
-@property (nonatomic) id<UIViewControllerContextTransitioning>          context;
-@property (nonatomic) CGFloat                                           percentComplete;
-@property (nonatomic) NSInteger                                         useCount;
-
 @end
+
 
 @implementation SPTransitionController
 
 - (instancetype)initWithNavigationController:(UINavigationController *)navigationController
 {
     self = [super init];
-    if (self) {
-        self.useCount = 0;
-        
+    if (self) {        
         if ([UIDevice isPad]) {
             UIPinchGestureRecognizer *pinchGesture = [[UIPinchGestureRecognizer alloc] initWithTarget:self
                                                                                                action:@selector(handlePinch:)];
@@ -109,10 +102,10 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     return self.pushPopAnimationController;
 }
 
-- (id <UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController
+- (id<UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController
                           interactionControllerForAnimationController:(id <UIViewControllerAnimatedTransitioning>) animationController
 {
-    if (self.hasActiveInteraction) {
+    if (animationController != self.pushPopAnimationController) {
         return nil;
     }
 
@@ -737,7 +730,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     // there's anything other than the List view on the top of the stack, we'll let the OS handle it.
     BOOL isTransitioningToList = [self.navigationController.topViewController isKindOfClass:[SPNoteListViewController class]];
     
-    if (isTransitioningToList && !_transitioning && sender.state == UIGestureRecognizerStateBegan) {
+    if (isTransitioningToList && sender.state == UIGestureRecognizerStateBegan) {
         [self postPopGestureNotification];
     }
     
@@ -746,8 +739,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 
 - (void)handlePinch:(UIPinchGestureRecognizer*)sender {
 
-    if (!_transitioning &&
-        sender.numberOfTouches >= 2 && // require two fingers
+    if (sender.numberOfTouches >= 2 && // require two fingers
         sender.scale < 1.0 && // pinch in
         sender.state == UIGestureRecognizerStateBegan) {
 

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -723,8 +723,8 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 
 #pragma mark - Gesture Recognizers
 
-- (void)handlePan:(UIPanGestureRecognizer *)sender {
-
+- (void)handlePan:(UIPanGestureRecognizer *)sender
+{
     // By the time this method is called, the existing topViewController has been popped –
     // so topViewController contains the view we are transitioning *to*.
     // We only want to handle the Editor > List transition with a custom transition, so if
@@ -738,8 +738,8 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     return;
 }
 
-- (void)handlePinch:(UIPinchGestureRecognizer*)sender {
-
+- (void)handlePinch:(UIPinchGestureRecognizer*)sender
+{
     if (sender.numberOfTouches >= 2 && // require two fingers
         sender.scale < 1.0 && // pinch in
         sender.state == UIGestureRecognizerStateBegan) {
@@ -750,8 +750,8 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     return;
 }
 
-- (void)postPopGestureNotification {
-    
+- (void)postPopGestureNotification
+{
     [[NSNotificationCenter defaultCenter] postNotificationName:SPTransitionControllerPopGestureTriggeredNotificationName
                                                         object:self];
 }

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -89,8 +89,8 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 - (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController
                                   animationControllerForOperation:(UINavigationControllerOperation)operation
                                                fromViewController:(UIViewController *)fromVC
-                                                 toViewController:(UIViewController *)toVC {
-    
+                                                 toViewController:(UIViewController *)toVC
+{    
     BOOL navigatingToMarkdownPreview = [fromVC isKindOfClass:[SPMarkdownPreviewViewController class]];
     if (!navigatingToMarkdownPreview) {
         return nil;

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -1,24 +1,8 @@
-#import <CoreGraphics/CoreGraphics.h>
 #import "Simplenote-Swift.h"
 
-#import "SPTransitionController.h"
-#import "SPAppDelegate.h"
-#import "VSThemeManager.h"
-#import "Note.h"
-#import "SPMarkdownPreviewViewController.h"
-#import "SPTextView.h"
-#import "SPEditorTextView.h"
-#import "NSMutableAttributedString+Styling.h"
-#import "SPTransitionSnapshot.h"
-#import "SPTextView.h"
-#import "SPInteractiveTextStorage.h"
-#import "NSString+Search.h"
-#import "NSTextStorage+Highlight.h"
-#import "NSString+Attributed.h"
-#import "UIImage+Colorization.h"
-#import "SPEmptyListView.h"
 #import "UIDevice+Extensions.h"
-#import "VSTheme+Extensions.h"
+#import "SPTransitionController.h"
+#import "SPMarkdownPreviewViewController.h"
 #import "SPInteractivePushPopAnimationController.h"
 
 

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -92,7 +92,6 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
                                                  toViewController:(UIViewController *)toVC {
     
     BOOL navigatingToMarkdownPreview = [fromVC isKindOfClass:[SPMarkdownPreviewViewController class]];
-
     if (!navigatingToMarkdownPreview) {
         return nil;
     }

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -3,10 +3,9 @@
 
 #import "SPTransitionController.h"
 #import "SPAppDelegate.h"
-#import "SPNoteEditorViewController.h"
 #import "VSThemeManager.h"
 #import "Note.h"
-#import "SPNoteListViewController.h"
+#import "SPMarkdownPreviewViewController.h"
 #import "SPTextView.h"
 #import "SPEditorTextView.h"
 #import "NSMutableAttributedString+Styling.h"
@@ -118,29 +117,21 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
                                                fromViewController:(UIViewController *)fromVC
                                                  toViewController:(UIViewController *)toVC {
     
-    BOOL navigatingFromListToEditor = [fromVC isKindOfClass:[SPNoteListViewController class]] &&
-                                      [toVC isKindOfClass:[SPNoteEditorViewController class]];
-    BOOL navigatingFromEditorToList = [fromVC isKindOfClass:[SPNoteEditorViewController class]] &&
-                                      [toVC isKindOfClass:[SPNoteListViewController class]];
+    BOOL navigatingToMarkdownPreview = [fromVC isKindOfClass:[SPMarkdownPreviewViewController class]];
 
-    if (navigatingFromListToEditor || navigatingFromEditorToList) {
-        // return self since ViewController adopts UIViewControllerAnimatedTransitioningProtocal
-        self.navigationOperation = operation;
-        return self;
-    } else {
-        self.pushPopAnimationController.navigationOperation = operation;
-
-        return self.pushPopAnimationController;
+    if (!navigatingToMarkdownPreview) {
+        return nil;
     }
 
-    return nil;
+    self.pushPopAnimationController.navigationOperation = operation;
+    return self.pushPopAnimationController;
 }
 
 - (id <UIViewControllerInteractiveTransitioning>)navigationController:(UINavigationController *)navigationController
                           interactionControllerForAnimationController:(id <UIViewControllerAnimatedTransitioning>) animationController
 {
     if (self.hasActiveInteraction) {
-        return self;
+        return nil;
     }
 
     return self.pushPopAnimationController.interactiveTransition;

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -83,7 +83,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 }
 */
 
-#pragma mark UINavigationControllerDelegate methods — Supporting Custom Transition Animations
+#pragma mark - UINavigationControllerDelegate
 
 
 - (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController
@@ -719,6 +719,9 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 }
 
  */
+
+
+#pragma mark - Gesture Recognizers
 
 - (void)handlePan:(UIPanGestureRecognizer *)sender {
 

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -66,10 +66,10 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 
 @implementation SPTransitionController
 
-- (instancetype)initWithTableView:(UITableView *)tableView navigationController:(UINavigationController *)navigationController {
+- (instancetype)initWithNavigationController:(UINavigationController *)navigationController
+{
     self = [super init];
     if (self) {
-        self.tableView = tableView;
         self.useCount = 0;
         
         if ([UIDevice isPad]) {

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -95,7 +95,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     return self;
 }
 
-
+/*
 #pragma mark UIViewControllerTransitioningDelegate methods — Supporting Custom Transition Animations
 
 - (id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented presentingController:(UIViewController *)presenting sourceController:(UIViewController *)source {
@@ -107,7 +107,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     
     return self;
 }
-
+*/
 
 #pragma mark UINavigationControllerDelegate methods — Supporting Custom Transition Animations
 

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -6,9 +6,9 @@
 #import "SPInteractivePushPopAnimationController.h"
 
 
+/*
 #define kEditorTransitionOffset 8
 
-/*
 #pragma mark - Constants
 
 static const CGFloat SPAnimationPushTableViewRowSelectionDuration = 0.55;
@@ -39,7 +39,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 
 @interface SPTransitionController () <UIGestureRecognizerDelegate>
 @property (nonatomic, strong) SPInteractivePushPopAnimationController   *pushPopAnimationController;
-@property (nonatomic, weak) UINavigationController                      *navigationController;
+@property (nonatomic,   weak) UINavigationController                    *navigationController;
 @end
 
 
@@ -48,12 +48,11 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 - (instancetype)initWithNavigationController:(UINavigationController *)navigationController
 {
     self = [super init];
-    if (self) {        
+    if (self) {
         if ([UIDevice isPad]) {
             UIPinchGestureRecognizer *pinchGesture = [[UIPinchGestureRecognizer alloc] initWithTarget:self
                                                                                                action:@selector(handlePinch:)];
             [navigationController.view addGestureRecognizer:pinchGesture];
-
         }
 
         // Note:

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -25,7 +25,7 @@
 
 #define kEditorTransitionOffset 8
 
-
+/*
 #pragma mark - Constants
 
 static const CGFloat SPAnimationPushTableViewRowSelectionDuration = 0.55;
@@ -47,7 +47,7 @@ static const CGFloat SPAnimationPopTableViewRowVelocity = 0.6;
 static const CGFloat SPAnimationEmptyStatePushDuration = 0.15;
 static const CGFloat SPAnimationEmptyStatePopDuration = 0.4;
 static const CGFloat SPAnimationDelayZero = 0.0;
-
+*/
 
 NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SPTransitionControllerPopGestureTriggeredNotificationName";
 
@@ -146,7 +146,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     return self.pushPopAnimationController.interactiveTransition;
 }
 
-
+/*
 #pragma mark CustomTransition
 
 - (UIView *)textViewSnapshotForNote:(Note *)note
@@ -753,6 +753,8 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
         [_context finishInteractiveTransition];
     }
 }
+
+ */
 
 - (void)handlePan:(UIPanGestureRecognizer *)sender {
 

--- a/Simplenote/Classes/SnapshotRenderer.swift
+++ b/Simplenote/Classes/SnapshotRenderer.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-
+/*
 /// Tool that allows us to generate a snapshot (UIView) for animation purposes.
 ///
 @objc
@@ -220,3 +220,4 @@ private struct Constants {
         return UIDevice.sp_isPad() ? maximumLengthPad : maximumLengthPhone
     }
 }
+*/

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -13,7 +13,6 @@
 #import "NSProcessInfo+Util.h"
 #import "SPModalActivityIndicator.h"
 #import "SPEditorTextView.h"
-#import "SPTransitionController.h"
 
 #import "SPObjectManager.h"
 #import "Note.h"

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -161,7 +161,6 @@
     self.noteEditorViewController = [SPNoteEditorViewController new];
 
     self.navigationController = [[SPNavigationController alloc] initWithRootViewController:_noteListViewController];
-    self.navigationController.delegate = self;
 
     self.sidebarViewController = [[SPSidebarContainerViewController alloc] initWithMainViewController:self.navigationController
                                                                                 sidebarViewController:self.tagListViewController];

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -43,10 +43,7 @@
 #pragma mark Private Properties
 #pragma mark ================================================================================
 
-@interface SPAppDelegate () <UINavigationControllerDelegate,
-                                SimperiumDelegate,
-                                SPBucketDelegate,
-                                PinLockDelegate>
+@interface SPAppDelegate () <SimperiumDelegate, SPBucketDelegate, PinLockDelegate>
 
 @property (strong, nonatomic) SPNavigationController        *navigationController;
 @property (strong, nonatomic) Simperium                     *simperium;


### PR DESCRIPTION
### Details
In this PR we're disabling Simplenote's custom transitions from List <> Editor.

Ref. #507 

cc @bummytime 
Thank you sir!!

### Test
1. Launch Simplenote
2. Press over any note 
3. Verify the Editor is presented with a Push transition
4. Verify that the Editor is dismissed when you press the top left **Back** button
5. Verify that the Editor is dismissed via Swipe to Dismiss gesture

### Known Issues:
- As a side effect of using the Standard Transition, the First Responder appears to be getting restored (when reopening the Editor). Issue #600
- The above appears to be an UIKit issue. Reproduced in a sample project, with no code (!!!)
- UX Glitches related to "First Responder Restoration" addressed via #607

### Release
These changes do not require release notes.
