### PR TITLE
Search Mode: Adjusting Sort Descriptors

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -180,7 +180,7 @@
 		B543C7DF23CF6AB400003A80 /* NotesListControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B543C7DE23CF6AB400003A80 /* NotesListControllerTests.swift */; };
 		B543C7E123CF76D900003A80 /* NotesListState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B543C7E023CF76D900003A80 /* NotesListState.swift */; };
 		B543C7E323CF76EA00003A80 /* NotesListFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B543C7E223CF76EA00003A80 /* NotesListFilter.swift */; };
-		B543C7E523CF775C00003A80 /* SortMode+Descriptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B543C7E423CF775C00003A80 /* SortMode+Descriptors.swift */; };
+		B543C7E523CF775C00003A80 /* NSSortDescriptor+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B543C7E423CF775C00003A80 /* NSSortDescriptor+Simplenote.swift */; };
 		B546BE97234E64F200A126DA /* SPTagListViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B546BE96234E64F200A126DA /* SPTagListViewCell.xib */; };
 		B546BE9E234F6CB700A126DA /* SPTagHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B546BE9D234F6CB700A126DA /* SPTagHeaderView.swift */; };
 		B546BEA0234F6DA000A126DA /* SPTagHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B546BE9F234F6DA000A126DA /* SPTagHeaderView.xib */; };
@@ -500,7 +500,7 @@
 		B543C7DE23CF6AB400003A80 /* NotesListControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesListControllerTests.swift; sourceTree = "<group>"; };
 		B543C7E023CF76D900003A80 /* NotesListState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotesListState.swift; path = Classes/NotesListState.swift; sourceTree = "<group>"; };
 		B543C7E223CF76EA00003A80 /* NotesListFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotesListFilter.swift; path = Classes/NotesListFilter.swift; sourceTree = "<group>"; };
-		B543C7E423CF775C00003A80 /* SortMode+Descriptors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SortMode+Descriptors.swift"; path = "Classes/SortMode+Descriptors.swift"; sourceTree = "<group>"; };
+		B543C7E423CF775C00003A80 /* NSSortDescriptor+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSSortDescriptor+Simplenote.swift"; path = "Classes/NSSortDescriptor+Simplenote.swift"; sourceTree = "<group>"; };
 		B546BE96234E64F200A126DA /* SPTagListViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPTagListViewCell.xib; path = Classes/SPTagListViewCell.xib; sourceTree = "<group>"; };
 		B546BE9D234F6CB700A126DA /* SPTagHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPTagHeaderView.swift; path = Classes/SPTagHeaderView.swift; sourceTree = "<group>"; };
 		B546BE9F234F6DA000A126DA /* SPTagHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPTagHeaderView.xib; path = Classes/SPTagHeaderView.xib; sourceTree = "<group>"; };
@@ -1129,6 +1129,7 @@
 				B56A696822F9D57200B90398 /* NSMutableAttributedString+Simplenote.swift */,
 				74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */,
 				B5B85BA22351730700AD5221 /* NSPredicate+Simplenote.swift */,
+				B543C7E423CF775C00003A80 /* NSSortDescriptor+Simplenote.swift */,
 				DE7E545A214E34C8008D9928 /* NSString+Count.swift */,
 				B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */,
 				B5FFC9CF23FC3D7A00BECF7D /* NSWritingDirection+Simplenote.swift */,
@@ -1223,7 +1224,6 @@
 				B543C7E223CF76EA00003A80 /* NotesListFilter.swift */,
 				B5476BBE23D8B686000E7723 /* NotesListSection.swift */,
 				B543C7E023CF76D900003A80 /* NotesListState.swift */,
-				B543C7E423CF775C00003A80 /* SortMode+Descriptors.swift */,
 			);
 			name = "Notes List";
 			sourceTree = "<group>";
@@ -2088,7 +2088,7 @@
 				375D24B721E01131007AB25A /* stack.c in Sources */,
 				373AD30821C4739500A4EA89 /* NSMutableAttributedString+Styling.m in Sources */,
 				B524AE112352CC7900EA11D4 /* UIScreen+Simplenote.swift in Sources */,
-				B543C7E523CF775C00003A80 /* SortMode+Descriptors.swift in Sources */,
+				B543C7E523CF775C00003A80 /* NSSortDescriptor+Simplenote.swift in Sources */,
 				B5421F3423CE79D7004DDC19 /* FetchedResultsControllerDelegateWrapper.swift in Sources */,
 				375D24B521E01131007AB25A /* context_test.c in Sources */,
 				46A3C97E17DFA81A002865AE /* SPNoteEditorViewController.m in Sources */,

--- a/Simplenote/Classes/NSSortDescriptor+Simplenote.swift
+++ b/Simplenote/Classes/NSSortDescriptor+Simplenote.swift
@@ -5,7 +5,7 @@ import Foundation
 //
 extension NSSortDescriptor {
 
-    /// Returns a NSSortDescriptor, to be applied over Note collections, so that the resulting collection relects the specified `SortMode`
+    /// Returns a NSSortDescriptor, to be applied over Note collections, so that the resulting collection reflects the specified `SortMode`
     ///
     static func descriptorForNotes(sortMode: SortMode) -> NSSortDescriptor {
         let sortKeySelector: Selector

--- a/Simplenote/Classes/NSSortDescriptor+Simplenote.swift
+++ b/Simplenote/Classes/NSSortDescriptor+Simplenote.swift
@@ -3,16 +3,16 @@ import Foundation
 
 // MARK: - SortMode List Methods
 //
-extension SortMode {
+extension NSSortDescriptor {
 
-    /// Returns a collection of SortDescriptors, to be applied over Note Entities, matching the Receiver's Case
+    /// Returns a NSSortDescriptor, to be applied over Note collections, so that the resulting collection relects the specified `SortMode`
     ///
-    var descriptorsForNotes: [NSSortDescriptor] {
+    static func descriptorForNotes(sortMode: SortMode) -> NSSortDescriptor {
         let sortKeySelector: Selector
         var sortSelector: Selector?
         var ascending = true
 
-        switch self {
+        switch sortMode {
         case .alphabeticallyAscending:
             sortKeySelector = #selector(getter: Note.content)
             sortSelector    = #selector(NSString.caseInsensitiveCompare)
@@ -32,17 +32,18 @@ extension SortMode {
             sortKeySelector = #selector(getter: Note.modificationDate)
         }
 
-        return [
-            NSSortDescriptor(keyPath: \Note.pinned, ascending: false),
-            NSSortDescriptor(key: NSStringFromSelector(sortKeySelector), ascending: ascending, selector: sortSelector)
-        ]
+        return NSSortDescriptor(key: NSStringFromSelector(sortKeySelector), ascending: ascending, selector: sortSelector)
     }
 
-    /// Returns a collection of SortDescriptors, to be applied over Tag Entities, matching the Receiver's Case
+    /// Returns a NSSortDescriptor that, when applied over a Tags collection, results in the Pinned Notes to be on top
     ///
-    var descriptorsForTags: [NSSortDescriptor] {
-        return [
-            NSSortDescriptor(keyPath: \Tag.name, ascending: self != .alphabeticallyDescending)
-        ]
+    static func descriptorForPinnedNotes() -> NSSortDescriptor {
+        return NSSortDescriptor(keyPath: \Note.pinned, ascending: false)
+    }
+
+    /// Returns a NSSortDescriptor, to be applied over Tag collections, so that the resulting collection relects the specified `SortMode`
+    ///
+    static func descriptorForTags(sortMode: SortMode) -> NSSortDescriptor {
+        return NSSortDescriptor(keyPath: \Tag.name, ascending: sortMode != .alphabeticallyDescending)
     }
 }

--- a/Simplenote/Classes/NSSortDescriptor+Simplenote.swift
+++ b/Simplenote/Classes/NSSortDescriptor+Simplenote.swift
@@ -41,9 +41,12 @@ extension NSSortDescriptor {
         return NSSortDescriptor(keyPath: \Note.pinned, ascending: false)
     }
 
-    /// Returns a NSSortDescriptor, to be applied over Tag collections, so that the resulting collection relects the specified `SortMode`
+    /// Returns a NSSortDescriptor, to be applied over Tag collections. Yields a sorted collection of Tags, by name, ascending
     ///
-    static func descriptorForTags(sortMode: SortMode) -> NSSortDescriptor {
-        return NSSortDescriptor(keyPath: \Tag.name, ascending: sortMode != .alphabeticallyDescending)
+    static func descriptorForTags() -> NSSortDescriptor {
+        let key = NSStringFromSelector(#selector(getter: Tag.name))
+        let selector = #selector(NSString.caseInsensitiveCompare)
+
+        return NSSortDescriptor(key: key, ascending: true, selector: selector)
     }
 }

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -19,7 +19,7 @@ class NotesListController: NSObject {
     ///
     private lazy var tagsController = ResultsController<Tag>(viewContext: viewContext,
                                                              matching: state.predicateForTags(),
-                                                             sortedBy: state.descriptorsForTags(sortMode: sortMode),
+                                                             sortedBy: state.descriptorsForTags(),
                                                              limit: limitForTagResults)
 
     /// Notes Changes: We group all of the Sections + Object changes, and notify our listeners in batch.
@@ -255,11 +255,8 @@ private extension NotesListController {
     }
 
     func refreshSortDescriptors() {
-        // Sort Mode might differ in Results / Search
-        let sortMode = sortModeForActiveState
-
-        notesController.sortDescriptors = state.descriptorsForNotes(sortMode: sortMode)
-        tagsController.sortDescriptors = state.descriptorsForTags(sortMode: sortMode)
+        notesController.sortDescriptors = state.descriptorsForNotes(sortMode: sortModeForActiveState)
+        tagsController.sortDescriptors = state.descriptorsForTags()
     }
 
     func refreshEverything() {
@@ -343,6 +340,8 @@ private extension NotesListController {
         return (transposedObjectChanges, transposedSectionChanges)
     }
 
+    /// Sort Mode might differ in Results / Search!
+    ///
     var sortModeForActiveState: SortMode {
         switch state {
         case .searching(_):

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -13,13 +13,13 @@ class NotesListController: NSObject {
     ///
     private lazy var notesController = ResultsController<Note>(viewContext: viewContext,
                                                                matching: state.predicateForNotes(filter: filter),
-                                                               sortedBy: sortMode.descriptorsForNotes)
+                                                               sortedBy: state.descriptorsForNotes(sortMode: sortMode))
 
     /// Tags Controller
     ///
     private lazy var tagsController = ResultsController<Tag>(viewContext: viewContext,
                                                              matching: state.predicateForTags(),
-                                                             sortedBy: sortMode.descriptorsForTags,
+                                                             sortedBy: state.descriptorsForTags(sortMode: sortMode),
                                                              limit: limitForTagResults)
 
     /// Notes Changes: We group all of the Sections + Object changes, and notify our listeners in batch.
@@ -255,9 +255,11 @@ private extension NotesListController {
     }
 
     func refreshSortDescriptors() {
+        // Sort Mode might differ in Results / Search
         let sortMode = sortModeForActiveState
-        notesController.sortDescriptors = sortMode.descriptorsForNotes
-        tagsController.sortDescriptors = sortMode.descriptorsForTags
+
+        notesController.sortDescriptors = state.descriptorsForNotes(sortMode: sortMode)
+        tagsController.sortDescriptors = state.descriptorsForTags(sortMode: sortMode)
     }
 
     func refreshEverything() {

--- a/Simplenote/Classes/NotesListState.swift
+++ b/Simplenote/Classes/NotesListState.swift
@@ -114,6 +114,32 @@ extension NotesListState {
 
         return NSPredicate.predicateForTag(keyword: keyword)
     }
+
+    /// Returns a collection of NSSortDescriptors that, once applied to a Notes collection, the specified SortMode will be reflected
+    ///
+    func descriptorsForNotes(sortMode: SortMode) -> [NSSortDescriptor] {
+        var descriptors = [NSSortDescriptor]()
+
+        switch self {
+        case .results:
+            descriptors.append(NSSortDescriptor.descriptorForPinnedNotes())
+        default:
+            // Search shouldn't be affected by pinned notes
+            break
+        }
+
+        descriptors.append(NSSortDescriptor.descriptorForNotes(sortMode: sortMode))
+
+        return descriptors
+    }
+
+    /// Returns a collection of NSSortDescriptors that, once applied to a Tags collection, the specified SortMode will be reflected
+    ///
+    func descriptorsForTags(sortMode: SortMode) -> [NSSortDescriptor] {
+        return [
+            NSSortDescriptor.descriptorForTags(sortMode: sortMode)
+        ]
+    }
 }
 
 

--- a/Simplenote/Classes/NotesListState.swift
+++ b/Simplenote/Classes/NotesListState.swift
@@ -135,9 +135,9 @@ extension NotesListState {
 
     /// Returns a collection of NSSortDescriptors that, once applied to a Tags collection, the specified SortMode will be reflected
     ///
-    func descriptorsForTags(sortMode: SortMode) -> [NSSortDescriptor] {
+    func descriptorsForTags() -> [NSSortDescriptor] {
         return [
-            NSSortDescriptor.descriptorForTags(sortMode: sortMode)
+            NSSortDescriptor.descriptorForTags()
         ]
     }
 }


### PR DESCRIPTION
### Details:
We're introducing two adjustments to the Search Mode:

1. We're not sorting anymore Pinned notes on top
2. Tags are always sorted in a fixed way (ascending / case insensitive)

Ref. #507

### Test
1. Launch the app
2. Pin a few notes
3. Press over the Search Bar
4. Enter a keyword that yields some of the pinned notes

- [x] Verify that Pinned Notes are no longer on top of the Search Results
- [x] Verify that inverting the sort order leaves the Tags suggestions untouched

### Release
These changes do not require release notes.
