### PR TITLE
SearchBar: Hidden when visualizing Trash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.16
 -----
- 
+-   The SearchBar will no longer be displayed when the Trash Filter is active.
+
 4.15
 -----
 -   Simplenote just got brand new App Icons!

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -86,6 +86,17 @@ extension SPNoteListViewController {
         tableView.contentInset.top = searchBarStackView.frame.height
         tableView.scrollIndicatorInsets.top = searchBarStackView.frame.height
     }
+
+    /// Scrolls to the First Row whenever the flag `mustScrollToFirstRow` was set to true
+    ///
+    @objc
+    func ensureFirstRowIsVisibleIfNeeded() {
+        guard mustScrollToFirstRow else {
+            return
+        }
+
+        ensureFirstRowIsVisible()
+        mustScrollToFirstRow = false
     }
 
     /// Workaround: Scroll to the very first row. Expected to be called *just* once, right after the view has been laid out, and has been moved
@@ -128,6 +139,21 @@ extension SPNoteListViewController {
     @objc
     func refreshTitle() {
         title = notesListController.filter.title
+    }
+
+    /// Toggles the SearchBar's Visibility, based on the active Filter.
+    ///
+    /// - Note: We're marking `mustScrollToFirstRow`, which will cause the layout pass to run `ensureFirstRowIsVisible`.
+    ///         Changing the SearchBar Visibility triggers a layout pass, which updates the Table's Insets, and scrolls up to the first row.
+    ///
+    @objc
+    func refreshSearchBar() {
+        guard searchBar.isHidden != isDeletedFilterActive else {
+            return
+        }
+
+        mustScrollToFirstRow = true
+        searchBar.isHidden = isDeletedFilterActive
     }
 
     /// Indicates if the Deleted Notes are onScreen

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -17,29 +17,39 @@ extension SPNoteListViewController {
         notesListController.performFetch()
     }
 
+    /// Sets up the Search StackView
+    ///
+    @objc
+    func configureSearchStackView() {
+        assert(searchBar != nil, "searchBar must be initialized first!")
+
+        searchBarStackView = UIStackView(arrangedSubviews: [searchBar])
+        searchBarStackView.axis = .vertical
+    }
+
     /// Sets up the Root ViewController
     ///
     @objc
     func configureRootView() {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         navigationBarBackground.translatesAutoresizingMaskIntoConstraints = false
-        searchBar.translatesAutoresizingMaskIntoConstraints = false
+        searchBarStackView.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(tableView)
         view.addSubview(navigationBarBackground)
-        view.addSubview(searchBar)
+        view.addSubview(searchBarStackView)
 
         NSLayoutConstraint.activate([
-            searchBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.searchBarInsets.left),
-            searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.searchBarInsets.right)
+            searchBarStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            searchBarStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.searchBarInsets.left),
+            searchBarStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.searchBarInsets.right)
         ])
 
         NSLayoutConstraint.activate([
             navigationBarBackground.topAnchor.constraint(equalTo: view.topAnchor),
             navigationBarBackground.leftAnchor.constraint(equalTo: view.leftAnchor),
             navigationBarBackground.rightAnchor.constraint(equalTo: view.rightAnchor),
-            navigationBarBackground.bottomAnchor.constraint(equalTo: searchBar.bottomAnchor)
+            navigationBarBackground.bottomAnchor.constraint(equalTo: searchBarStackView.bottomAnchor)
         ])
 
         NSLayoutConstraint.activate([
@@ -73,8 +83,9 @@ extension SPNoteListViewController {
     ///
     @objc
     func refreshTableViewInsets() {
-        tableView.contentInset.top = searchBar.frame.height
-        tableView.scrollIndicatorInsets.top = searchBar.frame.height
+        tableView.contentInset.top = searchBarStackView.frame.height
+        tableView.scrollIndicatorInsets.top = searchBarStackView.frame.height
+    }
     }
 
     /// Workaround: Scroll to the very first row. Expected to be called *just* once, right after the view has been laid out, and has been moved

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -13,6 +13,7 @@
 @property (nonatomic, strong, readonly) UISearchBar                         *searchBar;
 @property (nonatomic, strong, readonly) SPEmptyListView                     *emptyListView;
 @property (nonatomic, strong, readonly) UITableView                         *tableView;
+@property (nonatomic, strong) UIStackView                                   *searchBarStackView;
 @property (nonatomic, strong) NotesListController                           *notesListController;
 @property (nonatomic) BOOL                                                  firstLaunch;
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) UIStackView                                   *searchBarStackView;
 @property (nonatomic, strong) NotesListController                           *notesListController;
 @property (nonatomic) BOOL                                                  firstLaunch;
+@property (nonatomic) BOOL                                                  mustScrollToFirstRow;
 
 - (void)update;
 - (void)openNoteWithSimperiumKey:(NSString *)simperiumKey animated:(BOOL)animated;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -96,6 +96,7 @@
     [super viewDidLayoutSubviews];
     [self refreshTableViewInsets];
     [self updateTableHeaderSize];
+    [self ensureFirstRowIsVisibleIfNeeded];
 }
 
 - (void)didMoveToParentViewController:(UIViewController *)parent {
@@ -526,6 +527,7 @@
 {
     [self refreshListController];
     [self refreshTitle];
+    [self refreshSearchBar];
 
     BOOL isTrashOnScreen = self.isDeletedFilterActive;
     BOOL isNotEmpty = !self.isListEmpty;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -66,6 +66,7 @@
         [self configureNavigationBarBackground];
         [self configureTableView];
         [self configureSearchController];
+        [self configureSearchStackView];
         [self configureResultsController];
         [self configureRootView];
         [self updateRowHeight];

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -660,7 +660,7 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
 
 - (SPTransitionSnapshot *)backSearchBarSnapshotForListController:(SPNoteListViewController *)listController containerView:(UIView *)containerView {
     UIView *searchBarImage = [listController.searchBar imageRepresentationWithinImageView];
-    CGRect targetFrame = listController.searchBar.frame;
+    CGRect targetFrame = listController.searchBarStackView.frame;
 
     NSDictionary *animatedValues = [self animationValuesWithStartingFrame:targetFrame
                                                                finalFrame:targetFrame


### PR DESCRIPTION
### Details:
In this PR we're implementing a mechanism that hides the SearchBar when the user is visualizing the Trash 

Ref. #507 

cc @bummytime 
cc @SylvesterWilmott for sanity check! (Screenshot below!)

Thanks gentlemen!

### Test
1. Launch Simplenote
2. Trash some note
3. Press over the top left icon to reveal the Tags List
4. Press over Trash

- [x] Verify the SearchBar is no longer visible
- [x] Verify that scrolling the trashed note out of the visible area triggers the NavBar's Blur
- [x] Verify that opening **All Notes** again does show the Notes List (and that the first row is onScreen)

### Release
`RELEASE-NOTES.txt` was updated in c8b7526 with:

> The SearchBar will no longer be displayed when the Trash Filter is active.

---

### Screenshot Time!

<img src="https://user-images.githubusercontent.com/1195260/73210853-e0405b00-4129-11ea-8f90-643740c993e3.png" width="300">
