### PR TITLE
Updates Preview Generation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -   Search results now display matching tags!
 -   We're now supporting the `tag:keyword` search operator. Simplenote will yield Notes whose tag names contain such *keyword*.
 -   Notes List's Interface is now looking more beautiful than ever.
+-   The way in which Notes are previewed has been upgraded to fit more content onScreen.
 -   Search is now diacritic insensitive: type search terms with or without accents to get matches!
 -   Fixed a bug in which the Search Mode wouldn't properly be dismissed from the Editor
 -   Fixed a bug that caused the Editor's Keyboard Appearance not to match the selected theme

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		B5CFFFE222AA9AD100B968CD /* TextBundleWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CFFFE022AA9AD100B968CD /* TextBundleWrapper.m */; };
 		B5CFFFE722AA9DB100B968CD /* Uploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CFFFE622AA9DB100B968CD /* Uploader.swift */; };
 		B5CFFFE922AA9DD700B968CD /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CFFFE822AA9DD700B968CD /* Note.swift */; };
+		B5D367BE23ECF42D0024215D /* NSStringCondensingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D367BD23ECF42D0024215D /* NSStringCondensingTests.swift */; };
 		B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D3FCCE201F96AC00A813B7 /* StatusChecker.m */; };
 		B5D982D022F8643300C37C29 /* SPTextInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D982CF22F8643200C37C29 /* SPTextInputView.swift */; };
 		B5D982D222F8644000C37C29 /* SPSquaredButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D982D122F8644000C37C29 /* SPSquaredButton.swift */; };
@@ -600,6 +601,7 @@
 		B5CFFFE322AA9B1900B968CD /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 		B5CFFFE622AA9DB100B968CD /* Uploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Uploader.swift; sourceTree = "<group>"; };
 		B5CFFFE822AA9DD700B968CD /* Note.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Note.swift; sourceTree = "<group>"; };
+		B5D367BD23ECF42D0024215D /* NSStringCondensingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSStringCondensingTests.swift; sourceTree = "<group>"; };
 		B5D3ADAF1FC8C0A200F84B31 /* SimplenoteShare-Development.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SimplenoteShare-Development.entitlements"; sourceTree = "<group>"; };
 		B5D3ADB01FC8C0A300F84B31 /* SimplenoteShare-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SimplenoteShare-Internal.entitlements"; sourceTree = "<group>"; };
 		B5D3ADB21FC8C11A00F84B31 /* Simplenote.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Simplenote.entitlements; sourceTree = "<group>"; };
@@ -1032,6 +1034,7 @@
 			isa = PBXGroup;
 			children = (
 				B5B85BA4235173BF00AD5221 /* NSPredicateSimplenoteTests.swift */,
+				B5D367BD23ECF42D0024215D /* NSStringCondensingTests.swift */,
 				B51D7C7823D9CFA4005D4B77 /* StringSimplenoteTests.swift */,
 			);
 			name = Extensions;
@@ -2185,6 +2188,7 @@
 				B5421F4023CE7A1C004DDC19 /* MockupStorage+Sample.swift in Sources */,
 				B5421F4223CE7A25004DDC19 /* ResultsControllerTests.swift in Sources */,
 				B5B85BA5235173BF00AD5221 /* NSPredicateSimplenoteTests.swift in Sources */,
+				B5D367BE23ECF42D0024215D /* NSStringCondensingTests.swift in Sources */,
 				B51D7C7923D9CFA4005D4B77 /* StringSimplenoteTests.swift in Sources */,
 				B5421F4623CE7DEB004DDC19 /* ResultsControllerUIKitTests.swift in Sources */,
 				B5421F3C23CE7A14004DDC19 /* Constants.swift in Sources */,

--- a/Simplenote/Classes/CSSearchable+Helpers.swift
+++ b/Simplenote/Classes/CSSearchable+Helpers.swift
@@ -14,13 +14,9 @@ extension CSSearchableItemAttributeSet {
 
     convenience init(note: Note) {
         self.init(itemContentType: kUTTypeData as String)
-        if note.preview == nil {
-            note.createPreview()
-        }
+        note.ensurePreviewStringsAreAvailable()
         title = note.titlePreview
-
-        let index = note.preview.index(note.preview.startIndex, offsetBy: note.titlePreview.count)
-        contentDescription = String(note.preview[index...])
+        contentDescription = note.bodyPreview
     }
     
 }

--- a/Simplenote/Classes/NSString+Condensing.h
+++ b/Simplenote/Classes/NSString+Condensing.h
@@ -1,7 +1,19 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSString (Condensing)
 
-// Generates string with fewer whitespaces and special characters. Good for previews in UITableViews
-- (void)generatePreviewStrings:(void (^)(NSString *titlePreview, NSString *bodyPreview, NSString *contentPreview))block;
+/// Generates string with fewer whitespaces and special characters. Good for previews in UITableViews
+///
+- (void)generatePreviewStrings:(void (^)(NSString *titlePreview, NSString * _Nullable bodyPreview))block;
+
+/// Returns a version of the receiver with all of its newlines replaced with spaces.
+///
+/// -   Note: Multiple consecutive newlines will be replaced by a *single* space
+///
+- (NSString *)stringByReplacingNewlinesWithSpaces;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Simplenote/Classes/NSString+Condensing.m
+++ b/Simplenote/Classes/NSString+Condensing.m
@@ -2,49 +2,44 @@
 
 @implementation NSString (Condensing)
 
-- (void)generatePreviewStrings:(void (^)(NSString *titlePreview, NSString *bodyPreview, NSString *contentPreview))block {
-    
-    NSString *aString = [NSString stringWithString:self];
-    NSString *titlePreview;
-    NSString *contentPreview;
-    
-//    if (aString.length > 500)
-//        aString = [aString substringToIndex:500];
-    
-	NSString *contentTest = [aString stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-	
-	NSRange firstNewline = [contentTest rangeOfString: @"\n"];
-	if (firstNewline.location == NSNotFound) {
-		titlePreview = contentTest;
-		contentPreview = nil;
-	} else {
-		titlePreview = [contentTest substringToIndex:firstNewline.location];
-		contentPreview = [[contentTest substringFromIndex: firstNewline.location+1] stringByReplacingOccurrencesOfString:@"\n\n" withString:@" \n"];
-		
-		// Remove leading newline if applicable
-		NSRange nextNewline = [contentPreview rangeOfString: @"\n"];
-		if (nextNewline.location == 0)
-			contentPreview = [contentPreview substringFromIndex:1];
+- (void)generatePreviewStrings:(void (^)(NSString *titlePreview, NSString *bodyPreview))block
+{
+    NSString *trimmed = [self stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+    // Remove Markdown #'s from the title
+    NSRange cutRange = [trimmed rangeOfString:@"# "];
+    if (cutRange.location == 0) {
+        trimmed = [trimmed substringFromIndex:NSMaxRange(cutRange)];
+    }
+
+    // Do we even have more than one line?
+	NSInteger locationForBody = [trimmed rangeOfString: @"\n"].location;
+
+	if (locationForBody == NSNotFound) {
+        block(trimmed, nil);
+        return;
 	}
 
-    
-    // Remove Markdown #'s
-    if ([titlePreview hasPrefix:@"#"]) {
-        NSRange cutRange = [titlePreview rangeOfString:@"# "];
-        if (cutRange.location != NSNotFound)
-            titlePreview = [titlePreview substringFromIndex:cutRange.location + cutRange.length];
-    }
-    
+    // Split Title / Body
+    NSString *title = [trimmed substringToIndex:locationForBody];
+    NSString *body = [[trimmed substringFromIndex:locationForBody] stringByReplacingNewlinesWithSpaces];
 
-    if (contentPreview) {
-        
-        block(titlePreview, contentPreview, [NSString stringWithFormat:@"%@\n%@", titlePreview, contentPreview]);
-    
-    } else {
-        
-        block(titlePreview, nil, titlePreview);
+    block(title, body);
+}
 
+- (NSString *)stringByReplacingNewlinesWithSpaces
+{
+    if (self.length == 0) {
+        return self;
     }
+
+    // Newlines: \n *AND* \r's!
+    NSMutableArray *components = [[self componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]] mutableCopy];
+
+    // Note: The following nukes everything that tests true for `isEquals`: Every single empty string is gone!
+    [components removeObject:@""];
+
+    return [components componentsJoinedByString:@" "];
 }
 
 @end

--- a/Simplenote/Classes/Note.h
+++ b/Simplenote/Classes/Note.h
@@ -45,7 +45,7 @@
 @property (nonatomic,   copy) NSString          *systemTags;
 @property (nonatomic,   copy) NSString          *modificationDatePreview;
 @property (nonatomic,   copy) NSString          *creationDatePreview;
-@property (nonatomic,   copy) NSString          *preview;
+
 @property (nonatomic,   copy) NSString          *titlePreview;
 @property (nonatomic,   copy) NSString          *bodyPreview;
 

--- a/Simplenote/Classes/Note.m
+++ b/Simplenote/Classes/Note.m
@@ -20,7 +20,6 @@
 
 @synthesize creationDatePreview;
 @synthesize modificationDatePreview;
-@synthesize preview;
 @synthesize titlePreview;
 @synthesize bodyPreview;
 @synthesize tagsArray;
@@ -221,32 +220,30 @@ SEL notifySelector;
     [self didChangeValueForKey:@"systemTags"];    
 }
 
-- (void)ensurePreviewStringsAreAvailable {
-    if (self.preview != nil) {
+- (void)ensurePreviewStringsAreAvailable
+{
+    if (self.titlePreview != nil) {
         return;
     }
 
     [self createPreview];
 }
 
-- (void)createPreview {
-    
-    // trim content for preview
+- (void)createPreview
+{
     NSString *aString = self.content;
-    if (aString.length > 500)
+    if (aString.length > 500) {
         aString = [aString substringToIndex:500];
+    }
     
-    [aString generatePreviewStrings:^(NSString *title, NSString *body, NSString *content) {
+    [aString generatePreviewStrings:^(NSString *title, NSString *body) {
         self.titlePreview = title;
         self.bodyPreview = body;
-        self.preview = content;
     }];
 
-    if (self.preview.length == 0) {
-        NSString *placeholder = NSLocalizedString(@"New note...", @"Empty Note Placeholder");
-        self.titlePreview = placeholder;
+    if (self.titlePreview.length == 0) {
+        self.titlePreview = NSLocalizedString(@"New note...", @"Empty Note Placeholder");
         self.bodyPreview = nil;
-        self.preview = placeholder;
     }
     
     [self updateTagsArray];

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -36,6 +36,7 @@
 #import "UIImage+Colorization.h"
 #import "NSMutableAttributedString+Styling.h"
 #import "NSString+Search.h"
+#import "NSString+Condensing.h"
 #import "NSTextStorage+Highlight.h"
 #import "Simperium+Simplenote.h"
 #import "SPNavigationController.h"

--- a/SimplenoteTests/NSStringCondensingTests.swift
+++ b/SimplenoteTests/NSStringCondensingTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import XCTest
+@testable import Simplenote
+
+
+// MARK: - NSString+Condensing Unit Tests
+//
+class NSStringCondensingTests: XCTestCase {
+
+    /// Verifies that `generatePreviewStrings` yields an empty title and null body whenever the receiver is an empty string
+    ///
+    func testGeneratePreviewStringsYieldEmptyStringAndNullBodyWheneverTheReceiverIsEmpty() {
+        let sample: NSString = ""
+
+        let expectation = self.expectation(description: "generatePreviewStrings")
+        sample.generatePreviewStrings { (title, body) in
+            XCTAssertEqual(title, "")
+            XCTAssertNil(body)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    /// Verifies that `generatePreviewStrings` yields a Null Body when the receiver contains no newline marker
+    ///
+    func testGeneratePreviewStringsYieldNullBodyWhenThereIsJustOneString() {
+        let sample: NSString = "A lala lala long long le long long long YEAH!"
+
+        let expectation = self.expectation(description: "generatePreviewStrings")
+        sample.generatePreviewStrings { (title, body) in
+            XCTAssertEqual(title as NSString, sample)
+            XCTAssertNil(body)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    /// Verifies that `generatePreviewStrings` trims leading and trailing Newlines / Spaces
+    ///
+    func testGeneratePreviewStringsTrimsNewlinesAndSpacesAtLeadingAndTail() {
+        let sample: NSString = " \n\r\n\r\n\nMwah ha ha\n\n\n\n   \n  \n"
+
+        let expectation = self.expectation(description: "generatePreviewStrings")
+        sample.generatePreviewStrings { (title, body) in
+            XCTAssertEqual(title, "Mwah ha ha")
+            XCTAssertNil(body)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    /// Verifies that `generatePreviewStrings` strips the title from Markdown Title Markers `#`
+    ///
+    func testGeneratePreviewStringsTrimsLeadingMarkdown() {
+        let sample: NSString = "# Title"
+
+        let expectation = self.expectation(description: "generatePreviewStrings")
+        sample.generatePreviewStrings { (title, body) in
+            XCTAssertEqual(title, "Title")
+            XCTAssertNil(body)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    /// Verifies that `generatePreviewStrings` correctly splits the receiver in Title and Body
+    ///
+    func testGeneratePreviewStringsEffectivelySplitsTitleAndBody() {
+        let sample: NSString = "\n\r\n# Title\n\n\n\nLINE1\n\n\r\n\nLINE2\n\nLINE3\n\r\n\n"
+
+        let expectation = self.expectation(description: "generatePreviewStrings")
+        sample.generatePreviewStrings { (title, body) in
+            XCTAssertEqual(title, "Title")
+            XCTAssertEqual(body, "LINE1 LINE2 LINE3")
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    /// Verifies that `replacingNewlinesWithSpaces` returns an empty string, whenever the receiver is an empty string
+    ///
+    func testReplaceNewlinesWithSpacesDoesNotBreakWithEmptyStrings() {
+        let sample: NSString = ""
+
+        XCTAssertEqual(sample.replacingNewlinesWithSpaces(), "")
+    }
+
+    /// Verifies that `replacingNewlinesWithSpaces` returns an empty string, whenever the receiver is a string containing a single Newline
+    ///
+    func testReplaceNewlinesWithSpacesProperlyHandlesSingleNewlineString() {
+        let sample: NSString = "\n"
+
+        XCTAssertEqual(sample.replacingNewlinesWithSpaces(), "")
+    }
+
+    /// Verifies that `replacingNewlinesWithSpaces` returns an empty string, whenever the receiver is a string containing *Multiple* Newline(s)
+    ///
+    func testReplaceNewlinesWithSpacesProperlyHandlesMultipleNewlineString() {
+        let sample: NSString = "\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r"
+
+        XCTAssertEqual(sample.replacingNewlinesWithSpaces(), "")
+    }
+
+    /// Verifies that `replacingNewlinesWithSpaces` replaces consecutive newlines with a single space
+    ///
+    func testReplaceNewlinesWithSpacesTurnMultipleConsecutiveNewlinesIntoSingleSpace() {
+        let sample: NSString = "WORD1\n\n\n\r\nWORD2\nWORD3\n\r\n\r\n\rWORD4"
+
+        XCTAssertEqual(sample.replacingNewlinesWithSpaces(), "WORD1 WORD2 WORD3 WORD4")
+    }
+
+    /// Verifies that `replacingNewlinesWithSpaces` trims leading and trailing newlines
+    ///
+    func testReplaceNewlinesWithSpacesTrimsLeadingAndTrailingNewlines() {
+        let sample: NSString = "\n\r\n\r\n\n\nWORD1\nWORD2\n\nWORD3\n\n\n\n"
+
+        XCTAssertEqual(sample.replacingNewlinesWithSpaces(), "WORD1 WORD2 WORD3")
+    }
+}


### PR DESCRIPTION
### Details:
In this PR we're updating the way in which Notes are previewed. More content is expected to fit in the Notes List. How come?

1. The "Preview Body" is now replacing newline characters with a single space
2. And yes, multiple consecutive newlines will collapse into a **single** space

Unit tests and batteries included.

cc @bummytime @SylvesterWilmott 

Closes #522
Ref. #507

### Test
1. Launch Simplenote
2. Add a new note with multiple leading newlines (and / or spaces), at least a title string, and multiple body lines

- [x] Verify that the Note List displays the body in a "compact" way: newlines are expected to be replaced with a single space
- [x] Verify that Spotlight Indexed notes look exactly like the way they show up in the Notes List

### Release
`RELEASE-NOTES.txt` was updated in d780ca7 with:
 
> The way in which Notes are previewed has been upgraded to fit more content onScreen.

---

### Picture Time!
<img width="300" src="https://user-images.githubusercontent.com/1195260/74034084-4f257b80-4996-11ea-9f5b-2359ec43dcad.png"><img width="300" src="https://user-images.githubusercontent.com/1195260/74034078-4cc32180-4996-11ea-9bf5-6af160404add.png">
