### PR TITLE
Feature/beta builds on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
       - run:
           name: Build
           command: "bundle exec fastlane build_and_upload_release skip_confirm:true"
+          no_output_timeout: 60m
 
 workflows:
   simplenote_ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,30 @@ jobs:
       - store_artifacts:
           path: Artifacts
           destination: Artifacts
+  Release Build:
+    executor: 
+      name: ios/default
+      xcode-version: "11.2.1"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - git/shallow-checkout
+      - ios/install-dependencies:
+            bundle-install: true
+            pod-install: true
+      - run: 
+          name: Copy Secrets
+          command: bundle exec fastlane run configure_apply
+      - run: 
+          name: Install other tools
+          command: |
+            brew unlink python@2
+            brew install imagemagick
+            brew install ghostscript
+            curl -sL https://sentry.io/get-cli/ | bash
+      - run:
+          name: Build
+          command: "bundle exec fastlane build_and_upload_release skip_confirm:true"
 
 workflows:
   simplenote_ios:
@@ -79,4 +103,12 @@ workflows:
           filters:
             branches:
               ignore: /pull\/[0-9]+/
+  Release Build:
+    jobs:
+      - Release Build: 
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+(\.\d+)*$/ 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 63806fe4d1c870c16c7ab7114959dd420152e4b0
-  tag: 0.8.1
+  revision: d00351ee4e04d8a5f3305116dab017b2c389b1cf
+  tag: 0.9.1
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.8.1)
+    fastlane-plugin-wpmreleasetoolkit (0.9.1)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -131,7 +131,8 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git (1.5.0)
+    git (1.6.0)
+      rchardet (~> 1.8)
     google-api-client (0.36.4)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.9)
@@ -188,19 +189,20 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.9.2)
+    oj (3.10.5)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
     parallel (1.19.1)
     plist (3.5.0)
-    progress_bar (1.3.0)
+    progress_bar (1.3.1)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
-    rake (12.3.2)
-    rake-compiler (1.0.8)
+    rake (12.3.3)
+    rake-compiler (1.1.0)
       rake
+    rchardet (1.8.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -254,13 +254,13 @@ end
   # This lane builds the app and upload it for external distribution  
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
   # bundle exec fastlane build_and_upload_itc 
   # bundle exec fastlane build_and_upload_itc skip_confirm:true 
   #####################################################################################
-  desc "Builds and updates for distribution"
+  desc "Builds and uploads for distribution"
   lane :build_and_upload_itc do | options |
     ios_build_prechecks(skip_confirm: options[:skip_confirm], external: true) unless (options[:skip_prechecks])
     ios_build_preflight() unless (options[:skip_prechecks])
@@ -294,6 +294,20 @@ end
     )
 
     sh("rm #{dSYM_PATH}")
+
+    if (options[:create_release])
+      archive_zip_path = File.dirname(Dir.pwd) + "/Simplenote.xarchive.zip"
+      zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
+
+      version = ios_get_app_version()
+      create_release(repository:GHHELPER_REPO, 
+        version: version, 
+        release_notes_file_path:'./Simplenote/Resources/release_notes.txt',
+        release_assets:"#{archive_zip_path}"
+      )
+
+      sh("rm #{archive_zip_path}") 
+    end
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -178,7 +178,7 @@ end
   # This lane builds the app and upload it for both internal and external distribution 
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] [create_gh_release:<create release on GH>]
   #
   # Example:
   # bundle exec fastlane build_and_upload_release 
@@ -186,13 +186,17 @@ end
   #####################################################################################
   desc "Builds and updates for distribution"
   lane :build_and_upload_release do | options |
+    final_tag = (is_ci() == true) ? ios_validate_ci_build() : false
+    create_release = (final_tag && is_ci()) || options[:create_gh_release]
+
     ios_build_prechecks(skip_confirm: options[:skip_confirm], 
       internal: false,
-      internal_on_single_version: true, 
+      internal_on_single_version: !final_tag, 
       external: true)
+
     ios_build_preflight()
-    build_and_upload_internal(skip_prechecks: true, skip_confirm: options[:skip_confirm])
-    build_and_upload_itc(skip_prechecks: true, skip_confirm: options[:skip_confirm])
+    build_and_upload_internal(skip_prechecks: true, skip_confirm: options[:skip_confirm]) unless final_tag
+    build_and_upload_itc(skip_prechecks: true, skip_confirm: options[:skip_confirm], create_release: create_release)
   end
 
   #####################################################################################

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,5 +3,5 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-sentry'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.1'
 gem 'fastlane-plugin-appcenter', "1.8.0"


### PR DESCRIPTION
This PR introduces release builds on CI and it's built on top of https://github.com/Automattic/simplenote-ios/pull/716, so it should be merged after that one.

The builds are triggered by pushing a release tag.
Tags that don't have a version-like format are not considered.
On beta tags (x.y.z.a) the system runs the internal and app store builds and uploads the binaries to the related channels.
On final tags (x.z.) the system runs only the app store builds and creates a new release on GitHub.
The artifacts are uploaded to AppStore.

[This](https://github.com/Automattic/simplenote-ios/tree/release/4.17.test) branch has been checked out from the source of this PR and it has been adjusted with fake tags in order to test this PR.

The build log for the build triggered by a beta tag is here: https://circleci.com/gh/Automattic/simplenote-ios/1613. Note that the job fails as expected because the version was already present in the AppStore.

The build log for the build triggered by a final tag is here: https://circleci.com/gh/Automattic/simplenote-ios/1618 and the related draft release on GitHub is here: https://github.com/Automattic/simplenote-ios/releases.

_Note:_
As soon as this is approved and before merging it, we have to:
- remove the `4.16.1` tag from the repository.
- delete the `release/4.17.test` branch.
- delete the draft for release 4.16.1 on GitHub

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
