### PR TITLE
Light Color Adjustments

### DIFF
--- a/Simplenote/Classes/ColorStudio.swift
+++ b/Simplenote/Classes/ColorStudio.swift
@@ -112,7 +112,7 @@ enum ColorStudio: String {
     case red80          = "691c1c"
     case red90          = "451313"
     case red100         = "240a0a"
-    case spWhite        = "fefefe"
+    case spWhite        = "fefffe"
     case spYellow0      = "FE9500"
     case spYellow10     = "FE9F0A"
     case white          = "FFFFFF"

--- a/Simplenote/Classes/ColorStudio.swift
+++ b/Simplenote/Classes/ColorStudio.swift
@@ -113,6 +113,7 @@ enum ColorStudio: String {
     case red90          = "451313"
     case red100         = "240a0a"
     case spWhite        = "fefffe"
+    case spGray         = "efeff0"
     case spYellow0      = "FE9500"
     case spYellow10     = "FE9F0A"
     case white          = "FFFFFF"

--- a/Simplenote/Classes/ColorStudio.swift
+++ b/Simplenote/Classes/ColorStudio.swift
@@ -112,7 +112,6 @@ enum ColorStudio: String {
     case red80          = "691c1c"
     case red90          = "451313"
     case red100         = "240a0a"
-    case spWhite        = "fefffe"
     case spGray         = "efeff0"
     case spYellow0      = "FE9500"
     case spYellow10     = "FE9F0A"

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -180,12 +180,12 @@ extension UIColor {
 
     @objc
     static var simplenoteBackgroundColor: UIColor {
-        UIColor(lightColor: .spWhite, darkColor: .darkGray0_5)
+        UIColor(lightColor: .white, darkColor: .darkGray0_5)
     }
 
     @objc
     static var simplenoteNavigationBarBackgroundColor: UIColor {
-        UIColor(lightColor: .spWhite, darkColor: .darkGray0_5).withAlphaComponent(UIKitConstants.alpha0_6)
+        UIColor(lightColor: .white, darkColor: .darkGray0_5).withAlphaComponent(UIKitConstants.alpha0_6)
     }
 
     @objc

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -195,7 +195,7 @@ extension UIColor {
 
     @objc
     static var simplenoteTableViewHeaderBackgroundColor: UIColor {
-        UIColor(lightColor: .gray0, darkColor: .darkGray4)
+        UIColor(lightColor: .spGray, darkColor: .darkGray4)
     }
 
     @objc


### PR DESCRIPTION
Not much to note here, minor change to `spWhite` and contrast of table section headers

### Fix
Updating `spWhite` which can be found used on the light mode backgrounds as well as adjusting contrast of `TableViewHeader` which can be found in the new advanced search.

### Test
1. Visit any view in light mode
2. Notice that the white has been brought in line with iOS system defaults

1. Perform a search
2. Notice that the section headers have improved contrast

<img width="375" src="https://user-images.githubusercontent.com/36532468/74661947-de9a0e00-5190-11ea-9c4d-b8a7641f6bec.PNG">

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
