### PR TITLE
Update release-toolkit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: d00351ee4e04d8a5f3305116dab017b2c389b1cf
-  tag: 0.9.1
+  revision: e426345db3afc839ee463ec1ce8432f584880957
+  tag: 0.9.2
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.1)
+    fastlane-plugin-wpmreleasetoolkit (0.9.2)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -189,7 +189,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.5)
+    oj (3.10.6)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,7 +2,7 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.2'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', "1.8.0"
 


### PR DESCRIPTION
This PR updates `release-toolkit` in order to import the latest fixes. 

### Test
1. Verify that the CI is green.
2. Run `bundle install`, verify that there are no errors and that the repository is clean.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
