### PR TITLE
Stop tracking .bundle folder

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,0 @@
----
-BUNDLE_PATH: "vendor/bundle"
-BUNDLE_RETRY: "3"
-BUNDLE_JOBS: "3"

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ SimplenoteScreenshots/Credentials/
 # Bundler
 /vendor/
 /vendor/bundle/
+.bundle/
 
 # Dependencies
 /vendor/


### PR DESCRIPTION
### Fix
This PR removes the `.bundle/` folder from git. 
It's usually recommended not to commit that folder into the source control system because it can contain local paths and it usually tracks the installation of optional configurations, making them not optional anymore :-) 
`rake dependencies` checks that `bundle` has the right configuration on every run, so there's no need to have it in git. 

### Test
1. Delete your local `vendor` folder.
2. Run `rake dependencies`.
3. Verify that the `.bundle/config` file has been created and is git-ignored.
4. Verify that the `vendor` folder has been created and the Gems installed.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
