### PR TITLE
Tag Operator: Not producing partial matches

### DIFF
--- a/Simplenote/Classes/NSPredicate+Simplenote.swift
+++ b/Simplenote/Classes/NSPredicate+Simplenote.swift
@@ -22,7 +22,7 @@ extension NSPredicate {
                 continue
             }
 
-            output.append( NSPredicate(format: "tags CONTAINS[cd] %@", tag) )
+            output.append( NSPredicate(format: "tags CONTAINS[cd] %@", formattedTag(for: tag)) )
         }
 
         guard !output.isEmpty else {
@@ -51,12 +51,7 @@ extension NSPredicate {
     ///
     @objc
     static func predicateForNotes(tag: String) -> NSPredicate {
-        let filtered = tag.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "/", with: "\\/")
-
-        // Individual tags are surrounded by quotes, thus adding quotes to the selected tag ensures only the
-        // correct notes are shown
-        let format = String(format: "\"%@\"", filtered)
-        return NSPredicate(format: "tags CONTAINS[c] %@", format)
+        return NSPredicate(format: "tags CONTAINS[c] %@", formattedTag(for: tag))
     }
 
     /// Returns a NSPredicate that will match:
@@ -96,5 +91,18 @@ extension NSPredicate {
             NSPredicate(format: "name CONTAINS[cd] %@", tag),
             NSPredicate(format: "name <>[c] %@", tag)
         ])
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension NSPredicate {
+
+    /// Returns the received tag, escaped and surrounded by quotes: ensures only the *exact* tag matches are hit
+    ///
+    static func formattedTag(for tag: String) -> String {
+        let filtered = tag.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "/", with: "\\/")
+        return String(format: "\"%@\"", filtered)
     }
 }

--- a/SimplenoteTests/NSPredicateSimplenoteTests.swift
+++ b/SimplenoteTests/NSPredicateSimplenoteTests.swift
@@ -81,7 +81,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
     ///
     func testPredicateForNotesWithSearchTextMatchesNoteWheneverTagPayloadIsEmpty() {
         let entity = MockupNote()
-        entity.tags = "[ 'keyword' ]"
+        entity.tags = "[ \"keyword\" ]"
 
         let predicate = NSPredicate.predicateForNotes(searchText: "tag:")
         XCTAssertTrue(predicate.evaluate(with: entity))
@@ -91,7 +91,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
     ///
     func testPredicateForNotesWithSearchTextMatchesTagsWithDiacriticInsensitiveRule() {
         let entity = MockupNote()
-        entity.tags = "[ 'esdrújula' ]"
+        entity.tags = "[ \"esdrújula\" ]"
 
         let predicate = NSPredicate.predicateForNotes(searchText: "tag:esdrujula")
         XCTAssertTrue(predicate.evaluate(with: entity))
@@ -101,7 +101,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
     ///
     func testPredicateForNotesWithSearchTextMatchesNoteWithSpecifiedTag() {
         let entity = MockupNote()
-        entity.tags = "[ 'keyword' ]"
+        entity.tags = "[ \"keyword\" ]"
 
         let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword")
         XCTAssertTrue(predicate.evaluate(with: entity))
@@ -109,12 +109,12 @@ class NSPredicateSimplenoteTests: XCTestCase {
 
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` will  match entities that contain a partial match with the `tag:` operator
     ///
-    func testPredicateForNotesWithSearchTextMatchesNoteWithSpecifiedPartialTag() {
+    func testPredicateForNotesWithSearchTextDoesNotMatchNoteWithSpecifiedPartialTag() {
         let entity = MockupNote()
-        entity.tags = "[ 'keyword' ]"
+        entity.tags = "[ \"keyword\" ]"
 
         let predicate = NSPredicate.predicateForNotes(searchText: "tag:word")
-        XCTAssertTrue(predicate.evaluate(with: entity))
+        XCTAssertFalse(predicate.evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` will not match entities that do contain a given `tag:`, but lack the target content
@@ -122,7 +122,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForNotesWithSearchTextWillNotMatchEntityWithoutTargetContentEvenWhenTheSpecifiedTagIsThere() {
         let entity = MockupNote()
         entity.content = "unmatched"
-        entity.tags = "[ 'keyword' ]"
+        entity.tags = "[ \"keyword\" ]"
 
         let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword else")
         XCTAssertFalse(predicate.evaluate(with: entity))
@@ -133,7 +133,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForNotesWithSearchTextWillMatchEntityWithTargetContentAndTag() {
         let entity = MockupNote()
         entity.content = "something else"
-        entity.tags = "[ 'keyword' ]"
+        entity.tags = "[ \"keyword\" ]"
 
         let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword else something")
         XCTAssertTrue(predicate.evaluate(with: entity))


### PR DESCRIPTION
### Fix
In this PR we're updating the `tag:keyword` operator's behavior, so that it does not produce partial match results.

@aerych Sir, may I bug you with a fun PR?

Closes #672

### Test
1. Create a tag `test`
2. Create a tag `testing`
3. Add the tag `testing` to a note (and _don't_ add the tag `test` to it).
4. Search for `tag:test`

- [x] Verify that the note you've tagged in (3) does not show up in the results list
- [x] Verify that the unit tests are ever green!

### Release
These changes do not require release notes.
