### PR TITLE
Restoring SearchBar's Autocapitalization

### DIFF
--- a/Simplenote/Classes/SearchDisplayController.swift
+++ b/Simplenote/Classes/SearchDisplayController.swift
@@ -85,7 +85,6 @@ private extension SearchDisplayController {
         searchBar.delegate = self
         searchBar.placeholder = NSLocalizedString("Search", comment: "Search Placeholder")
         searchBar.searchBarStyle = .minimal
-        searchBar.autocapitalizationType = .none
         searchBar.sizeToFit()
     }
 


### PR DESCRIPTION
### Fix
Based on Sly's Feedback, in this (super short PR) we're restoring the SearchBar's Autocapitalization.

Ref. #507

### Test
1. Launch the app
2. Press over the Search Bar

- [x] Verify the text is automatically capitalized.

### Release
These changes do not require release notes.
