### PR TITLE
SPNoteTableViewCell: New ImageView Anchor

### DIFF
--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -48,6 +48,9 @@
                                                 </constraints>
                                             </imageView>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="JkE-9h-IB9" secondAttribute="trailing" id="f0V-J9-5xf"/>
+                                        </constraints>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
                                         <rect key="frame" x="0.0" y="20" width="370" height="41"/>


### PR DESCRIPTION
### Fix
In this PR we're adding an anchor to the Right Accessory Image (shared icon), in order to prevent unexpected animations.

Ref. #507
Closes #655

### Test
1. Launch Simplenote on an iPad Device
2. Share the top 3 notes (and wait until the right icon shows up)
3. Press over the Search Bar
4. Type a keyword that yields results. **Condition:** the top 3 results must not be shared notes
5. Hit Cancel

- [x] Verify the Shared Icon does not show up, animated, left to right.

### Release
These changes do not require release notes.
