### PR TITLE
Fix Onboarding Colours

### DIFF
--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -89,7 +89,7 @@ private extension SPOnboardingViewController {
     }
 
     func setupImageView() {
-        simplenoteImageView.tintColor = .simplenoteBlue30Color
+        simplenoteImageView.tintColor = .simplenoteBlue50Color
     }
 
     func setupLabels() {

--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -94,7 +94,7 @@ private extension SPOnboardingViewController {
 
     func setupLabels() {
         simplenoteLabel.text = OnboardingStrings.brandText
-        simplenoteLabel.textColor = UIColor.simplenoteGray80Color
+        simplenoteLabel.textColor = UIColor.simplenoteGray100Color
         simplenoteLabel.adjustsFontSizeToFitWidth = true
         simplenoteLabel.font = .preferredFont(for: .largeTitle, weight: .semibold)
 

--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -85,7 +85,7 @@ private extension SPOnboardingViewController {
         signUpButton.backgroundColor = .simplenoteBlue50Color
 
         loginButton.setTitle(OnboardingStrings.loginText, for: .normal)
-        loginButton.setTitleColor(.simplenoteBlue60Color, for: .normal)
+        loginButton.setTitleColor(.simplenoteBlue50Color, for: .normal)
     }
 
     func setupImageView() {

--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -93,15 +93,13 @@ private extension SPOnboardingViewController {
     }
 
     func setupLabels() {
-        let textColor = UIColor.simplenoteGray80Color
-
         simplenoteLabel.text = OnboardingStrings.brandText
-        simplenoteLabel.textColor = textColor
+        simplenoteLabel.textColor = UIColor.simplenoteGray80Color
         simplenoteLabel.adjustsFontSizeToFitWidth = true
         simplenoteLabel.font = .preferredFont(for: .largeTitle, weight: .semibold)
 
         headerLabel.text = OnboardingStrings.headerText
-        headerLabel.textColor = textColor
+        headerLabel.textColor = UIColor.simplenoteGray50Color
         headerLabel.adjustsFontSizeToFitWidth = true
         headerLabel.font = .preferredFont(forTextStyle: .title3)
     }

--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -98,7 +98,7 @@ private extension SPOnboardingViewController {
         simplenoteLabel.text = OnboardingStrings.brandText
         simplenoteLabel.textColor = textColor
         simplenoteLabel.adjustsFontSizeToFitWidth = true
-        simplenoteLabel.font = .preferredFont(forTextStyle: .largeTitle)
+        simplenoteLabel.font = .preferredFont(for: .largeTitle, weight: .semibold)
 
         headerLabel.text = OnboardingStrings.headerText
         headerLabel.textColor = textColor

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -77,6 +77,11 @@ extension UIColor {
     static var simplenoteGray80Color: UIColor {
         UIColor(studioColor: .gray80)
     }
+    
+    @objc
+    static var simplenoteGray100Color: UIColor {
+        UIColor(studioColor: .gray100)
+    }
 
     @objc
     static var simplenoteRed50Color: UIColor {


### PR DESCRIPTION
### Fix
Small PR to fix some onboarding styling. Includes:

- Text button changed from blue60 to blue50
- Logo colour changed from blue30 to blue50
- Font weight of "Simplenote" changed from Regular to Semibold
- Change tagline colour from gray80 to gray50
- Change title colour from gray80 to gray100

### Test
1. Go to the logged-out state of the app
2. Notice that the "Log In" button text is now the correct colour
3. Notice that the logo now appears as the same shade of blue as the "Sign Up' button
4. Notice that "Simplenote" now appears bolder and darker
5. Notice that the tagline/subtitle now appears lighter

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
