### PR TITLE
Notes List: Fixing Checklist Processing

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		051E7EA368E0DBAE2EE92CB9 /* Pods_SimplenoteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6184665CE9AF426D43E2C02 /* Pods_SimplenoteTests.framework */; };
 		371A8630213DF00E002E9120 /* SPPinLockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371A862F213DF00E002E9120 /* SPPinLockManager.swift */; };
 		373AD30821C4739500A4EA89 /* NSMutableAttributedString+Styling.m in Sources */ = {isa = PBXBuildFile; fileRef = 373AD30721C4739400A4EA89 /* NSMutableAttributedString+Styling.m */; };
-		374F5EF521BF057E00B57E8B /* SPChecklistTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374F5EF421BF057E00B57E8B /* SPChecklistTest.swift */; };
+		374F5EF521BF057E00B57E8B /* NSMutableAttributedStringStylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374F5EF421BF057E00B57E8B /* NSMutableAttributedStringStylingTests.swift */; };
 		375D24B121E01131007AB25A /* html5_blocks.c in Sources */ = {isa = PBXBuildFile; fileRef = 375D249D21E0112B007AB25A /* html5_blocks.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		375D24B221E01131007AB25A /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 375D249F21E0112C007AB25A /* buffer.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		375D24B321E01131007AB25A /* autolink.c in Sources */ = {isa = PBXBuildFile; fileRef = 375D24A021E0112C007AB25A /* autolink.c */; settings = {COMPILER_FLAGS = "-w"; }; };
@@ -366,7 +366,7 @@
 		371A862F213DF00E002E9120 /* SPPinLockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPPinLockManager.swift; sourceTree = "<group>"; };
 		373AD30621C4739300A4EA89 /* NSMutableAttributedString+Styling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableAttributedString+Styling.h"; sourceTree = "<group>"; };
 		373AD30721C4739400A4EA89 /* NSMutableAttributedString+Styling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableAttributedString+Styling.m"; sourceTree = "<group>"; };
-		374F5EF421BF057E00B57E8B /* SPChecklistTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPChecklistTest.swift; sourceTree = "<group>"; };
+		374F5EF421BF057E00B57E8B /* NSMutableAttributedStringStylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringStylingTests.swift; sourceTree = "<group>"; };
 		375D249C21E0112B007AB25A /* html.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = html.h; sourceTree = "<group>"; };
 		375D249D21E0112B007AB25A /* html5_blocks.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = html5_blocks.c; sourceTree = "<group>"; };
 		375D249E21E0112C007AB25A /* hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hash.h; sourceTree = "<group>"; };
@@ -1050,6 +1050,7 @@
 		B52F35D422F3573300724793 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				374F5EF421BF057E00B57E8B /* NSMutableAttributedStringStylingTests.swift */,
 				B5B85BA4235173BF00AD5221 /* NSPredicateSimplenoteTests.swift */,
 				B5D367BD23ECF42D0024215D /* NSStringCondensingTests.swift */,
 				B51D7C7823D9CFA4005D4B77 /* StringSimplenoteTests.swift */,
@@ -1113,7 +1114,6 @@
 				B58218A41FCC45330094ECA1 /* KeychainMigratorTests.swift */,
 				B5421F4123CE7A25004DDC19 /* ResultsControllerTests.swift */,
 				B5421F4523CE7DEB004DDC19 /* ResultsControllerUIKitTests.swift */,
-				374F5EF421BF057E00B57E8B /* SPChecklistTest.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -2213,7 +2213,7 @@
 			files = (
 				B52F35D322F356F500724793 /* UserDefaults+Tests.swift in Sources */,
 				B58218A51FCC45330094ECA1 /* KeychainMigratorTests.swift in Sources */,
-				374F5EF521BF057E00B57E8B /* SPChecklistTest.swift in Sources */,
+				374F5EF521BF057E00B57E8B /* NSMutableAttributedStringStylingTests.swift in Sources */,
 				B5B9AB4722EE9CC2001CB0AD /* UIImageSimplenoteTests.swift in Sources */,
 				B55AC57A22D27B9100D8CEB2 /* OptionsTests.swift in Sources */,
 				B543C7DF23CF6AB400003A80 /* NotesListControllerTests.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		B584DA36236722D400B2844A /* SPBlurEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B584DA35236722D400B2844A /* SPBlurEffectView.swift */; };
 		B58BF1FB23D78ADF00515B50 /* UITableViewRowAction+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BF1FA23D78ADF00515B50 /* UITableViewRowAction+Simplenote.swift */; };
 		B58C9F5723F2FCEC008C3480 /* SPPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58C9F5623F2FCEC008C3480 /* SPPlaceholderView.swift */; };
+		B59188C224005B8A0069EF96 /* NSString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */; };
 		B59314D81A486B3800B651ED /* SPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = B59314D61A486B3800B651ED /* SPConstants.m */; };
 		B59FFB43231851C700567627 /* UIGestureRecognizer+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59FFB42231851C700567627 /* UIGestureRecognizer+Simplenote.swift */; };
 		B5A6166F2150855300CBE47B /* Preferences.m in Sources */ = {isa = PBXBuildFile; fileRef = B594E61321508247001577EE /* Preferences.m */; };
@@ -564,6 +565,7 @@
 		B584DA35236722D400B2844A /* SPBlurEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPBlurEffectView.swift; path = Classes/SPBlurEffectView.swift; sourceTree = "<group>"; };
 		B58BF1FA23D78ADF00515B50 /* UITableViewRowAction+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITableViewRowAction+Simplenote.swift"; path = "Classes/UITableViewRowAction+Simplenote.swift"; sourceTree = "<group>"; };
 		B58C9F5623F2FCEC008C3480 /* SPPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPPlaceholderView.swift; path = Classes/SPPlaceholderView.swift; sourceTree = "<group>"; };
+		B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSString+Simplenote.swift"; path = "Classes/NSString+Simplenote.swift"; sourceTree = "<group>"; };
 		B59314D51A486B3800B651ED /* SPConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPConstants.h; sourceTree = "<group>"; };
 		B59314D61A486B3800B651ED /* SPConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPConstants.m; sourceTree = "<group>"; };
 		B594E60C21508170001577EE /* Simplenote 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 4.xcdatamodel"; sourceTree = "<group>"; };
@@ -1131,6 +1133,7 @@
 				B5B85BA22351730700AD5221 /* NSPredicate+Simplenote.swift */,
 				B543C7E423CF775C00003A80 /* NSSortDescriptor+Simplenote.swift */,
 				DE7E545A214E34C8008D9928 /* NSString+Count.swift */,
+				B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */,
 				B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */,
 				B5FFC9CF23FC3D7A00BECF7D /* NSWritingDirection+Simplenote.swift */,
 				B5CDE61D2150834C00C3FED4 /* Simperium+Simplenote.h */,
@@ -2073,6 +2076,7 @@
 				375D24B921E01131007AB25A /* version.c in Sources */,
 				B50F479F1D1D77FC00822748 /* UIAlertController+Helpers.swift in Sources */,
 				37E10E7720B3368700864E43 /* WPAuthHandler.m in Sources */,
+				B59188C224005B8A0069EF96 /* NSString+Simplenote.swift in Sources */,
 				46A3C97917DFA81A002865AE /* UIBarButtonItem+Images.m in Sources */,
 				375D24BB21E01131007AB25A /* html.c in Sources */,
 				B5B0DE24239AFD1D00F1009D /* SPFeedbackManager.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		B584DA36236722D400B2844A /* SPBlurEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B584DA35236722D400B2844A /* SPBlurEffectView.swift */; };
 		B58BF1FB23D78ADF00515B50 /* UITableViewRowAction+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BF1FA23D78ADF00515B50 /* UITableViewRowAction+Simplenote.swift */; };
 		B58C9F5723F2FCEC008C3480 /* SPPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58C9F5623F2FCEC008C3480 /* SPPlaceholderView.swift */; };
+		B59188C0240059950069EF96 /* NSRegularExpression+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59188BF240059950069EF96 /* NSRegularExpression+Simplenote.swift */; };
 		B59188C224005B8A0069EF96 /* NSString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */; };
 		B59314D81A486B3800B651ED /* SPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = B59314D61A486B3800B651ED /* SPConstants.m */; };
 		B59FFB43231851C700567627 /* UIGestureRecognizer+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59FFB42231851C700567627 /* UIGestureRecognizer+Simplenote.swift */; };
@@ -565,6 +566,7 @@
 		B584DA35236722D400B2844A /* SPBlurEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPBlurEffectView.swift; path = Classes/SPBlurEffectView.swift; sourceTree = "<group>"; };
 		B58BF1FA23D78ADF00515B50 /* UITableViewRowAction+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITableViewRowAction+Simplenote.swift"; path = "Classes/UITableViewRowAction+Simplenote.swift"; sourceTree = "<group>"; };
 		B58C9F5623F2FCEC008C3480 /* SPPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPPlaceholderView.swift; path = Classes/SPPlaceholderView.swift; sourceTree = "<group>"; };
+		B59188BF240059950069EF96 /* NSRegularExpression+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSRegularExpression+Simplenote.swift"; path = "Classes/NSRegularExpression+Simplenote.swift"; sourceTree = "<group>"; };
 		B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSString+Simplenote.swift"; path = "Classes/NSString+Simplenote.swift"; sourceTree = "<group>"; };
 		B59314D51A486B3800B651ED /* SPConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPConstants.h; sourceTree = "<group>"; };
 		B59314D61A486B3800B651ED /* SPConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPConstants.m; sourceTree = "<group>"; };
@@ -1131,6 +1133,7 @@
 				B56A696822F9D57200B90398 /* NSMutableAttributedString+Simplenote.swift */,
 				74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */,
 				B5B85BA22351730700AD5221 /* NSPredicate+Simplenote.swift */,
+				B59188BF240059950069EF96 /* NSRegularExpression+Simplenote.swift */,
 				B543C7E423CF775C00003A80 /* NSSortDescriptor+Simplenote.swift */,
 				DE7E545A214E34C8008D9928 /* NSString+Count.swift */,
 				B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */,
@@ -2084,6 +2087,7 @@
 				46A3C97B17DFA81A002865AE /* SPInteractiveTextStorage.m in Sources */,
 				E2B0862F1806FFB3001ED52D /* SPTagCompletionPill.m in Sources */,
 				F920265B2294661C0061B1DE /* BuildConfiguration.swift in Sources */,
+				B59188C0240059950069EF96 /* NSRegularExpression+Simplenote.swift in Sources */,
 				B5421F3823CE79F6004DDC19 /* ResultsController.swift in Sources */,
 				46A3C97C17DFA81A002865AE /* DTPinErrorView.m in Sources */,
 				B56E763622BD565700C5AA47 /* UIView+Simplenote.swift in Sources */,

--- a/Simplenote/Classes/NSRegularExpression+Simplenote.swift
+++ b/Simplenote/Classes/NSRegularExpression+Simplenote.swift
@@ -8,14 +8,14 @@ extension NSRegularExpression {
     /// Matches Checklists at the beginning of each line
     ///
     @objc
-    private(set) static var regexForChecklists: NSRegularExpression = {
+    static let regexForChecklists: NSRegularExpression = {
         try! NSRegularExpression(pattern: "^\\s*(-[ \t]+\\[[xX\\s]\\])", options: .anchorsMatchLines)
     }()
 
     /// Matches Checklists patterns that can be ANYWHERE in the string, not necessarily at the beginning of the string.
     ///
     @objc
-    private(set) static var regexForChecklistsEmbeddedAnywhere: NSRegularExpression = {
+    static let regexForChecklistsEmbeddedAnywhere: NSRegularExpression = {
         try! NSRegularExpression(pattern: "\\s*(-[ \t]+\\[[xX\\s]\\])", options: .anchorsMatchLines)
     }()
 }

--- a/Simplenote/Classes/NSRegularExpression+Simplenote.swift
+++ b/Simplenote/Classes/NSRegularExpression+Simplenote.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+
+// MARK: - NSRegularExpression
+//
+extension NSRegularExpression {
+
+    /// Matches Checklists at the beginning of each line
+    ///
+    @objc
+    private(set) static var regexForChecklists: NSRegularExpression = {
+        try! NSRegularExpression(pattern: "^\\s*(-[ \t]+\\[[xX\\s]\\])", options: .anchorsMatchLines)
+    }()
+
+    /// Matches Checklists patterns that can be ANYWHERE in the string, not necessarily at the beginning of the string.
+    ///
+    @objc
+    private(set) static var regexForChecklistsEmbeddedAnywhere: NSRegularExpression = {
+        try! NSRegularExpression(pattern: "\\s*(-[ \t]+\\[[xX\\s]\\])", options: .anchorsMatchLines)
+    }()
+}

--- a/Simplenote/Classes/NSRegularExpression+Simplenote.swift
+++ b/Simplenote/Classes/NSRegularExpression+Simplenote.swift
@@ -9,13 +9,13 @@ extension NSRegularExpression {
     ///
     @objc
     static let regexForChecklists: NSRegularExpression = {
-        try! NSRegularExpression(pattern: "^\\s*(-[ \t]+\\[[xX\\s]\\])", options: .anchorsMatchLines)
+        try! NSRegularExpression(pattern: "^\\s*(-[ \t]+\\[[xX\\s]?\\])", options: .anchorsMatchLines)
     }()
 
     /// Matches Checklists patterns that can be ANYWHERE in the string, not necessarily at the beginning of the string.
     ///
     @objc
     static let regexForChecklistsEmbeddedAnywhere: NSRegularExpression = {
-        try! NSRegularExpression(pattern: "\\s*(-[ \t]+\\[[xX\\s]\\])", options: .anchorsMatchLines)
+        try! NSRegularExpression(pattern: "\\s*(-[ \t]+\\[[xX\\s]?\\])", options: .anchorsMatchLines)
     }()
 }

--- a/Simplenote/Classes/NSString+Simplenote.swift
+++ b/Simplenote/Classes/NSString+Simplenote.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+
+// MARK: - NSString Simplenote Helpers
+//
+extension NSString {
+
+    /// Returns the full range of the receiver
+    ///
+    @objc
+    var rangeOfEntireString: NSRange {
+        NSRange(location: 0, length: length)
+    }
+}

--- a/Simplenote/Classes/NSString+Simplenote.swift
+++ b/Simplenote/Classes/NSString+Simplenote.swift
@@ -8,7 +8,7 @@ extension NSString {
     /// Returns the full range of the receiver
     ///
     @objc
-    var rangeOfEntireString: NSRange {
+    var fullRange: NSRange {
         NSRange(location: 0, length: length)
     }
 }

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -21,6 +21,8 @@
 @property (nonatomic) BOOL overideLockContentOffset;
 
 @property (nonatomic, strong) SPTagView *tagView;
+@property (nonatomic, strong) UIFont *checklistsFont;
+@property (nonatomic, strong) UIColor *checklistsTintColor;
 
 - (void)scrollToBottom;
 - (void)scrollToTop;

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -9,7 +9,6 @@
 #import "SPTextView.h"
 @class SPTagView;
 
-extern NSString *const CheckListRegExPattern;
 
 @protocol SPEditorTextViewDelegate <UITextViewDelegate>
 - (void)textView:(UITextView *)textView receivedInteractionWithURL:(NSURL *)url;

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -389,8 +389,9 @@ NSInteger const ChecklistCursorAdjustment = 2;
         return;
     }
 
-    UIColor *checklistColor = [UIColor simplenoteNoteBodyPreviewColor];
-    [self.textStorage processChecklistsWithColor:checklistColor allowsMultiplePerLine:NO];
+    [self.textStorage processChecklistsWithColor:self.checklistsTintColor
+                                      sizingFont:self.checklistsFont
+                           allowsMultiplePerLine:NO];
 }
 
 // Processes content of note editor, and replaces special string attachments with their plain

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -390,7 +390,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
     }
 
     UIColor *checklistColor = [UIColor simplenoteNoteBodyPreviewColor];
-    [self.textStorage processChecklistAttachmentsWithColor:checklistColor];
+    [self.textStorage processChecklistsWithColor:checklistColor];
 }
 
 // Processes content of note editor, and replaces special string attachments with their plain

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -15,7 +15,6 @@
 #import "VSTheme+Extensions.h"
 #import "Simplenote-Swift.h"
 
-NSString *const CheckListRegExPattern = @"^(\\s+)?(-[ \t]+\\[[xX\\s]\\])";
 NSString *const MarkdownUnchecked = @"- [ ]";
 NSString *const MarkdownChecked = @"- [x]";
 NSString *const TextAttachmentCharacterCode = @"\U0000fffc"; // Represents the glyph of an NSTextAttachment

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -391,7 +391,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
     }
 
     UIColor *checklistColor = [UIColor simplenoteNoteBodyPreviewColor];
-    [self.textStorage addChecklistAttachmentsForColor:checklistColor];
+    [self.textStorage processChecklistAttachmentsWithColor:checklistColor];
 }
 
 // Processes content of note editor, and replaces special string attachments with their plain

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -390,7 +390,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
     }
 
     UIColor *checklistColor = [UIColor simplenoteNoteBodyPreviewColor];
-    [self.textStorage processChecklistsWithColor:checklistColor];
+    [self.textStorage processChecklistsWithColor:checklistColor allowsMultiplePerLine:NO];
 }
 
 // Processes content of note editor, and replaces special string attachments with their plain

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -155,6 +155,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     _tagView = _noteEditorTextView.tagView;
     [_tagView applyStyle];
 
+    self.noteEditorTextView.checklistsFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
     self.noteEditorTextView.checklistsTintColor = [UIColor simplenoteNoteBodyPreviewColor];
     self.noteEditorTextView.backgroundColor = [UIColor simplenoteBackgroundColor];
     self.noteEditorTextView.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -126,6 +126,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     _noteEditorTextView = [[SPEditorTextView alloc] init];
     _noteEditorTextView.dataDetectorTypes = UIDataDetectorTypeAll;
     _noteEditorTextView.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    _noteEditorTextView.checklistsFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
 
     // Note:
     // Disable SmartDashes / Quotes in iOS 11.0, due to a glitch that broke sync. (Fixed in iOS 11.1).
@@ -142,8 +143,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     return [[VSThemeManager sharedManager] theme];
 }
 
-- (void)applyStyle {
-    
+- (void)applyStyle
+{    
     UIFont *bodyFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     UIFont *headlineFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
     UIColor *fontColor = [UIColor simplenoteNoteHeadlineColor];
@@ -154,8 +155,9 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     _tagView = _noteEditorTextView.tagView;
     [_tagView applyStyle];
 
-    _noteEditorTextView.backgroundColor = [UIColor simplenoteBackgroundColor];
-    _noteEditorTextView.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
+    self.noteEditorTextView.checklistsTintColor = [UIColor simplenoteNoteBodyPreviewColor];
+    self.noteEditorTextView.backgroundColor = [UIColor simplenoteBackgroundColor];
+    self.noteEditorTextView.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
 
     UIColor *backgroundColor = [UIColor simplenoteBackgroundColor];
     self.noteEditorTextView.backgroundColor = backgroundColor;

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -434,7 +434,7 @@ private extension NSAttributedString {
             .writingDirection: [NSWritingDirection.current.rawValue | NSWritingDirectionFormatType.override.rawValue]
         ])
 
-        output.addChecklistAttachments(for: textColor)
+        output.processChecklistAttachments(with: textColor)
 
         if let keywords = keywords {
             output.apply(color: highlightColor, toSubstringsMatching: keywords)

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -434,7 +434,7 @@ private extension NSAttributedString {
             .writingDirection: [NSWritingDirection.current.rawValue | NSWritingDirectionFormatType.override.rawValue]
         ])
 
-        output.processChecklistAttachments(with: textColor)
+        output.processChecklists(with: textColor)
 
         if let keywords = keywords {
             output.apply(color: highlightColor, toSubstringsMatching: keywords)

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -434,7 +434,7 @@ private extension NSAttributedString {
             .writingDirection: [NSWritingDirection.current.rawValue | NSWritingDirectionFormatType.override.rawValue]
         ])
 
-        output.processChecklists(with: textColor)
+        output.processChecklists(with: textColor, allowsMultiplePerLine: true)
 
         if let keywords = keywords {
             output.apply(color: highlightColor, toSubstringsMatching: keywords)

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -434,7 +434,7 @@ private extension NSAttributedString {
             .writingDirection: [NSWritingDirection.current.rawValue | NSWritingDirectionFormatType.override.rawValue]
         ])
 
-        output.processChecklists(with: textColor, allowsMultiplePerLine: true)
+        output.processChecklists(with: textColor, sizingFont: font, allowsMultiplePerLine: true)
 
         if let keywords = keywords {
             output.apply(color: highlightColor, toSubstringsMatching: keywords)

--- a/Simplenote/Classes/UIImageName.swift
+++ b/Simplenote/Classes/UIImageName.swift
@@ -39,6 +39,8 @@ enum UIImageName: Int, CaseIterable {
     case tags
     case tagsClosed
     case tagsOpen
+    case taskChecked
+    case taskUnchecked
     case trash
     case untagged
     case visibilityOn
@@ -120,6 +122,10 @@ extension UIImageName {
             return "icon_tags_close"
         case .tagsOpen:
             return "icon_tags_open"
+        case .taskChecked:
+            return "icon_task_checked"
+        case .taskUnchecked:
+            return "icon_task_unchecked"
         case .trash:
             return "icon_trash"
         case .untagged:

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -3,7 +3,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSMutableAttributedString (Checklists)
-- (void)processChecklistsWithColor:(UIColor *)color;
+- (void)processChecklistsWithColor:(UIColor *)color allowsMultiplePerLine:(BOOL)allowsMultiplePerLine;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -6,12 +6,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Replaces Checklist Markers with a SPTextAttachment at the exact same location.
 ///
-/// We're expecting a sizingFont because in the NotesList a UILabel is used (which lacks the full TextKit Stack),
-/// which makes it impossible to determine the current Font, from within the NSTextAttachment instance.
-///
 /// @param color: Tinting Color to be applied over the Image
 /// @param sizingFont: Font that should be used to determine the Attachment Size
 /// @param allowsMultiplePerLine: When **YES** we'll support multiple Checklists Image in the same line. Useful for the Notes List.
+///
+/// @Discussion
+/// When Multiple Lines are allowed, we'll prepend a space to any attachment that's not at location Zero. Otherwise notes that look like
+/// the following, will definitely look bad: the Checklist Image would end up by the preceding word, without spacing.
+///
+///  `Word -[ ] Item - [ ] Item - [ ] Item`
+///
+/// @Note
+/// We're expecting a sizingFont because in the NotesList a UILabel is used (which lacks the full TextKit Stack),
+/// which makes it impossible to determine the current Font, from within the NSTextAttachment instance.
 ///
 - (void)processChecklistsWithColor:(UIColor *)color
                         sizingFont:(UIFont *)sizingFont

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -1,12 +1,9 @@
 #import <Foundation/Foundation.h>
 
-
 NS_ASSUME_NONNULL_BEGIN
-extern NSString* const NSAttributedStringRegexForChecklists;
 
 @interface NSMutableAttributedString (Checklists)
-
 - (void)processChecklistAttachmentsWithColor:(UIColor *)color;
-
 @end
+
 NS_ASSUME_NONNULL_END

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -3,7 +3,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSMutableAttributedString (Checklists)
-- (void)processChecklistsWithColor:(UIColor *)color allowsMultiplePerLine:(BOOL)allowsMultiplePerLine;
+- (void)processChecklistsWithColor:(UIColor *)color
+                        sizingFont:(UIFont *)sizingFont
+             allowsMultiplePerLine:(BOOL)allowsMultiplePerLine;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -3,7 +3,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSMutableAttributedString (Checklists)
-- (void)processChecklistAttachmentsWithColor:(UIColor *)color;
+- (void)processChecklistsWithColor:(UIColor *)color;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -3,9 +3,20 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSMutableAttributedString (Checklists)
+
+/// Replaces Checklist Markers with a SPTextAttachment at the exact same location.
+///
+/// We're expecting a sizingFont because in the NotesList a UILabel is used (which lacks the full TextKit Stack),
+/// which makes it impossible to determine the current Font, from within the NSTextAttachment instance.
+///
+/// @param color: Tinting Color to be applied over the Image
+/// @param sizingFont: Font that should be used to determine the Attachment Size
+/// @param allowsMultiplePerLine: When **YES** we'll support multiple Checklists Image in the same line. Useful for the Notes List.
+///
 - (void)processChecklistsWithColor:(UIColor *)color
                         sizingFont:(UIFont *)sizingFont
              allowsMultiplePerLine:(BOOL)allowsMultiplePerLine;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Simplenote/NSMutableAttributedString+Styling.h
+++ b/Simplenote/NSMutableAttributedString+Styling.h
@@ -1,12 +1,12 @@
-//
-//  NSMutableAttributedString+TruncateToWidth.h
-//  Simplenote
-//
-
 #import <Foundation/Foundation.h>
 
-@interface NSMutableAttributedString (Styling)
 
-- (void)addChecklistAttachmentsForColor: (UIColor *)color;
+NS_ASSUME_NONNULL_BEGIN
+extern NSString* const NSAttributedStringRegexForChecklists;
+
+@interface NSMutableAttributedString (Checklists)
+
+- (void)processChecklistAttachmentsWithColor:(UIColor *)color;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -16,17 +16,13 @@
 
     NSString *plainString = [self.string copy];
     NSRegularExpression *regex = allowsMultiplePerLine ? NSRegularExpression.regexForChecklistsEmbeddedAnywhere : NSRegularExpression.regexForChecklists;
-    NSArray *matches = [regex matchesInString:plainString options:0 range:plainString.fullRange];
-    NSInteger positionAdjustment = 0;
+    NSArray *matches = [[[regex matchesInString:plainString
+                                        options:0
+                                          range:plainString.fullRange] reverseObjectEnumerator] allObjects];
 
     for (NSTextCheckingResult *match in matches) {
         NSRange matchedRange = match.range;
-        if (matchedRange.location == NSNotFound) {
-            continue;
-        }
-
-        NSRange adjustedRange = NSMakeRange(matchedRange.location - positionAdjustment, matchedRange.length);
-        if (NSMaxRange(adjustedRange) > self.length) {
+        if (matchedRange.location == NSNotFound || NSMaxRange(matchedRange) > self.length) {
             continue;
         }
 
@@ -39,15 +35,13 @@
         textAttachment.sizingFont = sizingFont;
 
         NSMutableAttributedString *attachmentString = [NSMutableAttributedString new];
-        if (allowsMultiplePerLine && adjustedRange.location != 0) {
+        if (allowsMultiplePerLine && matchedRange.location != 0) {
             [attachmentString appendString:NSString.spaceString];
         }
 
         [attachmentString appendAttachment:textAttachment];
 
-        [self replaceCharactersInRange:adjustedRange withAttributedString:attachmentString];
-
-        positionAdjustment += matchedRange.length - attachmentString.length;
+        [self replaceCharactersInRange:matchedRange withAttributedString:attachmentString];
     }
 }
 

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -5,15 +5,18 @@
 
 @implementation NSMutableAttributedString (Checklists)
 
-- (void)processChecklistAttachmentsWithColor:(UIColor *)color
+- (void)processChecklistsWithColor:(UIColor *)color
 {
     CGFloat dimension = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline].pointSize + 4;
     UIOffset offset = UIOffsetMake(0.0, -4.5);
 
-    [self processChecklistAttachmentsWithColor:color dimension:dimension offset:offset];
+    [self processChecklistsWithColor:color dimension:dimension offset:offset allowsMultiplePerLine:YES];
 }
 
-- (void)processChecklistAttachmentsWithColor:(UIColor *)color dimension:(CGFloat)dimension offset:(UIOffset)offset
+- (void)processChecklistsWithColor:(UIColor *)color
+                         dimension:(CGFloat)dimension
+                            offset:(UIOffset)offset
+             allowsMultiplePerLine:(BOOL)allowsMultiplePerLine
 {
     if (self.length == 0) {
         return;

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -14,7 +14,7 @@
         return;
     }
 
-    NSString *plainString = self.string.copy;
+    NSString *plainString = [self.string copy];
     NSRegularExpression *regex = allowsMultiplePerLine ? NSRegularExpression.regexForChecklistsEmbeddedAnywhere : NSRegularExpression.regexForChecklists;
     NSArray *matches = [regex matchesInString:plainString options:0 range:plainString.fullRange];
     NSInteger positionAdjustment = 0;

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -8,6 +8,7 @@
 
 - (void)processChecklistsWithColor:(UIColor *)color allowsMultiplePerLine:(BOOL)allowsMultiplePerLine
 {
+    // TODO: This is definitely wrong. Fix before merging please!
     CGFloat dimension = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline].pointSize + 4;
     UIOffset offset = UIOffsetMake(0.0, -4.5);
 

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -1,10 +1,6 @@
 #import "NSMutableAttributedString+Styling.h"
 #import "Simplenote-Swift.h"
 
-NSString* const NSAttributedStringRegexForChecklists        = @"^\\s*(-[ \t]+\\[[xX\\s]\\])";
-NSInteger const NSAttributedStringRegexExpectedMatchGroups  = 3;
-NSInteger const NSAttributedStringRegexGroupIndexPrefix     = 1;
-NSInteger const NSAttributedStringRegexGroupIndexContent    = 2;
 
 
 @implementation NSMutableAttributedString (Checklists)
@@ -24,7 +20,7 @@ NSInteger const NSAttributedStringRegexGroupIndexContent    = 2;
     }
 
     NSString *plainString = self.string.copy;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:NSAttributedStringRegexForChecklists options:NSRegularExpressionAnchorsMatchLines error:nil];
+    NSRegularExpression *regex = NSRegularExpression.regexForChecklists;
     NSArray *matches = [regex matchesInString:plainString options:0 range:self.rangeOfEntireString];
 
     if (matches.count == 0) {

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -21,7 +21,7 @@
 
     NSString *plainString = self.string.copy;
     NSRegularExpression *regex = NSRegularExpression.regexForChecklists;
-    NSArray *matches = [regex matchesInString:plainString options:0 range:self.rangeOfEntireString];
+    NSArray *matches = [regex matchesInString:plainString options:0 range:plainString.rangeOfEntireString];
 
     if (matches.count == 0) {
         return;
@@ -53,11 +53,6 @@
 
         positionAdjustment += matchedRange.length - attachmentString.length;
     }
-}
-
-- (NSRange)rangeOfEntireString
-{
-    return NSMakeRange(0, self.length);
 }
 
 @end

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -16,7 +16,7 @@
 
     NSString *plainString = self.string.copy;
     NSRegularExpression *regex = allowsMultiplePerLine ? NSRegularExpression.regexForChecklistsEmbeddedAnywhere : NSRegularExpression.regexForChecklists;
-    NSArray *matches = [regex matchesInString:plainString options:0 range:plainString.rangeOfEntireString];
+    NSArray *matches = [regex matchesInString:plainString options:0 range:plainString.fullRange];
     NSInteger positionAdjustment = 0;
 
     for (NSTextCheckingResult *match in matches) {

--- a/Simplenote/SPTextAttachment.swift
+++ b/Simplenote/SPTextAttachment.swift
@@ -1,28 +1,34 @@
-//
-//  SPTextAttachment.swift
-//  Simplenote
-//  Used in the note editor to distinguish if a checklist item is ticked or not.
-//
-
 import UIKit
 
-@objcMembers class SPTextAttachment: NSTextAttachment {
-    var checked = false
-    var attachmentColor: UIColor?
-    
-    @objc public convenience init(color: UIColor) {
-        self.init()
-        
-        attachmentColor = color
+
+// MARK: - SPTextAttachment
+//
+@objcMembers
+class SPTextAttachment: NSTextAttachment {
+
+    /// Indicates if we're in the Checked or Unchecked state
+    ///
+    var isChecked = false {
+        didSet {
+            refreshImage()
+        }
     }
-    
-    var isChecked: Bool {
-        get {
-            return checked
+
+    /// Updates the Attachment's Tint Color
+    ///
+    var tintColor: UIColor? {
+        didSet {
+            refreshImage()
         }
-        set(isChecked) {
-            checked = isChecked
-            image = UIImage(named: checked ? "icon_task_checked" : "icon_task_unchecked")?.withOverlayColor(attachmentColor)
+    }
+
+    /// Updates the Internal Image
+    ///
+    private func refreshImage() {
+        guard let tintColor = tintColor else {
+            return
         }
+
+        image = UIImage(named: isChecked ? "icon_task_checked" : "icon_task_unchecked")?.withOverlayColor(tintColor)
     }
 }

--- a/Simplenote/SPTextAttachment.swift
+++ b/Simplenote/SPTextAttachment.swift
@@ -29,6 +29,7 @@ class SPTextAttachment: NSTextAttachment {
             return
         }
 
-        image = UIImage(named: isChecked ? "icon_task_checked" : "icon_task_unchecked")?.withOverlayColor(tintColor)
+        let name: UIImageName = isChecked ? .taskChecked : .taskUnchecked
+        image = UIImage.image(name: name)?.withOverlayColor(tintColor)
     }
 }

--- a/Simplenote/SPTextAttachment.swift
+++ b/Simplenote/SPTextAttachment.swift
@@ -6,6 +6,10 @@ import UIKit
 @objcMembers
 class SPTextAttachment: NSTextAttachment {
 
+    /// Extra Sizing Points to be appled over the actual Sizing Font Size
+    ///
+    var extraDimensionPoints: CGFloat = 4
+
     /// Indicates if we're in the Checked or Unchecked state
     ///
     var isChecked = false {
@@ -22,9 +26,27 @@ class SPTextAttachment: NSTextAttachment {
         }
     }
 
-    /// Updates the Internal Image
+    /// Font to be used for Attachment Sizing purposes
     ///
-    private func refreshImage() {
+    var sizingFont: UIFont = .preferredFont(forTextStyle: .headline)
+
+
+    // MARK: - Overridden Methods
+
+    override func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+        let dimension = sizingFont.pointSize + extraDimensionPoints
+        let offsetY = round((sizingFont.capHeight - dimension) * 0.5)
+
+        return CGRect(x: 0, y: offsetY, width: dimension, height: dimension)
+    }
+}
+
+
+// MARK: - Private
+//
+private extension SPTextAttachment {
+
+    func refreshImage() {
         guard let tintColor = tintColor else {
             return
         }

--- a/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
+++ b/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
@@ -1,39 +1,38 @@
-//
-//  SPChecklistTest.swift
-//  SimplenoteTests
-//
-
 import XCTest
+@testable import Simplenote
 
-class SPChecklistTest: XCTestCase {
+
+// MARK: - NSMutableAttributedString Styling Tests
+//
+class NSMutableAttributedStringStylingTests: XCTestCase {
+
+    ///
+    ///
     func testChecklistShouldNotRenderWithinText() {
         let inlineChecklist = "This is a badly formed todo - [ ] Buy avocados"
-        
-        let regex = try! NSRegularExpression(pattern: CheckListRegExPattern, options: NSRegularExpression.Options.anchorsMatchLines)
-        
+        let regex = try! NSRegularExpression(pattern: NSAttributedStringRegexForChecklists, options: .anchorsMatchLines)
         let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
         
-        XCTAssertTrue(matches.count == 0)
-    }
-    
-    func testChecklistRenderWithPrefixedWhitespace() {
-        let inlineChecklist = "       - [ ] Buy avocados - [ ] "
-        
-        let regex = try! NSRegularExpression(pattern: CheckListRegExPattern, options: NSRegularExpression.Options.anchorsMatchLines)
-        
-        let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
-        
-        XCTAssertTrue(matches.count == 1)
-    }
-    
-    func testMatchProperlyFormattedChecklistSyntax() {
-        let inlineChecklist = "ToDo\n\n- [ ] Buy avocados\n- [ ] Ship it\n- [x ] Malformed!\n- [x] Correct."
-        
-        let regex = try! NSRegularExpression(pattern: CheckListRegExPattern, options: NSRegularExpression.Options.anchorsMatchLines)
-        
-        let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
-        
-        XCTAssertTrue(matches.count == 3)
+        XCTAssertTrue(matches.isEmpty)
     }
 
+    ///
+    ///
+    func testChecklistRenderWithPrefixedWhitespace() {
+        let inlineChecklist = "       - [ ] Buy avocados - [ ] "
+        let regex = try! NSRegularExpression(pattern: NSAttributedStringRegexForChecklists, options: .anchorsMatchLines)
+        let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
+
+        XCTAssertEqual(matches.count, 1)
+    }
+
+    ///
+    ///
+    func testMatchProperlyFormattedChecklistSyntax() {
+        let inlineChecklist = "ToDo\n\n- [ ] Buy avocados\n- [ ] Ship it\n- [x ] Malformed!\n- [x] Correct."
+        let regex = try! NSRegularExpression(pattern: NSAttributedStringRegexForChecklists, options: .anchorsMatchLines)
+        let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
+        
+        XCTAssertEqual(matches.count, 3)
+    }
 }

--- a/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
+++ b/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
@@ -45,4 +45,15 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
 
         XCTAssertTrue(matches.isEmpty)
     }
+
+    /// Verifies that `NSRegularExpression.regexForChecklistsEmbeddedAnywhere` matches multiple checklists in the same line
+    ///
+    func testRegexForChecklistsEmbeddedAnywhereProperlyMatchesMultipleChecklistsInTheSingleLine() {
+        let string = "           - [ ] Buy avocados - [ ] - [ ]- [ ] - [x]- [X]"
+        let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+
+        XCTAssertEqual(matches.count, 6)
+    }
+
 }

--- a/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
+++ b/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
@@ -6,24 +6,44 @@ import XCTest
 //
 class NSMutableAttributedStringStylingTests: XCTestCase {
 
-    /// Verifies that `NSRegularExpression.regexForChecklists` does not match checklists that are in the middle of a string
+    /// Verifies that `NSRegularExpression.regexForChecklists` will not match checklists that are in the middle of a string
     ///
     func testRegexForChecklistsWillNotMatchChecklistsLocatedAtTheMiddleOfTheString() {
-        let string = "This is a badly formed todo - [ ] Buy avocados"
+        let string = "This is a badly formed todo - [ ] Buy avocados - []"
         let regex = NSRegularExpression.regexForChecklists
         let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
         
         XCTAssertTrue(matches.isEmpty)
     }
 
+    /// Verifies that `NSRegularExpression.regexForChecklistsEmbeddedAnywhere` matches multiple checklists in the same line
+    ///
+    func testRegexForChecklistsEmbeddedAnywhereWillMatchChecklistsLocatedAtTheMiddleOfTheString() {
+        let string = "The second regex should consider this as a valid checklist - [ ] Buy avocados - []"
+        let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+
+        XCTAssertEqual(matches.count, 2)
+    }
+
     /// Verifies that `NSRegularExpression.regexForChecklists` matches multiple spacing prefixes
     ///
     func testRegexForChecklistsProperlyMatchesMultipleWhitespacePrefixes() {
-        let string = "           - [ ] Buy avocados - [ ] "
+        let string = "           - [ ] Buy avocados - [ ]"
         let regex = NSRegularExpression.regexForChecklists
         let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
 
         XCTAssertEqual(matches.count, 1)
+    }
+
+    /// Verifies that `NSRegularExpression.regexForChecklistsEmbeddedAnywhere` matches multiple spacing prefixes
+    ///
+    func testRegexForChecklistsEverywhereProperlyMatchesMultipleWhitespacePrefixes() {
+        let string = "           - [ ] Buy avocados - [ ]"
+        let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+
+        XCTAssertEqual(matches.count, 2)
     }
 
     /// Verifies that `NSRegularExpression.regexForChecklists` only matches corretly formed strings
@@ -46,14 +66,33 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         XCTAssertTrue(matches.isEmpty)
     }
 
-    /// Verifies that `NSRegularExpression.regexForChecklistsEmbeddedAnywhere` matches multiple checklists in the same line
+    /// Verifies that `NSRegularExpression.regexForChecklistsEverywhere` will not match malformed strings
     ///
-    func testRegexForChecklistsEmbeddedAnywhereProperlyMatchesMultipleChecklistsInTheSingleLine() {
-        let string = "           - [ ] Buy avocados - [ ] - [ ]- [ ] - [x]- [X]"
+    func testRegexForChecklistsEverywhereWillNotMatchMalformedChecklists() {
+        let string = "- [x ] Malformed!"
         let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
         let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
 
-        XCTAssertEqual(matches.count, 6)
+        XCTAssertTrue(matches.isEmpty)
     }
 
+    /// Verifies that `NSRegularExpression.regexForChecklists` will match checklists with no spaces between brackets
+    ///
+    func testRegexForChecklistsWillMatchChecklistsWithNoInternalSpaces() {
+        let string = "- [] Item"
+        let regex = NSRegularExpression.regexForChecklists
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+
+        XCTAssertEqual(matches.count, 1)
+    }
+
+    /// Verifies that `NSRegularExpression.regexForChecklistsEmbeddedAnywhere` will match checklists with no spaces between brackets
+    ///
+    func testRegexForChecklistsEverywhereWillMatchChecklistsWithNoInternalSpaces() {
+        let string = "- [] Item"
+        let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+
+        XCTAssertEqual(matches.count, 1)
+    }
 }

--- a/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
+++ b/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
@@ -11,7 +11,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsWillNotMatchChecklistsLocatedAtTheMiddleOfTheString() {
         let string = "This is a badly formed todo - [ ] Buy avocados - []"
         let regex = NSRegularExpression.regexForChecklists
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
         
         XCTAssertTrue(matches.isEmpty)
     }
@@ -21,7 +21,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsEmbeddedAnywhereWillMatchChecklistsLocatedAtTheMiddleOfTheString() {
         let string = "The second regex should consider this as a valid checklist - [ ] Buy avocados - []"
         let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 2)
     }
@@ -31,7 +31,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsProperlyMatchesMultipleWhitespacePrefixes() {
         let string = "           - [ ] Buy avocados - [ ]"
         let regex = NSRegularExpression.regexForChecklists
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 1)
     }
@@ -41,7 +41,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsEverywhereProperlyMatchesMultipleWhitespacePrefixes() {
         let string = "           - [ ] Buy avocados - [ ]"
         let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 2)
     }
@@ -51,7 +51,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsMatchProperlyFormattedChecklists() {
         let string = "ToDo\n\n- [ ] Buy avocados\n- [ ] Ship it\n- [x ] Malformed!\n- [x] Correct."
         let regex = NSRegularExpression.regexForChecklists
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
         
         XCTAssertEqual(matches.count, 3)
     }
@@ -61,7 +61,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsWillNotMatchMalformedChecklists() {
         let string = "- [x ] Malformed!"
         let regex = NSRegularExpression.regexForChecklists
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertTrue(matches.isEmpty)
     }
@@ -71,7 +71,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsEverywhereWillNotMatchMalformedChecklists() {
         let string = "- [x ] Malformed!"
         let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertTrue(matches.isEmpty)
     }
@@ -81,7 +81,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsWillMatchChecklistsWithNoInternalSpaces() {
         let string = "- [] Item"
         let regex = NSRegularExpression.regexForChecklists
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 1)
     }
@@ -91,7 +91,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
     func testRegexForChecklistsEverywhereWillMatchChecklistsWithNoInternalSpaces() {
         let string = "- [] Item"
         let regex = NSRegularExpression.regexForChecklistsEmbeddedAnywhere
-        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+        let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 1)
     }

--- a/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
+++ b/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
@@ -6,33 +6,43 @@ import XCTest
 //
 class NSMutableAttributedStringStylingTests: XCTestCase {
 
+    /// Verifies that `NSRegularExpression.regexForChecklists` does not match checklists that are in the middle of a string
     ///
-    ///
-    func testChecklistShouldNotRenderWithinText() {
-        let inlineChecklist = "This is a badly formed todo - [ ] Buy avocados"
-        let regex = try! NSRegularExpression(pattern: NSAttributedStringRegexForChecklists, options: .anchorsMatchLines)
-        let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
+    func testRegexForChecklistsWillNotMatchChecklistsLocatedAtTheMiddleOfTheString() {
+        let string = "This is a badly formed todo - [ ] Buy avocados"
+        let regex = NSRegularExpression.regexForChecklists
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
         
         XCTAssertTrue(matches.isEmpty)
     }
 
+    /// Verifies that `NSRegularExpression.regexForChecklists` matches multiple spacing prefixes
     ///
-    ///
-    func testChecklistRenderWithPrefixedWhitespace() {
-        let inlineChecklist = "       - [ ] Buy avocados - [ ] "
-        let regex = try! NSRegularExpression(pattern: NSAttributedStringRegexForChecklists, options: .anchorsMatchLines)
-        let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
+    func testRegexForChecklistsProperlyMatchesMultipleWhitespacePrefixes() {
+        let string = "           - [ ] Buy avocados - [ ] "
+        let regex = NSRegularExpression.regexForChecklists
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
 
         XCTAssertEqual(matches.count, 1)
     }
 
+    /// Verifies that `NSRegularExpression.regexForChecklists` only matches corretly formed strings
     ///
-    ///
-    func testMatchProperlyFormattedChecklistSyntax() {
-        let inlineChecklist = "ToDo\n\n- [ ] Buy avocados\n- [ ] Ship it\n- [x ] Malformed!\n- [x] Correct."
-        let regex = try! NSRegularExpression(pattern: NSAttributedStringRegexForChecklists, options: .anchorsMatchLines)
-        let matches = regex.matches(in: inlineChecklist, options: [], range: NSMakeRange(0, inlineChecklist.count))
+    func testRegexForChecklistsMatchProperlyFormattedChecklists() {
+        let string = "ToDo\n\n- [ ] Buy avocados\n- [ ] Ship it\n- [x ] Malformed!\n- [x] Correct."
+        let regex = NSRegularExpression.regexForChecklists
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
         
         XCTAssertEqual(matches.count, 3)
+    }
+
+    /// Verifies that `NSRegularExpression.regexForChecklists` will not match malformed strings
+    ///
+    func testRegexForChecklistsWillNotMatchMalformedChecklists() {
+        let string = "- [x ] Malformed!"
+        let regex = NSRegularExpression.regexForChecklists
+        let matches = regex.matches(in: string, options: [], range: string.rangeOfEntireString)
+
+        XCTAssertTrue(matches.isEmpty)
     }
 }


### PR DESCRIPTION
### Fix
In this PR we're:

1. Fixing Checklists Processing in the Notes List, so that not just the first Checkbox will get replaced by an image.
2. Adding new Unit Tests
3. And doing an overall cleanup

cc @bummytime (Thanks in advance Bummy!!)
Closes #663

### Test
1. Add a new note with the following content:
  ```
  - [ ] Uno
  - [ ] Dos
  - [ ] Tres
  - [ ] Catorce
  ```
2. Go back to the Notes List

- [ ] Verify every single checkmark gets a proper Checklist Image
- [x] Verify that the Checkmark aligns perfectly when the Dynamic Type settings are changed
- [x] Verify that the new Unit Tests are green

### Release
These changes do not require release notes.
