### PR TITLE
SPSectionHeaderView: Updates Leading Margins

### DIFF
--- a/Simplenote/Classes/SPSectionHeaderView.xib
+++ b/Simplenote/Classes/SPSectionHeaderView.xib
@@ -15,10 +15,10 @@
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dns-b6-tS7">
-                    <rect key="frame" x="20" y="5" width="402" height="48"/>
+                    <rect key="frame" x="28" y="5" width="394" height="48"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Search by Tag" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mCY-rM-Ize">
-                            <rect key="frame" x="0.0" y="0.0" width="402" height="48"/>
+                            <rect key="frame" x="0.0" y="0.0" width="394" height="48"/>
                             <viewLayoutGuide key="safeArea" id="bFo-VK-FYN"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <nil key="textColor"/>
@@ -50,7 +50,7 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dns-b6-tS7" secondAttribute="trailingMargin" id="8rI-63-x6f"/>
                 <constraint firstItem="dns-b6-tS7" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ry8-TP-QDs" secondAttribute="leadingMargin" id="E7N-df-pyY"/>
                 <constraint firstAttribute="bottom" secondItem="dns-b6-tS7" secondAttribute="bottom" constant="5" id="aYO-mA-wKK"/>
-                <constraint firstItem="dns-b6-tS7" firstAttribute="leading" secondItem="ry8-TP-QDs" secondAttribute="leadingMargin" id="hzK-5H-CBj"/>
+                <constraint firstItem="dns-b6-tS7" firstAttribute="leading" secondItem="ry8-TP-QDs" secondAttribute="leadingMargin" constant="8" id="hzK-5H-CBj"/>
                 <constraint firstItem="dns-b6-tS7" firstAttribute="centerX" secondItem="ry8-TP-QDs" secondAttribute="centerX" id="ron-Op-BfQ"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>


### PR DESCRIPTION
### Fix
In this PR we're slightly adjusting the Section Header's Leading Margin.

cc #507

### Test
1. Launch Simplenote
2. Press over the Search Bar

- [x] Verify that the Section Header looks great!

### Release
These changes do not require release notes.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/1195260/74034856-e50dd600-4997-11ea-856c-a8639dabd624.png">
