### PR TITLE
Search Highlight Background

### DIFF
--- a/Simplenote/Classes/NSMutableAttributedString+Simplenote.swift
+++ b/Simplenote/Classes/NSMutableAttributedString+Simplenote.swift
@@ -26,7 +26,7 @@ extension NSMutableAttributedString {
 
     /// Applies a given UIColor instance to substrings matching a given Keyword
     ///
-    func apply(color: UIColor, toSubstringsMatching keywords: String) {
+    func apply(fgColor: UIColor, bgColor: UIColor, to keywords: String) {
         let maxLength = foundationString.length
 
         for value in foundationString.ranges(forTerms: keywords) {
@@ -35,7 +35,8 @@ extension NSMutableAttributedString {
                 continue
             }
 
-            addAttribute(.foregroundColor, value: color, range: range)
+            addAttribute(.foregroundColor, value: fgColor, range: range)
+            addAttribute(.backgroundColor, value: bgColor, range: range)
         }
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -401,7 +401,8 @@ private extension SPNoteListViewController {
         cell.bodyText = note.bodyPreview
 
         cell.keywords = searchText
-        cell.keywordsTintColor = .simplenoteTintColor
+        cell.keywordsForegroundColor = .simplenoteKeywordForegroundColor
+        cell.keywordsBackgroundColor = .simplenoteKeywordBackgroundColor
 
         cell.refreshAttributedStrings()
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -85,7 +85,12 @@ class SPNoteTableViewCell: UITableViewCell {
     /// Highlighted Keywords's Tint Color
     /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
     ///
-    var keywordsTintColor: UIColor = .simplenoteTintColor
+    var keywordsForegroundColor: UIColor = .simplenoteKeywordForegroundColor
+
+    /// Highlighted Keywords's Tint Color
+    /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
+    ///
+    var keywordsBackgroundColor: UIColor = .simplenoteKeywordBackgroundColor
 
     /// Note's Title
     /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
@@ -151,19 +156,21 @@ class SPNoteTableViewCell: UITableViewCell {
     func refreshAttributedStrings() {
         titleLabel.attributedText = titleText.map {
             attributedText(from: $0,
-                           highlighing: keywords,
                            font: Style.headlineFont,
                            textColor: Style.headlineColor,
-                           highlightColor: keywordsTintColor)
+                           highlighting: keywords,
+                           keywordsForegroundColor: keywordsForegroundColor,
+                           keywordsBackgroundColor: keywordsBackgroundColor)
 
         }
 
         bodyLabel.attributedText = bodyText.map {
             attributedText(from: $0,
-                           highlighing: keywords,
                            font: Style.previewFont,
                            textColor: Style.previewColor,
-                           highlightColor: keywordsTintColor)
+                           highlighting: keywords,
+                           keywordsForegroundColor: keywordsForegroundColor,
+                           keywordsBackgroundColor: keywordsBackgroundColor)
         }
     }
 }
@@ -251,10 +258,11 @@ private extension SPNoteTableViewCell {
     /// Returns a NSAttributedString instance, stylizing the receiver with the current Highlighted Keywords + Font + Colors
     ///
     func attributedText(from string: String,
-                        highlighing keywords: String?,
                         font: UIFont,
                         textColor: UIColor,
-                        highlightColor: UIColor) -> NSAttributedString
+                        highlighting keywords: String?,
+                        keywordsForegroundColor: UIColor,
+                        keywordsBackgroundColor: UIColor) -> NSAttributedString
     {
         let output = NSMutableAttributedString(string: string, attributes: [
             .font: font,
@@ -265,7 +273,7 @@ private extension SPNoteTableViewCell {
         output.addChecklistAttachments(for: textColor)
 
         if let keywords = keywords {
-            output.apply(color: highlightColor, toSubstringsMatching: keywords)
+            output.apply(fgColor: keywordsForegroundColor, bgColor: keywordsBackgroundColor, to: keywords)
         }
 
         return output

--- a/Simplenote/Classes/SPTextView.m
+++ b/Simplenote/Classes/SPTextView.m
@@ -129,7 +129,7 @@
     
     NSMutableAttributedString *mutableAttributedString = [[NSMutableAttributedString alloc] initWithAttributedString:attributedString];
     [mutableAttributedString addAttribute:NSForegroundColorAttributeName
-                                    value:[UIColor simplenoteSearchHighlightTextColor]
+                                    value:[UIColor simplenoteKeywordWithinEditorForegroundColor]
                                     range:NSMakeRange(0, mutableAttributedString.length)];
 
     highlightLabel.attributedText = mutableAttributedString;

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -124,7 +124,7 @@ extension UIColor {
     }
 
     @objc
-    static var simplenoteSearchHighlightTextColor: UIColor {
+    static var simplenoteKeywordWithinEditorForegroundColor: UIColor {
         UIColor(studioColor: .white)
     }
 

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -135,7 +135,7 @@ extension UIColor {
 
     @objc
     static var simplenoteKeywordBackgroundColor: UIColor {
-        UIColor(lightColor: .blue0, darkColor: .gray70)
+        UIColor(lightColor: .blue0, darkColor: .darkGray8)
     }
 
     @objc

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -129,6 +129,16 @@ extension UIColor {
     }
 
     @objc
+    static var simplenoteKeywordForegroundColor: UIColor {
+        .simplenoteTintColor
+    }
+
+    @objc
+    static var simplenoteKeywordBackgroundColor: UIColor {
+        UIColor(lightColor: .blue0, darkColor: .gray70)
+    }
+
+    @objc
     static var simplenoteSwitchTintColor: UIColor {
         UIColor(lightColor: .gray5, darkColor: .darkGray4)
     }


### PR DESCRIPTION
### Details
In this PR we're adding a background to the Search Keyword Highlight within the Notes List.

cc @SylvesterWilmott this woooould be:

**Foreground:** `light: .blue50` / `dark: .blue30`
**Background**: `light: .blue0`  / `dark: .darkGray8`

cc'ing @bummytime for the code review 

Thanks in advance!!

Ref. #507


### Test
1. Launch the app
2. Press over the Search Bar
3. Type a keyword that yields at least one result

- [x] Verify the matching keywords are highlighted with a FG / BG
- [x] Verify this also works super in dark mode!

### Release
These changes do not require release notes.

### Screenshots
<img width="300" src="https://user-images.githubusercontent.com/1195260/74051682-2f527f80-49b7-11ea-996c-695692aa73e6.png"><img width="300" src="https://user-images.githubusercontent.com/1195260/74051689-311c4300-49b7-11ea-9642-69b42542a1b2.png">
