### PR TITLE
Adjust spacing in note table cell

### DIFF
--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -355,7 +355,7 @@ private enum Style {
 
     /// Represents the Insets applied to the container view
     ///
-    static let containerInsets = UIEdgeInsets(top: 13, left: 6, bottom: 13, right: 0)
+    static let containerInsets = UIEdgeInsets(top: 12, left: 6, bottom: 12, right: 0)
 
     /// Outer Vertical StackView's Spacing
     ///

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -88,11 +88,11 @@ Body L2</string>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="D1J-20-bJ0" secondAttribute="leading" id="8ai-Nb-yMT"/>
-                    <constraint firstItem="1kl-z0-0K0" firstAttribute="top" secondItem="D1J-20-bJ0" secondAttribute="top" constant="13" id="BLy-sw-4lE"/>
+                    <constraint firstItem="1kl-z0-0K0" firstAttribute="top" secondItem="D1J-20-bJ0" secondAttribute="top" constant="12" id="BLy-sw-4lE"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1kl-z0-0K0" secondAttribute="trailing" id="DVN-iO-uti"/>
                     <constraint firstAttribute="trailing" secondItem="1kl-z0-0K0" secondAttribute="trailing" constant="16" id="Ig2-uE-hva"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="centerX" secondItem="D1J-20-bJ0" secondAttribute="centerX" id="S72-c6-I0t"/>
-                    <constraint firstAttribute="bottom" secondItem="1kl-z0-0K0" secondAttribute="bottom" constant="13" id="VZK-oO-oh0"/>
+                    <constraint firstAttribute="bottom" secondItem="1kl-z0-0K0" secondAttribute="bottom" constant="12" id="VZK-oO-oh0"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="leading" secondItem="D1J-20-bJ0" secondAttribute="leading" constant="6" id="k1X-7o-aAs"/>
                 </constraints>
                 <variation key="default">

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -34,7 +34,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="370" height="20"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="348" height="20"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="346" height="20"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,10 +17,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1kl-z0-0K0" userLabel="Container View">
-                        <rect key="frame" x="6" y="13" width="392" height="61"/>
+                        <rect key="frame" x="6" y="12" width="392" height="63"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
-                                <rect key="frame" x="0.0" y="1" width="16" height="16"/>
+                                <rect key="frame" x="0.0" y="2" width="16" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="16" id="HlN-8B-Xzh"/>
                                     <constraint firstAttribute="width" constant="16" placeholder="YES" id="eu6-28-b8t"/>
@@ -28,19 +28,19 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
-                                <rect key="frame" x="22" y="0.0" width="370" height="61"/>
+                                <rect key="frame" x="22" y="0.0" width="370" height="63"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
-                                        <rect key="frame" x="0.0" y="0.0" width="370" height="18"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="370" height="20"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="348" height="18"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="348" height="20"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                                <rect key="frame" x="354" y="1" width="16" height="16"/>
+                                                <rect key="frame" x="354" y="2" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
                                                     <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
@@ -53,7 +53,7 @@
                                         </constraints>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
-                                        <rect key="frame" x="0.0" y="20" width="370" height="41"/>
+                                        <rect key="frame" x="0.0" y="22" width="370" height="41"/>
                                         <string key="text">Body L1
 Body L2</string>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -30,7 +30,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
                                 <rect key="frame" x="22" y="0.0" width="370" height="63"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
                                         <rect key="frame" x="0.0" y="0.0" width="370" height="20"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">


### PR DESCRIPTION
### Fix
Minor adjustments to spacing and insets for table cells

- Top and bottom padding changed from 13pt to 12pt
- Space between title label and right accessory changed from 6pt to 8pt

### Test
1. Open the app at the note list
2. Notice that the table cell spacing and insets have been adjusted

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
