### PR TITLE
Search: Displaying Relevant Dates

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		B5AD7AB11D1C82D3009725FB /* NSURLSessionConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AD7AB01D1C82D3009725FB /* NSURLSessionConfiguration+Extensions.swift */; };
 		B5ADF2251BAB14DD00F864DB /* VSTheme+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B5ADF2231BAB14DD00F864DB /* VSTheme+Extensions.m */; };
 		B5AEC38423FAC5D600D24221 /* DateFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AEC38323FAC5D600D24221 /* DateFormatter+Simplenote.swift */; };
+		B5AEC38623FAE70600D24221 /* Note+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AEC38523FAE70600D24221 /* Note+List.swift */; };
 		B5B06F3C1C31E119006F4495 /* SimplenoteShare-AppStore.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = B5B06F3B1C31E119006F4495 /* SimplenoteShare-AppStore.entitlements */; };
 		B5B0DE24239AFD1D00F1009D /* SPFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B0DE23239AFD1D00F1009D /* SPFeedbackManager.swift */; };
 		B5B85BA32351730700AD5221 /* NSPredicate+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B85BA22351730700AD5221 /* NSPredicate+Simplenote.swift */; };
@@ -577,6 +578,7 @@
 		B5ADF2221BAB14DD00F864DB /* VSTheme+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "VSTheme+Extensions.h"; path = "Classes/VSTheme+Extensions.h"; sourceTree = "<group>"; };
 		B5ADF2231BAB14DD00F864DB /* VSTheme+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "VSTheme+Extensions.m"; path = "Classes/VSTheme+Extensions.m"; sourceTree = "<group>"; };
 		B5AEC38323FAC5D600D24221 /* DateFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "DateFormatter+Simplenote.swift"; path = "Classes/DateFormatter+Simplenote.swift"; sourceTree = "<group>"; };
+		B5AEC38523FAE70600D24221 /* Note+List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Note+List.swift"; path = "Classes/Note+List.swift"; sourceTree = "<group>"; };
 		B5B06F3B1C31E119006F4495 /* SimplenoteShare-AppStore.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "SimplenoteShare-AppStore.entitlements"; sourceTree = "<group>"; };
 		B5B0DE23239AFD1D00F1009D /* SPFeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPFeedbackManager.swift; path = Classes/SPFeedbackManager.swift; sourceTree = "<group>"; };
 		B5B85BA22351730700AD5221 /* NSPredicate+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSPredicate+Simplenote.swift"; path = "Classes/NSPredicate+Simplenote.swift"; sourceTree = "<group>"; };
@@ -860,6 +862,7 @@
 				B5BE05521AB75C3B002417BF /* Settings.m */,
 				467D9C611788A54900785EF3 /* Note.h */,
 				467D9C621788A54900785EF3 /* Note.m */,
+				B5AEC38523FAE70600D24221 /* Note+List.swift */,
 				E25C39D417A42C4900B2591A /* PersonTag.h */,
 				E25C39D517A42C4900B2591A /* PersonTag.m */,
 				E283709817D7B46300AB562D /* SPAcitivitySafari.h */,
@@ -2012,6 +2015,7 @@
 				46A3C96217DFA81A002865AE /* SPTagListViewCell.m in Sources */,
 				B52B8A231BAAF80B002CC55D /* UIViewController+Extensions.m in Sources */,
 				B56A696022F9D53400B90398 /* SPAuthHandler.swift in Sources */,
+				B5AEC38623FAE70600D24221 /* Note+List.swift in Sources */,
 				B5B9AB4522EE8AF0001CB0AD /* UIImageName.swift in Sources */,
 				B5A6846D23CE84D400398BBC /* NotesListController.swift in Sources */,
 				B52BB74822CFBD540042C162 /* UIActivityViewController+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -290,6 +290,7 @@
 		B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F3000123F4502C007A7C59 /* SPSortBar.xib */; };
 		B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */; };
 		B5F52F0622CCEEF100B376F9 /* UIColor+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F52F0522CCEEF100B376F9 /* UIColor+Simplenote.swift */; };
+		B5FFC9D023FC3D7A00BECF7D /* NSWritingDirection+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FFC9CF23FC3D7A00BECF7D /* NSWritingDirection+Simplenote.swift */; };
 		D435D38FCA5863E8447D5C2C /* Pods_Automattic_SimplenoteShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */; };
 		DE7E545B214E34C8008D9928 /* NSString+Count.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E545A214E34C8008D9928 /* NSString+Count.swift */; };
 		E215C793180B115C00AD36B5 /* SPNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E215C791180B115C00AD36B5 /* SPNavigationController.m */; };
@@ -636,6 +637,7 @@
 		B5F3000123F4502C007A7C59 /* SPSortBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSortBar.xib; path = Classes/SPSortBar.xib; sourceTree = "<group>"; };
 		B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortBar.swift; path = Classes/SPSortBar.swift; sourceTree = "<group>"; };
 		B5F52F0522CCEEF100B376F9 /* UIColor+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIColor+Simplenote.swift"; path = "Classes/UIColor+Simplenote.swift"; sourceTree = "<group>"; };
+		B5FFC9CF23FC3D7A00BECF7D /* NSWritingDirection+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSWritingDirection+Simplenote.swift"; path = "Classes/NSWritingDirection+Simplenote.swift"; sourceTree = "<group>"; };
 		C07B32800E3C783BDF105B3A /* Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		DE7E545A214E34C8008D9928 /* NSString+Count.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSString+Count.swift"; path = "Classes/NSString+Count.swift"; sourceTree = "<group>"; };
 		DF3BADF5A954AA00BCF9B169 /* Pods-Automattic-Simplenote.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1129,6 +1131,7 @@
 				B5B85BA22351730700AD5221 /* NSPredicate+Simplenote.swift */,
 				DE7E545A214E34C8008D9928 /* NSString+Count.swift */,
 				B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */,
+				B5FFC9CF23FC3D7A00BECF7D /* NSWritingDirection+Simplenote.swift */,
 				B5CDE61D2150834C00C3FED4 /* Simperium+Simplenote.h */,
 				B5CDE61E2150834C00C3FED4 /* Simperium+Simplenote.m */,
 				B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */,
@@ -2111,6 +2114,7 @@
 				46A3C98417DFA81A002865AE /* SPHorizontalPickerView.m in Sources */,
 				46A3C98617DFA81A002865AE /* SPEntryListViewController.m in Sources */,
 				B56A696322F9D53400B90398 /* SPAuthViewController.swift in Sources */,
+				B5FFC9D023FC3D7A00BECF7D /* NSWritingDirection+Simplenote.swift in Sources */,
 				B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */,
 				B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */,
 				46A3C98817DFA81A002865AE /* Simplenote.xcdatamodeld in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		B5AB169C22FB2DF300B4EBA5 /* UIKitConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AB169B22FB2DF300B4EBA5 /* UIKitConstants.swift */; };
 		B5AD7AB11D1C82D3009725FB /* NSURLSessionConfiguration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AD7AB01D1C82D3009725FB /* NSURLSessionConfiguration+Extensions.swift */; };
 		B5ADF2251BAB14DD00F864DB /* VSTheme+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B5ADF2231BAB14DD00F864DB /* VSTheme+Extensions.m */; };
+		B5AEC38423FAC5D600D24221 /* DateFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AEC38323FAC5D600D24221 /* DateFormatter+Simplenote.swift */; };
 		B5B06F3C1C31E119006F4495 /* SimplenoteShare-AppStore.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = B5B06F3B1C31E119006F4495 /* SimplenoteShare-AppStore.entitlements */; };
 		B5B0DE24239AFD1D00F1009D /* SPFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B0DE23239AFD1D00F1009D /* SPFeedbackManager.swift */; };
 		B5B85BA32351730700AD5221 /* NSPredicate+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B85BA22351730700AD5221 /* NSPredicate+Simplenote.swift */; };
@@ -573,6 +574,7 @@
 		B5AD7AB01D1C82D3009725FB /* NSURLSessionConfiguration+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSURLSessionConfiguration+Extensions.swift"; sourceTree = "<group>"; };
 		B5ADF2221BAB14DD00F864DB /* VSTheme+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "VSTheme+Extensions.h"; path = "Classes/VSTheme+Extensions.h"; sourceTree = "<group>"; };
 		B5ADF2231BAB14DD00F864DB /* VSTheme+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "VSTheme+Extensions.m"; path = "Classes/VSTheme+Extensions.m"; sourceTree = "<group>"; };
+		B5AEC38323FAC5D600D24221 /* DateFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "DateFormatter+Simplenote.swift"; path = "Classes/DateFormatter+Simplenote.swift"; sourceTree = "<group>"; };
 		B5B06F3B1C31E119006F4495 /* SimplenoteShare-AppStore.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "SimplenoteShare-AppStore.entitlements"; sourceTree = "<group>"; };
 		B5B0DE23239AFD1D00F1009D /* SPFeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPFeedbackManager.swift; path = Classes/SPFeedbackManager.swift; sourceTree = "<group>"; };
 		B5B85BA22351730700AD5221 /* NSPredicate+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSPredicate+Simplenote.swift"; path = "Classes/NSPredicate+Simplenote.swift"; sourceTree = "<group>"; };
@@ -1145,6 +1147,7 @@
 				B58039852322D4F90083C916 /* UIView+ImageRepresentation.swift */,
 				B50E99F3234242130092F274 /* UISearchBar+Simplenote.swift */,
 				B5DF734322A56E2800602CE7 /* UserDefaults+Simplenote.swift */,
+				B5AEC38323FAC5D600D24221 /* DateFormatter+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2133,6 +2136,7 @@
 				46A3C99C17DFA81A002865AE /* NSString+Bullets.m in Sources */,
 				B58BF1FB23D78ADF00515B50 /* UITableViewRowAction+Simplenote.swift in Sources */,
 				E215C79A180B130B00AD36B5 /* SPTableViewController.m in Sources */,
+				B5AEC38423FAC5D600D24221 /* DateFormatter+Simplenote.swift in Sources */,
 				B5DF734622A5713600602CE7 /* SortMode.swift in Sources */,
 				46A3C99D17DFA81A002865AE /* SPAddCollaboratorsViewController.m in Sources */,
 				46A3C99F17DFA81A002865AE /* VSThemeManager.m in Sources */,

--- a/Simplenote/Classes/DateFormatter+Simplenote.swift
+++ b/Simplenote/Classes/DateFormatter+Simplenote.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+
+// MARK: - Simplenote Extension
+//
+extension DateFormatter {
+
+    /// Shared DateFormatters
+    ///
+    struct Simplenote {
+        static let listDateFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            return formatter
+        }()
+    }
+}

--- a/Simplenote/Classes/NSWritingDirection+Simplenote.swift
+++ b/Simplenote/Classes/NSWritingDirection+Simplenote.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+
+// MARK: - NSWritingDirection
+//
+extension NSWritingDirection {
+
+    /// Returns the *current* writing direction
+    ///
+    static var current: NSWritingDirection {
+        guard UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft else {
+            return .leftToRight
+        }
+
+        return .rightToLeft
+    }
+}

--- a/Simplenote/Classes/Note+List.swift
+++ b/Simplenote/Classes/Note+List.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+
+// MARK: - Note
+//
+extension Note {
+
+    /// Returns the Creation / Modification date for a given SortMode
+    ///
+    func date(for sortMode: SortMode) -> Date? {
+        switch sortMode {
+        case .alphabeticallyAscending, .alphabeticallyDescending:
+            return nil
+
+        case .createdNewest, .createdOldest:
+            return creationDate
+
+        case .modifiedNewest, .modifiedOldest:
+            return modificationDate
+        }
+    }
+}

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -525,7 +525,6 @@ private extension SPNoteListViewController {
         return cell
     }
 
-
     /// Returns the Prefix for a given note: We'll prepend the (Creation / Modification) Date, whenever we're in Search, and the Sort Option is relevant
     ///
     func prefixText(for note: Note) -> String? {

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -508,6 +508,8 @@ private extension SPNoteListViewController {
         cell.keywords = searchText
         cell.keywordsTintColor = .simplenoteTintColor
 
+        cell.prefixText = prefixText(for: note)
+
         cell.refreshAttributedStrings()
 
         return cell
@@ -521,6 +523,19 @@ private extension SPNoteListViewController {
         cell.leftImageTintColor = .simplenoteNoteShareStatusImageColor
         cell.titleText = String.searchOperatorForTags + tag.name
         return cell
+    }
+
+
+    /// Returns the Prefix for a given note: We'll prepend the (Creation / Modification) Date, whenever we're in Search, and the Sort Option is relevant
+    ///
+    func prefixText(for note: Note) -> String? {
+        guard case .searching = notesListController.state,
+            let date = note.date(for: notesListController.searchSortMode)
+            else {
+                return nil
+        }
+
+        return DateFormatter.Simplenote.listDateFormatter.string(from: date)
     }
 }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -182,7 +182,8 @@ class SPNoteTableViewCell: UITableViewCell {
             let prefixString = NSAttributedString(string: prefixText + String.space + String.space, attributes: [
                 .font: Style.prefixFont,
                 .foregroundColor: Style.headlineColor,
-                .paragraphStyle: Style.paragraphStyle
+                .paragraphStyle: Style.paragraphStyle,
+                .writingDirection: [NSWritingDirection.current.rawValue | NSWritingDirectionFormatType.override.rawValue]
             ])
 
             bodyString.append(prefixString)
@@ -429,7 +430,8 @@ private extension NSAttributedString {
         let output = NSMutableAttributedString(string: string, attributes: [
             .font: font,
             .foregroundColor: textColor,
-            .paragraphStyle: paragraphStyle
+            .paragraphStyle: paragraphStyle,
+            .writingDirection: [NSWritingDirection.current.rawValue | NSWritingDirectionFormatType.override.rawValue]
         ])
 
         output.addChecklistAttachments(for: textColor)

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -92,6 +92,10 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     var titleText: String?
 
+    /// Body's Prefix: Designed to display Dates (with a slightly different style) when appropriate.
+    ///
+    var prefixText: String?
+
     /// Note's Body
     /// - Note: Once the cell is fully initialized, please remember to run `refreshAttributedStrings`
     ///
@@ -146,25 +150,55 @@ class SPNoteTableViewCell: UITableViewCell {
         refreshConstraints()
     }
 
-    /// Refreshed the Title and Body AttributedString(s), based on the Text, Font and Highlight properties
+    /// Refreshed the Label(s) Attributed Strings: Keywords, Bullets and the Body Prefix will be taken into consideration
     ///
     func refreshAttributedStrings() {
+        refreshTitleAttributedString()
+        refreshBodyAttributedString()
+    }
+
+    /// Refreshes the Title AttributedString: We'll consider Keyword Highlight and Text Attachments (bullets)
+    ///
+    private func refreshTitleAttributedString() {
         titleLabel.attributedText = titleText.map {
-            attributedText(from: $0,
-                           highlighing: keywords,
-                           font: Style.headlineFont,
-                           textColor: Style.headlineColor,
-                           highlightColor: keywordsTintColor)
+            NSAttributedString.previewString(from: $0,
+                                             font: Style.headlineFont,
+                                             textColor: Style.headlineColor,
+                                             highlighing: keywords,
+                                             highlightColor: keywordsTintColor,
+                                             paragraphStyle: Style.paragraphStyle)
 
         }
 
-        bodyLabel.attributedText = bodyText.map {
-            attributedText(from: $0,
-                           highlighing: keywords,
-                           font: Style.previewFont,
-                           textColor: Style.previewColor,
-                           highlightColor: keywordsTintColor)
+    }
+
+    /// Refreshes the Body AttributedString: We'll consider Keyword Highlight and Text Attachments (bullets)
+    ///
+    /// - Note: The `prefixText`, if any, will be prepended to the BodyText
+    ///
+    private func refreshBodyAttributedString() {
+        let bodyString = NSMutableAttributedString()
+        if let prefixText = prefixText {
+            let prefixString = NSAttributedString(string: prefixText + String.space + String.space, attributes: [
+                .font: Style.prefixFont,
+                .foregroundColor: Style.headlineColor,
+                .paragraphStyle: Style.paragraphStyle
+            ])
+
+            bodyString.append(prefixString)
         }
+
+        if let suffixText = bodyText {
+            let suffixString = NSAttributedString.previewString(from: suffixText,
+                                                                font: Style.previewFont,
+                                                                textColor: Style.previewColor,
+                                                                highlighing: keywords,
+                                                                highlightColor: keywordsTintColor,
+                                                                paragraphStyle: Style.paragraphStyle)
+            bodyString.append(suffixString)
+        }
+
+        bodyLabel.attributedText = bodyString
     }
 }
 
@@ -246,29 +280,6 @@ private extension SPNoteTableViewCell {
         let isRightImageEmpty = accessoryRightImageView.image == nil
 
         accessoryRightImageView.isHidden = isRightImageEmpty
-    }
-
-    /// Returns a NSAttributedString instance, stylizing the receiver with the current Highlighted Keywords + Font + Colors
-    ///
-    func attributedText(from string: String,
-                        highlighing keywords: String?,
-                        font: UIFont,
-                        textColor: UIColor,
-                        highlightColor: UIColor) -> NSAttributedString
-    {
-        let output = NSMutableAttributedString(string: string, attributes: [
-            .font: font,
-            .foregroundColor: textColor,
-            .paragraphStyle: Style.paragraphStyle
-        ])
-
-        output.addChecklistAttachments(for: textColor)
-
-        if let keywords = keywords {
-            output.apply(color: highlightColor, toSubstringsMatching: keywords)
-        }
-
-        return output
     }
 }
 
@@ -387,9 +398,46 @@ private enum Style {
         .preferredFont(forTextStyle: .subheadline)
     }
 
+    /// Prefix Font: To be applied over the Body's Prefix (if any)
+    ///
+    static var prefixFont: UIFont {
+        .preferredFont(for: .subheadline, weight: .medium)
+    }
+
     /// Color to be applied over the cell upon selection
     ///
     static var selectionColor: UIColor {
         .simplenoteLightBlueColor
+    }
+}
+
+
+
+// MARK: - NSAttributedString Private Methods
+//
+private extension NSAttributedString {
+
+    /// Returns a NSAttributedString instance, stylizing the receiver with the current Highlighted Keywords + Font + Colors
+    ///
+    static func previewString(from string: String,
+                              font: UIFont,
+                              textColor: UIColor,
+                              highlighing keywords: String?,
+                              highlightColor: UIColor,
+                              paragraphStyle: NSParagraphStyle) -> NSAttributedString
+    {
+        let output = NSMutableAttributedString(string: string, attributes: [
+            .font: font,
+            .foregroundColor: textColor,
+            .paragraphStyle: paragraphStyle
+        ])
+
+        output.addChecklistAttachments(for: textColor)
+
+        if let keywords = keywords {
+            output.apply(color: highlightColor, toSubstringsMatching: keywords)
+        }
+
+        return output
     }
 }


### PR DESCRIPTION
### Details:
In this PR we're prefixing the **creation / modification** date to the Note's Body Preview, when we're in Search Mode, and the Sort Option is relevant (that is: we're sorting by Creation or Modification date).

Ref. #507

### Test
1. Launch Simplenote
2. Verify the Note List does not prepend any Date
3. Press over the Search Bar
4. Enter a keyword that yields results
5. Swipe downwards to dismiss the keyboard

- [x] Verify that **Alphabetical Sort** does not display dates
- [x] Verify that **Sort by Creation Date** (ascending / descending) prepend the Creation Date
- [x] Verify that **Sort by Modification Date** (ascending / descending) prepend the Modification Date

### Release
These changes do not require release notes.

### Screenshots
<img width="200" src="https://user-images.githubusercontent.com/1195260/74667031-54967900-5181-11ea-9bc5-070315930c22.png"><img width="200" src="https://user-images.githubusercontent.com/1195260/74667017-506a5b80-5181-11ea-9138-06995b61c88f.png">
