### PR TITLE
Localizing DTPinLock

### DIFF
--- a/Scripts/localize.py
+++ b/Scripts/localize.py
@@ -121,7 +121,7 @@ def localize(path):
     old = original + '.old'
     new = original + '.new'
 
-    genstrings_cmd = 'genstrings -q -o "%s" `find ./Simplenote ./Pods/WordPress-AppbotX -name "*.m" -o -name "*.swift"`'
+    genstrings_cmd = 'genstrings -q -o "%s" `find ./Simplenote ./External/DTPinLock -name "*.m" -o -name "*.swift"`'
 
     if os.path.isfile(original):
         os.rename(original, old)


### PR DESCRIPTION
### Fix
In this PR we're patching up the localizations script, so that `DTPinLock` strings are picked up.

**Note:** AppBotX was recently dropped.

@mokagio (or) @jkmassel: Gentelemen, may I bug any of you with a super quick fix?
Thanks in advance!!

Closes #713

### Test
1. Run `./Scripts/localize.py`
2. Verify new `Passcode-y` strings show up in `Simplenote/en.lproj/Localizable.strings`

### Release
These changes do not require release notes.
