### PR TITLE
Adjusting Launch Screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 -   Fixed a bug in which the Search Mode wouldn't properly be dismissed from the Editor
 -   Fixed a bug that caused the Editor's Keyboard Appearance not to match the selected theme
 -   Dark Mode is now darker than just dark, for an improved dark side experience.
+-   Simplenote's Launch Screen will now match iOS's Appearance Settings
 
 4.15.1
 ------

--- a/Simplenote/Colors.xcassets/simplenoteLaunchBackgroundColor.colorset/Contents.json
+++ b/Simplenote/Colors.xcassets/simplenoteLaunchBackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0x1A",
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1C"
+        }
+      }
+    }
+  ]
+}

--- a/Simplenote/Resources/LaunchScreen.storyboard
+++ b/Simplenote/Resources/LaunchScreen.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,16 +18,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="simplenote-logo" translatesAutoresizingMaskIntoConstraints="NO" id="bmg-w9-erw">
-                                <rect key="frame" x="152" y="393" width="110" height="110"/>
+                                <rect key="frame" x="171" y="412" width="72" height="72"/>
+                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="110" id="NQr-Rx-p4M"/>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="110" id="hMJ-RB-umE"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="110" id="wbb-4b-mOr"/>
-                                    <constraint firstAttribute="width" constant="110" id="zt9-RH-5UK"/>
+                                    <constraint firstAttribute="height" constant="72" id="NQr-Rx-p4M"/>
+                                    <constraint firstAttribute="width" constant="72" id="zt9-RH-5UK"/>
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" name="simplenoteLaunchBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="centerX" secondItem="bmg-w9-erw" secondAttribute="centerX" id="JCi-70-NwG"/>
                             <constraint firstAttribute="centerY" secondItem="bmg-w9-erw" secondAttribute="centerY" id="ose-LU-DXV"/>
@@ -41,5 +41,8 @@
     </scenes>
     <resources>
         <image name="simplenote-logo" width="220" height="220"/>
+        <namedColor name="simplenoteLaunchBackgroundColor">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
### Fix
In this PR we're adjusting the Launch Screen:

1. The image at the center is, as of now, smaller (72x72 points)
2. The background color is now System-Theme friendly. It'll adapt to the OS theme settings

cc @bummytime Yayyy!!

Ref. #478

### Test: Light Mode
1. Fresh install the app

- [x] Verify the Launch Screen looks great (in light mode)

### Test: Dark Mode
0. Open the Settings.app in your simulator
1. Scroll all the way down and press over the **Developer** row
2. Enable the **Dark Appearance** switch
3. Launch Simplenote

- [x] Verify the Launch Screen looks aaaawesome in Darth Mode

### Release
`RELEASE-NOTES.txt` was updated in 22a8dad with:
 
> Simplenote's Launch Screen will now match iOS's Appearance Settings

### Screenshots
<img width="200" src="https://user-images.githubusercontent.com/1195260/74532382-dbdbb680-4f0d-11ea-8757-209907de93a5.png"><img width="200" src="https://user-images.githubusercontent.com/1195260/74532378-d9795c80-4f0d-11ea-8821-833f41436499.png">
