### PR TITLE
Updates (Deleted) Swipeable Actions Colors

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -412,12 +412,12 @@ private extension SPNoteListViewController {
 
     func rowActionsForDeletedNote(_ note: Note) -> [UITableViewRowAction] {
         return [
-            UITableViewRowAction(style: .default, title: ActionTitle.restore, backgroundColor: .orange) { (_, _) in
+            UITableViewRowAction(style: .default, title: ActionTitle.restore, backgroundColor: .simplenoteRestoreActionColor) { (_, _) in
                 SPObjectManager.shared().restoreNote(note)
                 CSSearchableIndex.default().indexSearchableNote(note)
             },
 
-            UITableViewRowAction(style: .destructive, title: ActionTitle.delete, backgroundColor: .red) { (_, _) in
+            UITableViewRowAction(style: .destructive, title: ActionTitle.delete, backgroundColor: .simplenoteDestructiveActionColor) { (_, _) in
                 SPTracker.trackListNoteDeleted()
                 SPObjectManager.shared().permenentlyDeleteNote(note)
             }

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -154,6 +154,11 @@ extension UIColor {
     }
 
     @objc
+    static var simplenoteRestoreActionColor: UIColor {
+        UIColor(lightColor: .spYellow0, darkColor: .spYellow10)
+    }
+
+    @objc
     static var simplenoteBackgroundColor: UIColor {
         UIColor(lightColor: .spWhite, darkColor: .darkGray1)
     }


### PR DESCRIPTION
### Details:
We're further adjusting the Swipeable Actions colors, this time round, for deleted actions.

cc @SylvesterWilmott @bummytime 
Thank you gentlemen!

### Test
1. Launch the app
2. Delete a note
3. Open the trash
4. Swipe over the note you've just deleted

- [ ] Verify the Delete / Restore actions look exactly like in the screenshot below!

### Release
These changes do not require release notes.

### Picture Time!
![Simulator Screen Shot - iPhone Xs - 2020-02-06 at 11 28 01](https://user-images.githubusercontent.com/1195260/73946021-00171200-48d4-11ea-8bd9-11b4727f762a.png)
