### PR TITLE
Preventing insane bottom insets

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -670,11 +670,11 @@
     _keyboardHeight = MIN(keyboardFrame.size.height, keyboardFrame.size.width);
     
     UIEdgeInsets tableviewInsets = self.tableView.contentInset;
-    tableviewInsets.bottom += _keyboardHeight;
+    tableviewInsets.bottom = _keyboardHeight;
     self.tableView.contentInset = tableviewInsets;
     
     UIEdgeInsets scrollInsets = self.tableView.scrollIndicatorInsets;
-    scrollInsets.bottom += _keyboardHeight;
+    scrollInsets.bottom = _keyboardHeight;
     self.tableView.scrollIndicatorInsets = tableviewInsets;
 }
 


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug in which Bottom Insets were being incorrectly over-applied. 

Closes #603 

### Test
1. Perform any search
2. Lock your device
3. Unlock the device
4. Scroll to the bottom of the search results

- [x] Verify that the TableView's bottom insets are reasonable (and not twice the size of the keyboard).

### Release
These changes do not require release notes.
