### PR TITLE
Change launch screen background to black in dark mode

### DIFF
--- a/Simplenote/Colors.xcassets/simplenoteLaunchBackgroundColor.colorset/Contents.json
+++ b/Simplenote/Colors.xcassets/simplenoteLaunchBackgroundColor.colorset/Contents.json
@@ -1,23 +1,18 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "1.000",
           "alpha" : "1.000",
           "blue" : "1.000",
-          "green" : "1.000"
+          "green" : "1.000",
+          "red" : "1.000"
         }
-      }
+      },
+      "idiom" : "universal"
     },
     {
-      "idiom" : "universal",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -27,12 +22,17 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x1A",
           "alpha" : "1.000",
-          "blue" : "0x1E",
-          "green" : "0x1C"
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }


### PR DESCRIPTION
### Fix
Follow up to #788 to change the launch screen background to black in dark mode. This is to match with the new dark mode background colour.

<img width="375" alt="Screenshot 2020-07-10 at 10 38 35" src="https://user-images.githubusercontent.com/36532468/87140481-7c55bd00-c299-11ea-9fce-6dd9d0f548f1.png">


### Test
1. Make sure your device is set to dark mode
2. Launch Simplenote
3. Notice that the launch screen background now matches the primary background of the app in dark mode

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
