### PR TITLE
Text Style Fixes

### DIFF
--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -125,7 +125,7 @@ extension UIColor {
 
     @objc
     static var simplenoteNavigationBarTitleColor: UIColor {
-        UIColor(lightColor: .gray80, darkColor: .white)
+        UIColor(lightColor: .gray100, darkColor: .white)
     }
 
     @objc

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -220,7 +220,7 @@ extension UIColor {
 
     @objc
     static var simplenoteWindowBackgroundColor: UIColor {
-        UIColor(lightColor: .white, darkColor: .black)
+        UIColor(studioColor: .black)
     }
 
     @objc

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -95,7 +95,7 @@ extension UIColor {
 
     @objc
     static var simplenoteNoteHeadlineColor: UIColor {
-        UIColor(lightColor: .gray80, darkColor: .white)
+        UIColor(lightColor: .gray100, darkColor: .white)
     }
 
     @objc

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -235,7 +235,7 @@ extension UIColor {
 
     @objc
     static var simplenoteTextColor: UIColor {
-        UIColor(lightColor: .gray80, darkColor: .white)
+        UIColor(lightColor: .gray100, darkColor: .white)
     }
 
     @objc


### PR DESCRIPTION
### Fix
- Changes to the shade of grey used for dark text throughout the app which is more in line with iOS's black text.
- Applies a black window colour which can be seen in modal views.

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/36532468/75709659-032ad580-5cbb-11ea-92c6-8e2ec959e055.PNG)  |  ![](https://user-images.githubusercontent.com/36532468/75709763-31a8b080-5cbb-11ea-8cca-d75e2f106dde.PNG)


### Test
1. Open the Simplenote app
2. Make sure light theme is enabled
3. Notice that dark text is now darker (gray100)
4. Navigate to any note
5. Press the "i" icon
6. Press "Collaborate"
7. Notice that the app background (status bar area) is now black in line with iOS standards

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
