### PR TITLE
Update Fastlane iOS Simulator version for screenshots to 13.5

### DIFF
--- a/SimplenoteScreenshots/SnapshotHelper.swift
+++ b/SimplenoteScreenshots/SnapshotHelper.swift
@@ -38,22 +38,13 @@ func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
 }
 
 enum SnapshotError: Error, CustomDebugStringConvertible {
-    case cannotDetectUser
-    case cannotFindHomeDirectory
     case cannotFindSimulatorHomeDirectory
-    case cannotAccessSimulatorHomeDirectory(String)
     case cannotRunOnPhysicalDevice
 
     var debugDescription: String {
         switch self {
-        case .cannotDetectUser:
-            return "Couldn't find Snapshot configuration files - can't detect current user "
-        case .cannotFindHomeDirectory:
-            return "Couldn't find Snapshot configuration files - can't detect `Users` dir"
         case .cannotFindSimulatorHomeDirectory:
             return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
-        case .cannotAccessSimulatorHomeDirectory(let simulatorHostHome):
-            return "Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?"
         case .cannotRunOnPhysicalDevice:
             return "Can't use Snapshot on a physical device."
         }
@@ -75,7 +66,7 @@ open class Snapshot: NSObject {
         Snapshot.waitForAnimations = waitForAnimations
 
         do {
-            let cacheDir = try pathPrefix()
+            let cacheDir = try getCacheDirectory()
             Snapshot.cacheDirectory = cacheDir
             setLanguage(app)
             setLocale(app)
@@ -206,34 +197,22 @@ open class Snapshot: NSObject {
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
-    class func pathPrefix() throws -> URL? {
-        let homeDir: URL
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
         // on OSX config is stored in /Users/<username>/Library
         // and on iOS/tvOS/WatchOS it's in simulator's home dir
         #if os(OSX)
-            guard let user = ProcessInfo().environment["USER"] else {
-                throw SnapshotError.cannotDetectUser
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
             }
-
-            guard let usersDir = FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
-                throw SnapshotError.cannotFindHomeDirectory
-            }
-
-            homeDir = usersDir.appendingPathComponent(user)
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
         #else
-            #if arch(i386) || arch(x86_64)
-                guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
-                    throw SnapshotError.cannotFindSimulatorHomeDirectory
-                }
-                guard let homeDirUrl = URL(string: simulatorHostHome) else {
-                    throw SnapshotError.cannotAccessSimulatorHomeDirectory(simulatorHostHome)
-                }
-                homeDir = URL(fileURLWithPath: homeDirUrl.path)
-            #else
-                throw SnapshotError.cannotRunOnPhysicalDevice
-            #endif
+            throw SnapshotError.cannotRunOnPhysicalDevice
         #endif
-        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }
 }
 
@@ -300,4 +279,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.21]
+// SnapshotHelperVersion [1.22]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -672,5 +672,5 @@ def screenshot_devices()
 end
 
 def simulator_version
-  '13.4'
+  '13.6'
 end


### PR DESCRIPTION
This is due to us using macos-latest in the GitHub Actions workflow. It might be better to switch to a targeted macOS image instead.

Also notice we had to update the snapshot helper file. That was prompted by a build failure which I think is related to the new Simulator version only, since we didn't update Fastlane since the last screenshots build.

See https://github.com/Automattic/simplenote-ios/runs/815164553#step:9:1103

### Test

Add the "Needs Screenshots" label and verify the screenshots build starts on GitHub Actions. Then you might want to go take a break or work on something else because the build will take a while to finish.

If everything works, the build should be green with downloadable screenshots attachments, like [here](https://github.com/Automattic/simplenote-ios/pull/817/checks?check_run_id=901217752)

![image](https://user-images.githubusercontent.com/1218433/88252746-a7f19200-ccf2-11ea-9989-58e61a69cfe6.png)


### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.