### PR TITLE
Preserving NavigationBar Hidden state

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -103,6 +103,12 @@
     [self ensureTransitionControllerIsInitialized];
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    [self.searchController restoreNavigationBarStatus];
+}
+
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     [self showRatingViewIfNeeded];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -106,7 +106,7 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [self.searchController restoreNavigationBarStatus];
+    [self.searchController hideNavigationBarIfNecessary];
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/Simplenote/Classes/SearchDisplayController.swift
+++ b/Simplenote/Classes/SearchDisplayController.swift
@@ -64,6 +64,16 @@ class SearchDisplayController: NSObject {
         searchBar.text = searchText
         delegate?.searchDisplayController(self, updateSearchResults: searchText)
     }
+
+    /// This method will hide the NavigationBar whenever the SearchDisplayController is in active mode.
+    ///
+    /// We'll rely on this API to ensure transitions from List <> Editor are smooth: In Search Mode the list won't display the NavigationBar, but the
+    /// Editor is always expected to display a navbar. When going backwards, we'll always need to restore the navbar.
+    ///
+    @objc
+    func hideNavigationBarIfNecessary() {
+        updateNavigationBar(hidden: active)
+    }
 }
 
 


### PR DESCRIPTION
### Fix
In this PR we're fixing a glitch in which the Navigation Bar's state wouldn't be properly preserved when going from `List > Editor > List`, whenever the Search was active.

Ref. #507 

### Test
1. Launch Simplenote
2. Press over the Search Bar
3. Verify the Navigation Bar is hidden
4. Press over any row to open the Editor
5. Verify the Navigation Bar is hidden
6. Hide (or swipe) back
7. Verify the Navigation Bar remains hidden in the Notes List

### Release
These changes do not require release notes.
