### PR TITLE
Typography adjustments

### DIFF
--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -179,7 +179,7 @@ class SPNoteTableViewCell: UITableViewCell {
     private func refreshBodyAttributedString() {
         let bodyString = NSMutableAttributedString()
         if let prefixText = prefixText {
-            let prefixString = NSAttributedString(string: prefixText + String.space + String.space, attributes: [
+            let prefixString = NSAttributedString(string: prefixText + String.space, attributes: [
                 .font: Style.prefixFont,
                 .foregroundColor: Style.headlineColor,
                 .paragraphStyle: Style.paragraphStyle,

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -359,7 +359,7 @@ private enum Style {
 
     /// Outer Vertical StackView's Spacing
     ///
-    static let outerVerticalStackViewSpacing = CGFloat(2)
+    static let outerVerticalStackViewSpacing = CGFloat(4)
 
     /// TextView's paragraphStyle
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -335,7 +335,7 @@ private enum Style {
 
     /// Accessory's Minimum Size
     ///
-    static let accessoryImageMinimumSize = CGFloat(15)
+    static let accessoryImageMinimumSize = CGFloat(16)
 
     /// Accessory's Maximum Size (1.5 the asset's size)
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -355,7 +355,7 @@ private enum Style {
 
     /// Represents the Insets applied to the container view
     ///
-    static let containerInsets = UIEdgeInsets(top: 12, left: 6, bottom: 12, right: 0)
+    static let containerInsets = UIEdgeInsets(top: 13, left: 6, bottom: 13, right: 0)
 
     /// Outer Vertical StackView's Spacing
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -355,7 +355,7 @@ private enum Style {
 
     /// Represents the Insets applied to the container view
     ///
-    static let containerInsets = UIEdgeInsets(top: 13, left: 6, bottom: 13, right: 0)
+    static let containerInsets = UIEdgeInsets(top: 12, left: 6, bottom: 12, right: 0)
 
     /// Outer Vertical StackView's Spacing
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -359,7 +359,7 @@ private enum Style {
 
     /// Outer Vertical StackView's Spacing
     ///
-    static let outerVerticalStackViewSpacing = CGFloat(4)
+    static let outerVerticalStackViewSpacing = CGFloat(2)
 
     /// TextView's paragraphStyle
     ///

--- a/Simplenote/Classes/SPSortBar.swift
+++ b/Simplenote/Classes/SPSortBar.swift
@@ -97,8 +97,8 @@ private extension SPSortBar {
 
     func setupTextLabels() {
         titleLabel.text = NSLocalizedString("Sort by:", comment: "Sort By Title")
-        titleLabel.font = .preferredFont(for: .caption1, weight: .regular)
-        descriptionLabel.font = .preferredFont(for: .caption1, weight: .medium)
+        titleLabel.font = .systemFont(ofSize: 12.0)
+        descriptionLabel.font = .systemFont(ofSize: 12.0)
     }
 
     func setupOrderButton() {

--- a/Simplenote/Classes/UISearchBar+Simplenote.swift
+++ b/Simplenote/Classes/UISearchBar+Simplenote.swift
@@ -16,7 +16,7 @@ extension UISearchBar {
 
         // Apply font to search field by traversing subviews
         for textField in subviewsOfType(UITextField.self) {
-            textField.font = .preferredFont(forTextStyle: .body)
+            textField.font = .systemFont(ofSize: 17.0)
             textField.textColor = .simplenoteTextColor
             textField.keyboardAppearance = SPUserInterface.isDark ? .dark : .default
         }


### PR DESCRIPTION
### Fix
Fixing minor typography issues:

- Extra space removed from note cell timestamp prefix
- Note cell accessory minimum size adjusted
- Fix the font size of sort bar text (in line with iOS standards)
- Fix the font size of search bar text (in line with iOS Standards)

### Test
1. Visit the notes list
2. Pin a note
3. Notice that the pin is now 16pt instead of 15pt
4. Perform a search
5. Switch search mode to "Created" or "Modified"
6. Notice that the extra space was removed from the timestamp in the note cell
7. Adjust text size settings in iOS system preferences
8. Return to Simplenote
9. Notice that the sort bar text does not change
10. Notice that the search bar placeholder and input text does not change

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
