### PR TITLE
Implementing SortBar: Mark II

### DIFF
--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -63,11 +63,27 @@ class NotesListController: NSObject {
         }
     }
 
-    /// SortMode to be applied
+    /// SortMode to be applied to **regular** results
     ///
     var sortMode: SortMode = .alphabeticallyAscending {
         didSet {
             guard oldValue != sortMode else {
+                return
+            }
+
+            refreshSortDescriptors()
+        }
+    }
+
+    /// SortMode to be applied to Search Results
+    ///
+    var searchSortMode: SortMode = .alphabeticallyAscending {
+        didSet {
+            guard case .searching = state else {
+                return
+            }
+
+            guard oldValue != searchSortMode else {
                 return
             }
 
@@ -239,6 +255,7 @@ private extension NotesListController {
     }
 
     func refreshSortDescriptors() {
+        let sortMode = sortModeForActiveState
         notesController.sortDescriptors = sortMode.descriptorsForNotes
         tagsController.sortDescriptors = sortMode.descriptorsForTags
     }
@@ -322,5 +339,14 @@ private extension NotesListController {
         let transposedSectionChanges = noteSectionChanges.map { $0.transpose(toSection: state.sectionIndexForNotes) }
 
         return (transposedObjectChanges, transposedSectionChanges)
+    }
+
+    var sortModeForActiveState: SortMode {
+        switch state {
+        case .searching(_):
+            return searchSortMode
+        case .results:
+            return sortMode
+        }
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -656,8 +656,7 @@ extension SPNoteListViewController {
             }
         }
 
-        let cancelText = NSLocalizedString("Cancel", comment: "")
-        alertController.addCancelActionWithTitle(cancelText)
+        alertController.addCancelActionWithTitle(ActionTitle.cancel)
 
         feedbackGenerator.impactOccurred()
         present(alertController, animated: true, completion: nil)
@@ -668,6 +667,7 @@ extension SPNoteListViewController {
 // MARK: - Private Types
 //
 private enum ActionTitle {
+    static let cancel = NSLocalizedString("Cancel", comment: "Dismissing an interface")
     static let delete = NSLocalizedString("Delete", comment: "Trash (verb) - the action of deleting a note")
     static let pin = NSLocalizedString("Pin", comment: "Pin (verb) - the action of Pinning a note")
     static let restore = NSLocalizedString("Restore", comment: "Restore a note from the trash, marking it as undeleted")

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -204,6 +204,7 @@ extension SPNoteListViewController {
 
         notesListController.filter = filter
         notesListController.sortMode = Options.shared.listSortMode
+        notesListController.searchSortMode = Options.shared.searchSortMode
         notesListController.performFetch()
 
         tableView.reloadData()
@@ -650,7 +651,7 @@ extension SPNoteListViewController {
     @IBAction
     func sortOrderWasPressed() {
         feedbackGenerator.impactOccurred()
-//        sortMode = sortMode.inverse
+        Options.shared.searchSortMode = notesListController.searchSortMode.inverse
     }
 
     @IBAction
@@ -659,7 +660,7 @@ extension SPNoteListViewController {
 
         for mode in [SortMode.alphabeticallyAscending, .createdNewest, .modifiedNewest] {
             alertController.addDefaultActionWithTitle(mode.kind) { _ in
-//                self.sortMode = mode
+                Options.shared.searchSortMode = mode
             }
         }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -7,6 +7,14 @@ import UIKit
 //
 extension SPNoteListViewController {
 
+    /// Sets up the Feedback Generator!
+    ///
+    @objc
+    func configureImpactGenerator() {
+        feedbackGenerator = UIImpactFeedbackGenerator()
+        feedbackGenerator.prepare()
+    }
+
     /// Sets up the main TableView
     ///
     @objc

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -345,7 +345,7 @@ extension SPNoteListViewController: UIViewControllerPreviewingDelegate {
 extension SPNoteListViewController: UIScrollViewDelegate {
 
     public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        guard searchBar.isFirstResponder else {
+        guard searchBar.isFirstResponder, searchBar.text?.isEmpty == false else {
             return
         }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -657,6 +657,7 @@ extension SPNoteListViewController {
     @IBAction
     func sortModeWasPressed() {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alertController.popoverPresentationController?.sourceView = sortBar
 
         for mode in [SortMode.alphabeticallyAscending, .createdNewest, .modifiedNewest] {
             alertController.addDefaultActionWithTitle(mode.kind) { _ in

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -44,14 +44,12 @@ extension SPNoteListViewController {
         sortBar = SPSortBar.instantiateFromNib()
 
         sortBar.isHidden = true
-        sortBar.onSortModePress = {
-// TODO: Wire Me
-            NSLog("# onSortModePress")
+        sortBar.onSortModePress = { [weak self] in
+            self?.sortModeWasPressed()
         }
 
-        sortBar.onSortOrderPress = {
-// TODO: Wire Me
-            NSLog("# onSortOrderPress")
+        sortBar.onSortOrderPress = { [weak self] in
+            self?.sortOrderWasPressed()
         }
     }
 
@@ -634,6 +632,35 @@ extension SPNoteListViewController {
 
         // Keyboard onScreen: Consider the Sort Bar
         return keyboardHeight - sortBar.frame.height
+    }
+}
+
+
+// MARK: - Action Handlers
+//
+extension SPNoteListViewController {
+
+    @IBAction
+    func sortOrderWasPressed() {
+        feedbackGenerator.impactOccurred()
+//        sortMode = sortMode.inverse
+    }
+
+    @IBAction
+    func sortModeWasPressed() {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        for mode in [SortMode.alphabeticallyAscending, .createdNewest, .modifiedNewest] {
+            alertController.addDefaultActionWithTitle(mode.kind) { _ in
+//                self.sortMode = mode
+            }
+        }
+
+        let cancelText = NSLocalizedString("Cancel", comment: "")
+        alertController.addCancelActionWithTitle(cancelText)
+
+        feedbackGenerator.impactOccurred()
+        present(alertController, animated: true, completion: nil)
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -636,7 +636,7 @@ extension SPNoteListViewController {
 }
 
 
-// MARK: - Action Handlers
+// MARK: - Search Action Handlers
 //
 extension SPNoteListViewController {
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -240,6 +240,13 @@ extension SPNoteListViewController {
         searchController.updateSearchText(searchText: updated + .space)
     }
 
+    /// Refreshes the SortBar's Description Text
+    ///
+    @objc
+    func refreshSortBarText() {
+        sortBar.descriptionText = Options.shared.searchSortMode.description
+    }
+
     /// Displays the Emtpy State Placeholders, when / if needed
     ///
     @objc

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -14,6 +14,7 @@
 @property (nonatomic, strong, readonly) SPBlurEffectView                    *navigationBarBackground;
 @property (nonatomic, strong, readonly) UISearchBar                         *searchBar;
 @property (nonatomic, assign, readonly) BOOL                                isIndexingNotes;
+@property (nonatomic, strong) UIImpactFeedbackGenerator                     *feedbackGenerator;
 @property (nonatomic, strong) SPPlaceholderView                             *placeholderView;
 @property (nonatomic, strong) SPSortBar                                     *sortBar;
 @property (nonatomic, strong) UITableView                                   *tableView;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -55,6 +55,7 @@
     
     self = [super init];
     if (self) {
+        [self configureImpactGenerator];
         [self configureNavigationButtons];
         [self configureNavigationBarBackground];
         [self configureResultsController];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -478,6 +478,7 @@
     [self refreshListController];
     [self refreshTitle];
     [self refreshSearchBar];
+    [self refreshSortBarText];
 
     BOOL isTrashOnScreen = self.isDeletedFilterActive;
     BOOL isNotEmpty = !self.isListEmpty;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -192,7 +192,8 @@
 
     // Condensed Notes
     [nc addObserver:self selector:@selector(condensedPreferenceWasUpdated:) name:SPCondensedNoteListPreferenceChangedNotification object:nil];
-    [nc addObserver:self selector:@selector(sortOrderPreferenceWasUpdated:) name:SPNotesListSortModeChangedNotification object:nil];
+    [nc addObserver:self selector:@selector(sortModePreferenceWasUpdated:) name:SPNotesListSortModeChangedNotification object:nil];
+    [nc addObserver:self selector:@selector(sortModePreferenceWasUpdated:) name:SPSearchSortModeChangedNotification object:nil];
 
     // Register for keyboard notifications
     [nc addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
@@ -211,8 +212,8 @@
     [self updateTableViewMetrics];
 }
 
-- (void)sortOrderPreferenceWasUpdated:(id)sender {
-
+- (void)sortModePreferenceWasUpdated:(id)sender
+{
     [self update];
 }
 

--- a/Simplenote/Classes/SPNotifications.h
+++ b/Simplenote/Classes/SPNotifications.h
@@ -15,4 +15,5 @@
 extern NSString *const SPAlphabeticalTagSortPreferenceChangedNotification;
 extern NSString *const SPCondensedNoteListPreferenceChangedNotification;
 extern NSString *const SPNotesListSortModeChangedNotification;
+extern NSString *const SPSearchSortModeChangedNotification;
 extern NSString *const SPSimplenoteThemeChangedNotification;

--- a/Simplenote/Classes/SPNotifications.m
+++ b/Simplenote/Classes/SPNotifications.m
@@ -15,4 +15,5 @@
 NSString *const SPAlphabeticalTagSortPreferenceChangedNotification  = @"SPAlphabeticalTagSortPreferenceChangedNotification";
 NSString *const SPCondensedNoteListPreferenceChangedNotification    = @"SPCondensedNoteListPreferenceChangedNotification";
 NSString *const SPNotesListSortModeChangedNotification              = @"SPNotesListSortModeChangedNotification";
+NSString *const SPSearchSortModeChangedNotification                 = @"SPSearchSortModeChangedNotification";
 NSString *const SPSimplenoteThemeChangedNotification                = @"SPSimplenoteThemeChangedNotification";

--- a/Simplenote/Classes/SPSortBar.swift
+++ b/Simplenote/Classes/SPSortBar.swift
@@ -26,6 +26,17 @@ class SPSortBar: UIView {
     ///
     @IBOutlet private var descriptionLabel: UILabel!
 
+    /// Wraps up the Description Label Text
+    ///
+    var descriptionText: String? {
+        get {
+            descriptionLabel.text
+        }
+        set {
+            descriptionLabel.text = newValue
+        }
+    }
+
     /// Closure to be executed whenever the Sort Mode Button is pressed
     ///
     var onSortModePress: (() -> Void)?

--- a/Simplenote/Classes/SPTracker.h
+++ b/Simplenote/Classes/SPTracker.h
@@ -49,6 +49,7 @@
 + (void)trackSettingsPinlockEnabled:(BOOL)isOn;
 + (void)trackSettingsListCondensedEnabled:(BOOL)isOn;
 + (void)trackSettingsNoteListSortMode:(NSString *)description;
++ (void)trackSettingsSearchSortMode:(NSString *)description;
 + (void)trackSettingsThemeUpdated:(NSString *)themeName;
 
 #pragma mark - Sidebar

--- a/Simplenote/Classes/SPTracker.m
+++ b/Simplenote/Classes/SPTracker.m
@@ -185,6 +185,11 @@
     [self trackAutomatticEventWithName:@"settings_note_list_sort_mode" properties:@{ @"description" : description }];
 }
 
++ (void)trackSettingsSearchSortMode:(NSString *)description
+{
+    [self trackAutomatticEventWithName:@"settings_search_sort_mode" properties:@{ @"description" : description }];
+}
+
 + (void)trackSettingsThemeUpdated:(NSString *)themeName
 {
     NSParameterAssert(themeName);

--- a/Simplenote/Classes/UserDefaults+Simplenote.swift
+++ b/Simplenote/Classes/UserDefaults+Simplenote.swift
@@ -10,6 +10,7 @@ extension UserDefaults {
         case lastKnownVersionByRatingsFramework = "WPRatingsCurrentVersion"
         case listSortMode
         case listSortModeLegacy = "SPAlphabeticalSortPref"
+        case searchSortMode
         case theme
         case themeLegacy = "SPThemePref"
         case wordPressSessionKey = "SPAuthSessionKey"

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -75,7 +75,7 @@ extension Options {
         }
         set {
             defaults.set(newValue.rawValue, forKey: .searchSortMode)
-                SPTracker.trackSettingsSearchSortMode(newValue.description)
+            SPTracker.trackSettingsSearchSortMode(newValue.description)
             NotificationCenter.default.post(name: .SPSearchSortModeChanged, object: nil)
         }
     }

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -61,6 +61,25 @@ extension Options {
         }
     }
 
+    /// Returns the Search's Sort Mode. When it's undefined we'll fallback to the List's Sort Mode
+    ///
+    @objc
+    var searchSortMode: SortMode {
+        get {
+            guard defaults.containsObject(forKey: .searchSortMode) else {
+                return listSortMode
+            }
+
+            let payload = defaults.integer(forKey: .searchSortMode)
+            return SortMode(rawValue: payload) ?? .alphabeticallyAscending
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: .searchSortMode)
+                SPTracker.trackSettingsSearchSortMode(newValue.description)
+            NotificationCenter.default.post(name: .SPSearchSortModeChanged, object: nil)
+        }
+    }
+
     /// Returns the selected Theme
     ///
     @objc
@@ -105,6 +124,7 @@ extension Options {
     func reset() {
         defaults.removeObject(forKey: .theme)
         defaults.removeObject(forKey: .listSortMode)
+        defaults.removeObject(forKey: .searchSortMode)
     }
     
     /// Returns the number of Preview Lines we should use, per note

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -62,6 +62,7 @@ class NotesListControllerTests: XCTestCase {
         XCTAssertEqual(noteListController.numberOfObjects, notes.count)
 
         noteListController.sortMode = .alphabeticallyDescending
+        noteListController.searchSortMode = .alphabeticallyDescending
         noteListController.performFetch()
 
         let reversedNotes = Array(notes.reversed())
@@ -256,6 +257,29 @@ class NotesListControllerTests: XCTestCase {
 
         for (row, note) in notes.enumerated() {
             XCTAssertEqual(noteListController.indexPath(forObject: note), IndexPath(row: row, section: 1))
+        }
+    }
+
+    /// Verifies that the SortMode property properly applies the specified order mode to the retrieved entities
+    ///
+    func testListControllerProperlyAppliesSearchSortModeToSearchResults() {
+        let (notes, _, _) = insertSampleEntities(count: 100)
+
+        storage.save()
+        noteListController.beginSearch()
+
+        // Search Mode: Expect an inverted collection (regardless of the regular sort mode)
+        noteListController.sortMode = .alphabeticallyAscending
+        noteListController.searchSortMode = .alphabeticallyDescending
+
+        // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
+        noteListController.refreshSearchResults(keyword: "0")
+
+        let reversedNotes = Array(notes.reversed())
+        let retrievedNotes = noteListController.sections.first!.objects.compactMap { $0 as? Note }
+
+        for (index, note) in retrievedNotes.enumerated() {
+            XCTAssertEqual(note.content, reversedNotes[index].content)
         }
     }
 

--- a/SimplenoteTests/OptionsTests.swift
+++ b/SimplenoteTests/OptionsTests.swift
@@ -26,6 +26,14 @@ class OptionsTests: XCTestCase {
         XCTAssert(options.listSortMode == .alphabeticallyAscending)
     }
 
+    func testEmptySearchSortModeYieldsListSortMode() {
+        let options = Options(defaults: defaults)
+        XCTAssertEqual(options.listSortMode, options.searchSortMode)
+
+        options.listSortMode = .alphabeticallyDescending
+        XCTAssertEqual(options.searchSortMode, .alphabeticallyDescending)
+    }
+
     func testLegacyUnspecifiedThemeIsProperlyMigrated() {
         let options = Options(defaults: defaults)
 


### PR DESCRIPTION
### Details:
In this PR we're bringing the SortBar's to life:

- **NoteListController** now has a specific SortMode to be applied when retrieving search results
- **Notes List** now has a Feedback Generator, triggered whenever any of the SortBar buttons is pressed
- We're wiring the Sort Order button: active Sort Order will be inverted on press
- And we're also wiring the Sort Mode button: an Alert Controller will be presented, with the valid options.
- Last but not least, the current Search Sort Mode will now be displayed in the Sort Bar

**Any feedback will be very very oh so very much welcomed!!!**

Ref. #507

cc @bummytime

### Scenario: Sort Order
1. Launch Simplenote
2. Press over the Search Bar
3. Enter any keyword that yields at least one result
4. Scroll downwards to dismiss the keyboard

- [x] Verify that pressing over the Sort Order button (left corner, in the Sort Bar) inverts the Search Results

### Scenario: Sort Mode
1. Launch Simplenote
2. Press over the Search Bar
3. Enter any keyword that yields at least one result
4. Scroll downwards to dismiss the keyboard

- [x] Verify that pressing over the Sort Mode (center of the sort bar) presents an Alert with all of the available Sort Modes
- [x] Verify that the Search's Sort Mode is persisted among sessions (last option you've picked should always be the default)

### Release
These changes do not require release notes.
