### PR TITLE
Note Cell: UX Refresh!

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 -   Search results now display matching tags!
 -   We're now supporting the `tag:keyword` search operator. Simplenote will yield Notes whose tag names contain such *keyword*.
+-   Notes List's Interface is now looking more beautiful than ever.
 
 4.15
 -----

--- a/Simplenote/Classes/NSMutableAttributedString+Simplenote.swift
+++ b/Simplenote/Classes/NSMutableAttributedString+Simplenote.swift
@@ -6,6 +6,12 @@ import UIKit
 //
 extension NSMutableAttributedString {
 
+    /// Returns the (foundation) associated NSString
+    ///
+    var foundationString: NSString {
+        string as NSString
+    }
+
     /// Appends a given String with the specified Foreground Color
     ///
     func append(string: String, foregroundColor: UIColor? = nil) {
@@ -16,5 +22,20 @@ extension NSMutableAttributedString {
 
         let suffix = NSAttributedString(string: string, attributes: attributes)
         append(suffix)
+    }
+
+    /// Applies a given UIColor instance to substrings matching a given Keyword
+    ///
+    func apply(color: UIColor, toSubstringsMatching keywords: String) {
+        let maxLength = foundationString.length
+
+        for value in foundationString.ranges(forTerms: keywords) {
+            let range = value.rangeValue
+            guard NSMaxRange(range) <= maxLength else {
+                continue
+            }
+
+            addAttribute(.foregroundColor, value: color, range: range)
+        }
     }
 }

--- a/Simplenote/Classes/NSString+Search.h
+++ b/Simplenote/Classes/NSString+Search.h
@@ -10,6 +10,6 @@
 
 @interface NSString (Search)
 
--(NSArray *)rangesForTerms:(NSString *)terms;
+- (nonnull NSArray<NSValue *> *)rangesForTerms:(nonnull NSString *)terms;
 
 @end

--- a/Simplenote/Classes/NSString+Search.m
+++ b/Simplenote/Classes/NSString+Search.m
@@ -53,8 +53,8 @@
     
 }
 
-- (NSArray *)rangesForTerms:(NSString *)terms {
-    
+- (NSArray<NSValue *> *)rangesForTerms:(NSString *)terms
+{
 	NSMutableArray *rangesFound = [NSMutableArray arrayWithCapacity:5];
     
 	NSArray *termsArray = [terms componentsSeparatedByString:@" "];

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -318,10 +318,10 @@ private extension SPNoteListViewController {
         cell.accessibilityLabel = note.titlePreview
         cell.accessibilityHint = NSLocalizedString("Open note", comment: "Select a note to view in the note editor")
 
-        cell.accessoryLeftImage = note.published ? .image(name: .shared) : nil
-        cell.accessoryRightImage = note.pinned ? .image(name: .pin) : nil
-        cell.accessoryLeftTintColor = .simplenoteNoteStatusImageColor
-        cell.accessoryRightTintColor = .simplenoteNoteStatusImageColor
+        cell.accessoryLeftImage = note.pinned ? .image(name: .pin) : nil
+        cell.accessoryRightImage = note.published ? .image(name: .shared) : nil
+        cell.accessoryLeftTintColor = .simplenoteNotePinStatusImageColor
+        cell.accessoryRightTintColor = .simplenoteNoteShareStatusImageColor
 
         cell.rendersInCondensedMode = Options.shared.condensedNotesList
         cell.titleText = note.titlePreview

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -327,9 +327,10 @@ private extension SPNoteListViewController {
         cell.titleText = note.titlePreview
         cell.bodyText = note.bodyPreview
 
-        if let keyword = searchText, keyword.count > 0 {
-            cell.highlightSubstrings(matching: keyword, color: .simplenoteTintColor)
-        }
+        cell.keywords = searchText
+        cell.keywordsTintColor = .simplenoteTintColor
+
+        cell.refreshAttributedStrings()
 
         return cell
     }

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -77,37 +77,25 @@ class SPNoteTableViewCell: UITableViewCell {
         }
     }
 
-    /// Note's Title
+    /// Highlighted Keywords
+    /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
     ///
-    var titleText: String? {
-        get {
-            titleLabel.text
-        }
-        set {
-            guard let title = newValue else {
-                titleLabel.text = nil
-                return
-            }
+    var keywords: String?
 
-            titleLabel.attributedText = attributedText(from: title, font: Style.headlineFont, color: Style.headlineColor)
-        }
-    }
+    /// Highlighted Keywords's Tint Color
+    /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
+    ///
+    var keywordsTintColor: UIColor = .simplenoteTintColor
+
+    /// Note's Title
+    /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
+    ///
+    var titleText: String?
 
     /// Note's Body
+    /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
     ///
-    var bodyText: String? {
-        get {
-            bodyLabel.text
-        }
-        set {
-            guard let body = newValue else {
-                bodyLabel.text = nil
-                return
-            }
-
-            bodyLabel.attributedText = attributedText(from: body, font: Style.previewFont, color: Style.previewColor)
-        }
-    }
+    var bodyText: String?
 
     /// In condensed mode we simply won't render the bodyTextView
     ///
@@ -123,7 +111,7 @@ class SPNoteTableViewCell: UITableViewCell {
     /// Returns the Preview's Fragment Padding
     ///
     var bodyLineFragmentPadding: CGFloat {
-        return .zero
+        .zero
     }
 
 
@@ -157,11 +145,25 @@ class SPNoteTableViewCell: UITableViewCell {
         refreshConstraints()
     }
 
-    /// Highlights the partial matches with the specified color.
+    /// Refreshed the Title and Body AttributedString(s), based on the Text, Font and Highlight properties
     ///
-    func highlightSubstrings(matching keywords: String, color: UIColor) {
-//        titleTextView.textStorage.apply(color, toSubstringMatchingKeywords: keywords)
-//        bodyTextView.textStorage.apply(color, toSubstringMatchingKeywords: keywords)
+    func refreshAttributedStrings() {
+        titleLabel.attributedText = titleText.map {
+            attributedText(from: $0,
+                           highlighing: keywords,
+                           font: Style.headlineFont,
+                           textColor: Style.headlineColor,
+                           highlightColor: keywordsTintColor)
+
+        }
+
+        bodyLabel.attributedText = bodyText.map {
+            attributedText(from: $0,
+                           highlighing: keywords,
+                           font: Style.previewFont,
+                           textColor: Style.previewColor,
+                           highlightColor: keywordsTintColor)
+        }
     }
 }
 
@@ -215,8 +217,6 @@ private extension SPNoteTableViewCell {
     ///
     func refreshStyle() {
         backgroundColor = Style.backgroundColor
-        titleLabel.backgroundColor = Style.backgroundColor
-        bodyLabel.backgroundColor = Style.backgroundColor
 
         let selectedView = UIView(frame: bounds)
         selectedView.backgroundColor = Style.selectionColor
@@ -242,16 +242,26 @@ private extension SPNoteTableViewCell {
         accessoryRightImageView.isHidden = isRightImageEmpty
     }
 
-    /// Returns a NSAttributedString instance representing a given String, with the specified Font and Color. We'll also process Checklists!
+    /// Returns a NSAttributedString instance, stylizing the receiver with the current Highlighted Keywords + Font + Colors
     ///
-    func attributedText(from string: String, font: UIFont, color: UIColor) -> NSAttributedString {
+    func attributedText(from string: String,
+                        highlighing keywords: String?,
+                        font: UIFont,
+                        textColor: UIColor,
+                        highlightColor: UIColor) -> NSAttributedString
+    {
         let output = NSMutableAttributedString(string: string, attributes: [
             .font: font,
-            .foregroundColor: color,
+            .foregroundColor: textColor,
             .paragraphStyle: Style.paragraphStyle
         ])
 
-        output.addChecklistAttachments(for: color)
+        output.addChecklistAttachments(for: textColor)
+
+        if let keywords = keywords {
+            output.apply(color: highlightColor, toSubstringsMatching: keywords)
+        }
+
         return output
     }
 }

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -276,13 +276,13 @@ extension SPNoteTableViewCell {
     /// Note: Why these calculations? why not Autosizing cells?. Well... Performance.
     ///
     static var cellHeight: CGFloat {
-        let verticalPadding: CGFloat = 6
-        let topTextViewPadding: CGFloat = 5
-
         let numberLines = Options.shared.numberOfPreviewLines
         let lineHeight = UIFont.preferredFont(forTextStyle: .headline).lineHeight
 
-        let result = 2.0 * verticalPadding + 2.0 * topTextViewPadding + CGFloat(numberLines) * lineHeight
+        let paddingBetweenLabels = Options.shared.condensedNotesList ? .zero : Style.outerVerticalStackViewSpacing
+        let insets = Style.containerInsets
+
+        let result = insets.top + paddingBetweenLabels + CGFloat(numberLines) * lineHeight + insets.bottom
 
         return result.rounded(.up)
     }
@@ -312,6 +312,14 @@ private enum Style {
     /// Body's Maximum Lines
     ///
     static let maximumNumberOfBodyLines = 2
+
+    /// Represents the Insets applied to the container view
+    ///
+    static let containerInsets = UIEdgeInsets(top: 13, left: 0, bottom: 13, right: 0)
+
+    /// Outer Vertical StackView's Spacing
+    ///
+    static let outerVerticalStackViewSpacing = CGFloat(2)
 
     /// TextView's paragraphStyle
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -9,11 +9,11 @@ class SPNoteTableViewCell: UITableViewCell {
 
     /// Master View
     ///
-    @IBOutlet private var titleTextView: UITextView!
+    @IBOutlet private var titleLabel: UILabel!
 
     /// Accessory StackView
     ///
-    @IBOutlet private var bodyTextView: UITextView!
+    @IBOutlet private var bodyLabel: UILabel!
 
     /// Note's Left Accessory ImageView
     ///
@@ -81,15 +81,15 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     var titleText: String? {
         get {
-            titleTextView.text
+            titleLabel.text
         }
         set {
             guard let title = newValue else {
-                titleTextView.text = nil
+                titleLabel.text = nil
                 return
             }
 
-            titleTextView.attributedText = attributedText(from: title, font: Style.headlineFont, color: Style.headlineColor)
+            titleLabel.attributedText = attributedText(from: title, font: Style.headlineFont, color: Style.headlineColor)
         }
     }
 
@@ -97,15 +97,15 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     var bodyText: String? {
         get {
-            bodyTextView.text
+            bodyLabel.text
         }
         set {
             guard let body = newValue else {
-                bodyTextView.text = nil
+                bodyLabel.text = nil
                 return
             }
 
-            bodyTextView.attributedText = attributedText(from: body, font: Style.previewFont, color: Style.previewColor)
+            bodyLabel.attributedText = attributedText(from: body, font: Style.previewFont, color: Style.previewColor)
         }
     }
 
@@ -113,17 +113,17 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     var rendersInCondensedMode: Bool {
         get {
-            bodyTextView.isHidden
+            bodyLabel.isHidden
         }
         set {
-            bodyTextView.isHidden = newValue
+            bodyLabel.isHidden = newValue
         }
     }
 
     /// Returns the Preview's Fragment Padding
     ///
     var bodyLineFragmentPadding: CGFloat {
-        return bodyTextView.textContainer.lineFragmentPadding
+        return .zero
     }
 
 
@@ -160,8 +160,8 @@ class SPNoteTableViewCell: UITableViewCell {
     /// Highlights the partial matches with the specified color.
     ///
     func highlightSubstrings(matching keywords: String, color: UIColor) {
-        titleTextView.textStorage.apply(color, toSubstringMatchingKeywords: keywords)
-        bodyTextView.textStorage.apply(color, toSubstringMatchingKeywords: keywords)
+//        titleTextView.textStorage.apply(color, toSubstringMatchingKeywords: keywords)
+//        bodyTextView.textStorage.apply(color, toSubstringMatchingKeywords: keywords)
     }
 }
 
@@ -173,21 +173,14 @@ private extension SPNoteTableViewCell {
     /// Setup: TextView
     ///
     func setupTextViews() {
-        titleTextView.isAccessibilityElement = false
-        titleTextView.textContainerInset = .zero
+        titleLabel.isAccessibilityElement = false
+        bodyLabel.isAccessibilityElement = false
 
-        bodyTextView.isAccessibilityElement = false
-        bodyTextView.textContainerInset = .zero
+        titleLabel.numberOfLines = Style.maximumNumberOfTitleLines
+        titleLabel.lineBreakMode = .byWordWrapping
 
-        let titleTextContainer = titleTextView.textContainer
-        titleTextContainer.maximumNumberOfLines = Style.maximumNumberOfTitleLines
-        titleTextContainer.lineFragmentPadding = .zero
-        titleTextContainer.lineBreakMode = .byWordWrapping
-
-        let bodyTextContainer = bodyTextView.textContainer
-        bodyTextContainer.maximumNumberOfLines = Style.maximumNumberOfBodyLines
-        bodyTextContainer.lineFragmentPadding = .zero
-        bodyTextContainer.lineBreakMode = .byWordWrapping
+        bodyLabel.numberOfLines = Style.maximumNumberOfBodyLines
+        bodyLabel.lineBreakMode = .byWordWrapping
     }
 }
 
@@ -222,6 +215,8 @@ private extension SPNoteTableViewCell {
     ///
     func refreshStyle() {
         backgroundColor = Style.backgroundColor
+        titleLabel.backgroundColor = Style.backgroundColor
+        bodyLabel.backgroundColor = Style.backgroundColor
 
         let selectedView = UIView(frame: bounds)
         selectedView.backgroundColor = Style.selectionColor
@@ -290,11 +285,11 @@ private enum Style {
 
     /// Accessory's Ratio (measured against Line Size)
     ///
-    static let accessoryImageSizeRatio = CGFloat(0.75)
+    static let accessoryImageSizeRatio = CGFloat(0.70)
 
     /// Accessory's Minimum Size
     ///
-    static let accessoryImageMinimumSize = CGFloat(16)
+    static let accessoryImageMinimumSize = CGFloat(15)
 
     /// Accessory's Maximum Size
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -15,10 +15,6 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var bodyTextView: UITextView!
 
-    /// Accessory StackView's Top Constraint
-    ///
-    @IBOutlet private var accessoryStackView: UIStackView!
-
     /// Note's Left Accessory ImageView
     ///
     @IBOutlet private var accessoryLeftImageView: UIImageView!
@@ -151,7 +147,6 @@ class SPNoteTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         setupTextViews()
-        setupStackViews()
         refreshStyle()
         refreshConstraints()
     }
@@ -193,12 +188,6 @@ private extension SPNoteTableViewCell {
         bodyTextContainer.maximumNumberOfLines = Style.maximumNumberOfBodyLines
         bodyTextContainer.lineFragmentPadding = .zero
         bodyTextContainer.lineBreakMode = .byWordWrapping
-    }
-
-    /// Setup: StackView
-    ///
-    func setupStackViews() {
-        accessoryStackView.isLayoutMarginsRelativeArrangement = true
     }
 }
 
@@ -245,9 +234,6 @@ private extension SPNoteTableViewCell {
         let lineHeight = Style.headlineFont.lineHeight
         let accessoryDimension = ceil(lineHeight * Style.accessoryImageSizeRatio)
         let cappedDimension = max(min(accessoryDimension, Style.accessoryImageMaximumSize), Style.accessoryImageMinimumSize)
-        let accessoryPaddingTop = ceil((lineHeight - cappedDimension) * 0.5)
-
-        accessoryStackView.layoutMargins = UIEdgeInsets(top: accessoryPaddingTop, left: 0, bottom: 0, right: 0)
 
         accessoryLeftImageViewHeightConstraint.constant = cappedDimension
         accessoryRightImageViewHeightConstraint.constant = cappedDimension
@@ -256,12 +242,9 @@ private extension SPNoteTableViewCell {
     /// Refreshes Accessory ImageView(s) and StackView(s) visibility, as needed
     ///
     func refreshAccessoriesVisibility() {
-        let isLeftImageEmpty = accessoryLeftImageView.image == nil
         let isRightImageEmpty = accessoryRightImageView.image == nil
 
-        accessoryLeftImageView.isHidden = isLeftImageEmpty
         accessoryRightImageView.isHidden = isRightImageEmpty
-        accessoryStackView.isHidden = isLeftImageEmpty && isRightImageEmpty
     }
 
     /// Returns a NSAttributedString instance representing a given String, with the specified Font and Color. We'll also process Checklists!

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -145,6 +145,11 @@ class SPNoteTableViewCell: UITableViewCell {
         refreshConstraints()
     }
 
+    override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+        super.setHighlighted(highlighted, animated: animated)
+        refreshLabelsBackground(highlighted: highlighted)
+    }
+
     /// Refreshed the Title and Body AttributedString(s), based on the Text, Font and Highlight properties
     ///
     func refreshAttributedStrings() {
@@ -217,6 +222,8 @@ private extension SPNoteTableViewCell {
     ///
     func refreshStyle() {
         backgroundColor = Style.backgroundColor
+        titleLabel.backgroundColor = Style.backgroundColor
+        bodyLabel.backgroundColor = Style.backgroundColor
 
         let selectedView = UIView(frame: bounds)
         selectedView.backgroundColor = Style.selectionColor
@@ -240,6 +247,14 @@ private extension SPNoteTableViewCell {
         let isRightImageEmpty = accessoryRightImageView.image == nil
 
         accessoryRightImageView.isHidden = isRightImageEmpty
+    }
+
+    /// Refreshes the Label(s) BG Colors, to match the current highlight state (Re: Preventing alpha bending!)
+    ///
+    func refreshLabelsBackground(highlighted: Bool) {
+        let newBackgroundColor = highlighted ? Style.selectionColor : Style.backgroundColor
+        titleLabel.backgroundColor = newBackgroundColor
+        bodyLabel.backgroundColor = newBackgroundColor
     }
 
     /// Returns a NSAttributedString instance, stylizing the receiver with the current Highlighted Keywords + Font + Colors

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
@@ -65,19 +65,49 @@ Body L2</string>
                             <constraint firstItem="hr4-XQ-BeJ" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="0tK-Xg-kjU"/>
                             <constraint firstItem="DcU-7T-Fcq" firstAttribute="centerY" secondItem="TZs-9B-NXz" secondAttribute="centerY" id="1DO-qS-dlY"/>
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hr4-XQ-BeJ" secondAttribute="bottom" id="5Ty-3U-NG6"/>
+                            <constraint firstAttribute="width" priority="999" constant="640" id="SKQ-O4-NUA"/>
                             <constraint firstItem="TZs-9B-NXz" firstAttribute="leading" secondItem="1kl-z0-0K0" secondAttribute="leading" id="VNt-8A-Lx6"/>
                             <constraint firstItem="hr4-XQ-BeJ" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="i2g-uy-UlT"/>
                             <constraint firstAttribute="trailing" secondItem="hr4-XQ-BeJ" secondAttribute="trailing" id="xVp-8W-gqR"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="SKQ-O4-NUA"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <include reference="SKQ-O4-NUA"/>
+                            </mask>
+                        </variation>
                     </view>
                 </subviews>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
+                    <constraint firstItem="1kl-z0-0K0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="D1J-20-bJ0" secondAttribute="leading" id="8ai-Nb-yMT"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="top" secondItem="D1J-20-bJ0" secondAttribute="top" constant="13" id="BLy-sw-4lE"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1kl-z0-0K0" secondAttribute="trailing" id="DVN-iO-uti"/>
                     <constraint firstAttribute="trailing" secondItem="1kl-z0-0K0" secondAttribute="trailing" constant="16" id="Ig2-uE-hva"/>
+                    <constraint firstItem="1kl-z0-0K0" firstAttribute="centerX" secondItem="D1J-20-bJ0" secondAttribute="centerX" id="S72-c6-I0t"/>
                     <constraint firstAttribute="bottom" secondItem="1kl-z0-0K0" secondAttribute="bottom" constant="13" id="VZK-oO-oh0"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="leading" secondItem="D1J-20-bJ0" secondAttribute="leading" constant="6" id="k1X-7o-aAs"/>
                 </constraints>
+                <variation key="default">
+                    <mask key="constraints">
+                        <exclude reference="8ai-Nb-yMT"/>
+                        <exclude reference="DVN-iO-uti"/>
+                        <exclude reference="S72-c6-I0t"/>
+                    </mask>
+                </variation>
+                <variation key="heightClass=regular-widthClass=regular">
+                    <mask key="constraints">
+                        <include reference="8ai-Nb-yMT"/>
+                        <include reference="DVN-iO-uti"/>
+                        <exclude reference="Ig2-uE-hva"/>
+                        <include reference="S72-c6-I0t"/>
+                        <exclude reference="k1X-7o-aAs"/>
+                    </mask>
+                </variation>
             </tableViewCellContentView>
             <connections>
                 <outlet property="accessoryLeftImageView" destination="TZs-9B-NXz" id="3wj-z3-YdC"/>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -16,101 +16,74 @@
                 <rect key="frame" x="0.0" y="0.0" width="414" height="87"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="XmC-CY-iIl">
-                        <rect key="frame" x="6" y="12" width="396" height="75"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1kl-z0-0K0" userLabel="Container View">
+                        <rect key="frame" x="6" y="12" width="392" height="75"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
-                                <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
+                                <rect key="frame" x="0.0" y="2.5" width="16" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="16" id="HlN-8B-Xzh"/>
                                     <constraint firstAttribute="width" constant="16" placeholder="YES" id="eu6-28-b8t"/>
                                     <constraint firstAttribute="width" secondItem="TZs-9B-NXz" secondAttribute="height" multiplier="1:1" id="wnx-D6-YI9"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="LA6-xg-qi3">
-                                <rect key="frame" x="22" y="0.0" width="374" height="75"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
+                                <rect key="frame" x="22" y="0.0" width="370" height="20.5"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="LRq-hS-rwF">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="37.5"/>
-                                        <subviews>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" bouncesZoom="NO" editable="NO" text="Title" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LIn-CK-Yya" userLabel="Title Text View">
-                                                <rect key="frame" x="0.0" y="0.0" width="352" height="37.5"/>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
-                                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                            </textView>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                                <rect key="frame" x="358" y="0.0" width="16" height="16"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
-                                                    <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" priority="750" id="Yoh-kc-uRC"/>
-                                                    <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
-                                                </constraints>
-                                            </imageView>
-                                        </subviews>
-                                    </stackView>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" bouncesZoom="NO" editable="NO" text="Body" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GQu-W3-Owm" userLabel="Body Text View">
-                                        <rect key="frame" x="0.0" y="39.5" width="374" height="35.5"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
-                                        <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="348" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
+                                        <rect key="frame" x="354" y="2.5" width="16" height="16"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
+                                            <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
+                                            <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
+                                        </constraints>
+                                    </imageView>
                                 </subviews>
                             </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
+                                <rect key="frame" x="22" y="22.5" width="370" height="41"/>
+                                <string key="text">Body L1
+Body L2</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="width" priority="999" constant="640" id="iH3-jy-PVg"/>
+                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="centerY" secondItem="TZs-9B-NXz" secondAttribute="centerY" id="4cL-If-Vod"/>
+                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="RdA-CK-WaY"/>
+                            <constraint firstItem="TZs-9B-NXz" firstAttribute="leading" secondItem="1kl-z0-0K0" secondAttribute="leading" id="VNt-8A-Lx6"/>
+                            <constraint firstItem="Vjk-4O-P68" firstAttribute="top" secondItem="DcU-7T-Fcq" secondAttribute="bottom" constant="2" id="i70-nL-1Ns"/>
+                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="irX-cf-B0Q"/>
+                            <constraint firstAttribute="trailing" secondItem="Vjk-4O-P68" secondAttribute="trailing" id="m6z-SX-hRU"/>
+                            <constraint firstItem="Vjk-4O-P68" firstAttribute="leading" secondItem="DcU-7T-Fcq" secondAttribute="leading" id="qeO-Pk-WGa"/>
+                            <constraint firstAttribute="trailing" secondItem="DcU-7T-Fcq" secondAttribute="trailing" id="sZh-Vr-XeC"/>
+                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Vjk-4O-P68" secondAttribute="bottom" id="zmU-bd-U0d"/>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="iH3-jy-PVg"/>
-                            </mask>
-                        </variation>
-                        <variation key="heightClass=regular-widthClass=regular">
-                            <mask key="constraints">
-                                <include reference="iH3-jy-PVg"/>
-                            </mask>
-                        </variation>
-                    </stackView>
+                    </view>
                 </subviews>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="XmC-CY-iIl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="D1J-20-bJ0" secondAttribute="leading" id="92z-pa-Wyq"/>
-                    <constraint firstAttribute="trailing" secondItem="XmC-CY-iIl" secondAttribute="trailing" constant="12" id="Lf2-oh-Ap3"/>
-                    <constraint firstItem="XmC-CY-iIl" firstAttribute="leading" secondItem="D1J-20-bJ0" secondAttribute="leading" constant="6" id="Wat-Ma-tXB"/>
-                    <constraint firstItem="XmC-CY-iIl" firstAttribute="centerX" secondItem="D1J-20-bJ0" secondAttribute="centerX" id="ep7-PQ-UAW"/>
-                    <constraint firstItem="XmC-CY-iIl" firstAttribute="top" secondItem="D1J-20-bJ0" secondAttribute="top" constant="12" id="gHq-wH-J9e"/>
-                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="XmC-CY-iIl" secondAttribute="trailing" id="tHl-dw-y5Q"/>
-                    <constraint firstAttribute="bottom" secondItem="XmC-CY-iIl" secondAttribute="bottom" id="ytH-2Z-pIf"/>
+                    <constraint firstItem="1kl-z0-0K0" firstAttribute="top" secondItem="D1J-20-bJ0" secondAttribute="top" constant="12" id="BLy-sw-4lE"/>
+                    <constraint firstAttribute="trailing" secondItem="1kl-z0-0K0" secondAttribute="trailing" constant="16" id="Ig2-uE-hva"/>
+                    <constraint firstAttribute="bottom" secondItem="1kl-z0-0K0" secondAttribute="bottom" id="VZK-oO-oh0"/>
+                    <constraint firstItem="1kl-z0-0K0" firstAttribute="leading" secondItem="D1J-20-bJ0" secondAttribute="leading" constant="6" id="k1X-7o-aAs"/>
                 </constraints>
-                <variation key="default">
-                    <mask key="constraints">
-                        <exclude reference="92z-pa-Wyq"/>
-                        <exclude reference="ep7-PQ-UAW"/>
-                        <exclude reference="tHl-dw-y5Q"/>
-                    </mask>
-                </variation>
-                <variation key="heightClass=regular-widthClass=regular">
-                    <mask key="constraints">
-                        <include reference="92z-pa-Wyq"/>
-                        <exclude reference="Lf2-oh-Ap3"/>
-                        <exclude reference="Wat-Ma-tXB"/>
-                        <include reference="ep7-PQ-UAW"/>
-                        <include reference="tHl-dw-y5Q"/>
-                    </mask>
-                </variation>
             </tableViewCellContentView>
             <connections>
                 <outlet property="accessoryLeftImageView" destination="TZs-9B-NXz" id="3wj-z3-YdC"/>
                 <outlet property="accessoryLeftImageViewHeightConstraint" destination="HlN-8B-Xzh" id="K9g-dy-gnc"/>
                 <outlet property="accessoryRightImageView" destination="JkE-9h-IB9" id="C8T-9a-MyY"/>
                 <outlet property="accessoryRightImageViewHeightConstraint" destination="ugA-mm-Glv" id="59a-zM-gKJ"/>
-                <outlet property="bodyTextView" destination="GQu-W3-Owm" id="Jw5-Al-6Id"/>
-                <outlet property="titleTextView" destination="LIn-CK-Yya" id="HXH-Rm-zK1"/>
+                <outlet property="bodyLabel" destination="Vjk-4O-P68" id="hJu-fn-IhG"/>
+                <outlet property="titleLabel" destination="eEk-9d-8ay" id="ZG4-CB-3jJ"/>
             </connections>
             <point key="canvasLocation" x="135" y="166.37323943661971"/>
         </tableViewCell>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -17,63 +17,65 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1kl-z0-0K0" userLabel="Container View">
-                        <rect key="frame" x="6" y="12" width="392" height="75"/>
+                        <rect key="frame" x="6" y="13" width="392" height="61"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
-                                <rect key="frame" x="0.0" y="2.5" width="16" height="16"/>
+                                <rect key="frame" x="0.0" y="1" width="16" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="16" id="HlN-8B-Xzh"/>
                                     <constraint firstAttribute="width" constant="16" placeholder="YES" id="eu6-28-b8t"/>
                                     <constraint firstAttribute="width" secondItem="TZs-9B-NXz" secondAttribute="height" multiplier="1:1" id="wnx-D6-YI9"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
-                                <rect key="frame" x="22" y="0.0" width="370" height="20.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
+                                <rect key="frame" x="22" y="0.0" width="370" height="61"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
-                                        <rect key="frame" x="0.0" y="0.0" width="348" height="20.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
+                                        <rect key="frame" x="0.0" y="0.0" width="370" height="18"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
+                                                <rect key="frame" x="0.0" y="0.0" width="348" height="18"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
+                                                <rect key="frame" x="354" y="1" width="16" height="16"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
+                                                    <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
+                                                    <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
+                                    </stackView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
+                                        <rect key="frame" x="0.0" y="20" width="370" height="41"/>
+                                        <string key="text">Body L1
+Body L2</string>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                        <rect key="frame" x="354" y="2.5" width="16" height="16"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
-                                            <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
-                                            <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
-                                        </constraints>
-                                    </imageView>
                                 </subviews>
                             </stackView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
-                                <rect key="frame" x="22" y="22.5" width="370" height="41"/>
-                                <string key="text">Body L1
-Body L2</string>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="centerY" secondItem="TZs-9B-NXz" secondAttribute="centerY" id="4cL-If-Vod"/>
-                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="RdA-CK-WaY"/>
+                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="0tK-Xg-kjU"/>
+                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="centerY" secondItem="TZs-9B-NXz" secondAttribute="centerY" id="1DO-qS-dlY"/>
+                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hr4-XQ-BeJ" secondAttribute="bottom" id="5Ty-3U-NG6"/>
                             <constraint firstItem="TZs-9B-NXz" firstAttribute="leading" secondItem="1kl-z0-0K0" secondAttribute="leading" id="VNt-8A-Lx6"/>
-                            <constraint firstItem="Vjk-4O-P68" firstAttribute="top" secondItem="DcU-7T-Fcq" secondAttribute="bottom" constant="2" id="i70-nL-1Ns"/>
-                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="irX-cf-B0Q"/>
-                            <constraint firstAttribute="trailing" secondItem="Vjk-4O-P68" secondAttribute="trailing" id="m6z-SX-hRU"/>
-                            <constraint firstItem="Vjk-4O-P68" firstAttribute="leading" secondItem="DcU-7T-Fcq" secondAttribute="leading" id="qeO-Pk-WGa"/>
-                            <constraint firstAttribute="trailing" secondItem="DcU-7T-Fcq" secondAttribute="trailing" id="sZh-Vr-XeC"/>
-                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Vjk-4O-P68" secondAttribute="bottom" id="zmU-bd-U0d"/>
+                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="i2g-uy-UlT"/>
+                            <constraint firstAttribute="trailing" secondItem="hr4-XQ-BeJ" secondAttribute="trailing" id="xVp-8W-gqR"/>
                         </constraints>
                     </view>
                 </subviews>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="1kl-z0-0K0" firstAttribute="top" secondItem="D1J-20-bJ0" secondAttribute="top" constant="12" id="BLy-sw-4lE"/>
+                    <constraint firstItem="1kl-z0-0K0" firstAttribute="top" secondItem="D1J-20-bJ0" secondAttribute="top" constant="13" id="BLy-sw-4lE"/>
                     <constraint firstAttribute="trailing" secondItem="1kl-z0-0K0" secondAttribute="trailing" constant="16" id="Ig2-uE-hva"/>
-                    <constraint firstAttribute="bottom" secondItem="1kl-z0-0K0" secondAttribute="bottom" id="VZK-oO-oh0"/>
+                    <constraint firstAttribute="bottom" secondItem="1kl-z0-0K0" secondAttribute="bottom" constant="13" id="VZK-oO-oh0"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="leading" secondItem="D1J-20-bJ0" secondAttribute="leading" constant="6" id="k1X-7o-aAs"/>
                 </constraints>
             </tableViewCellContentView>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,49 +16,49 @@
                 <rect key="frame" x="0.0" y="0.0" width="414" height="87"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="XmC-CY-iIl">
-                        <rect key="frame" x="15" y="12" width="384" height="75"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="XmC-CY-iIl">
+                        <rect key="frame" x="6" y="12" width="396" height="75"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="LA6-xg-qi3">
-                                <rect key="frame" x="0.0" y="0.0" width="260" height="75"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
+                                <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="16" id="HlN-8B-Xzh"/>
+                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="eu6-28-b8t"/>
+                                    <constraint firstAttribute="width" secondItem="TZs-9B-NXz" secondAttribute="height" multiplier="1:1" id="wnx-D6-YI9"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="LA6-xg-qi3">
+                                <rect key="frame" x="22" y="0.0" width="374" height="75"/>
                                 <subviews>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" bouncesZoom="NO" editable="NO" text="Title" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LIn-CK-Yya" userLabel="Title Text View">
-                                        <rect key="frame" x="0.0" y="0.0" width="260" height="38"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
-                                        <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="LRq-hS-rwF">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="37.5"/>
+                                        <subviews>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" bouncesZoom="NO" editable="NO" text="Title" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LIn-CK-Yya" userLabel="Title Text View">
+                                                <rect key="frame" x="0.0" y="0.0" width="352" height="37.5"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
+                                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
+                                                <rect key="frame" x="358" y="0.0" width="16" height="16"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
+                                                    <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" priority="750" id="Yoh-kc-uRC"/>
+                                                    <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
+                                    </stackView>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" bouncesZoom="NO" editable="NO" text="Body" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GQu-W3-Owm" userLabel="Body Text View">
-                                        <rect key="frame" x="0.0" y="39" width="260" height="36"/>
+                                        <rect key="frame" x="0.0" y="39.5" width="374" height="35.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                                         <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
-                                </subviews>
-                            </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DuU-Wj-LTr">
-                                <rect key="frame" x="276" y="0.0" width="108" height="50"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
-                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" priority="751" constant="16" id="HlN-8B-Xzh"/>
-                                            <constraint firstAttribute="width" priority="750" constant="16" placeholder="YES" id="eu6-28-b8t"/>
-                                            <constraint firstAttribute="width" secondItem="TZs-9B-NXz" secondAttribute="height" multiplier="1:1" priority="750" id="wnx-D6-YI9"/>
-                                        </constraints>
-                                    </imageView>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                        <rect key="frame" x="58" y="0.0" width="50" height="50"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" priority="750" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
-                                            <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" priority="750" id="Yoh-kc-uRC"/>
-                                            <constraint firstAttribute="height" priority="751" constant="16" id="ugA-mm-Glv"/>
-                                        </constraints>
-                                    </imageView>
                                 </subviews>
                             </stackView>
                         </subviews>
@@ -80,8 +80,8 @@
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="XmC-CY-iIl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="D1J-20-bJ0" secondAttribute="leading" id="92z-pa-Wyq"/>
-                    <constraint firstAttribute="trailing" secondItem="XmC-CY-iIl" secondAttribute="trailing" constant="15" id="Lf2-oh-Ap3"/>
-                    <constraint firstItem="XmC-CY-iIl" firstAttribute="leading" secondItem="D1J-20-bJ0" secondAttribute="leading" constant="15" id="Wat-Ma-tXB"/>
+                    <constraint firstAttribute="trailing" secondItem="XmC-CY-iIl" secondAttribute="trailing" constant="12" id="Lf2-oh-Ap3"/>
+                    <constraint firstItem="XmC-CY-iIl" firstAttribute="leading" secondItem="D1J-20-bJ0" secondAttribute="leading" constant="6" id="Wat-Ma-tXB"/>
                     <constraint firstItem="XmC-CY-iIl" firstAttribute="centerX" secondItem="D1J-20-bJ0" secondAttribute="centerX" id="ep7-PQ-UAW"/>
                     <constraint firstItem="XmC-CY-iIl" firstAttribute="top" secondItem="D1J-20-bJ0" secondAttribute="top" constant="12" id="gHq-wH-J9e"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="XmC-CY-iIl" secondAttribute="trailing" id="tHl-dw-y5Q"/>
@@ -109,7 +109,6 @@
                 <outlet property="accessoryLeftImageViewHeightConstraint" destination="HlN-8B-Xzh" id="K9g-dy-gnc"/>
                 <outlet property="accessoryRightImageView" destination="JkE-9h-IB9" id="C8T-9a-MyY"/>
                 <outlet property="accessoryRightImageViewHeightConstraint" destination="ugA-mm-Glv" id="59a-zM-gKJ"/>
-                <outlet property="accessoryStackView" destination="DuU-Wj-LTr" id="LL5-py-saf"/>
                 <outlet property="bodyTextView" destination="GQu-W3-Owm" id="Jw5-Al-6Id"/>
                 <outlet property="titleTextView" destination="LIn-CK-Yya" id="HXH-Rm-zK1"/>
             </connections>

--- a/Simplenote/Classes/SnapshotRenderer.swift
+++ b/Simplenote/Classes/SnapshotRenderer.swift
@@ -112,10 +112,10 @@ private extension SnapshotRenderer {
     func configure(tableViewCell: SPNoteTableViewCell, note: Note, searchQuery: String?) {
         tableViewCell.titleText = note.titlePreview
         tableViewCell.bodyText = note.bodyPreview
-        tableViewCell.accessoryLeftImage = note.published ? .image(name: .shared) : nil
-        tableViewCell.accessoryRightImage = note.pinned ? .image(name: .pin) : nil
-        tableViewCell.accessoryLeftTintColor = accessoryColor
-        tableViewCell.accessoryRightTintColor = accessoryColor
+        tableViewCell.accessoryLeftImage = note.pinned ? .image(name: .pin) : nil
+        tableViewCell.accessoryRightImage = note.published ? .image(name: .shared) : nil
+        tableViewCell.accessoryLeftTintColor = .simplenoteNotePinStatusImageColor
+        tableViewCell.accessoryRightTintColor = .simplenoteNoteShareStatusImageColor
         tableViewCell.rendersInCondensedMode = Options.shared.condensedNotesList
 
         if let searchQuery = searchQuery {
@@ -145,12 +145,6 @@ private extension SnapshotRenderer {
 // MARK: - Private dynamic properties
 //
 private extension SnapshotRenderer {
-
-    /// Returns the Note's Status Image Color
-    ///
-    var accessoryColor: UIColor {
-        return .simplenoteNoteStatusImageColor
-    }
 
     /// Returns the (current) Body Color
     ///

--- a/Simplenote/Classes/SnapshotRenderer.swift
+++ b/Simplenote/Classes/SnapshotRenderer.swift
@@ -110,6 +110,8 @@ private extension SnapshotRenderer {
     /// Configures a given SPNoteTableViewCell instance in order to properly render a given Note, with the specified Search Query.
     ///
     func configure(tableViewCell: SPNoteTableViewCell, note: Note, searchQuery: String?) {
+        tableViewCell.keywords = searchQuery
+        tableViewCell.keywordsTintColor = .simplenoteTintColor
         tableViewCell.titleText = note.titlePreview
         tableViewCell.bodyText = note.bodyPreview
         tableViewCell.accessoryLeftImage = note.pinned ? .image(name: .pin) : nil
@@ -118,9 +120,7 @@ private extension SnapshotRenderer {
         tableViewCell.accessoryRightTintColor = .simplenoteNoteShareStatusImageColor
         tableViewCell.rendersInCondensedMode = Options.shared.condensedNotesList
 
-        if let searchQuery = searchQuery {
-            tableViewCell.highlightSubstrings(matching: searchQuery, color: .simplenoteTintColor)
-        }
+        tableViewCell.refreshAttributedStrings()
     }
 
     /// Returns a NSMutableAttributedString instance representing a given note:

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -99,7 +99,12 @@ extension UIColor {
     }
 
     @objc
-    static var simplenoteNoteStatusImageColor: UIColor {
+    static var simplenoteNotePinStatusImageColor: UIColor {
+        .simplenoteTintColor
+    }
+
+    @objc
+    static var simplenoteNoteShareStatusImageColor: UIColor {
         UIColor(lightColor: .gray50, darkColor: .gray30)
     }
 


### PR DESCRIPTION
### Details:
In this PR we're refreshing the Note Cell UX, to match the Advanced Search Mockups.

cc @bummytime (Thank you sir!!)
cc @SylvesterWilmott for UX review (screenshots attached in a file, belooow, LOTS of them).

Closes #585
Ref. #507
Ref. #481

### Scenario: New UX
1. Log into your account
2. Verify the Notes List looks as expected
3. Verify the transition between List <> Editor works fine
4. Verify that the Condensed Mode looks great (**Settings > Condensed Note List**)
5. Verify that the new Cell reacts properly to Dynamic Typing

**Please:** Repeat for several iPhone variations + OS(s), along with iPad Multitasking.

### Scenario: Rows gone AWOL
- This scenario involves doing a bit of an override. Please DM me for details!

### Release
`RELEASE-NOTES.txt` was updated in 2416443 with:
 
> Notes List's Interface is now looking more beautiful than ever.

---

### Screenshots:

[Screenshots.zip](https://github.com/Automattic/simplenote-ios/files/4130081/Screenshots.zip)
