### PR TITLE
Fixes Issue 126 - Pin Lock UI Can Become Misaligned

### DIFF
--- a/External/DTPinLock/DTPinLockController.m
+++ b/External/DTPinLock/DTPinLockController.m
@@ -230,6 +230,7 @@
     
     secondPagePinGroup = [[UIView alloc] initWithFrame:CGRectMake(leftMargin, 74, neededWidth, 53)];
     secondPagePinGroup.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+    secondPagePinGroup.center = CGPointMake(baseViewController.secondPageView.frame.size.width / 2.0, secondPagePinGroup.center.y);
     [baseViewController.secondPageView addSubview:secondPagePinGroup];
     
     


### PR DESCRIPTION
This PR addresses the bug report #126 where it is possible for the Simplenote UI Pin lock to become misaligned to one side under certain circumstances

# Fix
The pin lock is comprised of two different views created at the same time, one off screen and one on screen.  On the first screen the pin lock dashes and dots have a specified center point, but the second page dashes and dots did not.  This led to them being created correctly in the right place, but depending on the visible screen space, they could be moved to far to one side.

This PR sets a specific point for the center of the secondPagePinGroup in DTPinLockController.

Note:  Problem only occurred on the second pin lock page, and the unlock page.

### Test
I tested a few sized devices, and the issue seemed easier to replicate on an iPad, especially using split screen.
Test in standard screen (portrait mode and landscape):
1. Open Simplenote
2. Go to Settings > Pin Lock
3. Set a pin lock
4. confirm the second page of pins (confirmation page) is centered

Follow the same steps while using split screen with another app

Try disabling the pin lock as well in both cases, check for the pin lock to be centered

### Release
Fixes a UI problem where the pin lock would not appear centered.