### PR TITLE
Support the unicode bullet as a list item bullet in unordered lists

### DIFF
--- a/Simplenote/Classes/UITextView+Simplenote.m
+++ b/Simplenote/Classes/UITextView+Simplenote.m
@@ -32,7 +32,7 @@ const int ChecklistItemLength = 3;
     NSString *lineString                = [rawString substringWithRange:lineRange];
     NSString *cleanLineString           = [lineString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     NSString *textAttachmentCode = @"\U0000fffc"; // Represents the glyph of an NSTextAttachment
-    NSArray *const bullets              = @[@"*", @"+", @"-", textAttachmentCode];
+    NSArray *const bullets              = @[@"*", @"+", @"-", @"•", textAttachmentCode];
     NSString *stringToAppendToNewLine   = nil;
     
     for (NSString *bullet in bullets) {


### PR DESCRIPTION
### Fix
Support the unicode bullet character `•` as a list item bullet because lists copied from HTML or word documents may contain this character.

### Test
1. Open Simplenote
2. Create an unordered list with unicode bullets •
  ```
    • list item a
    • list item b
  ```
3. Press enter after the first item
4. A new list item should be opened, starting with a unicode bullet •

### Review
Anyone can perform the review.

### Release
> Added support for the unicode bullet • in list items