### PR TITLE
SPBlurEffectView: Change maximumAlphaGradientOffset to 22 from 30

### DIFF
--- a/Simplenote/Classes/SPBlurEffectView.swift
+++ b/Simplenote/Classes/SPBlurEffectView.swift
@@ -88,7 +88,7 @@ extension SPBlurEffectView {
     ///
     @objc
     func adjustAlphaMatchingContentOffset(of scrollView: UIScrollView) {
-        let maximumAlphaGradientOffset = CGFloat(30)
+        let maximumAlphaGradientOffset = CGFloat(22)
         let normalizedOffset = scrollView.adjustedContentInset.top + scrollView.contentOffset.y
         let newAlpha = min(max(normalizedOffset / maximumAlphaGradientOffset, 0), 1)
 


### PR DESCRIPTION
### Fix
Fixing the offset of the navigation bar blur fade in which fixes a scenario where characters from the first item in the notes list are seen through the navigation bar background.

### Test
1. Go to the notes list
2. Scroll
3. Notice that the blur is faded in before the characters of the first item in the notes list is scrolled beneath the navigation bar

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/36532468/83779247-9ccf9d80-a683-11ea-8c4c-4005ca719e1b.png)  |  ![](https://user-images.githubusercontent.com/36532468/83779305-ad801380-a683-11ea-913e-17521f7e873c.png)


### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
