### PR TITLE
Fix Dark Dividers in Light Mode

### DIFF
--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -225,7 +225,7 @@ extension UIColor {
 
     @objc
     static var simplenoteDividerColor: UIColor {
-        UIColor(lightColor: .gray40, darkColor: .darkGray4).withAlphaComponent(UIKitConstants.alpha0_6)
+        UIColor(lightColor: .gray30, darkColor: .darkGray4).withAlphaComponent(UIKitConstants.alpha0_6)
     }
 
     @objc


### PR DESCRIPTION
### Fix
Minor adjustments to the style of dividers in light mode making them lighter.

### Test
1. Open the app in light mode
2. Notice the dividers are less harsh

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
