### PR TITLE
Update rake to fix a security warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
-    rake (12.3.2)
+    rake (12.3.3)
     rake-compiler (1.0.8)
       rake
     representable (3.0.4)


### PR DESCRIPTION
So I thought we got rid of rake entirely in https://github.com/Automattic/simplenote-ios/pull/699, but it turns out the gemspec for the release toolkit specifies it as a dependency.

Fortunately, it's loosely tied to the minor version, so this change just updates it in this repo to disable the security warning.