### PR TITLE
Increase contrast of dividers in dark mode

### DIFF
--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -230,7 +230,7 @@ extension UIColor {
 
     @objc
     static var simplenoteDividerColor: UIColor {
-        UIColor(lightColor: .gray40, darkColor: .darkGray4).withAlphaComponent(UIKitConstants.alpha0_5)
+        UIColor(lightColor: .gray40, darkColor: .darkGray4).withAlphaComponent(UIKitConstants.alpha0_6)
     }
 
     @objc


### PR DESCRIPTION
### Fix
Follow up to #788 to increase the contrast of dividers in the new dark mode. This change brings us in line with the system contrast.

### Test
1. Use the app in dark mode
2. Notice that the dividers are more visible

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
