### PR TITLE
Adjusting Logout Overlay

### DIFF
--- a/Simplenote/Classes/SPModalActivityIndicator.h
+++ b/Simplenote/Classes/SPModalActivityIndicator.h
@@ -1,11 +1,3 @@
-//
-//  SPModalActivityIndicator.h
-//  Simplenote
-//
-//  Created by Tom Witkin on 8/30/13.
-//  Copyright (c) 2013 Automattic. All rights reserved.
-//
-
 #import <UIKit/UIKit.h>
 
 @interface SPModalActivityIndicator : UIView {

--- a/Simplenote/Classes/SPModalActivityIndicator.m
+++ b/Simplenote/Classes/SPModalActivityIndicator.m
@@ -1,12 +1,6 @@
-//
-//  SPModalActivityIndicator.m
-//  Simplenote
-//
-//  Created by Tom Witkin on 8/30/13.
-//  Copyright (c) 2013 Automattic. All rights reserved.
-//
-
 #import "SPModalActivityIndicator.h"
+#import "Simplenote-Swift.h"
+
 
 @implementation SPModalActivityIndicator
 
@@ -14,7 +8,7 @@
     
     SPModalActivityIndicator *alertView = [[SPModalActivityIndicator alloc] initWithFrame:CGRectZero];
 
-    UIActivityIndicatorView *activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    UIActivityIndicatorView *activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
     [activityIndicator startAnimating];
     
     [alertView showWithContentView:activityIndicator];
@@ -51,7 +45,7 @@
 
 - (void)applyStyling {
     
-    self.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.8];
+    self.backgroundColor = [UIColor simplenoteModalOverlayColor];
 }
 
 -(void)setupLayout {

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -189,6 +189,11 @@ extension UIColor {
     }
 
     @objc
+    static var simplenoteModalOverlayColor: UIColor {
+        UIColor(studioColor: .black).withAlphaComponent(UIKitConstants.alpha0_4)
+    }
+
+    @objc
     static var simplenoteTableViewBackgroundColor: UIColor {
         UIColor(lightColor: .gray0, darkColor: .darkGray0)
     }

--- a/Simplenote/Classes/UIKitConstants.swift
+++ b/Simplenote/Classes/UIKitConstants.swift
@@ -6,6 +6,7 @@ import Foundation
 @objcMembers
 class UIKitConstants: NSObject {
     static let alpha0_0 = CGFloat(0)
+    static let alpha0_4 = CGFloat(0.4)
     static let alpha0_5 = CGFloat(0.5)
     static let alpha0_6 = CGFloat(0.6)
     static let alpha1_0 = CGFloat(1)


### PR DESCRIPTION
### Fix
In this PR we're adjusting the Logout Overlay color, so that it looks great in Light / Dark Mode.

cc @bummytime (Thankyooou!!!)

Ref. #478

### Test
1. Launch the app
2. Open the Settings UI
3. Switch over to the Light Mode
4. Logout from Simplenote

- [x] Verify the Overlay looks great
- [x] Repeat in Dark Mode, and verify the Overlay also looks great!

### Release
These changes do not require release notes.

### Screenshots
<img width="200" src="https://user-images.githubusercontent.com/1195260/74531628-f876ef00-4f0b-11ea-838c-7846cef0a9e6.png"><img width="200" src="https://user-images.githubusercontent.com/1195260/74531631-fb71df80-4f0b-11ea-8482-b1cd67abbbee.png">
