### PR TITLE
Perform screenshot composition in CI

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -57,6 +57,7 @@ jobs:
 
     - name: Compose
       run: |
+        git lfs fetch && git lfs checkout
         brew install pkg-config imagemagick@6
         BUNDLE_WITH=screenshots bundle install
         bundle exec fastlane create_promo_screenshots

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    name: Build Application
+    name: Generate Screenshots
     if: contains(github.event.pull_request.labels.*.name, 'Needs Screenshots')
     runs-on: macos-latest
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -54,3 +54,15 @@ jobs:
       with:
         name: screenshots
         path: fastlane/screenshots
+
+    - name: Compose
+      run: |
+        brew install pkg-config imagemagick@6
+        BUNDLE_WITH=screenshots bundle install
+        bundle exec fastlane create_promo_screenshots
+
+    - uses: actions/upload-artifact@v1
+      name: Upload all promo screenshots as artifacts
+      with:
+        name: promo_screenshots
+        path: fastlane/promo_screenshots

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -494,6 +494,20 @@ end
       UI.user_error!("Git LFS not enabled – Unable to generate promo screenshots. Run `git lfs install && git lfs fetch && git lfs pull` to fix this.")
     end
 
+    # This value is defined in style.css. It would be good if there was a way
+    # to make it parametric, so that if we update the CSS we don't risk this
+    # getting out of sync.
+    font_name = "SourceSansPro-Regular.ttf"
+    user_font_directory = File.join(Dir.home, "Library/Fonts")
+    user_font_path = File.join(user_font_directory, font_name)
+    if File.exists?(user_font_path)
+      UI.success("Custom font #{font_name} already installed locally.")
+    else
+      UI.message("Installing #{font_name} at #{user_font_path}.")
+      `mkdir -p #{user_font_directory}`
+      `cp #{File.join(Dir.pwd, "appstoreres/assets/#{font_name}")} #{user_font_path}`
+    end
+
     promo_screenshots(
       orig_folder: options[:source] || screenshots_directory,
       metadata_folder: File.join(Dir.pwd, "metadata"),

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -497,7 +497,7 @@ end
     promo_screenshots(
       orig_folder: options[:source] || screenshots_directory,
       metadata_folder: File.join(Dir.pwd, "metadata"),
-      output_folder: File.join(Dir.pwd, "/promo_screenshots"),
+      output_folder: promo_screenshots_directory,
       force: options[:force] || true
     )
   end
@@ -610,6 +610,10 @@ end
 
 def screenshots_directory()
   File.join(fastlane_directory, "screenshots")
+end
+
+def promo_screenshots_directory()
+  File.join(fastlane_directory, "promo_screenshots")
 end
 
 def screenshot_devices()

--- a/fastlane/appstoreres/.gitattributes
+++ b/fastlane/appstoreres/.gitattributes
@@ -1,1 +1,2 @@
 assets/*.png filter=lfs diff=lfs merge=lfs -text
+assets/*.ttf filter=lfs diff=lfs merge=lfs -text

--- a/fastlane/appstoreres/assets/SourceSansPro-Regular.ttf
+++ b/fastlane/appstoreres/assets/SourceSansPro-Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9868de61ff2bab0b5a3a6d01c4b76f299459f08c6ae2f2c0383b4f9f6bedbf3
+size 269108

--- a/fastlane/metadata/en-US/app_store_screenshot_1.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_1.txt
@@ -1,0 +1,2 @@
+A simple
+note taking experience

--- a/fastlane/metadata/en-US/app_store_screenshot_2.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_2.txt
@@ -1,0 +1,1 @@
+Sync everything across all your devices

--- a/fastlane/metadata/en-US/app_store_screenshot_3.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_3.txt
@@ -1,0 +1,1 @@
+Collaborate and work together

--- a/fastlane/metadata/en-US/app_store_screenshot_4.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_4.txt
@@ -1,0 +1,2 @@
+Stay organized
+with tags

--- a/fastlane/metadata/en-US/app_store_screenshot_5.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_5.txt
@@ -1,0 +1,1 @@
+Find what you're looking for instantly

--- a/fastlane/metadata/en-US/app_store_screenshot_6.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_6.txt
@@ -1,0 +1,1 @@
+Protect your notes with a passcode lock


### PR DESCRIPTION
### What it does
Runs the screenshot composition in CI.

### Test
Add the "Needs Screenshots" label to trigger a screenshot generation run, and check that there is an attachment with the composed screenshots. Like [here](https://github.com/Automattic/simplenote-ios/pull/754/checks?check_run_id=676696033).

<img width="300" alt="Screen Shot 2020-05-15 at 11 52 59 am" src="https://user-images.githubusercontent.com/1218433/82003053-bee88800-96a2-11ea-9bd4-b175a47f8dff.png">

You might notice that the composed screenshots don't use the custom font 😞 I don't know why that's the case as in the [build output](https://github.com/Automattic/simplenote-ios/pull/754/checks?check_run_id=676696033#step:11:266) it looks like the font installation was successful.

<img width="683" alt="Screen Shot 2020-05-15 at 12 47 21 pm" src="https://user-images.githubusercontent.com/1218433/82006035-3c63c680-96aa-11ea-8554-5f6f97c1fe0d.png">

_The font is just the system standard, Times New Roman, I think._

I'd still like to get this code merged, so that it's all there and ready to be used if we need. I'll followup with another PR that disables this step (to save CI time) and adds instruction of how to run the composition locally.


### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.