### PR TITLE
Remove rake to fix a CVE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org' do
-  gem 'rake'
   gem 'cocoapods', '1.7.5'
   gem 'cocoapods-repo-update', '~> 0.0.3'
   gem 'xcpretty-travis-formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,6 @@ DEPENDENCIES
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!
-  rake!
   rubyzip (~> 1.3)!
   xcpretty-travis-formatter!
 


### PR DESCRIPTION
Fixes another warning, this one caused by rake.

**To Test**
1. Ensure all tests are passing
2. Check out this branch and run rake dependencies
3. Everything should work great.