### PR TITLE
Restoring results when the Search Keyword is Empty

### DIFF
--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -193,8 +193,15 @@ extension NotesListController {
 
     /// Refreshes the FetchedObjects so that they match a given Keyword
     ///
+    /// -   Note: Whenever the Keyword is actually empty, we'll fallback to regular results. Capisci?
+    ///
     @objc
     func refreshSearchResults(keyword: String) {
+        guard !keyword.isEmpty else {
+            state = .results
+            return
+        }
+
         state = .searching(keyword: keyword)
     }
 

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -188,7 +188,7 @@ extension NotesListController {
     ///
     @objc
     func beginSearch() {
-// TODO: we should actually switch to `state = .history`
+        // NO-OP: Initially meant for History, keeping it around for both consistency and future purposes.
     }
 
     /// Refreshes the FetchedObjects so that they match a given Keyword

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -292,6 +292,15 @@ extension SPNoteListViewController: UITableViewDataSource {
 //
 extension SPNoteListViewController: UITableViewDelegate {
 
+    public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        // Notes:
+        //  1.  No need to estimate. We precalculate the Height elsewhere, and we can return the *Actual* value
+        //  2.  We always scroll to the first row whenever Search Results are updated. If we don't implement this method,
+        //      UITableView ends up jumping off elsewhere!
+        //
+        return self.tableView(tableView, heightForRowAt: indexPath)
+    }
+
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         switch notesListController.object(at: indexPath) {
         case is Note:
@@ -301,6 +310,14 @@ extension SPNoteListViewController: UITableViewDelegate {
         default:
             return .zero
         }
+    }
+
+    public func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        guard notesListController.sections[section].displaysTitle else {
+            return .leastNormalMagnitude
+        }
+
+        return Constants.estimatedHeightForHeaderInSection
     }
 
     public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -460,6 +477,10 @@ private enum ActionTitle {
 }
 
 private enum Constants {
+
+    /// Section Header's Estimated Height
+    ///
+    static let estimatedHeightForHeaderInSection = CGFloat(30)
 
     /// Where do these insets come from?
     /// `For other subviews in your view hierarchy, the default layout margins are normally 8 points on each side`

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -62,10 +62,10 @@
     if (self) {
         [self configureNavigationButtons];
         [self configureNavigationBarBackground];
+        [self configureResultsController];
         [self configureTableView];
         [self configureSearchController];
         [self configureSearchStackView];
-        [self configureResultsController];
         [self configureRootView];
         [self updateRowHeight];
         [self startListeningToNotifications];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -385,12 +385,12 @@
 
 - (void)performSearchWithKeyword:(NSString *)keyword
 {
-    [self.notesListController refreshSearchResultsWithKeyword:keyword];
-  
     [SPTracker trackListNotesSearched];
-    
-    [self refreshListController];
+
+    [self.notesListController refreshSearchResultsWithKeyword:keyword];
+    [self.tableView reloadData];
     [self updateViewIfEmpty];
+
     if ([self.tableView numberOfRowsInSection:0]) {
         [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]
                               atScrollPosition:UITableViewScrollPositionTop

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -388,14 +388,11 @@
     [SPTracker trackListNotesSearched];
 
     [self.notesListController refreshSearchResultsWithKeyword:keyword];
-    [self.tableView reloadData];
-    [self updateViewIfEmpty];
 
-    if ([self.tableView numberOfRowsInSection:0]) {
-        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]
-                              atScrollPosition:UITableViewScrollPositionTop
-                                      animated:NO];
-    }
+    [self.tableView scrollToTopWithAnimation:NO];
+    [self.tableView reloadData];
+
+    [self updateViewIfEmpty];
     
     [self.searchTimer invalidate];
     self.searchTimer = nil;


### PR DESCRIPTION
### Details:
In this PR we're fixing a few UX inconsistencies:

1. Whenever the Search Keyword is **empty**, we're now displaying, back again, the list of notes that was onScreen prior to entering the Search Mode.
2. I've spotted a **double FRC fetch** that was being performed when the Keyword was updated (potentially legacy code), and removed that.
3. **PLUS:** UITableView's Height Estimation APIs have been implemented, in order to prevent the TableView from jumping all over the place.

Ref. #507

### Test: Empty Keyword
1. Launch Simplenote
2. Press over the Search Bar
3. Enter any keyword
4. Delete such keyword

 - [x] Verify that the List onScreen is exactly what you had in (1) or (2)

### Test: Invalid Offset
1. Launch Simplenote
2. Scroll downwards (anywhere!)
3. Press over the Search Bar
4. Enter a partial keyword that yields results
5. Verify that the TableView was scrolled to the very first row
6. Scroll anywhere!
7. Continue typing the keyword, so that the Search Results are updated
8. Verify that the TableView is scrolled to the top, the second the Search Results are updated
9. Press over the **Cancel** button, by the search bar
10. Verify the TableView was scrolled to the top

### Release
These changes do not require release notes.
