### PR TITLE
Update rake to fix a CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
-    rake (12.3.2)
+    rake (12.3.3)
     rake-compiler (1.0.8)
       rake
     representable (3.0.4)


### PR DESCRIPTION
Fixes _another_ warning, this one caused by `rake`.

**To Test**
1) Ensure all tests are passing
2) Check out this branch and run `rake dependencies`
3) Everything should work great.