### PR TITLE
UIColor+Studio: Updates Secondary Action Color

### DIFF
--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -140,7 +140,7 @@ extension UIColor {
 
     @objc
     static var simplenoteSecondaryActionColor: UIColor {
-        UIColor(lightColor: .spYellow0, darkColor: .spYellow10)
+        UIColor(lightColor: .blue50, darkColor: .blue30)
     }
 
     @objc


### PR DESCRIPTION
### Details:
In this (quick!) PR we're updating the Pin / Unpin swipeable action color.

@bummytime Thank you sir!!

### Test
1. Launch Simplenote
2. Swipe over any of your notes

 - [ ] Verify the Pin / Unpin action is now blue!

### Release
These changes do not require release notes.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/1195260/73864788-fbddec80-4820-11ea-8b5f-5d49cdf14f1d.png">

<img width="300" src="https://user-images.githubusercontent.com/1195260/73864781-f8e2fc00-4820-11ea-9d72-f55f4e015ef3.png">
