### PR TITLE
Feature/add release creation on gh

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 63806fe4d1c870c16c7ab7114959dd420152e4b0
-  tag: 0.8.1
+  revision: d00351ee4e04d8a5f3305116dab017b2c389b1cf
+  tag: 0.9.1
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.8.1)
+    fastlane-plugin-wpmreleasetoolkit (0.9.1)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -131,7 +131,8 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git (1.5.0)
+    git (1.6.0)
+      rchardet (~> 1.8)
     google-api-client (0.36.4)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.9)
@@ -188,19 +189,20 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.9.2)
+    oj (3.10.5)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
     parallel (1.19.1)
     plist (3.5.0)
-    progress_bar (1.3.0)
+    progress_bar (1.3.1)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
-    rake (12.3.2)
-    rake-compiler (1.0.8)
+    rake (12.3.3)
+    rake-compiler (1.1.0)
       rake
+    rchardet (1.8.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -254,13 +254,13 @@ end
   # This lane builds the app and upload it for external distribution  
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
   # bundle exec fastlane build_and_upload_itc 
   # bundle exec fastlane build_and_upload_itc skip_confirm:true 
   #####################################################################################
-  desc "Builds and updates for distribution"
+  desc "Builds and uploads for distribution"
   lane :build_and_upload_itc do | options |
     ios_build_prechecks(skip_confirm: options[:skip_confirm], external: true) unless (options[:skip_prechecks])
     ios_build_preflight() unless (options[:skip_prechecks])
@@ -294,6 +294,20 @@ end
     )
 
     sh("rm #{dSYM_PATH}")
+
+    if (options[:create_release])
+      archive_zip_path = File.dirname(Dir.pwd) + "/Simplenote.xarchive.zip"
+      zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
+
+      version = ios_get_app_version()
+      create_release(repository:GHHELPER_REPO, 
+        version: version, 
+        release_notes_file_path:'./Simplenote/Resources/release_notes.txt',
+        release_assets:"#{archive_zip_path}"
+      )
+
+      sh("rm #{archive_zip_path}") 
+    end
   end
 
   #####################################################################################

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,5 +3,5 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-sentry'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.1'
 gem 'fastlane-plugin-appcenter', "1.8.0"


### PR DESCRIPTION
This PR updates the `build_and_upload_itc` lane adding the creation of the GitHub release and the upload of the the xarchive.

### Test
- Checkout a new test branch from this one.
- Comment out the `testflight` step from the `build_and_upload_itc` lane, so that we don't upload unuseful stuff.
- Commit the changes you made above to the test branch.
- Run `bundle exec fastlane build_and_upload_itc create_release:true`.
- Verify that after the build, a new release has been drafted in GitHub and the XArchive and the release notes have been uploaded.

_Clean Up_
- Delete the release from GitHub.
- Delete the test branch from your repo.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
