### PR TITLE
Improve side menu accessibility via VoiceOver

### DIFF
--- a/Simplenote/Classes/SPTagListViewCell.m
+++ b/Simplenote/Classes/SPTagListViewCell.m
@@ -12,6 +12,13 @@
 - (void)awakeFromNib {
     [super awakeFromNib];
     [self refreshStyle];
+    // Don't use textField as an accessibility element.
+    // Instead use textField value as a cell accessibility label.
+    self.textField.isAccessibilityElement = NO;
+}
+
+- (NSString *)accessibilityLabel {
+    return self.textField.text;
 }
 
 - (void)prepareForReuse {

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -370,9 +370,6 @@ static const NSInteger SPTagListEmptyStateSectionCount  = 1;
             [self configureBottomCell:cell atIndexPath:indexPath];
             break;
     }
-
-    cell.accessibilityLabel = cell.textField.text;
-    cell.textField.isAccessibilityElement = NO;
 }
 
 - (void)configureSystemCell:(SPTagListViewCell *)cell atIndexPath:(NSIndexPath *)indexPath {

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -370,6 +370,9 @@ static const NSInteger SPTagListEmptyStateSectionCount  = 1;
             [self configureBottomCell:cell atIndexPath:indexPath];
             break;
     }
+
+    cell.accessibilityLabel = cell.textField.text;
+    cell.textField.isAccessibilityElement = NO;
 }
 
 - (void)configureSystemCell:(SPTagListViewCell *)cell atIndexPath:(NSIndexPath *)indexPath {
@@ -399,7 +402,6 @@ static const NSInteger SPTagListEmptyStateSectionCount  = 1;
     cell.textField.text = tagName;
     cell.textField.delegate = self;
     cell.iconImage = nil;
-    cell.accessibilityLabel = tagName;
     cell.delegate = self;
 }
 


### PR DESCRIPTION
### Fix
Currently text fields inside cells act as an accessibility elements and provide accessibility label. This makes it impossible to open linked screens via double tap as the action is connected to the cell.

This PR sets accessibility label on for a cell based on a text field value and prevents text field to become an accessibility element. Now cell acts as an accessibility element, can be selected and linked screen can be opened via double tap.

<img src="https://user-images.githubusercontent.com/54751/87306653-a0730180-c518-11ea-8c1c-c44fda0d6907.PNG" width="300px" />

<img src="https://user-images.githubusercontent.com/54751/87306661-a49f1f00-c518-11ea-8280-e2f163b4260d.PNG" width="300px" />


### Test
1. Turn VoiceOver on
2. Open side menu and try to open linked screen and edit tags 

