### PR TITLE
Notes List: Updates SearchBar's Placeholder

### DIFF
--- a/Simplenote/Classes/NotesListState.swift
+++ b/Simplenote/Classes/NotesListState.swift
@@ -5,7 +5,6 @@ import Foundation
 //
 enum NotesListState {
     case results
-//  TODO: case history
     case searching(keyword: String)
 }
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -314,6 +314,7 @@
     self.searchController.delegate = self;
     self.searchController.presenter = self;
 
+    self.searchBar.placeholder = NSLocalizedString(@"Search notes or tags", @"SearchBar's Placeholder Text");
     [self.searchBar applySimplenoteStyle];
 }
 


### PR DESCRIPTION
### Fix
In this PR we're updating the SearchBar's Placeholder, to match the new mockups.

**And** we're also nuking a dead TODO, since Search History has ben called out.

cc @bummytime *Thank you!!!*
Ref. #507

### Test
1. Launch the app
2. Verify the SearchBar's placeholder reads as `Search notes or tags`


### Release
These changes do not require release notes.
