### PR TITLE
Tags Normalization

### DIFF
--- a/Simplenote/Classes/NSString+Simplenote.swift
+++ b/Simplenote/Classes/NSString+Simplenote.swift
@@ -19,10 +19,12 @@ extension NSString {
         components(separatedBy: .space).first ?? String(self)
     }
 
-    /// Percent Encodes all of the non alphanumeric characters in the receiver
+    /// Encodes the receiver as a `Tag Hash`
     ///
     @objc
-    var byEncodingNonAlphanumerics: String? {
-        addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+    var byEncodingAsTagHash: String {
+        precomposedStringWithCanonicalMapping
+            .lowercased()
+            .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? self as String
     }
 }

--- a/Simplenote/Classes/NSString+Simplenote.swift
+++ b/Simplenote/Classes/NSString+Simplenote.swift
@@ -33,6 +33,6 @@ extension NSString {
     ///              For that reason we must check on the `encoded` lenght (and not the actual raw string length)
     @objc
     var isValidTagName: Bool {
-        byEncodingAsTagHash.count < SimplenoteConstants.maximumTagLength
+        byEncodingAsTagHash.count <= SimplenoteConstants.maximumTagLength
     }
 }

--- a/Simplenote/Classes/NSString+Simplenote.swift
+++ b/Simplenote/Classes/NSString+Simplenote.swift
@@ -27,4 +27,12 @@ extension NSString {
             .lowercased()
             .addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? self as String
     }
+
+    /// Indicates if the receiver is a valid Tag Name
+    /// - Important: `Tag.name` is used as the entity's `simperiumKey`, and the backend imposes a length.
+    ///              For that reason we must check on the `encoded` lenght (and not the actual raw string length)
+    @objc
+    var isValidTagName: Bool {
+        byEncodingAsTagHash.count < SimplenoteConstants.maximumTagLength
+    }
 }

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -55,6 +55,11 @@
     return [self tagForName:tagName] != nil;
 }
 
+// This API performs `Tag` comparison by checking the `encoded tag hash`, in order to
+// normalize / isolate ourselves from potential Unicode-Y issues.
+//
+// Ref. https://github.com/Automattic/simplenote-macos/pull/617
+//
 - (Tag *)tagForName:(NSString *)tagName
 {
     NSString *targetTagHash = tagName.byEncodingAsTagHash;

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -166,8 +166,7 @@
 
     // Finally Insert the new Tag
     SPBucket *tagBucket = [[SPAppDelegate sharedDelegate].simperium bucketForName:@"Tag"];
-    NSString *objectKey = newTagName.precomposedStringWithCanonicalMapping.lowercaseString.byEncodingNonAlphanumerics;
-    Tag *newTag = [tagBucket insertNewObjectForKey:objectKey];
+    Tag *newTag = [tagBucket insertNewObjectForKey:newTagName.byEncodingAsTagHash];
     newTag.index = @(index);
     newTag.name = newTagName;
 

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -57,12 +57,13 @@
 
 - (Tag *)tagForName:(NSString *)tagName
 {
+    NSString *targetTagHash = tagName.byEncodingAsTagHash;
     for (Tag *tag in self.tags) {
-        if ([tag.name compare:tagName options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+        if ([tag.name.byEncodingAsTagHash isEqualToString:targetTagHash]) {
             return tag;
         }
     }
-    
+
     return nil;
 }
 

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -325,7 +325,10 @@
     NSString *filteredString = [string substringUpToFirstSpace];
     NSString *updatedString = [textField.text stringByReplacingCharactersInRange:range withString:filteredString];
 
-    if (updatedString.length <= SimplenoteConstants.maximumTagLength) {
+    // Important:
+    // `Tag.name` is used as the entity's `simperiumKey`, and the backend imposes a length.
+    // For that reason we must check on the `encoded` lenght (and not the actual raw string length)
+    if (updatedString.byEncodingAsTagHash.length <= SimplenoteConstants.maximumTagLength) {
         textField.text = updatedString;
     }
 

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -325,10 +325,7 @@
     NSString *filteredString = [string substringUpToFirstSpace];
     NSString *updatedString = [textField.text stringByReplacingCharactersInRange:range withString:filteredString];
 
-    // Important:
-    // `Tag.name` is used as the entity's `simperiumKey`, and the backend imposes a length.
-    // For that reason we must check on the `encoded` lenght (and not the actual raw string length)
-    if (updatedString.byEncodingAsTagHash.length <= SimplenoteConstants.maximumTagLength) {
+    if (updatedString.isValidTagName) {
         textField.text = updatedString;
     }
 

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -601,10 +601,7 @@ static const NSInteger SPTagListEmptyStateSectionCount  = 1;
     NSString *updatedString = [textField.text stringByReplacingCharactersInRange:range withString:filteredString];
     BOOL editContainsSpaces = filteredString.length < string.length;
 
-    // Important:
-    // `Tag.name` is used as the entity's `simperiumKey`, and the backend imposes a length.
-    // For that reason we must check on the `encoded` lenght (and not the actual raw string length)
-    if (updatedString.byEncodingAsTagHash.length <= SimplenoteConstants.maximumTagLength) {
+    if (updatedString.isValidTagName) {
         textField.text = updatedString;
     }
 

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -601,7 +601,10 @@ static const NSInteger SPTagListEmptyStateSectionCount  = 1;
     NSString *updatedString = [textField.text stringByReplacingCharactersInRange:range withString:filteredString];
     BOOL editContainsSpaces = filteredString.length < string.length;
 
-    if (updatedString.length <= SimplenoteConstants.maximumTagLength) {
+    // Important:
+    // `Tag.name` is used as the entity's `simperiumKey`, and the backend imposes a length.
+    // For that reason we must check on the `encoded` lenght (and not the actual raw string length)
+    if (updatedString.byEncodingAsTagHash.length <= SimplenoteConstants.maximumTagLength) {
         textField.text = updatedString;
     }
 

--- a/Simplenote/Classes/SimplenoteConstants.swift
+++ b/Simplenote/Classes/SimplenoteConstants.swift
@@ -12,5 +12,5 @@ class SimplenoteConstants: NSObject {
 
     /// Tag(s) Max Length
     ///
-    static let maximumTagLength = 5
+    static let maximumTagLength = 256
 }

--- a/Simplenote/Classes/SimplenoteConstants.swift
+++ b/Simplenote/Classes/SimplenoteConstants.swift
@@ -12,5 +12,5 @@ class SimplenoteConstants: NSObject {
 
     /// Tag(s) Max Length
     ///
-    static let maximumTagLength = 256
+    static let maximumTagLength = 5
 }

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -21,14 +21,39 @@ class NSStringSimplenoteTests: XCTestCase {
         XCTAssertEqual(sample.substringUpToFirstSpace, textBeforeSpace)
     }
 
-    /// Verifies that `byEncodingNonAlphanumerics` effectively escapes all of the non alphanumeric characters
+    /// Verifies that `byEncodingAsTagHash` effectively escapes all of the non alphanumeric characters
     ///
-    func testByEncodingNonAlphanumericsPercentEncodesAllOfTheNonAlphanumericCharactersInTheReceiver() {
+    func testByEncodingAsTagHashEncodesAllOfTheNonAlphanumericCharactersInTheReceiver() {
         let sample = "1234567890!@#$%^&*()-_+[]';./,qwertyuiopasdfghjkl;'zxcvbnm,./🔥😂😃🤪👍🦆🏴‍☠️☝️😯"
-        let escaped = sample.byEncodingNonAlphanumerics ?? ""
-        let escapedSet = CharacterSet(charactersIn: escaped)
+        let encoded = sample.byEncodingAsTagHash
+        let escapedSet = CharacterSet(charactersIn: encoded)
         let expectedSet = CharacterSet(charactersIn: "%").union(.alphanumerics)
 
         XCTAssertTrue(expectedSet.isSuperset(of: escapedSet))
+    }
+
+    /// Verifies that `byEncodingAsTagHash` allows us to properly compare Unicode Strings that would otherwise evaluate as not equal.
+    /// Although our (three) sample strings yield the exact same character`ṩ`, regular `isEqualString` API returns `false`.
+    ///
+    /// By relying on `byEncodingAsTagHash` we can properly identify matching strings.
+    ///
+    /// - Note: When using the `Swift.String` class, the same comparison is actually correct.
+    ///
+    func testByEncodingTagAsHashAllowsUsToProperlyCompareStringsThatEvaluateAsNotEqualOtherwise() {
+        let sampleA = NSString(stringLiteral: "\u{0073}\u{0323}\u{0307}")
+        let sampleB = NSString(stringLiteral: "\u{0073}\u{0307}\u{0323}")
+        let sampleC = NSString(stringLiteral: "\u{1E69}")
+
+        let hashA = sampleA.byEncodingAsTagHash
+        let hashB = sampleB.byEncodingAsTagHash
+        let hashC = sampleC.byEncodingAsTagHash
+
+        XCTAssertNotEqual(sampleA, sampleB)
+        XCTAssertNotEqual(sampleA, sampleC)
+        XCTAssertNotEqual(sampleB, sampleC)
+
+        XCTAssertEqual(hashA, hashB)
+        XCTAssertEqual(hashA, hashC)
+        XCTAssertEqual(hashB, hashC)
     }
 }


### PR DESCRIPTION
## Details:
In this PR we're bringing over several enhancements introduced [in this macOS Issue](https://github.com/Automattic/simplenote-macos/pull/617)

- Encapsulates **Tag Hash** generation in a NSString extension
- Encapsulates **Tag Name** validation in a (new) NSString extension
- Updates Tag Lookup mechanism, so that comparison is based on Hash rather than on Strings. [Details here!](https://github.com/Automattic/simplenote-ios/pull/828/files#diff-502ce6a4227df26c1d3c682811133e70R42)

@aerych Sir!! since you've validated the first part, mind taking a quick peek? (nothing big should have changed!!)
**Thank you!!**

/cc @dmsnell **NOW** we're talkin'! 😃 

Ref. #824

## Scenario: Note Editor
1. Checkout commit cd4f251
2. Press over the top right button to add a new Note
3. Press over the Tags Editor

- [ ] Verify that new tags can have at most 5 characters (**this is for testing!** actual limit is 256 char).
- [x] Verify that special characters are allowed (parentheses, comma).
- [x] Verify that pressing a space "commits" the text you've typed.

> **IMPORTANT:** Length is enforced against **encoded** tag name. Using non alphanumeric characters will yield a much lower limit!

## Scenario: Tags Editor
1. Checkout commit cd4f251
2. Press over the top left button to reveal the Tags Editor
3. Long press over any tag

- [x] Verify that pressing **Delete** effectively removes the new Tag.
- [x] Verify that pressing Rename allows you to edit the Tag Name (**up to 5 characters**, for testing purposes!).
- [x] Verify that during a rename OP pressing spacebar "Commits" the edit.

> **IMPORTANT:** Length is enforced against **encoded** tag name. Using non alphanumeric characters will yield a much lower limit!

## Release
These changes do not require release notes.
