### PR TITLE
Dismiss the keyboard when search is pressed

### DIFF
--- a/Simplenote/Classes/SearchDisplayController.swift
+++ b/Simplenote/Classes/SearchDisplayController.swift
@@ -150,6 +150,10 @@ extension SearchDisplayController: UISearchBarDelegate {
         delegate?.searchDisplayController(self, updateSearchResults: searchText)
     }
 
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+    }
+
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         dismiss()
     }


### PR DESCRIPTION
### Details:
In this PR we're updating the SearchBar's Behavior: whenever the Keyboard's **Search** button is pressed, we'll now hide the keyboard.

Ref. #507

cc @bummytime Thaaaankyooouuuussiiiir!!

### Test
1. Launch the app
2. Press over the Search Bar
3. Press over the **Search** keyboard button

- [x] Verify the keyboard gets dismissed immediately
- [x] Verify that the Search Bar remains in Search Mode (cancel button, navbar hidden!)

### Release
These changes do not require release notes.
