### PR TITLE
Password Autofill

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 -   Fixed a bug in which the Search Mode wouldn't properly be dismissed from the Editor
 -   Fixed a bug that caused the Editor's Keyboard Appearance not to match the selected theme
 -   Dark Mode is now darker than just dark, for an improved dark side experience.
+-   Simplenote now supports Password Autofill support. Logging in has never been faster!
 
 4.15.1
 ------

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -27,6 +27,7 @@ class SPAuthViewController: UIViewController {
             emailInputView.rightViewMode = .always
             emailInputView.textColor = .simplenoteGray80Color
             emailInputView.delegate = self
+            emailInputView.textContentType = .username
         }
     }
 
@@ -53,6 +54,7 @@ class SPAuthViewController: UIViewController {
             passwordInputView.rightViewInsets = AuthenticationConstants.onePasswordInsets
             passwordInputView.textColor = .simplenoteGray80Color
             passwordInputView.delegate = self
+            passwordInputView.textContentType = .password
         }
     }
 

--- a/Simplenote/Classes/SPTextInputView.swift
+++ b/Simplenote/Classes/SPTextInputView.swift
@@ -205,6 +205,17 @@ class SPTextInputView: UIView {
         }
     }
 
+    /// ContentType: Autofill Support!
+    ///
+    var textContentType: UITextContentType {
+        get {
+            textField.textContentType
+        }
+        set {
+            textField.textContentType = newValue
+        }
+    }
+
     /// When toggled, the border color will be updated to borderColorError
     ///
     var inErrorState: Bool = false {

--- a/Simplenote/Simplenote-Internal.entitlements
+++ b/Simplenote/Simplenote-Internal.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:simplenote.com</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.$(CFBundleIdentifier)</string>

--- a/Simplenote/Simplenote.entitlements
+++ b/Simplenote/Simplenote.entitlements
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>previous-application-identifiers</key>
+	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>4ESDVWK654.com.codality.NotationalFlow</string>
+		<string>webcredentials:simplenote.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
@@ -13,6 +13,10 @@
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+		<string>4ESDVWK654.com.codality.NotationalFlow</string>
+	</array>
+	<key>previous-application-identifiers</key>
+	<array>
 		<string>4ESDVWK654.com.codality.NotationalFlow</string>
 	</array>
 </dict>


### PR DESCRIPTION
### Details:
In this PR we're setting up Simplenote.com as an associated domain, and bringing in support for Password Autofill in the Auth screens.

cc @bummytime (this is a cool one!!)

### Test
0. Make sure you've got your simplenote.com credentials stored in 1Password
1. Fresh install the app
2. Open the Authentication UI

- [x] Verify the Autofill bar gets properly populated
- [x] Verify that pressing the Autofill bar properly loads the Username + Password

### Release
`RELEASE-NOTES.txt` was updated in e5f61c0 with:
 
> Simplenote now supports Password Autofill support. Logging in has never been faster!

### Screenshot!
<img width="200" src="https://user-images.githubusercontent.com/1195260/74553912-0beb7f80-4f37-11ea-9c6d-139ce65b9b4f.png">
