### PR TITLE
Fixing List Processing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 4.17
 -----
 -   Fixed an issue that caused the Notes List to show up incorrectly, in Right to Left languages.
+-   Fixed a bug that removed whitelines in between List Items.
 
 4.16
 -----

--- a/Simplenote/Classes/NSRegularExpression+Simplenote.swift
+++ b/Simplenote/Classes/NSRegularExpression+Simplenote.swift
@@ -18,4 +18,17 @@ extension NSRegularExpression {
     static let regexForChecklistsEmbeddedAnywhere: NSRegularExpression = {
         try! NSRegularExpression(pattern: "\\s*(-[ \t]+\\[[xX\\s]?\\])", options: .anchorsMatchLines)
     }()
+
+
+    /// Both our Checklist regexes look like this: `"^\\s*(EXPRESSION)"`
+    /// This will produce two resulting NSRange(s): a top level one, including the full match, and a "capture group"
+    /// By requesting the Range for `EXPRESSION` we'd be able to track **exactly** the location of our list marker `- [ ]` (disregarding, thus, the leading space).
+    ///
+    @objc
+    static let regexForChecklistsExpectedNumberOfRanges = 2
+
+    /// Checklist's Match Marker Range
+    ///
+    @objc
+    static let regexForChecklistsMarkerRangeIndex = 1
 }

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -3,10 +3,6 @@
 #import "Simplenote-Swift.h"
 
 
-// Note: Capture Group Mark I: We're only interested in replacing the `- [ ]` marker, not the leading spaces
-//
-static NSUInteger const ListRangeIndex = 1;
-
 
 @implementation NSMutableAttributedString (Checklists)
 
@@ -25,11 +21,11 @@ static NSUInteger const ListRangeIndex = 1;
                                           range:plainString.fullRange] reverseObjectEnumerator] allObjects];
 
     for (NSTextCheckingResult *match in matches) {
-        if (ListRangeIndex >= match.numberOfRanges) {
+        if (NSRegularExpression.regexForChecklistsExpectedNumberOfRanges != match.numberOfRanges) {
             continue;
         }
 
-        NSRange matchedRange = [match rangeAtIndex:ListRangeIndex];
+        NSRange matchedRange = [match rangeAtIndex:NSRegularExpression.regexForChecklistsMarkerRangeIndex];
         if (matchedRange.location == NSNotFound || NSMaxRange(matchedRange) > self.length) {
             continue;
         }

--- a/Simplenote/NSMutableAttributedString+Styling.m
+++ b/Simplenote/NSMutableAttributedString+Styling.m
@@ -3,6 +3,10 @@
 #import "Simplenote-Swift.h"
 
 
+// Note: Capture Group Mark I: We're only interested in replacing the `- [ ]` marker, not the leading spaces
+//
+static NSUInteger const ListRangeIndex = 1;
+
 
 @implementation NSMutableAttributedString (Checklists)
 
@@ -21,7 +25,11 @@
                                           range:plainString.fullRange] reverseObjectEnumerator] allObjects];
 
     for (NSTextCheckingResult *match in matches) {
-        NSRange matchedRange = match.range;
+        if (ListRangeIndex >= match.numberOfRanges) {
+            continue;
+        }
+
+        NSRange matchedRange = [match rangeAtIndex:ListRangeIndex];
         if (matchedRange.location == NSNotFound || NSMaxRange(matchedRange) > self.length) {
             continue;
         }

--- a/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
+++ b/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
@@ -6,6 +6,11 @@ import XCTest
 //
 class NSMutableAttributedStringStylingTests: XCTestCase {
 
+    /// Every Match is expected to have two ranges: one containing the leading spaces, and a second one containing *just* the checklist marker
+    ///
+    private let numberOfExpectedRangesPerMatch = 2
+
+
     /// Verifies that `NSRegularExpression.regexForChecklists` will not match checklists that are in the middle of a string
     ///
     func testRegexForChecklistsWillNotMatchChecklistsLocatedAtTheMiddleOfTheString() {
@@ -24,6 +29,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 2)
+        XCTAssertTrue(verifyEveryMatch(in: matches, contains: numberOfExpectedRangesPerMatch))
     }
 
     /// Verifies that `NSRegularExpression.regexForChecklists` matches multiple spacing prefixes
@@ -34,6 +40,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 1)
+        XCTAssertTrue(verifyEveryMatch(in: matches, contains: numberOfExpectedRangesPerMatch))
     }
 
     /// Verifies that `NSRegularExpression.regexForChecklistsEmbeddedAnywhere` matches multiple spacing prefixes
@@ -44,6 +51,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 2)
+        XCTAssertTrue(verifyEveryMatch(in: matches, contains: numberOfExpectedRangesPerMatch))
     }
 
     /// Verifies that `NSRegularExpression.regexForChecklists` only matches corretly formed strings
@@ -54,6 +62,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         let matches = regex.matches(in: string, options: [], range: string.fullRange)
         
         XCTAssertEqual(matches.count, 3)
+        XCTAssertTrue(verifyEveryMatch(in: matches, contains: numberOfExpectedRangesPerMatch))
     }
 
     /// Verifies that `NSRegularExpression.regexForChecklists` will not match malformed strings
@@ -84,6 +93,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 1)
+        XCTAssertTrue(verifyEveryMatch(in: matches, contains: numberOfExpectedRangesPerMatch))
     }
 
     /// Verifies that `NSRegularExpression.regexForChecklistsEmbeddedAnywhere` will match checklists with no spaces between brackets
@@ -94,5 +104,22 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         let matches = regex.matches(in: string, options: [], range: string.fullRange)
 
         XCTAssertEqual(matches.count, 1)
+        XCTAssertTrue(verifyEveryMatch(in: matches, contains: numberOfExpectedRangesPerMatch))
+    }
+}
+
+
+// MARK: - Internal Helpers
+//
+private extension NSMutableAttributedStringStylingTests {
+
+    /// Verifies that all of the TextCheckingResults contain the specified number of ranges
+    ///
+    func verifyEveryMatch(in matches: [NSTextCheckingResult], contains numberOfRanges: Int) -> Bool {
+        for match in matches where match.numberOfRanges != numberOfRanges {
+            return false
+        }
+
+        return true
     }
 }


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that removes whitespaces in between List Items.

cc @aerych sir, may I bug you with **yet another** Lists-Y issue? (iOS this time!)

cc @msilbers Shipping in 4.17!

**Thank you!!!**

Closes #707

### Test
1. Add a new note
2. Write a random word in the title and please **return** 4 times
3. Press the top right icon (Lists) to insert a List
4. Verify a new bullet gets added exactly where you had the cursor
5. Type a random word
6. Press **return** 4 times
7. Repeat steps 3 thru 5: Add a new List with a word
8. Hit Back

- [x] Verify the list looks **exactly** the way you left it in step (6)


### Release
`RELEASE-NOTES.txt` was updated in dbdeb7b with:
 
> Fixed a bug that removed whitelines in between List Items.
