### PR TITLE
First pass at wiring up state restoration.

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -215,7 +215,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         self.userActivity = [NSUserActivity openNoteActivityFor:_currentNote];
     }
 
-    [self ensureTagViewIsVisible];
     [self ensureEditorIsFirstResponder];
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -262,17 +262,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     }
 }
 
-- (void)ensureTagViewIsVisible
-{
-    if (_tagView.alpha >= UIKitConstants.alpha1_0) {
-        return;
-    }
-
-    [UIView animateWithDuration:UIKitConstants.animationShortDuration animations:^{
-        self.tagView.alpha = UIKitConstants.alpha1_0;
-     }];
-}
-
 - (void)startListeningToThemeNotifications {
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(themeDidChange) name:VSThemeManagerThemeDidChangeNotification object:nil];
@@ -1375,7 +1364,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                              newFrame.origin.y += newFrame.size.height;
                              
                              snapshot.frame = newFrame;
-                             self.tagView.alpha = 1.0;
 
                          } completion:^(BOOL finished) {
                              

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -655,11 +655,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     bBlankNote = NO;
     bModified = NO;
     self.previewing = NO;
-
-    // hide the tags field
-    if (!self.voiceoverEnabled) {
-        self.tagView.alpha = UIKitConstants.alpha0_0;
-    }
 }
 
 - (void)clearNote {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -218,30 +218,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     [self ensureEditorIsFirstResponder];
 }
 
-- (void)encodeRestorableStateWithCoder:(NSCoder *)coder
-{
-    [super encodeRestorableStateWithCoder:coder];
-    [coder encodeObject:self.currentNote.localID forKey:@"currentNoteKey"];
-}
-
-- (void)decodeRestorableStateWithCoder:(NSCoder *)coder
-{
-    NSString *key = [coder decodeObjectForKey:@"currentNoteKey"];
-
-    NSManagedObjectContext *context = [[SPAppDelegate sharedDelegate] managedObjectContext];
-
-    NSURL *url = [NSURL URLWithString:key];
-    NSManagedObjectID *objectID = [context.persistentStoreCoordinator managedObjectIDForURIRepresentation:url];
-
-    Note *note = [context existingObjectWithID:objectID error:nil];
-
-    if (note) {
-        [self updateNote:note];
-    } else {
-        [self.navigationController popViewControllerAnimated:NO];
-    }
-}
-
 - (void)configureNavigationBarBackground
 {
     NSAssert(self.navigationBarBackground == nil, @"NavigationBarBackground was already initialized!");

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -192,18 +192,15 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-    
     [super viewWillAppear:animated];
 
     [self setupNavigationController];
     [self setBackButtonTitleForSearchingMode: bSearching];
     [self resetNavigationBarToIdentityWithAnimation:NO completion:nil];
     [self sizeNavigationContainer];
-
-    [self ensureTagViewIsVisible];
     [self highlightSearchResultsIfNeeded];
     [self startListeningToKeyboardNotifications];
-    
+
     [self refreshNavigationBarButtons];
 }
 
@@ -218,7 +215,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         self.userActivity = [NSUserActivity openNoteActivityFor:_currentNote];
     }
 
-
+    [self ensureTagViewIsVisible];
     [self ensureEditorIsFirstResponder];
 }
 
@@ -658,7 +655,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     bBlankNote = NO;
     bModified = NO;
     self.previewing = NO;
-    
+
     // hide the tags field
     if (!self.voiceoverEnabled) {
         self.tagView.alpha = UIKitConstants.alpha0_0;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -208,6 +208,10 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 {
     [super viewDidAppear:animated];
 
+    /// Note:
+    /// This must happen in viewDidAppear (and not before) because of State Restoration.
+    /// Decode happens right after `viewWillAppear`, and this way we get to avoid spurious empty notes.
+    ///
     if (!_currentNote) {
         [self newButtonAction:nil];
     } else {

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -160,8 +160,24 @@ extension SPNoteListViewController {
         tableView.dataSource = self
 
         notesListController.onBatchChanges = { [weak self] (sectionsChangeset, objectsChangeset) in
-            self?.tableView.performBatchChanges(sectionsChangeset: sectionsChangeset, objectsChangeset: objectsChangeset) { _ in
-                self?.displayPlaceholdersIfNeeded()
+            guard let `self` = self else {
+                return
+            }
+
+            /// Note:
+            ///  1. State Restoration might cause this ViewController not to be onScreen
+            ///  2. When that happens, any remote change might cause a Batch Update
+            ///  3. And the above yields a crash
+            ///
+            /// In this snipept we're preventing a beautiful `_Bug_Detected_In_Client_Of_UITableView_Invalid_Number_Of_Rows_In_Section` exception
+            ///
+            guard let _ = self.view.window else {
+                self.tableView.reloadData()
+                return
+            }
+
+            self.tableView.performBatchChanges(sectionsChangeset: sectionsChangeset, objectsChangeset: objectsChangeset) { _ in
+                self.displayPlaceholdersIfNeeded()
             }
         }
     }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -88,8 +88,8 @@
     [self ensureFirstRowIsVisibleIfNeeded];
 }
 
-- (void)didMoveToParentViewController:(UIViewController *)parent {
-    [super didMoveToParentViewController:parent];
+- (void)willMoveToParentViewController:(UIViewController *)parent {
+    [super willMoveToParentViewController:parent];
     [self ensureFirstRowIsVisible];
     [self ensureTransitionControllerIsInitialized];
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -72,6 +72,7 @@
         [self registerForPeekAndPop];
         [self refreshStyle];
         [self update];
+        self.mustScrollToFirstRow = YES;
     }
     
     return self;

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -178,8 +178,12 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     NSParameterAssert(self.mainViewController);
     NSParameterAssert(self.sidebarViewController);
 
+    [self.mainViewController willMoveToParentViewController:self];
+    [self.sidebarViewController willMoveToParentViewController:self];
     [self addChildViewController:self.mainViewController];
     [self addChildViewController:self.sidebarViewController];
+    [self.mainViewController didMoveToParentViewController:self];
+    [self.sidebarViewController didMoveToParentViewController:self];
 }
 
 - (void)attachMainView
@@ -187,7 +191,6 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     NSParameterAssert(self.mainView);
 
     [self.view addSubview:self.mainView];
-    [self.mainViewController didMoveToParentViewController:self];
 }
 
 - (void)attachSidebarView
@@ -203,7 +206,6 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     sidebarView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleRightMargin;
 
     [self.view insertSubview:sidebarView atIndex:0];
-    [self.sidebarViewController didMoveToParentViewController:self];
 }
 
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -187,6 +187,7 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     NSParameterAssert(self.mainView);
 
     [self.view addSubview:self.mainView];
+    [self.mainViewController didMoveToParentViewController:self];
 }
 
 - (void)attachSidebarView
@@ -202,6 +203,7 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     sidebarView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleRightMargin;
 
     [self.view insertSubview:sidebarView atIndex:0];
+    [self.sidebarViewController didMoveToParentViewController:self];
 }
 
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -204,6 +204,12 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     [self.view insertSubview:sidebarView atIndex:0];
 }
 
+- (void)encodeRestorableStateWithCoder:(NSCoder *)coder
+{
+    [super encodeRestorableStateWithCoder:coder];
+    [coder encodeObject:self.mainViewController forKey:@"MainControllerEncodeKey"];
+    [coder encodeObject:self.sidebarViewController forKey:@"SideControllerEncodeKey"];
+}
 
 #pragma mark - Notifications
 

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -19,3 +19,64 @@ extension SPAppDelegate {
         return name
     }
 }
+
+@objc
+extension SPAppDelegate: UIViewControllerRestoration {
+    static let tagsListIdentifier = SPTagsListViewController.classNameWithoutNamespaces
+    static let noteListIdentifier = SPNoteListViewController.classNameWithoutNamespaces
+    static let noteEditorIdentifier = SPNoteEditorViewController.classNameWithoutNamespaces
+    static let sidebarIdentifier = SPSidebarContainerViewController.classNameWithoutNamespaces
+    static let navControllerIdentifier = SPNavigationController.classNameWithoutNamespaces
+
+    @objc
+    func configureStateRestoration() {
+        tagListViewController.restorationIdentifier = SPAppDelegate.tagsListIdentifier
+        tagListViewController.restorationClass = SPAppDelegate.self
+
+        noteListViewController.restorationIdentifier = SPAppDelegate.noteListIdentifier
+        noteListViewController.restorationClass = SPAppDelegate.self
+
+        noteEditorViewController.restorationIdentifier = SPAppDelegate.noteEditorIdentifier
+        noteEditorViewController.restorationClass = SPAppDelegate.self
+
+        navigationController.restorationIdentifier = SPAppDelegate.navControllerIdentifier
+        navigationController.restorationClass = SPAppDelegate.self
+
+        sidebarViewController.restorationIdentifier = SPAppDelegate.sidebarIdentifier
+        sidebarViewController.restorationClass = SPAppDelegate.self
+    }
+
+    @objc
+    public static func viewController(withRestorationIdentifierPath identifierComponents: [String], coder: NSCoder) -> UIViewController? {
+
+        guard
+            let appDelegate = UIApplication.shared.delegate as? SPAppDelegate,
+            let component = identifierComponents.last
+        else {
+            return nil
+        }
+
+        if component == tagsListIdentifier {
+            return appDelegate.tagListViewController
+        }
+
+        if component == noteListIdentifier {
+            return appDelegate.noteListViewController
+        }
+
+        if component == noteEditorIdentifier {
+            return appDelegate.noteEditorViewController
+        }
+
+        if component == navControllerIdentifier {
+            return appDelegate.navigationController
+        }
+
+        if component == sidebarIdentifier {
+            return appDelegate.sidebarViewController
+        }
+
+        return nil
+    }
+
+}

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -6,6 +6,7 @@
 @class SPTagsListViewController;
 @class SPNoteListViewController;
 @class SPNoteEditorViewController;
+@class SPNavigationController;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) SPTagsListViewController                  *tagListViewController;
 @property (strong, nonatomic) SPNoteListViewController                  *noteListViewController;
 @property (strong, nonatomic) SPNoteEditorViewController                *noteEditorViewController;
+@property (strong, nonatomic) SPNavigationController                    *navigationController;
 
 @property (nullable, strong, nonatomic) NSString                        *selectedTag;
 @property (assign, nonatomic) BOOL										bSigningUserOut;

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -44,7 +44,6 @@
 
 @interface SPAppDelegate () <SimperiumDelegate, SPBucketDelegate, PinLockDelegate>
 
-@property (strong, nonatomic) SPNavigationController        *navigationController;
 @property (strong, nonatomic) Simperium                     *simperium;
 @property (strong, nonatomic) NSManagedObjectContext        *managedObjectContext;
 @property (strong, nonatomic) NSManagedObjectModel          *managedObjectModel;
@@ -194,8 +193,7 @@
 #pragma mark ================================================================================
 #pragma mark AppDelegate Methods
 #pragma mark ================================================================================
-
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey,id> *)launchOptions
 {
     // Migrate keychain items
     KeychainMigrator *keychainMigrator = [[KeychainMigrator alloc] init];
@@ -203,13 +201,19 @@
 //    [keychainMigrator testMigration];
     [keychainMigrator migrateIfNecessary];
 
-	// Setup Frameworks
+    // Setup Frameworks
     [self setupThemeNotifications];
     [self setupSimperium];
-	[self setupAppCenter];
+    [self setupAppCenter];
     [self setupCrashLogging];
     [self setupDefaultWindow];
+    [self configureStateRestoration];
 
+    return YES;
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
 	// Once the UI is wired, Auth Simperium
 	[self authenticateSimperium];
 
@@ -306,6 +310,15 @@
     [self.noteEditorViewController save];
 }
 
+- (BOOL)application:(UIApplication *)application shouldSaveApplicationState:(NSCoder *)coder
+{
+    return YES;
+}
+
+- (BOOL)application:(UIApplication *)application shouldRestoreApplicationState:(NSCoder *)coder
+{
+    return YES;
+}
 
 #pragma mark Background Fetch
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -310,12 +310,24 @@
     [self.noteEditorViewController save];
 }
 
+// Deprecated in iOS 13.2. Per the docs, this method will not be called in favor of the new secure version when both are defined.
 - (BOOL)application:(UIApplication *)application shouldSaveApplicationState:(NSCoder *)coder
 {
     return YES;
 }
 
+- (BOOL)application:(UIApplication *)application shouldSaveSecureApplicationState:(NSCoder *)coder
+{
+    return YES;
+}
+
+// Deprecated in iOS 13.2. Per the docs, this method will not be called in favor of the new secure version when both are defined.
 - (BOOL)application:(UIApplication *)application shouldRestoreApplicationState:(NSCoder *)coder
+{
+    return YES;
+}
+
+- (BOOL)application:(UIApplication *)application shouldRestoreSecureApplicationState:(NSCoder *)coder
 {
     return YES;
 }


### PR DESCRIPTION
In this PR we attempt to enable state restoration so that if the user was previously viewing a note, they will be returned to that note when relaunching the app. 

###Fix
Fixes #810 

### Test
1. Launch the app and view a note.
2. Background the app to trigger state restoration.
3. In Xcode, stop debugging. 
4. Launch the app again. 
5. Confirm the app restores the note you were previously viewing. 
6. Check the list view UI and make sure it looks good and there are no unexpected new notes.

Repeat the test for iPhone and iPad form factors.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

@jleandroperez here's a fun one for ya :D  (Bear with me a bit, my ObjC is a little rusty!)