### PR TITLE
List: Enabling Row Separators

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -17,8 +17,12 @@ extension SPNoteListViewController {
         tableView.delegate = self
 
         tableView.alwaysBounceVertical = true
-
         tableView.tableFooterView = UIView()
+
+        tableView.layoutMargins = .zero
+        tableView.separatorInset = .zero
+        tableView.separatorInsetReference = .fromAutomaticInsets
+        tableView.separatorStyle = UIDevice.sp_isPad() ? .none : .singleLine
 
         tableView.register(SPNoteTableViewCell.loadNib(), forCellReuseIdentifier: SPNoteTableViewCell.reuseIdentifier)
         tableView.register(SPTagTableViewCell.loadNib(), forCellReuseIdentifier: SPTagTableViewCell.reuseIdentifier)

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -7,6 +7,24 @@ import UIKit
 //
 extension SPNoteListViewController {
 
+    /// Sets up the main TableView
+    ///
+    @objc
+    func configureTableView() {
+        assert(tableView == nil, "tableView is already initialized!")
+
+        tableView = UITableView()
+        tableView.delegate = self
+
+        tableView.alwaysBounceVertical = true
+
+        tableView.tableFooterView = UIView()
+
+        tableView.register(SPNoteTableViewCell.loadNib(), forCellReuseIdentifier: SPNoteTableViewCell.reuseIdentifier)
+        tableView.register(SPTagTableViewCell.loadNib(), forCellReuseIdentifier: SPTagTableViewCell.reuseIdentifier)
+        tableView.register(SPSectionHeaderView.loadNib(), forHeaderFooterViewReuseIdentifier: SPSectionHeaderView.reuseIdentifier)
+    }
+
     /// Sets up the Results Controller
     ///
     @objc

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -13,7 +13,7 @@
 @property (nonatomic, strong, readonly) SPBlurEffectView                    *navigationBarBackground;
 @property (nonatomic, strong, readonly) UISearchBar                         *searchBar;
 @property (nonatomic, strong, readonly) SPEmptyListView                     *emptyListView;
-@property (nonatomic, strong, readonly) UITableView                         *tableView;
+@property (nonatomic, strong) UITableView                                   *tableView;
 @property (nonatomic, strong) UIStackView                                   *searchBarStackView;
 @property (nonatomic, strong, readonly) SearchDisplayController             *searchController;
 @property (nonatomic, strong) NotesListController                           *notesListController;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -142,6 +142,7 @@
 {
     self.noteRowHeight = SPNoteTableViewCell.cellHeight;
     self.tagRowHeight = SPTagTableViewCell.cellHeight;
+    self.tableView.separatorInset = SPNoteTableViewCell.separatorInsets;
     [self.tableView reloadData];
 }
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -40,8 +40,6 @@
 @property (nonatomic, strong) UIBarButtonItem                       *sidebarButton;
 @property (nonatomic, strong) UIBarButtonItem                       *emptyTrashButton;
 
-@property (nonatomic, strong) UITableView                           *tableView;
-
 @property (nonatomic, strong) SearchDisplayController               *searchController;
 @property (nonatomic, strong) UIActivityIndicatorView               *activityIndicator;
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -65,7 +65,7 @@
         [self configureSearchStackView];
         [self configureResultsController];
         [self configureRootView];
-        [self updateRowHeight];
+        [self updateTableViewMetrics];
         [self startListeningToNotifications];
         [self startDisplayingEntities];
         
@@ -138,7 +138,7 @@
     self.navigationController.delegate = self.transitionController;
 }
 
-- (void)updateRowHeight
+- (void)updateTableViewMetrics
 {
     self.noteRowHeight = SPNoteTableViewCell.cellHeight;
     self.tagRowHeight = SPTagTableViewCell.cellHeight;
@@ -203,13 +203,14 @@
     [nc addObserver:self selector:@selector(themeDidChange) name:VSThemeManagerThemeDidChangeNotification object:nil];
 }
 
-- (void)condensedPreferenceWasUpdated:(id)sender {
-
-    [self updateRowHeight];
+- (void)condensedPreferenceWasUpdated:(id)sender
+{
+    [self updateTableViewMetrics];
 }
 
-- (void)contentSizeWasUpdated:(id)sender {
-    [self updateRowHeight];
+- (void)contentSizeWasUpdated:(id)sender
+{
+    [self updateTableViewMetrics];
 }
 
 - (void)sortOrderPreferenceWasUpdated:(id)sender {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -291,20 +291,6 @@
     self.navigationBarBackground = [SPBlurEffectView navigationBarBlurView];
 }
 
-- (void)configureTableView {
-    NSAssert(_tableView == nil, @"_tableView is already initialized!");
-
-    self.tableView = [UITableView new];
-    self.tableView.delegate = self;
-    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
-    self.tableView.tableFooterView = [UIView new];
-    self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.tableView.alwaysBounceVertical = YES;
-    [self.tableView registerNib:[SPNoteTableViewCell loadNib] forCellReuseIdentifier:[SPNoteTableViewCell reuseIdentifier]];
-    [self.tableView registerNib:[SPTagTableViewCell loadNib] forCellReuseIdentifier:[SPTagTableViewCell reuseIdentifier]];
-    [self.tableView registerNib:[SPSectionHeaderView loadNib] forHeaderFooterViewReuseIdentifier:[SPSectionHeaderView reuseIdentifier]];
-}
-
 - (void)configureSearchController {
     NSAssert(_searchController == nil, @"_searchController is already initialized!");
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -226,11 +226,10 @@ private extension SPNoteTableViewCell {
     /// Accessory's StackView should be aligned against the PreviewTextView's first line center
     ///
     func refreshConstraints() {
-        let accessoryDimension = Style.headlineFont.inlineAssetHeight()
-        let cappedDimension = max(min(accessoryDimension, Style.accessoryImageMaximumSize), Style.accessoryImageMinimumSize)
+        let dimension = Style.accessoryImageDimension
 
-        accessoryLeftImageViewHeightConstraint.constant = cappedDimension
-        accessoryRightImageViewHeightConstraint.constant = cappedDimension
+        accessoryLeftImageViewHeightConstraint.constant = dimension
+        accessoryRightImageViewHeightConstraint.constant = dimension
     }
 
     /// Refreshes Accessory ImageView(s) and StackView(s) visibility, as needed
@@ -291,6 +290,12 @@ extension SPNoteTableViewCell {
 // MARK: - Cell Styles
 //
 private enum Style {
+
+    /// Accessory's Dimension, based on the (current) Headline Font Size
+    ///
+    static var accessoryImageDimension: CGFloat {
+        max(min(headlineFont.inlineAssetHeight(), accessoryImageMaximumSize), accessoryImageMinimumSize)
+    }
 
     /// Accessory's Minimum Size
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -277,10 +277,26 @@ private extension SPNoteTableViewCell {
 //
 extension SPNoteTableViewCell {
 
+    /// TableView's Separator Insets: Expected to align **exactly** with the label(s) Leading.
+    /// In order to get the TableView to fully respect this the following must be fulfilled:
+    ///
+    ///     1.  tableViewCell(s).layoutMargins = .zero
+    ///     2.  tableView.layoutMargins = .zero
+    ///     2.  tableView.separatorInsetReference = `.fromAutomaticInsets
+    ///
+    /// Then, and only then, this will work ferpectly 🔥
+    ///
+    @objc
+    static var separatorInsets: UIEdgeInsets {
+        let left = Style.containerInsets.left + Style.accessoryImageDimension + Style.accessoryImagePaddingRight
+        return UIEdgeInsets(top: .zero, left: left, bottom: .zero, right: .zero)
+    }
+
     /// Returns the Height that the receiver would require to be rendered, given the current User Settings (number of preview lines).
     ///
     /// Note: Why these calculations? why not Autosizing cells?. Well... Performance.
     ///
+    @objc
     static var cellHeight: CGFloat {
         let numberLines = Options.shared.numberOfPreviewLines
         let lineHeight = UIFont.preferredFont(forTextStyle: .headline).lineHeight
@@ -313,6 +329,10 @@ private enum Style {
     ///
     static let accessoryImageMaximumSize = CGFloat(24)
 
+    /// Accessory's Right Padding
+    ///
+    static let accessoryImagePaddingRight = CGFloat(6)
+
     /// Title's Maximum Lines
     ///
     static let maximumNumberOfTitleLines = 1
@@ -323,7 +343,7 @@ private enum Style {
 
     /// Represents the Insets applied to the container view
     ///
-    static let containerInsets = UIEdgeInsets(top: 13, left: 0, bottom: 13, right: 0)
+    static let containerInsets = UIEdgeInsets(top: 13, left: 6, bottom: 13, right: 0)
 
     /// Outer Vertical StackView's Spacing
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -134,6 +134,7 @@ class SPNoteTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        setupMargins()
         setupTextViews()
         refreshStyle()
         refreshConstraints()
@@ -171,6 +172,13 @@ class SPNoteTableViewCell: UITableViewCell {
 // MARK: - Private Methods: Initialization
 //
 private extension SPNoteTableViewCell {
+
+    /// Setup: Layout Margins
+    ///
+    func setupMargins() {
+        // Note: This one affects the TableView's separatorInsets
+        layoutMargins = .zero
+    }
 
     /// Setup: TextView
     ///

--- a/Simplenote/Classes/SPTagTableViewCell.swift
+++ b/Simplenote/Classes/SPTagTableViewCell.swift
@@ -75,6 +75,7 @@ class SPTagTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        setupMargins()
         refreshStyle()
         refreshConstraints()
     }
@@ -90,6 +91,13 @@ class SPTagTableViewCell: UITableViewCell {
 // MARK: - Private Methods
 //
 private extension SPTagTableViewCell {
+
+    /// Setup: Layout Margins
+    ///
+    func setupMargins() {
+        // Note: This one affects the TableView's separatorInsets
+        layoutMargins = .zero
+    }
 
     /// Refreshes the current Style current style
     ///


### PR DESCRIPTION
### Details:
In this PR we're enabling Row Separators on iPhone Devices. iPad is up next (after SplitView is in place).

Ref. #507

cc @bummytime (Thank you sir!!)
cc @SylvesterWilmott 

### Test
1. Launch the app on an iPhone
2. Verify the Note Cell separator's leading aligns perfectly below the Label(s)
3. Verify that the Tag Cell matches the Note Cell (trigger any search that yields Tags)

### Release
These changes do not require release notes.
