### PR TITLE
Editor Adjustments

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.21
 -----
--   New darker dark mode
+-   New darker dark mode.
+-   Updated editor typography.
  
 4.20.1
 ------

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -146,7 +146,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 - (void)applyStyle
 {    
     UIFont *bodyFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    UIFont *headlineFont = [UIFont preferredFontFor:UIFontTextStyleTitle2 weight:UIFontWeightBold];
+    UIFont *headlineFont = [UIFont preferredFontFor:UIFontTextStyleTitle1 weight:UIFontWeightBold];
     UIColor *fontColor = [UIColor simplenoteNoteHeadlineColor];
 
     NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];

--- a/Simplenote/Simplenote-DB5.plist
+++ b/Simplenote/Simplenote-DB5.plist
@@ -15,7 +15,7 @@
 		<key>noteBodyLineHeightPercentage~ipad</key>
 		<string>0.40</string>
 		<key>noteSidePadding</key>
-		<integer>15</integer>
+		<integer>20</integer>
 		<key>noteSidePadding~regular</key>
 		<integer>64</integer>
 		<key>noteTopPadding</key>


### PR DESCRIPTION
### Fix
* Stylistic change of note title to a larger system font size. This is prompted by the change seen in Apple Notes in iOS14.
* Increase side paddings of the entire note

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/36532468/87451141-5d3b9000-c5f7-11ea-99fd-940274bb9ffb.png)  |  ![](https://user-images.githubusercontent.com/36532468/87451179-6e849c80-c5f7-11ea-87f7-0ed75bedf224.png)

### Test
1. Open any note
2. Confirm that the title is larger
3. Confirm that the note side padding is larger

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in d1962b7 with:

> Updated editor typography.
