### PR TITLE
Fixes Interactive Scrollbar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.22
 -----
 -   Fixed several layout issues that affected the Editor
+-   Now it's possible to interactively drag the Scroll Bar within the Editor
  
 4.21
 -----

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -191,7 +191,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
     // Limit a recognized touch to the SPTextView, so that taps on tags still work as expected
-    return [touch.view isKindOfClass:[SPTextView class]];
+    return ![touch.view isDescendantOfView:self.tagView];
 }
 
 - (BOOL)becomeFirstResponder


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that caused the Scroll Indicator not to accept long press gestures, and thus, made it impossible to move along the document super quickly.

@guarani Paul!! Can I bug you with a super simple PR?
Thanks in advance!!

Closes #733

### Test
1. Open a long document
2. Scroll a tiny bit, so that the Scroll Bar appears
3. Press over the Scroll Indicator / Scroll Bar

- [ ] Verify that after a second, the Indicator increases its size, and accepts drag events
- [ ] Verify that pressing over the Tags Editor works as expected
- [ ] Verify that you can add / delete tags, from the Tags Editor


### Release
`RELEASE-NOTES.txt` was updated in 5b0e92a with:

> Now it's possible to interactively drag the Scroll Bar within the Editor
