### PR TITLE
Fix tag search text colour

### DIFF
--- a/Simplenote/Classes/SPTagTableViewCell.swift
+++ b/Simplenote/Classes/SPTagTableViewCell.swift
@@ -204,7 +204,7 @@ private enum Style {
     /// Headline Color: To be applied over the first preview line
     ///
     static var textColor: UIColor {
-        .simplenoteNoteHeadlineColor
+        .simplenoteTextColor
     }
 
     /// Color to be applied over the cell upon selection


### PR DESCRIPTION
### Fix
Related to #788. This fixes a colour error for the text colour of a tag search.

### Test
1. Perform a tag search while in dark mode
2. Confirm that the text is white and not grey

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
