### PR TITLE
Add crypto compliance key

### DIFF
--- a/Simplenote/Simplenote-Info.plist
+++ b/Simplenote/Simplenote-Info.plist
@@ -39,6 +39,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>${VERSION_LONG}</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>


### PR DESCRIPTION
### Fix
This PR adds the `ITSAppUsesNonExemptEncryption` key so that our binaries are accepted by Apple without having to confirm all the crypto stuff every time. 

Thanks @jkmassel for suggesting this!

### Review
 Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
