### PR TITLE
Properly Dismissing Feedback UI

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 4.16
 -----
- 
+
+4.15.1
+------
+-   We've fixed a bug that prevented the Feedback UI from being dismissed
+
 4.15
 -----
 -   Simplenote just got brand new App Icons!

--- a/Simplenote/Classes/SPFeedbackManager.swift
+++ b/Simplenote/Classes/SPFeedbackManager.swift
@@ -5,12 +5,22 @@ import SafariServices
 
 // MARK: - SPFeedbackManager
 //
+@objcMembers
 class SPFeedbackManager: NSObject {
+
+    /// Ladies and gentlemen, yet another Singleton!
+    ///
+    static let shared = SPFeedbackManager()
+
+    /// Let's just hide the initializer?
+    ///
+    private override init() {
+        // NO-OP
+    }
 
     /// Returns a ViewController capable of dealing with User Feedback. By default: MailComposer, and as a fallback... Safari!
     ///
-    @objc
-    static func feedbackViewController() -> UIViewController {
+    func feedbackViewController() -> UIViewController {
         guard MFMailComposeViewController.canSendMail() else {
             return SFSafariViewController(url: SPCredentials.simplenoteFeedbackURL)
         }
@@ -20,7 +30,18 @@ class SPFeedbackManager: NSObject {
         let mailViewController = MFMailComposeViewController()
         mailViewController.setSubject(subjectText)
         mailViewController.setToRecipients([SPCredentials.simplenoteFeedbackMail])
+        mailViewController.mailComposeDelegate = self
 
         return mailViewController
+    }
+}
+
+
+// MARK: - MFMailComposeViewControllerDelegate
+//
+extension SPFeedbackManager: MFMailComposeViewControllerDelegate {
+
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+         controller.dismiss(animated: true, completion: nil)
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -1201,7 +1201,7 @@
 
 - (void)displayFeedbackUI
 {
-    UIViewController *feedbackViewController = [SPFeedbackManager feedbackViewController];
+    UIViewController *feedbackViewController = [[SPFeedbackManager shared] feedbackViewController];
     feedbackViewController.modalPresentationStyle = UIModalPresentationFormSheet;
     [self presentViewController:feedbackViewController animated:YES completion:nil];
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -1145,9 +1145,9 @@
 - (void)showRatingViewIfNeeded
 {
     if (![[SPRatingsHelper sharedInstance] shouldPromptForAppReview]) {
-//        return;
+        return;
     }
-
+    
     [SPTracker trackRatingsPromptSeen];
 
     UIView *ratingsView = self.tableView.tableHeaderView ?: [self newRatingsView];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -1145,9 +1145,9 @@
 - (void)showRatingViewIfNeeded
 {
     if (![[SPRatingsHelper sharedInstance] shouldPromptForAppReview]) {
-        return;
+//        return;
     }
-    
+
     [SPTracker trackRatingsPromptSeen];
 
     UIView *ratingsView = self.tableView.tableHeaderView ?: [self newRatingsView];


### PR DESCRIPTION
### Fix
***(Required)*** Add a concise description of what you fixed.  If this is related to an issue, add a link to it.  If applicable, add screenshots, animations, or videos to help illustrate the fix.

cc @bummytime

Closes #636

### Test
0. Setup a Mail Account in iOS's Mail App
1. Checkout commit d3a124f to test this PR
2. Launch Simplenote
3. Press over **Could be better**
4. Press over **Send feedback**
5. Fill in a sample email
6. Press over the top right button to send

- [x] Verify the UI **effectively** gets dismissed!
- [ ] Verify the email reaches Zendesk

### Release
`RELEASE-NOTES.txt` was updated in 5ef4f66 with:

> We've fixed a bug that prevented the Feedback UI from being dismissed
