### PR TITLE
Spring Cleaning: New Note Info Sub-task

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1007,6 +1007,15 @@
 			name = Categories;
 			sourceTree = "<group>";
 		};
+		4A3076E1246FE4A200D7CAD1 /* Note Options */ = {
+			isa = PBXGroup;
+			children = (
+				4A56F167246E6AD700B6A9AB /* NoteInfoViewController.xib */,
+				4A56F166246E6AD700B6A9AB /* NoteInfoViewController.swift */,
+			);
+			name = "Note Options";
+			sourceTree = "<group>";
+		};
 		564CAA42AA330D16FDBDD081 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1656,6 +1665,7 @@
 			children = (
 				B56A695122F9CCF400B90398 /* Onboarding */,
 				B5A6846B23CE84B900398BBC /* Notes List */,
+				4A3076E1246FE4A200D7CAD1 /* Note Options */,
 				E2F1497F179D8E1A00DC9690 /* Settings */,
 				E25C39CE17A41F3400B2591A /* SPAddCollaboratorsViewController.h */,
 				E25C39CF17A41F3400B2591A /* SPAddCollaboratorsViewController.m */,
@@ -1665,8 +1675,6 @@
 				E215C791180B115C00AD36B5 /* SPNavigationController.m */,
 				E28A760D178CBE6D008659DE /* SPNoteEditorViewController.h */,
 				E28A760E178CBE6D008659DE /* SPNoteEditorViewController.m */,
-				4A56F166246E6AD700B6A9AB /* NoteInfoViewController.swift */,
-				4A56F167246E6AD700B6A9AB /* NoteInfoViewController.xib */,
 				E20DED0217AE07340086AB5F /* SPPopoverContainerViewController.h */,
 				E20DED0317AE07340086AB5F /* SPPopoverContainerViewController.m */,
 				E2922AC0180CA06B003AF914 /* SPSidebarContainerViewController.h */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		46A3C9C217DFA81A002865AE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E29ADD4417848E8500E55842 /* InfoPlist.strings */; };
 		46A3C9C317DFA81A002865AE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E29ADD4D17848E8500E55842 /* Images.xcassets */; };
 		46A3C9C417DFA81A002865AE /* Simplenote-DB5.plist in Resources */ = {isa = PBXBuildFile; fileRef = E2FCA5F21789118A00FC229D /* Simplenote-DB5.plist */; };
+		4A56F168246E6AD700B6A9AB /* NoteInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A56F166246E6AD700B6A9AB /* NoteInfoViewController.swift */; };
+		4A56F169246E6AD700B6A9AB /* NoteInfoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A56F167246E6AD700B6A9AB /* NoteInfoViewController.xib */; };
 		74388F4422CFFA30001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
 		74388F4622CFFA8B001C5EC0 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */; };
 		74388F4722CFFAB6001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
@@ -463,6 +465,8 @@
 		467D9C7F1788D47500785EF3 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		46A3C9D717DFA81A002865AE /* Simplenote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Simplenote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		46A3C9DC17DFA866002865AE /* Simplenote-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Simplenote-Info.plist"; sourceTree = "<group>"; };
+		4A56F166246E6AD700B6A9AB /* NoteInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NoteInfoViewController.swift; path = Classes/NoteInfoViewController.swift; sourceTree = "<group>"; };
+		4A56F167246E6AD700B6A9AB /* NoteInfoViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = NoteInfoViewController.xib; path = Classes/NoteInfoViewController.xib; sourceTree = "<group>"; };
 		593EA1C08A9F76E3833C3E80 /* Pods-SimplenoteTests.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		697B9622931545E466B5E186 /* Pods-Automattic-SimplenoteShare.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		6AE4CF60906DA6D08F64E5B3 /* Pods-Automattic-Simplenote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.release.xcconfig"; sourceTree = "<group>"; };
@@ -1661,6 +1665,8 @@
 				E215C791180B115C00AD36B5 /* SPNavigationController.m */,
 				E28A760D178CBE6D008659DE /* SPNoteEditorViewController.h */,
 				E28A760E178CBE6D008659DE /* SPNoteEditorViewController.m */,
+				4A56F166246E6AD700B6A9AB /* NoteInfoViewController.swift */,
+				4A56F167246E6AD700B6A9AB /* NoteInfoViewController.xib */,
 				E20DED0217AE07340086AB5F /* SPPopoverContainerViewController.h */,
 				E20DED0317AE07340086AB5F /* SPPopoverContainerViewController.m */,
 				E2922AC0180CA06B003AF914 /* SPSidebarContainerViewController.h */,
@@ -1939,6 +1945,7 @@
 				46A3C9C317DFA81A002865AE /* Images.xcassets in Resources */,
 				B5AA4B5A22F46B300072BF5D /* Colors.xcassets in Resources */,
 				B5476BBB23D89B66000E7723 /* SPSectionHeaderView.xib in Resources */,
+				4A56F169246E6AD700B6A9AB /* NoteInfoViewController.xib in Resources */,
 				B5767F9122FDF2B900052D81 /* LaunchScreen.storyboard in Resources */,
 				B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */,
 				46A3C9C417DFA81A002865AE /* Simplenote-DB5.plist in Resources */,
@@ -2370,6 +2377,7 @@
 				B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */,
 				46A3C9AF17DFA81A002865AE /* NSString+Condensing.m in Sources */,
 				B50F47A41D1D78EA00822748 /* SPRatingsHelper.m in Sources */,
+				4A56F168246E6AD700B6A9AB /* NoteInfoViewController.swift in Sources */,
 				371A8630213DF00E002E9120 /* SPPinLockManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -12,7 +12,7 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
     @IBOutlet private weak var tablewView: UITableView!
     
     @objc var dismissAction: (() -> Void)?
-    @objc var note: Note?
+    @objc var note: Note!
     @objc var hasSafeAreas = false
     
     private var cells = [UITableViewCell]()
@@ -21,6 +21,10 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        guard note != nil else {
+            fatalError()
+        }
         
         setUpTitleLabel()
         setUpTableCells()
@@ -48,34 +52,26 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         cells.removeAll()
         
         // Default cell height will be 44 points.
-        // Use custom text colors here?
-        // newCell.textLabel?.textColor = .simplenoteGray50Color
         
-        if let info = localizedNoteInfo() {
-            for (label, detail) in info {
-                let newCell = UITableViewCell.init(style: .value1, reuseIdentifier: nil)
-                newCell.textLabel?.text = label
-                newCell.detailTextLabel?.text = detail
-                
-                newCell.textLabel?.textColor = .simplenoteTextColor
-                newCell.detailTextLabel?.textColor = .simplenoteTextColor
-                newCell.backgroundColor = .clear
-                
-                newCell.selectionStyle = .none
-                
-                cells.append(newCell)
-            }
+        let info = localizedNoteInfo()
+        for (label, detail) in info {
+            let newCell = UITableViewCell.init(style: .value1, reuseIdentifier: nil)
+            newCell.textLabel?.text = label
+            newCell.detailTextLabel?.text = detail
+            
+            newCell.textLabel?.textColor = .simplenoteTextColor
+            newCell.detailTextLabel?.textColor = .simplenoteTextColor
+            newCell.backgroundColor = .clear
+            
+            newCell.selectionStyle = .none
+            
+            cells.append(newCell)
         }
     }
     
     // MARK: - Helpers
     
-    func localizedNoteInfo() -> [(label: String, detail: String)]? {
-        
-        guard let note = note else {
-            print("No note set for sheet.")
-            return nil
-        }
+    func localizedNoteInfo() -> [(label: String, detail: String)] {
         
         // Date Formatter
         let dateFormatter = localizedDateFormatter()

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -42,6 +42,7 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
                 let newCell = UITableViewCell.init(style: .value1, reuseIdentifier: nil)
                 newCell.textLabel?.text = label
                 newCell.detailTextLabel?.text = detail
+                newCell.backgroundColor = .clear
                 cells.append(newCell)
             }
         }

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -44,7 +44,7 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
     
     func setUpTitleLabel() {
         
-        titleLabel.text = NSLocalizedString("Information", comment: "Information Sheet label");
+        titleLabel.text = Labels.header
     }
     
     func setUpTableCells() {
@@ -85,26 +85,12 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         let wordCount = String(s.wordCount)
         let charCount = String(s.charCount)
         
-        let lables = localizedLabels()
-        
         var array = [(label: String, detail: String)]()
         
-        array.append((label: lables[0], detail: modifictionDate))
-        array.append((label: lables[1], detail: creationDate))
-        array.append((label: lables[2], detail: wordCount))
-        array.append((label: lables[3], detail: charCount))
-        
-        return array
-    }
-    
-    func localizedLabels() -> [String] {
-        
-        var array = [String]()
-        
-        array.append(NSLocalizedString("Modified", comment: "Date Modified label"))
-        array.append(NSLocalizedString("Created", comment: "Date Created label"))
-        array.append(NSLocalizedString("Words", comment: "Word Countlabel"))
-        array.append(NSLocalizedString("Characters", comment: "Character Count label"))
+        array.append((label: Labels.modified, detail: modifictionDate))
+        array.append((label: Labels.created, detail: creationDate))
+        array.append((label: Labels.words, detail: wordCount))
+        array.append((label: Labels.characters, detail: charCount))
         
         return array
     }
@@ -151,4 +137,17 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         
         return cells[indexPath.row]
     }
+}
+
+// MARK: - UITableView Label Strings
+//
+private enum Labels {
+    
+    static let header = NSLocalizedString("Information", comment: "Note Info header label");
+    
+    static let created = NSLocalizedString("Created", comment: "Date Created label")
+    static let modified = NSLocalizedString("Modified", comment: "Date Modified label")
+    
+    static let characters = NSLocalizedString("Characters", comment: "Character Count label")
+    static let words = NSLocalizedString("Words", comment: "Word Count label")
 }

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -77,12 +77,9 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
     
     func localizedNoteInfo() -> [(label: String, detail: String)] {
         
-        // Date Formatter
-        let dateFormatter = localizedDateFormatter()
-        
         // Created & modified dates
-        let creationDate = dateFormatter.string(from: note.creationDate)
-        let modifictionDate = dateFormatter.string(from: note.modificationDate)
+        let creationDate = NoteInfoViewController.dateFormatter.string(from: note.creationDate)
+        let modifictionDate = NoteInfoViewController.dateFormatter.string(from: note.modificationDate)
         
         // Char & word counts
         let s = note.content as NSString
@@ -97,20 +94,6 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         array.append((label: Labels.characters, detail: charCount))
         
         return array
-    }
-    
-    func localizedDateFormatter() -> DateFormatter {
-        
-        // Localized format string respecting device settings.
-        // Could make relative date formatting a Defaults option.
-        
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeStyle = .short
-        dateFormatter.dateStyle = .medium
-        dateFormatter.locale = Locale.current
-        dateFormatter.doesRelativeDateFormatting = true
-        
-        return dateFormatter
     }
     
     // MARK: - Actions
@@ -143,15 +126,37 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
     }
 }
 
+// MARK: - Static Date Formatter
+//
+private extension NoteInfoViewController {
+    
+    /// Static DateFormatter to avoid initializing this multiple times.
+    ///
+    static var dateFormatter: DateFormatter = {
+      let newFormatter = DateFormatter()
+      newFormatter.timeStyle = .short
+      newFormatter.dateStyle = .medium
+      newFormatter.locale = Locale.current
+      newFormatter.doesRelativeDateFormatting = true
+      return newFormatter
+    }()
+}
+
 // MARK: - UITableView Label Strings
 //
 private enum Labels {
     
+    /// The localized view title/header.
+    ///
     static let header = NSLocalizedString("Information", comment: "Note Info header label");
     
+    /// Localized created/modified labels.
+    ///
     static let created = NSLocalizedString("Created", comment: "Date Created label")
     static let modified = NSLocalizedString("Modified", comment: "Date Modified label")
     
+    /// Localalized character/word count labels.
+    ///
     static let characters = NSLocalizedString("Characters", comment: "Character Count label")
     static let words = NSLocalizedString("Words", comment: "Word Count label")
 }

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -57,6 +57,9 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
                 let newCell = UITableViewCell.init(style: .value1, reuseIdentifier: nil)
                 newCell.textLabel?.text = label
                 newCell.detailTextLabel?.text = detail
+                
+                newCell.textLabel?.textColor = .simplenoteTextColor
+                newCell.detailTextLabel?.textColor = .simplenoteTextColor
                 newCell.backgroundColor = .clear
                 cells.append(newCell)
             }

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -13,9 +13,13 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
     
     @objc var dismissAction: (() -> Void)?
     @objc var note: Note!
-    @objc var hasSafeAreas = false
+    @objc var hasSafeAreas = true
     
     private var cells = [UITableViewCell]()
+    
+    // The design spec calls for an extra 36 points of space on devices that
+    // don't define any safe area insets. So any iPhone device with a home button.
+    private let SEBottomPadding: CGFloat = 36;
     
     // MARK: - View Lifecycle
     
@@ -31,13 +35,13 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         
         if dismissAction == nil {
             dismissButton.isHidden = true
+        } else if !hasSafeAreas {
+            // Add in some padding for older devices.
+            // ie: Not on iPad and no safe areas.
+            self.view.frame.size.height += SEBottomPadding
         }
         
         tablewView.tableFooterView = UIView()
-        
-        if hasSafeAreas {
-            self.view.frame.size.height -= 36
-        }
     }
     
     // MARK: - Set Up

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -1,0 +1,141 @@
+//
+//  Created by Kevin LaCoste on 2020-05-15.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class NoteInfoViewController: UIViewController, UITableViewDataSource {
+    
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var tablewView: UITableView!
+    
+    @objc var dismissAction: (() -> Void)? = nil
+    @objc var note: Note?
+    
+    var cells = [UITableViewCell]()
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUpTitleLabel()
+        setUpTableCells()
+        
+        tablewView.dataSource = self
+    }
+    
+    // MARK: - Set Up
+    
+    func setUpTitleLabel() {
+        
+        titleLabel.text = NSLocalizedString("Information", comment: "Information Sheet label");
+    }
+    
+    func setUpTableCells() {
+        
+        cells.removeAll()
+        
+        if let info = localizedNoteInfo() {
+            for (label, detail) in info {
+                let newCell = UITableViewCell.init(style: .value1, reuseIdentifier: nil)
+                newCell.textLabel?.text = label
+                newCell.detailTextLabel?.text = detail
+                cells.append(newCell)
+            }
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    func localizedNoteInfo() -> [(label: String, detail: String)]? {
+        
+        guard let note = note else {
+            print("No note set for sheet.")
+            return nil
+        }
+        
+        // Date Formatter
+        let dateFormatter = localizedDateFormatter()
+        
+        // Created & modified dates
+        let creationDate = dateFormatter.string(from: note.creationDate)
+        let modifictionDate = dateFormatter.string(from: note.modificationDate)
+        
+        // Char & word counts
+        let s = note.content as NSString
+        let wordCount = String(s.wordCount)
+        let charCount = String(s.charCount)
+        
+        let lables = localizedLabels()
+        
+        var array = [(label: String, detail: String)]()
+        
+        array.append((label: lables[0], detail: modifictionDate))
+        array.append((label: lables[1], detail: creationDate))
+        array.append((label: lables[2], detail: wordCount))
+        array.append((label: lables[3], detail: charCount))
+        
+        return array
+    }
+    
+    func localizedLabels() -> [String] {
+        
+        var array = [String]()
+        
+        array.append(NSLocalizedString("Modified", comment: "Date Modified label"))
+        array.append(NSLocalizedString("Created", comment: "Date Created label"))
+        array.append(NSLocalizedString("Words", comment: "Word Countlabel"))
+        array.append(NSLocalizedString("Characters", comment: "Character Count label"))
+        
+        return array
+    }
+    
+    func localizedDateFormatter() -> DateFormatter {
+        
+        // Localized format string respecting device settings.
+        // Could make relative date formatting a Defaults option.
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeStyle = .short
+        dateFormatter.dateStyle = .medium
+        dateFormatter.locale = Locale.current
+        dateFormatter.doesRelativeDateFormatting = true
+        
+        return dateFormatter
+    }
+    
+    func specDateFormatter() -> DateFormatter {
+        
+        // Hard-coded format string to match design spec.
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MMM d, yyyy, HH:mm"
+        
+        return dateFormatter
+    }
+    
+    // MARK: - Actions
+    
+    @IBAction func dismissButtonTapped(_ sender: UIButton) {
+        
+        if dismissAction != nil {
+            dismissAction!()
+        } else {
+            print("No action defined for dismiss button.")
+        }
+    }
+    
+    // MARK: - UITableViewDataSource methods
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        
+        return cells.count;
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        return cells[indexPath.row]
+    }
+}

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -12,6 +12,7 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
     
     @objc var dismissAction: (() -> Void)? = nil
     @objc var note: Note?
+    @objc var hasSafeAreas = false
     
     var cells = [UITableViewCell]()
     
@@ -24,6 +25,11 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         setUpTableCells()
         
         tablewView.dataSource = self
+        tablewView.tableFooterView = UIView()
+        
+        if hasSafeAreas {
+            self.view.frame.size.height -= 36
+        }
     }
     
     // MARK: - Set Up
@@ -36,6 +42,10 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
     func setUpTableCells() {
         
         cells.removeAll()
+        
+        // Default cell height will be 44 points.
+        // Use custom text colors here?
+        // newCell.textLabel?.textColor = .simplenoteGray50Color
         
         if let info = localizedNoteInfo() {
             for (label, detail) in info {

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -8,6 +8,7 @@ import UIKit
 class NoteInfoViewController: UIViewController, UITableViewDataSource {
     
     @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var dismissButton: UIButton!
     @IBOutlet weak var tablewView: UITableView!
     
     @objc var dismissAction: (() -> Void)? = nil
@@ -23,6 +24,10 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         
         setUpTitleLabel()
         setUpTableCells()
+        
+        if dismissAction == nil {
+            dismissButton.isHidden = true
+        }
         
         tablewView.dataSource = self
         tablewView.tableFooterView = UIView()

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -7,15 +7,15 @@ import UIKit
 
 class NoteInfoViewController: UIViewController, UITableViewDataSource {
     
-    @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var dismissButton: UIButton!
-    @IBOutlet weak var tablewView: UITableView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var dismissButton: UIButton!
+    @IBOutlet private weak var tablewView: UITableView!
     
-    @objc var dismissAction: (() -> Void)? = nil
+    @objc var dismissAction: (() -> Void)?
     @objc var note: Note?
     @objc var hasSafeAreas = false
     
-    var cells = [UITableViewCell]()
+    private var cells = [UITableViewCell]()
     
     // MARK: - View Lifecycle
     
@@ -29,7 +29,6 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
             dismissButton.isHidden = true
         }
         
-        tablewView.dataSource = self
         tablewView.tableFooterView = UIView()
         
         if hasSafeAreas {
@@ -128,25 +127,15 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         return dateFormatter
     }
     
-    func specDateFormatter() -> DateFormatter {
-        
-        // Hard-coded format string to match design spec.
-        
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MMM d, yyyy, HH:mm"
-        
-        return dateFormatter
-    }
-    
     // MARK: - Actions
     
     @IBAction func dismissButtonTapped(_ sender: UIButton) {
         
-        if dismissAction != nil {
-            dismissAction!()
-        } else {
-            print("No action defined for dismiss button.")
+        guard let action = dismissAction else {
+            return
         }
+        
+        action()
     }
     
     @objc func refresh() {

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -61,6 +61,9 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
                 newCell.textLabel?.textColor = .simplenoteTextColor
                 newCell.detailTextLabel?.textColor = .simplenoteTextColor
                 newCell.backgroundColor = .clear
+                
+                newCell.selectionStyle = .none
+                
                 cells.append(newCell)
             }
         }

--- a/Simplenote/Classes/NoteInfoViewController.swift
+++ b/Simplenote/Classes/NoteInfoViewController.swift
@@ -149,6 +149,12 @@ class NoteInfoViewController: UIViewController, UITableViewDataSource {
         }
     }
     
+    @objc func refresh() {
+        
+        setUpTableCells()
+        tablewView.reloadData()
+    }
+    
     // MARK: - UITableViewDataSource methods
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -29,7 +29,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="525" height="65"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvm-Tz-ZMd">
-                            <rect key="frame" x="15" y="10" width="450" height="45"/>
+                            <rect key="frame" x="20" y="10" width="445" height="45"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -54,7 +54,7 @@
                         <constraint firstItem="SeM-AW-1nd" firstAttribute="centerY" secondItem="3tN-Qh-m5L" secondAttribute="centerY" id="GyV-69-QHt"/>
                         <constraint firstAttribute="bottom" secondItem="dvm-Tz-ZMd" secondAttribute="bottom" constant="10" id="Ur5-pJ-jFa"/>
                         <constraint firstAttribute="trailing" secondItem="SeM-AW-1nd" secondAttribute="trailing" constant="16" id="hdU-jv-uoA"/>
-                        <constraint firstItem="dvm-Tz-ZMd" firstAttribute="leading" secondItem="3tN-Qh-m5L" secondAttribute="leading" constant="15" id="sX2-ma-f3R"/>
+                        <constraint firstItem="dvm-Tz-ZMd" firstAttribute="leading" secondItem="3tN-Qh-m5L" secondAttribute="leading" constant="20" id="sX2-ma-f3R"/>
                         <constraint firstAttribute="trailing" secondItem="dvm-Tz-ZMd" secondAttribute="trailing" constant="60" id="yVU-Pt-f3Y"/>
                     </constraints>
                 </view>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -29,7 +29,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="525" height="65"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvm-Tz-ZMd">
-                            <rect key="frame" x="12" y="10" width="92.5" height="45"/>
+                            <rect key="frame" x="15" y="10" width="450" height="45"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -53,8 +53,9 @@
                         <constraint firstAttribute="height" constant="65" id="8vE-Y0-NbP"/>
                         <constraint firstItem="SeM-AW-1nd" firstAttribute="centerY" secondItem="3tN-Qh-m5L" secondAttribute="centerY" id="GyV-69-QHt"/>
                         <constraint firstAttribute="bottom" secondItem="dvm-Tz-ZMd" secondAttribute="bottom" constant="10" id="Ur5-pJ-jFa"/>
-                        <constraint firstItem="dvm-Tz-ZMd" firstAttribute="leading" secondItem="3tN-Qh-m5L" secondAttribute="leading" constant="12" id="fqe-Cl-Zxw"/>
                         <constraint firstAttribute="trailing" secondItem="SeM-AW-1nd" secondAttribute="trailing" constant="16" id="hdU-jv-uoA"/>
+                        <constraint firstItem="dvm-Tz-ZMd" firstAttribute="leading" secondItem="3tN-Qh-m5L" secondAttribute="leading" constant="15" id="sX2-ma-f3R"/>
+                        <constraint firstAttribute="trailing" secondItem="dvm-Tz-ZMd" secondAttribute="trailing" constant="60" id="yVU-Pt-f3Y"/>
                     </constraints>
                 </view>
             </subviews>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -21,7 +21,7 @@
             <rect key="frame" x="0.0" y="0.0" width="525" height="277"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="syt-EH-qNc">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="syt-EH-qNc">
                     <rect key="frame" x="0.0" y="65" width="525" height="212"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </tableView>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -28,8 +28,8 @@
                     <rect key="frame" x="0.0" y="0.0" width="431" height="65"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvm-Tz-ZMd">
-                            <rect key="frame" x="12" y="10" width="116" height="45"/>
-                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="22"/>
+                            <rect key="frame" x="12" y="10" width="92.5" height="45"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -22,7 +22,7 @@
             <subviews>
                 <tableView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="syt-EH-qNc">
                     <rect key="frame" x="0.0" y="65" width="431" height="221"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3tN-Qh-m5L" customClass="UIStackView">
                     <rect key="frame" x="0.0" y="0.0" width="431" height="65"/>
@@ -57,7 +57,7 @@
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="3tN-Qh-m5L" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="ExP-N7-Yr5"/>
                 <constraint firstItem="3tN-Qh-m5L" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="MJZ-E9-Je1"/>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -17,15 +17,15 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="431" height="286"/>
+            <rect key="frame" x="0.0" y="0.0" width="525" height="277"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="syt-EH-qNc">
-                    <rect key="frame" x="0.0" y="65" width="431" height="221"/>
+                    <rect key="frame" x="0.0" y="65" width="525" height="212"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3tN-Qh-m5L" customClass="UIStackView">
-                    <rect key="frame" x="0.0" y="0.0" width="431" height="65"/>
+                    <rect key="frame" x="0.0" y="0.0" width="525" height="65"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvm-Tz-ZMd">
                             <rect key="frame" x="12" y="10" width="92.5" height="45"/>
@@ -34,7 +34,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SeM-AW-1nd">
-                            <rect key="frame" x="383" y="16.5" width="32" height="32"/>
+                            <rect key="frame" x="477" y="16.5" width="32" height="32"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="32" id="CY4-1v-h5d"/>
                                 <constraint firstAttribute="width" constant="32" id="lpu-rQ-eCl"/>
@@ -59,17 +59,17 @@
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
+                <constraint firstAttribute="bottom" secondItem="syt-EH-qNc" secondAttribute="bottom" id="C7l-mo-yLs"/>
                 <constraint firstItem="3tN-Qh-m5L" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="ExP-N7-Yr5"/>
                 <constraint firstItem="3tN-Qh-m5L" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="MJZ-E9-Je1"/>
-                <constraint firstAttribute="bottom" secondItem="syt-EH-qNc" secondAttribute="bottom" id="Swi-Ve-pcD"/>
+                <constraint firstItem="syt-EH-qNc" firstAttribute="top" secondItem="3tN-Qh-m5L" secondAttribute="bottom" id="Oc8-Wb-FYi"/>
                 <constraint firstItem="3tN-Qh-m5L" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="Ty1-iN-qtM"/>
-                <constraint firstItem="syt-EH-qNc" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="iDU-K4-Emp"/>
-                <constraint firstItem="syt-EH-qNc" firstAttribute="top" secondItem="3tN-Qh-m5L" secondAttribute="bottom" id="nv6-GD-c1c"/>
-                <constraint firstItem="syt-EH-qNc" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="y1m-E2-AaN"/>
+                <constraint firstItem="syt-EH-qNc" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="dN3-82-7R7"/>
+                <constraint firstAttribute="trailing" secondItem="syt-EH-qNc" secondAttribute="trailing" id="neD-8o-fYb"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <point key="canvasLocation" x="150" y="150.33482142857142"/>
+            <point key="canvasLocation" x="218.11594202898553" y="217.29910714285714"/>
         </view>
     </objects>
     <resources>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteInfoViewController" customModule="Simplenote" customModuleProvider="target">
+            <connections>
+                <outlet property="tablewView" destination="syt-EH-qNc" id="BW4-BP-8ZP"/>
+                <outlet property="titleLabel" destination="dvm-Tz-ZMd" id="YvD-WB-fe5"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="431" height="286"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="syt-EH-qNc">
+                    <rect key="frame" x="0.0" y="65" width="431" height="221"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3tN-Qh-m5L" customClass="UIStackView">
+                    <rect key="frame" x="0.0" y="0.0" width="431" height="65"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dvm-Tz-ZMd">
+                            <rect key="frame" x="12" y="10" width="116" height="45"/>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="22"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SeM-AW-1nd">
+                            <rect key="frame" x="383" y="16.5" width="32" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="32" id="CY4-1v-h5d"/>
+                                <constraint firstAttribute="width" constant="32" id="lpu-rQ-eCl"/>
+                            </constraints>
+                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <state key="normal" image="xmark.circle.fill" catalog="system"/>
+                            <connections>
+                                <action selector="dismissButtonTapped:" destination="-1" eventType="touchUpInside" id="YiP-1D-ps9"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstItem="dvm-Tz-ZMd" firstAttribute="top" secondItem="3tN-Qh-m5L" secondAttribute="top" constant="10" id="2Ft-Od-O9w"/>
+                        <constraint firstAttribute="height" constant="65" id="8vE-Y0-NbP"/>
+                        <constraint firstItem="SeM-AW-1nd" firstAttribute="centerY" secondItem="3tN-Qh-m5L" secondAttribute="centerY" id="GyV-69-QHt"/>
+                        <constraint firstAttribute="bottom" secondItem="dvm-Tz-ZMd" secondAttribute="bottom" constant="10" id="Ur5-pJ-jFa"/>
+                        <constraint firstItem="dvm-Tz-ZMd" firstAttribute="leading" secondItem="3tN-Qh-m5L" secondAttribute="leading" constant="12" id="fqe-Cl-Zxw"/>
+                        <constraint firstAttribute="trailing" secondItem="SeM-AW-1nd" secondAttribute="trailing" constant="16" id="hdU-jv-uoA"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="3tN-Qh-m5L" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="ExP-N7-Yr5"/>
+                <constraint firstItem="3tN-Qh-m5L" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="MJZ-E9-Je1"/>
+                <constraint firstAttribute="bottom" secondItem="syt-EH-qNc" secondAttribute="bottom" id="Swi-Ve-pcD"/>
+                <constraint firstItem="3tN-Qh-m5L" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="Ty1-iN-qtM"/>
+                <constraint firstItem="syt-EH-qNc" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="iDU-K4-Emp"/>
+                <constraint firstItem="syt-EH-qNc" firstAttribute="top" secondItem="3tN-Qh-m5L" secondAttribute="bottom" id="nv6-GD-c1c"/>
+                <constraint firstItem="syt-EH-qNc" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="y1m-E2-AaN"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="150" y="150.33482142857142"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="xmark.circle.fill" catalog="system" width="128" height="121"/>
+    </resources>
+</document>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -18,11 +18,11 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="525" height="277"/>
+            <rect key="frame" x="0.0" y="0.0" width="525" height="241"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="syt-EH-qNc">
-                    <rect key="frame" x="0.0" y="65" width="525" height="212"/>
+                    <rect key="frame" x="0.0" y="65" width="525" height="176"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="mhq-VT-i42"/>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteInfoViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
+                <outlet property="dismissButton" destination="SeM-AW-1nd" id="U3S-84-KnM"/>
                 <outlet property="tablewView" destination="syt-EH-qNc" id="BW4-BP-8ZP"/>
                 <outlet property="titleLabel" destination="dvm-Tz-ZMd" id="YvD-WB-fe5"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>

--- a/Simplenote/Classes/NoteInfoViewController.xib
+++ b/Simplenote/Classes/NoteInfoViewController.xib
@@ -24,6 +24,9 @@
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="syt-EH-qNc">
                     <rect key="frame" x="0.0" y="65" width="525" height="212"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="mhq-VT-i42"/>
+                    </connections>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3tN-Qh-m5L" customClass="UIStackView">
                     <rect key="frame" x="0.0" y="0.0" width="525" height="65"/>

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -53,9 +53,6 @@
     NSMutableDictionary *noteVersionData;
 }
 
-// Redeclare navigationController property with downcast.
-@property(nonatomic, readonly, strong) SPNavigationController *navigationController;
-
 // Navigation Back Button
 @property (nonatomic, strong) UIButton *backButton;
 

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -4,7 +4,9 @@
 #import "SPTagView.h"
 #import "SPAddCollaboratorsViewController.h"
 #import "SPHorizontalPickerView.h"
+#import "SPNavigationController.h"
 #import <Simperium/Simperium.h>
+
 @class Note;
 @class SPTextView;
 @class SPEditorTextView;
@@ -49,8 +51,10 @@
     
     NSInteger currentVersion;
     NSMutableDictionary *noteVersionData;
-    
 }
+
+// Redeclare navigationController property with downcast.
+@property(nonatomic, readonly, strong) SPNavigationController *navigationController;
 
 // Navigation Back Button
 @property (nonatomic, strong) UIButton *backButton;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -64,6 +64,7 @@
 @property (nonatomic, strong) UIButton *checklistButton;
 @property (nonatomic, strong) UIButton *keyboardButton;
 @property (nonatomic, strong) UIButton *createNoteButton;
+@property (nonatomic, strong) UIButton *noteOptionsButton;
 
 @property (nonatomic, strong) Note *currentNote;
 @property (nonatomic, strong) SPEditorTextView *noteEditorTextView;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -831,6 +831,9 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 #pragma mark - View Utilities
 
+// TODO: Remove rotation blocking
+// Once we have a new Versions UI in place, that is!
+
 - (void)enableRotation
 {
     [(SPNavigationController *)self.navigationController setDisableRotation:NO];
@@ -1435,17 +1438,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     [self updateNoteInfoController];
 }
 
-- (void)updateNoteInfoController
-{
-    if (self.noteInfoViewController == nil) {
-        return;
-    }
-    
-    // Update the Note Info if onscreen.
-    
-    [self.noteInfoViewController refresh];
-}
-
 - (void)didReceiveVersion:(NSString *)version data:(NSDictionary *)data {
     
     if (bViewingVersions) {
@@ -1471,6 +1463,17 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     }];
 
     [alertController presentFromRootViewController];
+}
+
+- (void)updateNoteInfoController
+{
+    if (self.noteInfoViewController == nil) {
+        return;
+    }
+    
+    // Update the Note Info if onscreen.
+    
+    [self.noteInfoViewController refresh];
 }
 
 #pragma mark barButton action methods
@@ -2097,8 +2100,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         CGRect newFrame = newActionSheet.contentView.frame;
         newFrame = CGRectInset(newFrame, 12, 0);
         newActionSheet.contentView.frame = newFrame;
-        
-        [self disableRotation];
         
         self.infoActionSheet = newActionSheet;
     }

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -51,6 +51,9 @@ CGFloat const SPBackButtonImagePadding              = -18;
 CGFloat const SPBackButtonTitlePadding              = -15;
 CGFloat const SPSelectedAreaPadding                 = 20;
 
+CGFloat const SPActionSheetCornerRadius             = 15;
+CGFloat const SPActionSheetContentPadding           = 12;
+
 @interface SPNoteEditorViewController ()<SPEditorTextViewDelegate,
                                         SPInteractivePushViewControllerProvider,
                                         SPInteractiveDismissableViewController,
@@ -2060,9 +2063,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     viewController.modalPresentationStyle = UIModalPresentationPopover;
     [viewController.popoverPresentationController setSourceView:self.noteOptionsButton];
     
-    // Need to manually tweak the view size here.
-    // TODO: Magic number to constant
-    CGFloat preferredHeight = viewController.view.frame.size.height - 36;
+    // Set preferredContentSize to respect hieght from the XIB.
+    CGFloat preferredHeight = viewController.view.frame.size.height;
     CGRect newFrame = CGRectMake(0, 0, 0, preferredHeight);
     viewController.preferredContentSize = newFrame.size;
     
@@ -2086,15 +2088,13 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     NSArray *views = @[viewController.view];
     SPActionSheet *newActionSheet = [SPActionSheet showActionSheetInView:self.navigationController.view withMessage:nil withContentViewArray:views withButtonTitleArray:nil delegate:self];
     newActionSheet.swipeToDismiss = YES;
-    newActionSheet.contentView.layer.cornerRadius = 15;
-    // TODO: Magic number to constant
-    // Above: 15, below: 12.
+    newActionSheet.contentView.layer.cornerRadius = SPActionSheetCornerRadius;
 
     // Post setup frame tweaking.
-    // The SPActionSheet sets up a 12 pixel boarder.
+    // The SPActionSheet sets up 12 pixels of padding around the view.
     // We don't want that so remove it here.
     CGRect newFrame = newActionSheet.contentView.frame;
-    newFrame = CGRectInset(newFrame, 12, 0);
+    newFrame = CGRectInset(newFrame, SPActionSheetContentPadding, 0);
     newActionSheet.contentView.frame = newFrame;
     
     self.infoActionSheet = newActionSheet;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -422,9 +422,18 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                                        self.backButton.frame.size.width,
                                        navigationButtonContainer.frame.size.height);
     
+    // Set up the right-side navigation buttons.
+    
     CGFloat previousXOrigin = navigationButtonContainer.frame.size.width + trailingPadding;
     CGFloat buttonWidth = [self.theme floatForKey:@"barButtonWidth"];
     CGFloat buttonHeight = buttonWidth;
+    
+    self.noteOptionsButton.frame = CGRectMake(previousXOrigin - buttonWidth,
+                                              SPBarButtonYOriginAdjustment,
+                                              buttonWidth,
+                                              buttonHeight);
+    
+    previousXOrigin = self.noteOptionsButton.frame.origin.x;
     
     self.keyboardButton.frame = CGRectMake(previousXOrigin - buttonWidth,
                                            SPBarButtonYOriginAdjustment,
@@ -491,7 +500,15 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     [navigationButtonContainer addSubview:self.backButton];
     
     
-    // setup right buttons
+    // Set up right-side navigation buttons.
+    
+    self.noteOptionsButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameEllipsis]
+                                                target:self
+                                              selector:@selector(noteOptionsButtonAction:)];
+    
+    // TODO: Accessibility Labels
+    // Currently only the actionButton has the necessary values in place.
+    
     self.actionButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameInfo]
                                       target:self
                                     selector:@selector(actionButtonAction:)];
@@ -514,11 +531,13 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                                           selector:@selector(keyboardButtonAction:)];
     self.keyboardButton.accessibilityLabel = NSLocalizedString(@"Dismiss keyboard", nil);
     
+    self.noteOptionsButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     self.keyboardButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     self.createNoteButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     self.actionButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     self.checklistButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     
+    [navigationButtonContainer addSubview:self.noteOptionsButton];
     [navigationButtonContainer addSubview:self.keyboardButton];
     [navigationButtonContainer addSubview:self.createNoteButton];
     [navigationButtonContainer addSubview:self.actionButton];
@@ -1432,8 +1451,16 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 #pragma mark barButton action methods
 
-- (void)keyboardButtonAction:(id)sender {
+- (void)noteOptionsButtonAction:(id)sender
+{
+    // TODO: Implement new Note Options UI
+    // For now, we show the new Note Info bottom sheet.
     
+    [self viewInfoAction];
+}
+
+- (void)keyboardButtonAction:(id)sender
+{
     [self endEditing:sender];
     [_tagView endEditing:YES];
 }
@@ -1735,9 +1762,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
             [self viewVersionAction:activityView];
             break;
         } case 2: {
-            // TODO: Revert this before merge
-            // [self addCollaboratorsAction:activityView];
-            [self viewInfoAction];
+            [self addCollaboratorsAction:activityView];
             break;
         } case 3: {
             [SPTracker trackEditorNoteDeleted];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1432,6 +1432,18 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 		[_tagView setupWithTagNames:tags];
     }
     [self updatePublishUI];
+    [self updateNoteInfoController];
+}
+
+- (void)updateNoteInfoController
+{
+    if (self.noteInfoViewController == nil) {
+        return;
+    }
+    
+    // Update the Note Info if onscreen.
+    
+    [self.noteInfoViewController refresh];
 }
 
 - (void)didReceiveVersion:(NSString *)version data:(NSDictionary *)data {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -2050,6 +2050,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     // Configure view controller for sheet.
     NoteInfoViewController *infoViewController = [NoteInfoViewController new];
     infoViewController.note = self.currentNote;
+    infoViewController.hasSafeAreas = (self.view.safeAreaInsets.bottom != 0);
     infoViewController.dismissAction = ^{
         [self.infoActionSheet dismiss];
     };

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -2050,14 +2050,11 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     // Configure view controller for sheet.
     NoteInfoViewController *infoViewController = [NoteInfoViewController new];
     infoViewController.note = self.currentNote;
-    infoViewController.hasSafeAreas = (self.view.safeAreaInsets.bottom != 0);
-    infoViewController.dismissAction = ^{
-        [self.infoActionSheet dismiss];
-    };
     
-    // Configure SPActionSheet for display.
+    // Configure for display.
     if ([UIDevice isPad] && !self.isViewHorizontallyCompact) {
         
+        // UIModalPresentationPopover.
         infoViewController.modalPresentationStyle = UIModalPresentationPopover;
         [infoViewController.popoverPresentationController setSourceView:self.noteOptionsButton];
         
@@ -2071,6 +2068,12 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         
     } else {
         
+        infoViewController.hasSafeAreas = (self.view.safeAreaInsets.bottom != 0);
+        infoViewController.dismissAction = ^{
+            [self.infoActionSheet dismiss];
+        };
+
+        // Configure SPActionSheet for display.
         NSArray *views = @[infoViewController.view];
         SPActionSheet *newActionSheet = [SPActionSheet showActionSheetInView:self.navigationController.view withMessage:nil withContentViewArray:views withButtonTitleArray:nil delegate:self];
         newActionSheet.swipeToDismiss = YES;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -829,6 +829,18 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     [self refreshNavigationBarButtons];
 }
 
+#pragma mark - View Utilities
+
+- (void)enableRotation
+{
+    [(SPNavigationController *)self.navigationController setDisableRotation:NO];
+}
+
+- (void)disableRotation
+{
+    [(SPNavigationController *)self.navigationController setDisableRotation:YES];
+}
+
 #pragma mark - UIPopoverPresentationControllerDelegate
 
 - (void)popoverPresentationControllerDidDismissPopover:(UIPopoverPresentationController *)popoverPresentationController
@@ -1807,7 +1819,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         [_noteEditorTextView setEditable:YES];
         noteVersionData = nil;
         
-        [self.navigationController setDisableRotation:NO];
+        [self enableRotation];
     }
     
     [actionSheet dismiss];
@@ -2021,7 +2033,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     versionActionSheet.tapToDismiss = NO;
     versionActionSheet.cancelButtonIndex = 0;
     
-    [self.navigationController setDisableRotation:YES];
+    [self disableRotation];
 }
 
 - (void)viewInfoAction
@@ -2063,7 +2075,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         newActionSheet.contentView.frame = newFrame;
     }
     
-    [self.navigationController setDisableRotation:YES];
+    [self disableRotation];
     
     self.infoActionSheet = newActionSheet;
     self.noteInfoViewController = infoViewController;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -2056,29 +2056,38 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     };
     
     // Configure SPActionSheet for display.
-    NSArray *views = @[infoViewController.view];
-    SPActionSheet *newActionSheet = [SPActionSheet showActionSheetInView:self.navigationController.view withMessage:nil withContentViewArray:views withButtonTitleArray:nil delegate:self];
-    newActionSheet.swipeToDismiss = YES;
-    newActionSheet.contentView.layer.cornerRadius = 15;
-    
-    // Post setup frame tweaking.
-    // The SPActionSheet sets up a 12 pixel boarder.
-    // We don't want that so remove it here.
-    CGRect newFrame = newActionSheet.contentView.frame;
-    newFrame = CGRectInset(newFrame, 12, 0);
-    newActionSheet.contentView.frame = newFrame;
-    
-    // TODO: Work on iPad sizing
-    // Our iPad sizing logic needs more work.
-    BOOL isPad = [UIDevice isPad];
-    if (isPad) {
-        newFrame = CGRectInset(newFrame, 225, 0);
+    if ([UIDevice isPad] && !self.isViewHorizontallyCompact) {
+        
+        infoViewController.modalPresentationStyle = UIModalPresentationPopover;
+        [infoViewController.popoverPresentationController setSourceView:self.noteOptionsButton];
+        
+        CGFloat preferredHeight = infoViewController.view.frame.size.height - 36;
+        CGRect newFrame = CGRectMake(0, 0, 0, preferredHeight);
+        infoViewController.preferredContentSize = newFrame.size;
+        
+        [self presentViewController:infoViewController animated:YES completion:^{
+            self.noteInfoViewController = nil;
+        }];
+        
+    } else {
+        
+        NSArray *views = @[infoViewController.view];
+        SPActionSheet *newActionSheet = [SPActionSheet showActionSheetInView:self.navigationController.view withMessage:nil withContentViewArray:views withButtonTitleArray:nil delegate:self];
+        newActionSheet.swipeToDismiss = YES;
+        newActionSheet.contentView.layer.cornerRadius = 15;
+        
+        // Post setup frame tweaking.
+        // The SPActionSheet sets up a 12 pixel boarder.
+        // We don't want that so remove it here.
+        CGRect newFrame = newActionSheet.contentView.frame;
+        newFrame = CGRectInset(newFrame, 12, 0);
         newActionSheet.contentView.frame = newFrame;
+        
+        [self disableRotation];
+        
+        self.infoActionSheet = newActionSheet;
     }
     
-    [self disableRotation];
-    
-    self.infoActionSheet = newActionSheet;
     self.noteInfoViewController = infoViewController;
 }
 


### PR DESCRIPTION
### Fix

This PR adds the new navigation button and implements the new Note Info UI behind it.

![ezgif-7-c9243cb9d8ce](https://user-images.githubusercontent.com/40267301/82117025-34864e00-97a0-11ea-80a8-e3e343517345.gif)

Sub-task of #741.

### Test Button

1. Select any note
2. Confirm the new "..." button is visible
3. Confirm the Note Info view appears correctly

### Test View

1. Confirm table ignores taps
2. Confirm note details are correct
3. Confirm bottom sheet responds to swipes
4. Confirm "x" button dismisses view

### Review

This PR is to merge changes to the `741-note-options` "feature" branch. Not into `develop`.

**Notes for** @SylvesterWilmott 

1. The "x" button doesn't match the system default. May need a new image to get this exactly right. Currently uses an existing image from the project.
2. Date formats do not match design spec. Currently using the localized system settings (ie: the user's settings). The Note Options class has a date formatter that matches the spec too, if that is preferred.
3. I'll need to know some min/max sizes for the sheet on the iPad. Right now it does some rough sizing but it's not what it should be.

Please let me know if there is anything that looks off!

**Notes for** @jleandroperez 

- I've set up the `741-note-options` branch as the "feature" branch.
- I went with a XIB here as storyboards where a bit harder to wrangle into a bottom sheet like this. No layout in code.
- The UITableView uses standard UITableViewCell for now as these match the design spec. We can always introduce a custom subclass if needed though.
- The Note Info view is fully localized in code.
- I set up the "x" button to use a block-based callback instead of a delegate.
- Local data is declared as optional. Not sure what the best practice is for Swift and would love to hear your thoughts on this.

I'm thinking`var note: Note?` vs `var note: Note!` vs ? If we went with `!` we could test and fatal in `viewDidLoad` but assume the values are set everywhere else, much like how IBOutlets are handled.

### Release

Initial release notes are already part of the `741-note-options` branch. Those will need to be reviewed before merging the feature branch back to `develop` but should be fine for now.