### PR TITLE
New component to embed a view controller in a card-like view

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -137,6 +137,9 @@
 		74F6637F22BADB5000FA147E /* ExtensionPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6637E22BADB5000FA147E /* ExtensionPresentationController.swift */; };
 		74F6638122BADBD200FA147E /* ExtensionPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638022BADBD200FA147E /* ExtensionPresentationAnimator.swift */; };
 		74F6638322BADD0300FA147E /* SharePresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638222BADD0300FA147E /* SharePresentationController.swift */; };
+		A68ABCA224ABCFFA00715EBD /* SPCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA124ABCFFA00715EBD /* SPCardViewController.swift */; };
+		A68ABCA624ABFA5800715EBD /* UIView+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */; };
+		A68ABCA824ABFB5300715EBD /* SPShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA724ABFB5300715EBD /* SPShadowView.swift */; };
 		B504D4DE23D2014200AEED27 /* IndexPath+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504D4DD23D2014200AEED27 /* IndexPath+Simplenote.swift */; };
 		B504D4E023D2018800AEED27 /* ResultsObjectChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504D4DF23D2018800AEED27 /* ResultsObjectChange.swift */; };
 		B504D4E223D201C300AEED27 /* ResultsSectionChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504D4E123D201C300AEED27 /* ResultsSectionChange.swift */; };
@@ -482,6 +485,9 @@
 		9F2210B2EE42B513C4C92372 /* Pods-Automattic-Simplenote.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		9F225454D6472EDCA812A4C5 /* Pods-Automattic-Simplenote.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		A22187FB12EF52A765E6D4EC /* Pods-SimplenoteTests.distribution appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution appstore.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution appstore.xcconfig"; sourceTree = "<group>"; };
+		A68ABCA124ABCFFA00715EBD /* SPCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPCardViewController.swift; path = Classes/SPCardViewController.swift; sourceTree = "<group>"; };
+		A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Constraints.swift"; sourceTree = "<group>"; };
+		A68ABCA724ABFB5300715EBD /* SPShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPShadowView.swift; sourceTree = "<group>"; };
 		A774E3E4F5041D36FBE400BD /* Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig"; sourceTree = "<group>"; };
 		AE066B9C23C9166D41F1A732 /* Pods-SimplenoteTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B303123B163A5C7805D10DC7 /* Pods-Automattic-Simplenote.distribution adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution adhoc.xcconfig"; sourceTree = "<group>"; };
@@ -1235,6 +1241,7 @@
 				B524AE102352CC7900EA11D4 /* UIScreen+Simplenote.swift */,
 				B56A696622F9D55F00B90398 /* UIView+Animations.swift */,
 				B56E763522BD565700C5AA47 /* UIView+Simplenote.swift */,
+				A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */,
 				B52646A922D3E04C00EBF299 /* UIViewController+Simplenote.swift */,
 				74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */,
 				B524AE0E2352BE9200EA11D4 /* UITableView+Simplenote.swift */,
@@ -1498,6 +1505,7 @@
 				B546BE9D234F6CB700A126DA /* SPTagHeaderView.swift */,
 				B546BE9F234F6DA000A126DA /* SPTagHeaderView.xib */,
 				37E55A6621BF2B1800F14241 /* SPTextAttachment.swift */,
+				A68ABCA724ABFB5300715EBD /* SPShadowView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1669,6 +1677,7 @@
 				B56C8CA1234CEAF100FE55F4 /* SPTagsListViewController.xib */,
 				17C421D01BE0BABE00752B56 /* SPMarkdownPreviewViewController.h */,
 				17C421D11BE0BABE00752B56 /* SPMarkdownPreviewViewController.m */,
+				A68ABCA124ABCFFA00715EBD /* SPCardViewController.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -2245,6 +2254,7 @@
 				B59188C0240059950069EF96 /* NSRegularExpression+Simplenote.swift in Sources */,
 				B5421F3823CE79F6004DDC19 /* ResultsController.swift in Sources */,
 				46A3C97C17DFA81A002865AE /* DTPinErrorView.m in Sources */,
+				A68ABCA824ABFB5300715EBD /* SPShadowView.swift in Sources */,
 				B56E763622BD565700C5AA47 /* UIView+Simplenote.swift in Sources */,
 				46A3C97D17DFA81A002865AE /* NSTextStorage+Highlight.m in Sources */,
 				B5E4082D235DE41A00D4E1DF /* UIColor+Studio.swift in Sources */,
@@ -2346,11 +2356,13 @@
 				375D24B221E01131007AB25A /* buffer.c in Sources */,
 				B54B04D82407169500401FBB /* SPAppDelegate+Extensions.swift in Sources */,
 				B50E99F4234242130092F274 /* UISearchBar+Simplenote.swift in Sources */,
+				A68ABCA624ABFA5800715EBD /* UIView+Constraints.swift in Sources */,
 				46A3C9A717DFA81A002865AE /* DTPinLockController.m in Sources */,
 				B56A696522F9D54600B90398 /* SPLabel.swift in Sources */,
 				46A3C9A917DFA81A002865AE /* SPModalActivityIndicator.m in Sources */,
 				B550F93822BA814D00091939 /* NSUserActivity+Shortcuts.swift in Sources */,
 				B570D2D92360F16F006E1C85 /* UIBlurEffect+Simplenote.swift in Sources */,
+				A68ABCA224ABCFFA00715EBD /* SPCardViewController.swift in Sources */,
 				B5CBEF4222D3B419009DBE67 /* Bundle+Simplenote.swift in Sources */,
 				B575736C232D454300443C2E /* UIColor+Helpers.swift in Sources */,
 				37E55A6721BF2B1800F14241 /* SPTextAttachment.swift in Sources */,

--- a/Simplenote/Classes/SPCardViewController.swift
+++ b/Simplenote/Classes/SPCardViewController.swift
@@ -16,6 +16,10 @@ final class SPCardViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        stopListeningToNotifications()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -24,6 +28,10 @@ final class SPCardViewController: UIViewController {
         addShadowView()
         setupContainerView()
         addChildViewController()
+
+        refreshStyle()
+
+        startListeningToNotifications()
     }
 }
 
@@ -39,7 +47,6 @@ private extension SPCardViewController {
     func setupContainerView() {
         view.addFillingSubview(containerView)
 
-        containerView.backgroundColor = UIColor.simplenoteCardBackgroundColor.withAlphaComponent(Constants.backgroundAlpha)
         containerView.layer.cornerRadius = Constants.cornerRadius
         containerView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         containerView.layer.masksToBounds = true
@@ -49,6 +56,27 @@ private extension SPCardViewController {
         addChild(viewController)
         containerView.addFillingSubview(viewController.view)
         viewController.didMove(toParent: self)
+    }
+
+    func refreshStyle() {
+        containerView.backgroundColor = UIColor.simplenoteCardBackgroundColor.withAlphaComponent(Constants.backgroundAlpha)
+    }
+}
+
+// MARK: - Notifications
+//
+private extension SPCardViewController {
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(themeDidChange), name: .VSThemeManagerThemeDidChange, object: nil)
+    }
+
+    func stopListeningToNotifications() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc func themeDidChange() {
+        refreshStyle()
     }
 }
 

--- a/Simplenote/Classes/SPCardViewController.swift
+++ b/Simplenote/Classes/SPCardViewController.swift
@@ -39,7 +39,7 @@ private extension SPCardViewController {
     func setupContainerView() {
         view.addFillingSubview(containerView)
 
-        containerView.backgroundColor = UIColor.simplenoteCardBackgroundColor.withAlphaComponent(0.97)
+        containerView.backgroundColor = UIColor.simplenoteCardBackgroundColor.withAlphaComponent(Constants.backgroundAlpha)
         containerView.layer.cornerRadius = Constants.cornerRadius
         containerView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         containerView.layer.masksToBounds = true
@@ -57,5 +57,6 @@ private extension SPCardViewController {
 private extension SPCardViewController {
     struct Constants {
         static let cornerRadius: CGFloat = 10.0
+        static let backgroundAlpha: CGFloat = 0.97
     }
 }

--- a/Simplenote/Classes/SPCardViewController.swift
+++ b/Simplenote/Classes/SPCardViewController.swift
@@ -1,0 +1,61 @@
+import UIKit
+
+// MARK: - SPCardViewController
+//
+final class SPCardViewController: UIViewController {
+    private let viewController: UIViewController
+    private let containerView = UIView()
+
+    init(viewController: UIViewController) {
+        self.viewController = viewController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .clear
+
+        addShadowView()
+        setupContainerView()
+        addChildViewController()
+    }
+}
+
+// MARK: - Private Methods
+//
+private extension SPCardViewController {
+    func addShadowView() {
+        let shadowView = SPShadowView(cornerRadius: Constants.cornerRadius,
+                                      roundedCorners: [.topLeft, .topRight])
+        view.addFillingSubview(shadowView)
+    }
+
+    func setupContainerView() {
+        view.addFillingSubview(containerView)
+
+        containerView.backgroundColor = UIColor.simplenoteBackgroundColor.withAlphaComponent(0.97)
+        containerView.layer.cornerRadius = Constants.cornerRadius
+        containerView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
+        containerView.layer.masksToBounds = true
+    }
+
+    func addChildViewController() {
+        addChild(viewController)
+        containerView.addFillingSubview(viewController.view)
+        viewController.didMove(toParent: self)
+    }
+}
+
+// MARK: - Constants
+//
+private extension SPCardViewController {
+    struct Constants {
+        static let cornerRadius: CGFloat = 10.0
+    }
+}

--- a/Simplenote/Classes/SPCardViewController.swift
+++ b/Simplenote/Classes/SPCardViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-// MARK: - SPCardViewController
+// MARK: - SPCardViewController wraps passed viewController in a view with rounded corners and a shadow
 //
 final class SPCardViewController: UIViewController {
     private let viewController: UIViewController

--- a/Simplenote/Classes/SPCardViewController.swift
+++ b/Simplenote/Classes/SPCardViewController.swift
@@ -39,7 +39,7 @@ private extension SPCardViewController {
     func setupContainerView() {
         view.addFillingSubview(containerView)
 
-        containerView.backgroundColor = UIColor.simplenoteBackgroundColor.withAlphaComponent(0.97)
+        containerView.backgroundColor = UIColor.simplenoteCardBackgroundColor.withAlphaComponent(0.97)
         containerView.layer.cornerRadius = Constants.cornerRadius
         containerView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         containerView.layer.masksToBounds = true

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -189,6 +189,11 @@ extension UIColor {
     }
 
     @objc
+    static var simplenoteCardBackgroundColor: UIColor {
+        UIColor(lightColor: .white, darkColor: .darkGray2)
+    }
+
+    @objc
     static var simplenoteNavigationBarBackgroundColor: UIColor {
         UIColor(lightColor: .white, darkColor: .darkGray1).withAlphaComponent(UIKitConstants.alpha0_8)
     }

--- a/Simplenote/SPShadowView.swift
+++ b/Simplenote/SPShadowView.swift
@@ -1,0 +1,97 @@
+import UIKit
+
+// MARK: - SPShadowView
+//
+// SPShadowView draws outside shadow, while everyting inside is kept transparent
+//
+final class SPShadowView: UIView {
+    private let cornerRadius: CGFloat
+    private let roundedCorners: UIRectCorner
+    private let maskLayer: CAShapeLayer = CAShapeLayer()
+
+    override var bounds: CGRect {
+        didSet {
+            updatePath()
+        }
+    }
+
+    /// Designated Initializer
+    ///
+    ///  - cornerRadius: The radius of each corner oval
+    ///  - roundedCorners: A bitmask value that identifies the corners that you want rounded
+    ///
+    init(cornerRadius: CGFloat, roundedCorners: UIRectCorner) {
+        self.cornerRadius = cornerRadius
+        self.roundedCorners = roundedCorners
+
+        super.init(frame: .zero)
+        configure()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Private Methods
+//
+private extension SPShadowView {
+
+    /// Initial configuration of the view
+    ///
+    func configure() {
+        backgroundColor = .clear
+
+        configureShadow()
+        configureMask()
+
+        updatePath()
+    }
+
+    /// Configuration of the shadow
+    ///
+    func configureShadow() {
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOffset = Constants.shadowOffset
+        layer.shadowOpacity = Constants.shadowOpacity
+        layer.shadowRadius = Constants.shadowRadius
+        layer.shouldRasterize = true
+        layer.rasterizationScale = UIScreen.main.scale
+    }
+
+    /// Configuration of the mask
+    ///
+    func configureMask() {
+        maskLayer.backgroundColor = UIColor.black.cgColor
+        maskLayer.fillRule = .evenOdd
+        layer.mask = maskLayer
+    }
+
+    /// Updates paths of the shadow and the mask to reflect the view bounds
+    ///
+    func updatePath() {
+        let roundedPath = UIBezierPath(roundedRect: bounds,
+                                       byRoundingCorners: roundedCorners,
+                                       cornerRadii: CGSize(width: cornerRadius, height: cornerRadius))
+
+        layer.shadowPath = roundedPath.cgPath
+
+        // Path including outside shadow
+        let maskPath = UIBezierPath(rect: bounds.insetBy(dx: -Constants.shadowRadius * 2 - abs(layer.shadowOffset.width),
+                                                         dy: -Constants.shadowRadius * 2 - abs(layer.shadowOffset.height)))
+        maskPath.append(roundedPath)
+        maskPath.usesEvenOddFillRule = true
+        maskLayer.path = maskPath.cgPath
+    }
+}
+
+// MARK: - Constants
+//
+private extension SPShadowView {
+    struct Constants {
+        static let shadowOpacity: Float = 0.1
+        static let shadowRadius: CGFloat = 4.0
+        static let shadowOffset = CGSize(width: 0, height: -2)
+    }
+}

--- a/Simplenote/SPShadowView.swift
+++ b/Simplenote/SPShadowView.swift
@@ -9,6 +9,14 @@ final class SPShadowView: UIView {
     private let roundedCorners: UIRectCorner
     private let maskLayer: CAShapeLayer = CAShapeLayer()
 
+    /// Shadow color
+    ///
+    var shadowColor = UIColor.black {
+        didSet {
+            configureShadow()
+        }
+    }
+
     override var bounds: CGRect {
         didSet {
             updatePath()
@@ -17,8 +25,9 @@ final class SPShadowView: UIView {
 
     /// Designated Initializer
     ///
-    ///  - cornerRadius: The radius of each corner oval
-    ///  - roundedCorners: A bitmask value that identifies the corners that you want rounded
+    ///  - Parameters:
+    ///     - cornerRadius: The radius of each corner oval
+    ///     - roundedCorners: A bitmask value that identifies the corners that you want rounded
     ///
     init(cornerRadius: CGFloat, roundedCorners: UIRectCorner) {
         self.cornerRadius = cornerRadius
@@ -52,7 +61,7 @@ private extension SPShadowView {
     /// Configuration of the shadow
     ///
     func configureShadow() {
-        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowColor = shadowColor.cgColor
         layer.shadowOffset = Constants.shadowOffset
         layer.shadowOpacity = Constants.shadowOpacity
         layer.shadowRadius = Constants.shadowRadius

--- a/Simplenote/UIView+Constraints.swift
+++ b/Simplenote/UIView+Constraints.swift
@@ -8,8 +8,6 @@ extension UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(view)
-        view.frame = bounds.inset(by: edgeInsets)
-
         let constraints = [
             view.leadingAnchor.constraint(equalTo: useSafeArea ? safeAreaLayoutGuide.leadingAnchor : leadingAnchor, constant: edgeInsets.left),
             view.trailingAnchor.constraint(equalTo: useSafeArea ? safeAreaLayoutGuide.trailingAnchor : trailingAnchor, constant: -edgeInsets.right),

--- a/Simplenote/UIView+Constraints.swift
+++ b/Simplenote/UIView+Constraints.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+extension UIView {
+    func addFillingSubview(_ view: UIView,
+                           edgeInsets: UIEdgeInsets = .zero,
+                           useSafeArea: Bool = false) {
+
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(view)
+        view.frame = bounds.inset(by: edgeInsets)
+
+        let constraints = [
+            view.leadingAnchor.constraint(equalTo: useSafeArea ? safeAreaLayoutGuide.leadingAnchor : leadingAnchor, constant: edgeInsets.left),
+            view.trailingAnchor.constraint(equalTo: useSafeArea ? safeAreaLayoutGuide.trailingAnchor : trailingAnchor, constant: -edgeInsets.right),
+            view.topAnchor.constraint(equalTo: useSafeArea ? safeAreaLayoutGuide.topAnchor : topAnchor, constant: edgeInsets.top),
+            view.bottomAnchor.constraint(equalTo: useSafeArea ? safeAreaLayoutGuide.bottomAnchor : bottomAnchor, constant: -edgeInsets.bottom)
+        ]
+
+        NSLayoutConstraint.activate(constraints)
+    }
+}


### PR DESCRIPTION
### Details

This PR add a new `SPCardViewController` component, which can embed another view controller in a view with rounded corners, shadow and a little bit transparent background.
This component will be used to wrap and show new history slider on the note editor screen, but not used anywhere at the moment.

### Notes
This is part of https://github.com/Automattic/simplenote-ios/issues/762
Will follow up with another PR for History Slider

### Release
> These changes do not require release notes.

### Screenshots

These are the example of how the component looks like.

<p float="left">
<img src="https://user-images.githubusercontent.com/54751/86287532-9c75e400-bbe8-11ea-8d78-102be0980f61.png" width="320" />
<img src="https://user-images.githubusercontent.com/54751/86287536-9f70d480-bbe8-11ea-9de4-0fcc5595d2b0.png" width="320" />
</p>
