### PR TITLE
Filtering out (reserved) Tag Names

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		B5476BBD23D8A71D000E7723 /* UIFont+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BBC23D8A71D000E7723 /* UIFont+Simplenote.swift */; };
 		B5476BBF23D8B686000E7723 /* NotesListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BBE23D8B686000E7723 /* NotesListSection.swift */; };
 		B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */; };
+		B54B04D82407169500401FBB /* SPAppDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */; };
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B550F93122BA65CD00091939 /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93022BA65CD00091939 /* ActivityType.swift */; };
 		B550F93322BA6A3300091939 /* ShortcutsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93222BA6A3300091939 /* ShortcutsHandler.swift */; };
@@ -512,6 +513,7 @@
 		B5476BBC23D8A71D000E7723 /* UIFont+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIFont+Simplenote.swift"; path = "Classes/UIFont+Simplenote.swift"; sourceTree = "<group>"; };
 		B5476BBE23D8B686000E7723 /* NotesListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotesListSection.swift; path = Classes/NotesListSection.swift; sourceTree = "<group>"; };
 		B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "String+Simplenote.swift"; path = "Classes/String+Simplenote.swift"; sourceTree = "<group>"; };
+		B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPAppDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		B55051811A4328B9002A1093 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		B550F93022BA65CD00091939 /* ActivityType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ActivityType.swift; path = Classes/ActivityType.swift; sourceTree = "<group>"; };
 		B550F93222BA6A3300091939 /* ShortcutsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShortcutsHandler.swift; path = Classes/ShortcutsHandler.swift; sourceTree = "<group>"; };
@@ -1523,6 +1525,7 @@
 				B5BDD8721BEA6B01006EB940 /* Simplenote-Bridging-Header.h */,
 				E29ADD4A17848E8500E55842 /* SPAppDelegate.h */,
 				E29ADD4B17848E8500E55842 /* SPAppDelegate.m */,
+				B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */,
 			);
 			path = Simplenote;
 			sourceTree = "<group>";
@@ -2181,6 +2184,7 @@
 				46A3C9A417DFA81A002865AE /* SPToggle.m in Sources */,
 				46A3C9A617DFA81A002865AE /* SPActionSheet.m in Sources */,
 				375D24B221E01131007AB25A /* buffer.c in Sources */,
+				B54B04D82407169500401FBB /* SPAppDelegate+Extensions.swift in Sources */,
 				B50E99F4234242130092F274 /* UISearchBar+Simplenote.swift in Sources */,
 				46A3C9A717DFA81A002865AE /* DTPinLockController.m in Sources */,
 				B56A696522F9D54600B90398 /* SPLabel.swift in Sources */,

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1418,9 +1418,9 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     // Set the note's markdown tag according to the global preference (defaults NO for new accounts)
     newNote.markdown = [[NSUserDefaults standardUserDefaults] boolForKey:kSimplenoteMarkdownDefaultKey];
 
-    NSString *currentTag = [[SPAppDelegate sharedDelegate] selectedTag];
-    if ([currentTag length] > 0) {
-        [newNote addTag:currentTag];
+    NSString *filteredTagName = [[SPAppDelegate sharedDelegate] filteredTagName];
+    if (filteredTagName.length > 0) {
+        [newNote addTag:filteredTagName];
     }
     
     // animate current note off the screen and begin editing new note

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+
+// MARK: - Internal Methods
+//
+extension SPAppDelegate {
+
+    /// Returns the actual Selected Tag Name **Excluding** navigation tags, such as Trash or Untagged Notes.
+    ///
+    /// TODO: This should be gone... **the second** the AppDelegate is Swift-y. We should simply keep a `NoteListFilter` instance.
+    ///
+    @objc
+    var filteredTagName: String? {
+        guard let selectedTag = SPAppDelegate.shared().selectedTag,
+            case let .tag(name) = NotesListFilter(selectedTag: selectedTag) else {
+                return nil
+        }
+
+        return name
+    }
+}


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug which would cause an internal string, to be leaked to the user interface.

@aerych **Thank you** for spotting this one!!!

### Test: Unfiltered Notes
1. Launch the app
2. Select the `Untagged Notes` filter
3. Add a new note

- [x] Verify the Tag List is clean, and no strange strings show up

### Test: Regressions
1. Launch the app
2. Select any User-Y defined tags
3. Add a new note

- [ ] Verify that the tag you've selected in (3) gets pre-loaded to the tags list

### Release
These changes do not require release notes.
