### PR TITLE
 Dismissing SearchBar's Responder status on Scroll

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -238,6 +238,20 @@ extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
 }
 
 
+// MARK: - UIScrollViewDelegate
+//
+extension SPNoteListViewController: UIScrollViewDelegate {
+
+    public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        guard searchBar.isFirstResponder else {
+            return
+        }
+
+        searchBar.resignFirstResponder()
+    }
+}
+
+
 // MARK: - UITableViewDataSource
 //
 extension SPNoteListViewController: UITableViewDataSource {


### PR DESCRIPTION
### Details:
In this PR we're updating the Note List's behavior so that the Search Bar looses its First Responder status, whenever the user scrolls over the Search Results

Ref. #507

### Test
1. Launch Simplenote
2. Press over the Search Bar
3. Swipe downwards

- [x] Verify the Keyboard is hidden immediately
- [x] Verify the **Cancel** button remains onScreen (right hand side of the Search Bar!)

### Release
These changes do not require release notes.
