### PR TITLE
Update separator colour

### DIFF
--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -230,7 +230,7 @@ extension UIColor {
 
     @objc
     static var simplenoteDividerColor: UIColor {
-        UIColor(lightColor: .gray30, darkColor: .darkGray4).withAlphaComponent(UIKitConstants.alpha0_6)
+        UIColor(lightColor: .gray40, darkColor: .darkGray4).withAlphaComponent(UIKitConstants.alpha0_5)
     }
 
     @objc


### PR DESCRIPTION
### Fix
Align separator colours more closely to iOS defaults. We use our own colours for separators, this PR uses colours that are closer to the contrast found in iOS defaults.

### Test
1. Open the app anywhere
2. Notice that separator colours are less contrasting with the background
3. Notice that separator colours are closer to iOS defaults

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
