### PR TITLE
Analytics: Application State Events

### DIFF
--- a/Simplenote/Classes/SPTracker.h
+++ b/Simplenote/Classes/SPTracker.h
@@ -13,6 +13,10 @@
 + (void)refreshMetadataWithEmail:(NSString *)email;
 + (void)refreshMetadataForAnonymousUser;
 
+#pragma mark - Application State
++ (void)trackApplicationOpened;
++ (void)trackApplicationClosed;
+
 #pragma mark - Note Editor
 + (void)trackEditorChecklistInserted;
 + (void)trackEditorNoteCreated;

--- a/Simplenote/Classes/SPTracker.m
+++ b/Simplenote/Classes/SPTracker.m
@@ -20,6 +20,19 @@
 }
 
 
+#pragma mark - Application State
+
++ (void)trackApplicationOpened
+{
+    [self trackAutomatticEventWithName:@"application_opened" properties:nil];
+}
+
++ (void)trackApplicationClosed
+{
+    [self trackAutomatticEventWithName:@"application_closed" properties:nil];
+}
+
+
 #pragma mark - Note Editor
 
 + (void)trackEditorNoteCreated

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -242,7 +242,19 @@
     return YES;
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application {
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    [self ensurePinlockIsDismissed];
+    [SPTracker trackApplicationOpened];
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    [SPTracker trackApplicationClosed];
+}
+
+- (void)ensurePinlockIsDismissed
+{
     // Dismiss the pin lock window if the user has returned to the app before their preferred timeout length
     if (self.pinLockWindow != nil
         && [self.pinLockWindow isKeyWindow]


### PR DESCRIPTION
### Fix
In this PR we're wiring analytics for Application State events.

@guarani Paul!! May I bug you with a really quick one?
Thanks in advance!!

/cc @belcherj I owed you this one sir!

Closes #780 

### Test
- [x] Verify that after launching the app `🔵 Tracked: application_opened` shows up in the console
- [x] Verify that after backgrounding the app `🔵 Tracked: application_closed` shows in the console!

### Release
These changes do not require release notes.
