### PR TITLE
Update and organize the testing checklist

### DIFF
--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -1,57 +1,66 @@
 ## Testing
 
+### Login
+
 - [ ] Logout
 - [ ] Login with wrong password fails
-- [ ] Login with correct password
+- [ ] Login with correct password succeeds
+
+### Sync
+
 - [ ] Create new note appears in other device
-- [ ] Changes to new note sync to other device
-- [ ] Changes to new note sync from other device (after debounce delay)
-- [ ] New tag immediately syncs to other device
-- [ ] New tag immediately syncs from other device
-- [ ] Removed tag immediately syncs to other device
-- [ ] Removed tag immediately syncs from other device
+- [ ] Changes to new note sync to/from other device
+- [ ] New tag immediately syncs to/from other device
+- [ ] Removed tag immediately syncs to/from other device
 - [ ] Note publishes with link
 - [ ] Note unpublishes
-- [ ] Note publish change syncs from other device (visible with dialog open)
-- [ ] Markdown setting syncs from other device
+- [ ] Note publish change syncs _from_ other device
+- [ ] Markdown setting syncs to/from other device
 - [ ] Preview mode disappears/reappears when receiving remote changes to markdown setting
-- [ ] Note pinning syncs immediately from either direction
+- [ ] Note pinning syncs immediately to/from other device
 - [ ] Note pinning works regardless if selecting in list view or from note info
-- [ ] Viewing history on one device leaves note unchanged on other device
 - [ ] Restoring history immediately syncs note from both directions
-- [ ] Can view trashed notes by selecting Trash
-- [ ] Can delete note forever from trash screen
-- [ ] Can restore note from trash screen
-- [ ] Can trash note
+- [ ] After disabling network connectivity and making changes, selecting Log Out triggers an `Unsynced Notes Detected` alert
+- [ ] After going back online, changes sync
+
+### Note editor
+
 - [ ] Can preview markdown by swiping
-- [ ] Can flip to edit mode by swiping
-- [ ] Markdown syntax unrendered in note list when markdown disabled
+- [ ] Can flip to edit mode (from markdown preview) by swiping
+- [ ] Using the Insert checklist item from the format menu inserts a checklist
+- [ ] "Undo" undoes the last edit
+- [ ] Typing `- [x]` creates a checked checklist item
+- [ ] Typing `- [ ]` created an unchecked checklist item
+- [ ] Typing `-`, `+`, or `*` creates a list
+- [ ] All list bullet types render to markdown lists
+- [ ] Added URL is linkified
+- [ ] Long-tapping on link opens the link in new window (regular tap in preview)
+
+### Tags & search
+
 - [ ] Can filter by tag when clicking on tag in tag drawer
-- [ ] Can add tag to note and have it appear in filtered tag view when previously not in filter
 - [ ] Searching in the search field highlights matches in note list
 - [ ] Searching in the search field highlights matches in the note editor
 - [ ] Clearing the search field immediately updates filtered notes
 - [ ] Clicking on different tags or All Notes or Trash immediately updates filtered notes
-- [ ] Can search by keyword, filtering debounced
+- [ ] Can search by keyword
 - [ ] Tag auto-completes appear when typing in search field
-- [ ] Typing tag: and something else, like tag:te results in autocomplete results starting with that something else, e.g. test
+- [ ] Typing `tag:` and something else, like `tag:te` results in autocomplete tag results including that something else, e.g. `test`
 - [ ] Tag suggestions suggest tags regardless of case
-- [ ] Search field updates with results of tag:test format search string
-- [ ] Can toggle sidebar
-- [ ] Syncs when introducing sequential surrogate pairs sharing the same high surrogate, e.g. 🅰🅱 to 🅰🅰🅱
-- [ ] After disabling network connectivity and making changes, selecting Log Out triggers an "Unsynced Notes Detected" alert
-- [ ] When going back online, changes sync
+- [ ] Search field updates with results of `tag:test` format search string
+
+### Trash
+
+- [ ] Can view trashed notes by selecting `Trash`
+- [ ] Can delete note forever from trash screen
+- [ ] Can restore note from trash screen
+- [ ] Can trash note
+
+### Settings
+
 - [ ] Can change analytics sharing setting
-- [ ] Changing Condensed Note List mode immediately updates and reflects in note list
+- [ ] Changing `Condensed Note List` mode immediately updates and reflects in note list
 - [ ] For each sort type the pinned notes appear first in the note list
-- [ ] Changing Theme immediately updates app for desired color scheme
-- [ ] Using the Insert checklist item from the format menu inserts a checklist
-- [ ] "Undo" undoes the last edit
-- [ ] Typing - [x] creates a checked checklist item
-- [ ] Typing - [ ] created an unchecked checklist item
-- [ ] Typing - creates a list
-- [ ] Changing - to + changes the list item bullet, also for * and • (u2022)
-- [ ] All list bullet types render to markdown lists center dot doesn't render as list
-- [ ] Added URL is linkified
-- [ ] When long-tapping on link it opens in new window (regular tap in preview)
-- [ ] Can print note in plaintext view
+- [ ] Changing `Theme` immediately updates app for desired color scheme
+- [ ] After setting a passcode, passcode (or Touch/Face ID if also enabled) is required to resume the app
+- [ ] Can turn passcode lock off with correct 4-digit passcode (also disables Touch/Face ID)


### PR DESCRIPTION
### Fix

These changes should make the testing checklist a little more readable and focused:

* Organize the tests into general areas of the app
* Combine some tests (e.g. under sync, tests that sync "to/from" another device instead of two tests)
* Remove tests that aren't relevant or critical on iOS
* Add a couple tests for passcode lock

Tests removed (listing them here since the other changes make hard to easily identify them in the diff):

* Viewing history on one device leaves note unchanged on other device
* Markdown syntax unrendered in note list when markdown disabled
* Can toggle sidebar
* Syncs when introducing sequential surrogate pairs sharing the same high surrogate, e.g. 🅰🅱 to 🅰🅰🅱
* Changing - to + changes the list item bullet, also for * and • (u2022)
* Can print note in plaintext view

### Review

Only one reviewer required. @jleandroperez do these changes (especially the items I added/removed) look good to you, in terms of making sure the checklist covers the most important functionality in the app?

### Release

These changes do not require release notes.
