### PR TITLE
Tags Editor: RTL Support

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.20
 -----
 -   Fixed RTL support in the Authentication Screens.
+-   Fixed RTL support in the Tags Editor.
 
 4.19
 -----

--- a/Simplenote/Classes/SPTagView.h
+++ b/Simplenote/Classes/SPTagView.h
@@ -41,7 +41,7 @@
     NSArray *tagCompletionPills;
 }
 
-@property (nonatomic, assign) id<SPTagViewDelegate> tagDelegate;
+@property (nonatomic, weak) id<SPTagViewDelegate> tagDelegate;
 
 - (void)clearAllTags;
 - (BOOL)setupWithTagNames:(NSArray *)tagNames;

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -53,19 +53,21 @@
         
         tagPills = [NSMutableArray array];
 
+        [self ensureRightToLeftSupportIsInitialized];
         [self applyStyle];
     }
     
     return self;
 }
 
-- (void)applyStyle {
+- (void)applyStyle
+{
     self.backgroundColor = [UIColor simplenoteBackgroundColor];
     addTagField.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
 }
 
-- (void)layoutSubviews {
-    
+- (void)layoutSubviews
+{
     CGFloat xOrigin = 0.0;
     CGFloat spacing = [self.theme floatForKey:@"tagViewItemSideSpacing"];
     
@@ -176,7 +178,7 @@
                                                   target:self
                                                   action:@selector(tagPillTapped:)
                                           deletionAction:@selector(removeTagAction:)];
-    
+    pill.transform = [self transformForScrollViewContent];
     [tagPills addObject:pill];
     [tagScrollView addSubview:pill];
     
@@ -210,6 +212,7 @@
                                                                                action:@selector(tagCompletionPillTapped:)
                                                                        deletionAction:nil];
 
+                matchButton.transform = [self transformForScrollViewContent];
                 [autoCompleteScrollView addSubview:matchButton];
                 [fields addObject:matchButton];
                 
@@ -476,7 +479,7 @@
             location.y < view.frame.size.height);
 }
 
-#pragma mark UIScrollViewDelegate methods
+#pragma mark - UIScrollViewDelegate methods
 
 // allow touches outside view
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
@@ -489,5 +492,38 @@
     return [super hitTest:point withEvent:event];
 }
 
+
+#pragma mark - RTL Support
+
+- (void)ensureRightToLeftSupportIsInitialized
+{
+    if (self.userInterfaceLayoutDirection != UIUserInterfaceLayoutDirectionRightToLeft) {
+        return;
+    }
+
+    /// Note:
+    /// In order to support RTL, we need our tags to be anchored to the right hand side of the screen (our origin of coordinates).
+    ///
+    /// In our current approach, we'll vertically flip the container TagView, and flip again all of its subviews: [Tag Pills, Autocompletion and New Tag Editor]
+    /// This will rendered a right-anchored Tags Editor, in just a few lines.
+    ///
+    self.transform = [self verticalFlipTransform];
+    addTagField.transform = [self verticalFlipTransform];
+    addTagField.textAlignment = NSTextAlignmentRight;
+}
+
+- (CGAffineTransform)verticalFlipTransform
+{
+    return CGAffineTransformScale(CGAffineTransformIdentity, -1, 1);
+}
+
+- (CGAffineTransform)transformForScrollViewContent
+{
+    if (self.userInterfaceLayoutDirection != UIUserInterfaceLayoutDirectionRightToLeft) {
+        return CGAffineTransformIdentity;
+    }
+
+    return self.verticalFlipTransform;
+}
 
 @end

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -27,13 +27,10 @@
 
 @implementation SPTagView
 
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {
-        
-        // setup self
-        
         tagScrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
         tagScrollView.scrollsToTop = NO;
         tagScrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth;


### PR DESCRIPTION
### Description:
In this PR we're bringing RTL support over to the Tags Editor.

@aerych WDYT? (Thanks in advance!!!)
I actually started by patching old layout code... and I realized... wow, this can be really easy! 

Ref. #19 

### Details:
In order to support RTL, we need our tags to be anchored to the right hand side of the screen (our origin of coordinates). There are (at least!) three alternatives to achieve so:

1. Rebuild all the things with Autolayout support (potentially StackView + ScrollView)
2. Update the `layoutSubviews` API so that views are anchored otherwise
3. Simply apply a CGAffineTransform, and flip vertically the containers

Since a major Tags Editor refactor is already in the pipeline, in this PR we're implementing (3), in about ~30 lines of code 😄 

### Scenario: LTR
1. Launch Simplenote and log into your account
2. Open any note without tags

- [x] Verify the **Tag...** placeholder is anchored **to the left**
- [x] Verify that after **adding a new tag** the placeholder moves to the right
- [x] Verify that after **deleting any tag** the placeholder moves to the left
- [x] Verify that the **Tag Suggestions** are anchored to the left side (and scrolls properly)

### Scenario: RTL
0. Set the Application Language to `Right to Left Pseudolanguage`
1. Launch Simplenote and log into your account
2. Open any note without tags

- [x] Verify the **Tag...** placeholder is anchored **to the right**
- [x] Verify that after **adding a new t
ag** the placeholder moves to the left
- [x] Verify that after **deleting any tag** the placeholder moves to the right
- [x] Verify that the **Tag Suggestions** are anchored to the right side (and scrolls properly)

### Release
`RELEASE-NOTES.txt` was updated in 3cbd1ad with:
 
> Fixed RTL support in the Tags Editor

### Screenshots
<img width="200" src="https://user-images.githubusercontent.com/1195260/84441685-9b1d5100-ac12-11ea-94b3-6921f88e101f.png"> <img width="200" src="https://user-images.githubusercontent.com/1195260/84441693-9f496e80-ac12-11ea-8f26-61cab40082a6.png">


