### PR TITLE
Not restoring First Responder

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -18,7 +18,6 @@ extern NSString *const CheckListRegExPattern;
 
 @interface SPEditorTextView : SPTextView
 
-@property (nonatomic) BOOL editing;
 @property (nonatomic) BOOL lockContentOffset;
 @property (nonatomic) BOOL overideLockContentOffset;
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -86,8 +86,11 @@ NSInteger const ChecklistCursorAdjustment = 2;
         tapGestureRecognizer.cancelsTouchesInView = NO;
         
         [self addGestureRecognizer:tapGestureRecognizer];
+
+        // Why: Data Detectors simply don't work if `isEditable = YES`
         [self setEditable:NO];
     }
+
     return self;
 }
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -158,11 +158,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
 {
     _editing = editing;
     self.editable = editing;
-    
-    // HACK:
-    // God, forgive me. After enabling edit mode, "former" linkified substrings are rendered with a black color.
-    // This forces UITextView to render those substrings with the same color as the rest of the TextView.
-    self.textColor = self.textColor;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -86,7 +86,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         tapGestureRecognizer.cancelsTouchesInView = NO;
         
         [self addGestureRecognizer:tapGestureRecognizer];
-        [self setEditing:NO];
+        [self setEditable:NO];
     }
     return self;
 }
@@ -154,12 +154,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self setNeedsLayout];
 }
 
-- (void)setEditing:(BOOL)editing
-{
-    _editing = editing;
-    self.editable = editing;
-}
-
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
     // Limit a recognized touch to the SPTextView, so that taps on tags still work as expected
@@ -168,7 +162,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
 
 - (BOOL)becomeFirstResponder
 {
-    [self setEditing:YES];
+    [self setEditable:YES];
     return [super becomeFirstResponder];
 }
 
@@ -200,7 +194,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
 
 - (void)didEndEditing:(NSNotification *)notification
 {
-    [self setEditing:NO];
+    [self setEditable:NO];
 }
 
 // Fixes are modified versions of https://gist.github.com/agiletortoise/a24ccbf2d33aafb2abc1

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -209,10 +209,15 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         self.userActivity = [NSUserActivity openNoteActivityFor:_currentNote];
     }
 
-    [self ensureEditorIsFirstResponder];
     [self ensureTagViewIsVisible];
     [self highlightSearchResultsIfNeeded];
     [self startListeningToKeyboardNotifications];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self ensureEditorIsFirstResponder];
 }
 
 - (void)configureNavigationBarBackground
@@ -580,11 +585,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         keyboardButton.hidden = !editing;
         newButton.hidden = editing;
     }
-}
-
-- (void)setIsPreviewing:(BOOL)isPreviewing {
-    _isPreviewing = isPreviewing;
-    [self ensureEditorIsFirstResponder];
 }
 
 - (void)setBackButtonTitleForSearchingMode:(BOOL)searching{

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -36,7 +36,6 @@
 
 @import SafariServices;
 
-NSString * const kWillAddNewNote = @"SPWillAddNewNote";
 
 CGFloat const SPCustomTitleViewHeight               = 44.0f;
 CGFloat const SPPaddingiPadCompactWidthPortrait     = 8.0f;
@@ -1384,13 +1383,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     }
     
     bDisableShrinkingNavigationBar = YES; // disable the navigation bar shrinking to avoid weird animations
-    
-    [[NSNotificationCenter defaultCenter] postNotificationName:kWillAddNewNote
-                                                        object:self];
-    
-    // Save current note first MAY NOT NEED THIS IF NOTE CANNOT BE VISIABLE AT SAME TIME
-    //    note.content = noteEditor.string;
-    //    [self save];
     
 	NSManagedObjectContext *context = [[SPAppDelegate sharedDelegate] managedObjectContext];
     Note *newNote = [NSEntityDescription insertNewObjectForEntityForName:@"Note" inManagedObjectContext:context];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -54,6 +54,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 @interface SPNoteEditorViewController ()<SPEditorTextViewDelegate,
                                         SPInteractivePushViewControllerProvider,
+                                        SPInteractiveDismissableViewController,
                                         UIPopoverPresentationControllerDelegate>
 {
     NSUInteger cursorLocationBeforeRemoteUpdate;
@@ -810,6 +811,18 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         }];
     });
 }
+
+
+#pragma mark - SPInteractiveDismissableViewController
+
+- (BOOL)requiresFirstResponderRestorationBypass
+{
+    // Whenever an Interactive Dismiss OP kicks off, we're requesting the "First Responder Restoration" mechanism
+    // to be overridden.
+    // Ref. https://github.com/Automattic/simplenote-ios/issues/600
+    return YES;
+}
+
 
 #pragma mark search
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1427,19 +1427,15 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                          } completion:^(BOOL finished) {
                              
                              [snapshot removeFromSuperview];
-                             
+                             [self.noteEditorTextView becomeFirstResponder];
+
                          }];
-        
+
     } else {
-        
+
         [self updateNote:newNote];
         bBlankNote = YES;
     }
-    
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self->_noteEditorTextView becomeFirstResponder];
-    });
     
     bDisableShrinkingNavigationBar = NO;
 }

--- a/Simplenote/Classes/SPTransitionController.h
+++ b/Simplenote/Classes/SPTransitionController.h
@@ -4,8 +4,11 @@
 extern NSString *const SPTransitionControllerPopGestureTriggeredNotificationName;
 
 
+@protocol SPInteractiveDismissableViewController
+@property (readonly) BOOL requiresFirstResponderRestorationBypass;
+@end
+
+
 @interface SPTransitionController : NSObject <UINavigationControllerDelegate>
-
 - (instancetype)initWithNavigationController:(UINavigationController *)navigationController;
-
 @end

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -108,7 +108,27 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
         return YES;
     }
 
-    return self.navigationController.viewControllers.count > 1;
+
+    BOOL recognizerShouldBegin = self.navigationController.viewControllers.count > 1;
+    if (recognizerShouldBegin) {
+        [self bypassFirstResponderRestorationIfNeeded];
+    }
+
+    return recognizerShouldBegin;
+}
+
+- (void)bypassFirstResponderRestorationIfNeeded
+{
+    UIViewController<SPInteractiveDismissableViewController> *dismissableViewController = (UIViewController<SPInteractiveDismissableViewController> *)self.navigationController.topViewController;
+    if (![dismissableViewController conformsToProtocol:@protocol(SPInteractiveDismissableViewController)]) {
+        return;
+    }
+
+    if (!dismissableViewController.requiresFirstResponderRestorationBypass) {
+        return;
+    }
+
+    [dismissableViewController.view endEditing:YES];
 }
 
 @end


### PR DESCRIPTION
### Fix
In this PR we're neutralizing the UIKit's mechanism in charge of restoring the First Responder (whenever a ViewController is reused), since it's the known cause of a quite bad UI bug.

For the record, I've pulled together a [Sample Project demonstrating the First Responder bug](https://github.com/jleandroperez/ResponderRestorationKeyboardBug).

[Sample video of the glitch available here](https://github.com/jleandroperez/ResponderRestorationKeyboardBug/blob/master/Demo.mp4)

Closes #600

### Note:
Since we were in the neighborhood, an ancient UITextView workaround has been removed

Ref. **Legacy Repository** #248

### Scenario: First Responder Restoration
1. Log into your account
2. Make sure you've got at least one empty note, and one non-empty note

- [x] Verify that opening an Empty Note gets the keyboard onScreen without any UX glitch
- [x] Verify that opening a non empty note **does not** get the keyboard onScreen
- [x] Verify that force pressing over an Empty Note also gets the keyboard onScreen, without issues
- [x] Verify that force pressing over a non empty note **does not** get the keyboard onscreen
- [x] Verify that adding a new note from the List gets the editor onScreen, and opens the Keyboard
- [x] Verify that adding a new note from within the editor also gets the keyboard onScreen

### Scenario: Workaround Removal
1. Launch Simplenote
2. Enable the Dark Mode
3. Open a note that has links
4. Enter Edit mode

- [x] Verify that Links are readable with the keyboard dismissed (and get rendered in blue-ish)
- [x] Verify that Links are (also) readable when pressing the TextView (should turn the same color as the rest of the document!)

### Release
These changes do not require release notes.
