### PR TITLE
Add automation for release wrap up steps

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -163,6 +163,13 @@ end
     ios_update_metadata(options) unless ios_current_branch_is_hotfix
     ios_bump_version_beta() unless ios_current_branch_is_hotfix
     ios_final_tag(options)
+
+    # Wrap up
+    version = ios_get_app_version()
+    removebranchprotection(repository:GHHELPER_REPO, branch: "release/#{version}")
+    setfrozentag(repository:GHHELPER_REPO, milestone: version, freeze: false)
+    create_new_milestone(repository:GHHELPER_REPO)
+    close_milestone(repository:GHHELPER_REPO, milestone: version)
   end
   
   #####################################################################################


### PR DESCRIPTION
This PR adds some steps to the `release_finalize` Fastlane action:

- removing the branch protection.
- removing the frozen tag.
- closing the milestone.
- creating a new milestone.

## To test:
Testing is a bit tricky as it requires to change the state of the release.
The easiest way is probably to mock up a release and to test only the new steps in the lane. The following steps use 4.18 as test version because it doesn't affect the current release (4.16) and the milestone currently used in develop (4.17).

**Set up**
1. Checkout a `release/4.18` branch out of this branch.
2. Change the version in `Version.public.xcconfig` to `4.18`.
3. Comment the `ios_update_metadata(options)`, `ios_bump_version_beta()` and `ios_final_tag(options)` steps in the lane as they will fail.
4. Commit and push the branch.
5. Enable branch protection for `release/4.18` in GitHub.
6. Create the `4.18` milestone in GitHub, put the due date and add the frozen tag.

**Test**
7. Run `bundle exec fastlane finalize_release`.
8. Verify that the `4.18` milestone is closed and the frozen tag removed.
9. Verify that the branch protection for the `release/4.18` branch has been removed.
10. Verify that a new milestone is created in GitHub with the correct due date.

Wrap up
11. Reopen the 14.4 milestone.
12. Delete the release/14.4 branch.

### Review
 Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
