### PR TITLE
SPNoteListViewController: Preventing UITableView Crash

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -356,9 +356,19 @@
 - (void)searchDisplayControllerDidEndSearch:(SearchDisplayController *)controller
 {
     [self invalidateSearchTimer];
+
+    /// Note:
+    ///  - `endSearch` switches the List Controller to `.results`, and drops immediately the Tags section (if any)
+    ///  - `dismissSortBar` may (under unknown scenarios) trigger a UITableView refresh sequence
+    ///
+    /// Because of the reasons above, we must always ensure `endSearch` is followed by `update` (which reloads the table!)
+    ///
+    /// Ref. https://github.com/Automattic/simplenote-ios/issues/777
+    ///
     [self.notesListController endSearch];
-    [self dismissSortBar];
     [self update];
+
+    [self dismissSortBar];
 }
 
 


### PR DESCRIPTION
### Details
Under unknown circumstances, running `dismissSortBar` may cause the TableView to refresh/reload its cells.

If that happens exactly in between operations that (A) `refresh the FRC predicate` and (B) `reload the tableView`, we risk a crash. In that precise spot, the TableView is unaware that the datasource was changed, and may request an entity that isn't available anymore.

In this PR we're inverting a sequence, so that nothing comes in between (A) and (B).

@danielebogo you game for a reaaaally fun PR?
Thank you sir!!

Closes #777

#### Note:
I've **not been able** to directly reproduce the original crash (!)

### Test
1. Log into the app
2. Press over the search bar
3. Type anything that yields results for Tags / Notes.
4. Press `Cancel` to stop searching

- [x] Verify the app doesn't crash 😄 

### Release
These changes do not require release notes.
