### PR TITLE
Preventing First Row Animation Glitch

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -350,9 +350,6 @@
 
 - (BOOL)searchDisplayControllerShouldBeginSearch:(SearchDisplayController *)controller
 {
-    [self.notesListController beginSearch];
-    [self.tableView reloadData];
-
     return YES;
 }
 
@@ -371,7 +368,9 @@
 
 - (void)searchDisplayControllerWillBeginSearch:(SearchDisplayController *)controller
 {
-    // NO-OP
+    // Note: We avoid switching to SearchMode in `shouldBegin` because it might cause layout issues!
+    [self.notesListController beginSearch];
+    [self.tableView reloadData];
 }
 
 - (void)searchDisplayControllerDidEndSearch:(SearchDisplayController *)controller


### PR DESCRIPTION
### Fix
In this PR we're fixing a tiny (yet awful) animation glitch, triggered whenever the user enters Search Mode.

I've attached, below, a sample video demonstrating the glitch (in Slow Motion).

Ref. #507 

### Test
1. Launch the app
2. Press over the Search Bar

- [ ] Verify the first row remains **in the exact same position** it was

### Release
These changes do not require release notes.

---

[FirstRowJumps.mov.zip](https://github.com/Automattic/simplenote-ios/files/4149768/FirstRowJumps.mov.zip)
