### PR TITLE
Revert "Search Highlight Background"

### DIFF
--- a/Simplenote/Classes/NSMutableAttributedString+Simplenote.swift
+++ b/Simplenote/Classes/NSMutableAttributedString+Simplenote.swift
@@ -26,7 +26,7 @@ extension NSMutableAttributedString {
 
     /// Applies a given UIColor instance to substrings matching a given Keyword
     ///
-    func apply(fgColor: UIColor, bgColor: UIColor, to keywords: String) {
+    func apply(color: UIColor, toSubstringsMatching keywords: String) {
         let maxLength = foundationString.length
 
         for value in foundationString.ranges(forTerms: keywords) {
@@ -35,8 +35,7 @@ extension NSMutableAttributedString {
                 continue
             }
 
-            addAttribute(.foregroundColor, value: fgColor, range: range)
-            addAttribute(.backgroundColor, value: bgColor, range: range)
+            addAttribute(.foregroundColor, value: color, range: range)
         }
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -418,8 +418,7 @@ private extension SPNoteListViewController {
         cell.bodyText = note.bodyPreview
 
         cell.keywords = searchText
-        cell.keywordsForegroundColor = .simplenoteKeywordForegroundColor
-        cell.keywordsBackgroundColor = .simplenoteKeywordBackgroundColor
+        cell.keywordsTintColor = .simplenoteTintColor
 
         cell.refreshAttributedStrings()
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -85,12 +85,7 @@ class SPNoteTableViewCell: UITableViewCell {
     /// Highlighted Keywords's Tint Color
     /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
     ///
-    var keywordsForegroundColor: UIColor = .simplenoteKeywordForegroundColor
-
-    /// Highlighted Keywords's Tint Color
-    /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
-    ///
-    var keywordsBackgroundColor: UIColor = .simplenoteKeywordBackgroundColor
+    var keywordsTintColor: UIColor = .simplenoteTintColor
 
     /// Note's Title
     /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
@@ -156,21 +151,19 @@ class SPNoteTableViewCell: UITableViewCell {
     func refreshAttributedStrings() {
         titleLabel.attributedText = titleText.map {
             attributedText(from: $0,
+                           highlighing: keywords,
                            font: Style.headlineFont,
                            textColor: Style.headlineColor,
-                           highlighting: keywords,
-                           keywordsForegroundColor: keywordsForegroundColor,
-                           keywordsBackgroundColor: keywordsBackgroundColor)
+                           highlightColor: keywordsTintColor)
 
         }
 
         bodyLabel.attributedText = bodyText.map {
             attributedText(from: $0,
+                           highlighing: keywords,
                            font: Style.previewFont,
                            textColor: Style.previewColor,
-                           highlighting: keywords,
-                           keywordsForegroundColor: keywordsForegroundColor,
-                           keywordsBackgroundColor: keywordsBackgroundColor)
+                           highlightColor: keywordsTintColor)
         }
     }
 }
@@ -258,11 +251,10 @@ private extension SPNoteTableViewCell {
     /// Returns a NSAttributedString instance, stylizing the receiver with the current Highlighted Keywords + Font + Colors
     ///
     func attributedText(from string: String,
+                        highlighing keywords: String?,
                         font: UIFont,
                         textColor: UIColor,
-                        highlighting keywords: String?,
-                        keywordsForegroundColor: UIColor,
-                        keywordsBackgroundColor: UIColor) -> NSAttributedString
+                        highlightColor: UIColor) -> NSAttributedString
     {
         let output = NSMutableAttributedString(string: string, attributes: [
             .font: font,
@@ -273,7 +265,7 @@ private extension SPNoteTableViewCell {
         output.addChecklistAttachments(for: textColor)
 
         if let keywords = keywords {
-            output.apply(fgColor: keywordsForegroundColor, bgColor: keywordsBackgroundColor, to: keywords)
+            output.apply(color: highlightColor, toSubstringsMatching: keywords)
         }
 
         return output

--- a/Simplenote/Classes/SPTextView.m
+++ b/Simplenote/Classes/SPTextView.m
@@ -129,7 +129,7 @@
     
     NSMutableAttributedString *mutableAttributedString = [[NSMutableAttributedString alloc] initWithAttributedString:attributedString];
     [mutableAttributedString addAttribute:NSForegroundColorAttributeName
-                                    value:[UIColor simplenoteKeywordWithinEditorForegroundColor]
+                                    value:[UIColor simplenoteSearchHighlightTextColor]
                                     range:NSMakeRange(0, mutableAttributedString.length)];
 
     highlightLabel.attributedText = mutableAttributedString;

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -124,18 +124,8 @@ extension UIColor {
     }
 
     @objc
-    static var simplenoteKeywordWithinEditorForegroundColor: UIColor {
+    static var simplenoteSearchHighlightTextColor: UIColor {
         UIColor(studioColor: .white)
-    }
-
-    @objc
-    static var simplenoteKeywordForegroundColor: UIColor {
-        .simplenoteTintColor
-    }
-
-    @objc
-    static var simplenoteKeywordBackgroundColor: UIColor {
-        UIColor(lightColor: .blue0, darkColor: .darkGray8)
     }
 
     @objc


### PR DESCRIPTION
### Details:

We're reverting PR #630 based on @SylvesterWilmott 's feedback.

**Plus:** Sly also spotted a bug in which, when in Search Mode, the Note Cells wouldn't properly render. Such issue was also tracked down to NSAttributedString's `.background` property usage (causing layout issues).

cc @bummytime (Thank you sir!)

### Testing:
1. Launch the app
2. Press over the Search Bar
3. Type a keyword that yields at least one result

- [x] Verify the matching keywords are highlighted without Background Highlight
