### PR TITLE
New note options view UI

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		46A3C9C217DFA81A002865AE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E29ADD4417848E8500E55842 /* InfoPlist.strings */; };
 		46A3C9C317DFA81A002865AE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E29ADD4D17848E8500E55842 /* Images.xcassets */; };
 		46A3C9C417DFA81A002865AE /* Simplenote-DB5.plist in Resources */ = {isa = PBXBuildFile; fileRef = E2FCA5F21789118A00FC229D /* Simplenote-DB5.plist */; };
+		498297F024E5B186009493EF /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498297EF24E5B186009493EF /* SwitchTableViewCell.swift */; };
+		498297F224E5B232009493EF /* NoteOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498297F124E5B232009493EF /* NoteOptionsViewController.swift */; };
 		74388F4422CFFA30001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
 		74388F4622CFFA8B001C5EC0 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */; };
 		74388F4722CFFAB6001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
@@ -465,6 +467,8 @@
 		467D9C7F1788D47500785EF3 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		46A3C9D717DFA81A002865AE /* Simplenote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Simplenote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		46A3C9DC17DFA866002865AE /* Simplenote-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Simplenote-Info.plist"; sourceTree = "<group>"; };
+		498297EF24E5B186009493EF /* SwitchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwitchTableViewCell.swift; path = Classes/SwitchTableViewCell.swift; sourceTree = "<group>"; };
+		498297F124E5B232009493EF /* NoteOptionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NoteOptionsViewController.swift; path = Classes/NoteOptionsViewController.swift; sourceTree = "<group>"; };
 		593EA1C08A9F76E3833C3E80 /* Pods-SimplenoteTests.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		697B9622931545E466B5E186 /* Pods-Automattic-SimplenoteShare.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		6AE4CF60906DA6D08F64E5B3 /* Pods-Automattic-Simplenote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.release.xcconfig"; sourceTree = "<group>"; };
@@ -1476,6 +1480,7 @@
 				E22BCDF51794F53600A17ED2 /* SPActivityView.h */,
 				E22BCDF61794F53600A17ED2 /* SPActivityView.m */,
 				E22BCE0017960CBC00A17ED2 /* SPButton.h */,
+				498297EF24E5B186009493EF /* SwitchTableViewCell.swift */,
 				E22BCE0117960CBC00A17ED2 /* SPButton.m */,
 				B5DF733F22A54EE800602CE7 /* SPDefaultTableViewCell.swift */,
 				E21F57B717C1244E001F02D3 /* SPEditorTextView.h */,
@@ -1668,6 +1673,7 @@
 				E215C791180B115C00AD36B5 /* SPNavigationController.m */,
 				E28A760D178CBE6D008659DE /* SPNoteEditorViewController.h */,
 				E28A760E178CBE6D008659DE /* SPNoteEditorViewController.m */,
+				498297F124E5B232009493EF /* NoteOptionsViewController.swift */,
 				B552AB8624B8E75E00E5E115 /* SPNoteEditorViewController+Extensions.swift */,
 				E20DED0217AE07340086AB5F /* SPPopoverContainerViewController.h */,
 				E20DED0317AE07340086AB5F /* SPPopoverContainerViewController.m */,
@@ -2306,6 +2312,7 @@
 				B5C9F71E193E75FE00FD2491 /* SPDebugViewController.m in Sources */,
 				B5A6166F2150855300CBE47B /* Preferences.m in Sources */,
 				46A3C98B17DFA81A002865AE /* SPHorizontalPickerViewCell.m in Sources */,
+				498297F024E5B186009493EF /* SwitchTableViewCell.swift in Sources */,
 				46A3C98E17DFA81A002865AE /* SPObjectManager.m in Sources */,
 				B5DF734F22A599D100602CE7 /* SPNotifications.m in Sources */,
 				46A3C98F17DFA81A002865AE /* SPNoteListViewController.m in Sources */,
@@ -2368,6 +2375,7 @@
 				B58039862322D4F90083C916 /* UIView+ImageRepresentation.swift in Sources */,
 				46A3C9AD17DFA81A002865AE /* VSThemeLoader.m in Sources */,
 				B5358C5A2371DFBC007604E0 /* UITextView+Simplenote.swift in Sources */,
+				498297F224E5B232009493EF /* NoteOptionsViewController.swift in Sources */,
 				46A3C9AE17DFA81A002865AE /* SPTextView.m in Sources */,
 				37FD30481FC4CFA2008D0B78 /* KeychainMigrator.swift in Sources */,
 				B584DA36236722D400B2844A /* SPBlurEffectView.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		46A3C9C417DFA81A002865AE /* Simplenote-DB5.plist in Resources */ = {isa = PBXBuildFile; fileRef = E2FCA5F21789118A00FC229D /* Simplenote-DB5.plist */; };
 		498297F024E5B186009493EF /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498297EF24E5B186009493EF /* SwitchTableViewCell.swift */; };
 		498297F224E5B232009493EF /* NoteOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498297F124E5B232009493EF /* NoteOptionsViewController.swift */; };
+		498297F424E7C9BE009493EF /* Value1TableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498297F324E7C9BE009493EF /* Value1TableViewCell.swift */; };
 		74388F4422CFFA30001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
 		74388F4622CFFA8B001C5EC0 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */; };
 		74388F4722CFFAB6001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
@@ -469,6 +470,7 @@
 		46A3C9DC17DFA866002865AE /* Simplenote-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Simplenote-Info.plist"; sourceTree = "<group>"; };
 		498297EF24E5B186009493EF /* SwitchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwitchTableViewCell.swift; path = Classes/SwitchTableViewCell.swift; sourceTree = "<group>"; };
 		498297F124E5B232009493EF /* NoteOptionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NoteOptionsViewController.swift; path = Classes/NoteOptionsViewController.swift; sourceTree = "<group>"; };
+		498297F324E7C9BE009493EF /* Value1TableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Value1TableViewCell.swift; path = Classes/Value1TableViewCell.swift; sourceTree = "<group>"; };
 		593EA1C08A9F76E3833C3E80 /* Pods-SimplenoteTests.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		697B9622931545E466B5E186 /* Pods-Automattic-SimplenoteShare.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		6AE4CF60906DA6D08F64E5B3 /* Pods-Automattic-Simplenote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.release.xcconfig"; sourceTree = "<group>"; };
@@ -1165,6 +1167,7 @@
 		B546BE9A234E758E00A126DA /* TableViewCells */ = {
 			isa = PBXGroup;
 			children = (
+				498297F324E7C9BE009493EF /* Value1TableViewCell.swift */,
 				E22A17C817A2D5AD00383575 /* SPTagListViewCell.h */,
 				E22A17C917A2D5AD00383575 /* SPTagListViewCell.m */,
 				B546BE96234E64F200A126DA /* SPTagListViewCell.xib */,
@@ -2216,6 +2219,7 @@
 				B513FB2622EF6A7400B178AC /* VSTheme+Keys.swift in Sources */,
 				B5DF734022A54EE800602CE7 /* SPDefaultTableViewCell.swift in Sources */,
 				B5476BB223D88F49000E7723 /* SPTagTableViewCell.swift in Sources */,
+				498297F424E7C9BE009493EF /* Value1TableViewCell.swift in Sources */,
 				B52AC186233587F8007B2E75 /* UITraitCollection+Simplenote.swift in Sources */,
 				B56A696922F9D57200B90398 /* NSMutableAttributedString+Simplenote.swift in Sources */,
 				B535F2E72399BFB600C1DDCA /* SPRatingsPromptView.swift in Sources */,

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -139,6 +139,7 @@ class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.text = NSLocalizedString("Copy Link", comment: "Note Options: Copy Link")
                     cell.textLabel?.textColor = .simplenoteGray20Color
                     cell.accessibilityHint = NSLocalizedString("Tap to copy link", comment: "Accessibility hint on cell that copies public URL of note")
+                    cell.isUserInteractionEnabled = false
                 },
                 handler: { [weak self] in
                     self?.handleCopyLink()

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -1,11 +1,3 @@
-//
-//  NoteOptionsViewController.swift
-//  Simplenote
-//
-//  Created by Matthew Cheetham on 11/08/2020.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
-
 import UIKit
 
 /// A class used to display options for the note that is currently being edited

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -126,7 +126,7 @@ class NoteOptionsViewController: UITableViewController {
             var cellType: UITableViewCell.Type {
                 switch self {
                 case .Value1:
-                    return UITableViewCell.self
+                    return Value1TableViewCell.self
                 case .Switch:
                     return SwitchTableViewCell.self
                 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -26,7 +26,7 @@ class NoteOptionsViewController: UITableViewController {
     }
 
     //MARKL - View Setup
-    /// Configures a dismiss 
+    /// Configures a dismiss button for the navigation bar
     func setupDoneButton() {
         let doneButton = UIBarButtonItem(title: NSLocalizedString("Done", comment: "Note options: Done"),
                                          style: .done,
@@ -35,6 +35,7 @@ class NoteOptionsViewController: UITableViewController {
         navigationItem.rightBarButtonItem = doneButton
     }
 
+    /// Applies Simplenote styling to the view controller
     func setupViewStyles() {
         tableView.backgroundColor = .simplenoteTableViewBackgroundColor
         tableView.separatorColor = .simplenoteDividerColor

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -25,7 +25,7 @@ class NoteOptionsViewController: UITableViewController {
         registerTableCells()
     }
 
-    //MARKL - View Setup
+    // MARK: - View Setup
     /// Configures a dismiss button for the navigation bar
     func setupDoneButton() {
         let doneButton = UIBarButtonItem(title: NSLocalizedString("Done", comment: "Note options: Done"),

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -184,7 +184,7 @@ class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.text = NSLocalizedString("Move to Trash", comment: "Note Options: Move to Trash")
                     cell.textLabel?.textColor = .simplenoteDestructiveActionColor
                     cell.accessibilityHint = NSLocalizedString("Tap to move this note to trash", comment: "Accessibility hint on cell that moves a note to trash")
-            },
+                },
                 handler: { [weak self] in
                     self?.handleMoveToTrash()
                 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -32,6 +32,7 @@ class NoteOptionsViewController: UITableViewController {
                                          style: .done,
                                          target: self,
                                          action: #selector(handleDone(button:)))
+        doneButton.accessibilityHint = NSLocalizedString("Dismisses the note options view", comment: "Accessibility hint for dismissing the note options view")
         navigationItem.rightBarButtonItem = doneButton
     }
 
@@ -94,6 +95,7 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! SwitchTableViewCell
                     cell.textLabel?.text = NSLocalizedString("Pin to Top", comment: "Note Options: Pin to Top")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handlePinToTop(sender:)), for: .primaryActionTriggered)
+                    cell.cellSwitch.accessibilityHint = NSLocalizedString("Tap to toggle pin to top", comment: "Accessibility hint for toggling pin to top")
                 }
             ),
             Row(style: .Switch,
@@ -101,12 +103,14 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! SwitchTableViewCell
                     cell.textLabel?.text = NSLocalizedString("Markdown", comment: "Note Options: Toggle Markdown")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handleMarkdown(sender:)), for: .primaryActionTriggered)
+                    cell.cellSwitch.accessibilityHint = NSLocalizedString("Tap to toggle markdown mode", comment: "Accessibility hint for toggling markdown mode")
                 }
             ),
             Row(style: .Value1,
                 configuration: { (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Share", comment: "Note Options: Show Share Options")
+                    cell.accessibilityHint = NSLocalizedString("Tap to open share options", comment: "Accessibility hint on cell that activates share sheet")
                 },
                 handler: { [weak self] in
                     self?.handleShare()
@@ -116,6 +120,7 @@ class NoteOptionsViewController: UITableViewController {
                 configuration: { (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("History", comment: "Note Options: Show History")
+                    cell.accessibilityHint = NSLocalizedString("Tap to open history", comment: "Accessibility hint on cell that opens note history view")
                 },
                 handler: { [weak self] in
                     self?.handleHistory()
@@ -133,6 +138,7 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! SwitchTableViewCell
                     cell.textLabel?.text = NSLocalizedString("Publish", comment: "Note Options: Publish")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handlePublish(sender:)), for: .primaryActionTriggered)
+                    cell.cellSwitch.accessibilityHint = NSLocalizedString("Tap to toggle publish state", comment: "Accessibility hint on switch that toggles publish state")
                 }
             ),
             Row(style: .Value1,
@@ -140,6 +146,7 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Copy Link", comment: "Note Options: Copy Link")
                     cell.textLabel?.textColor = .simplenoteGray20Color
+                    cell.accessibilityHint = NSLocalizedString("Tap to copy link", comment: "Accessibility hint on cell that copies public URL of note")
                 },
                 handler: { [weak self] in
                     self?.handleCopyLink()
@@ -158,6 +165,7 @@ class NoteOptionsViewController: UITableViewController {
                 configuration: { (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Collaborate", comment: "Note Options: Collaborate")
+                    cell.accessibilityLabel = NSLocalizedString("Tap to open collaboration menu", comment: "Accessibility hint on cell that opens collaboration menu")
                 },
                 handler: { [weak self] in
                     self?.handleCollaborate()
@@ -175,6 +183,7 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Move to Trash", comment: "Note Options: Move to Trash")
                     cell.textLabel?.textColor = .simplenoteDestructiveActionColor
+                    cell.accessibilityHint = NSLocalizedString("Tap to move this note to trash", comment: "Accessibility hint on cell that moves a note to trash")
             },
                 handler: { [weak self] in
                     self?.handleMoveToTrash()

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -19,7 +19,25 @@ class NoteOptionsViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        title = NSLocalizedString("Options", comment: "Note Options: Title")
+        setupDoneButton()
+        setupViewStyles()
         registerTableCells()
+    }
+
+    //MARKL - View Setup
+    /// Configures a dismiss 
+    func setupDoneButton() {
+        let doneButton = UIBarButtonItem(title: NSLocalizedString("Done", comment: "Note options: Done"),
+                                         style: .done,
+                                         target: self,
+                                         action: #selector(handleDone(button:)))
+        navigationItem.rightBarButtonItem = doneButton
+    }
+
+    func setupViewStyles() {
+        tableView.backgroundColor = .simplenoteTableViewBackgroundColor
+        tableView.separatorColor = .simplenoteDividerColor
     }
 
     // MARK: - Table helpers
@@ -251,5 +269,11 @@ class NoteOptionsViewController: UITableViewController {
 
     func handleMoveToTrash() {
         ///Handle move to tash logic here
+    }
+
+    // MARK: - Navigation button handling
+    @objc
+    func handleDone(button: UIBarButtonItem) {
+        dismiss(animated: true)
     }
 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -14,7 +14,7 @@ class NoteOptionsViewController: UITableViewController {
     /// Array of `Section`s to display in the view.
     /// Each `Section` has `Rows` that are used for display
     fileprivate var sections: [Section] {
-        return [optionsSection]
+        return [optionsSection, linkSection, collaborationSection, trashSection]
     }
 
     override func viewDidLoad() {
@@ -72,12 +72,95 @@ class NoteOptionsViewController: UITableViewController {
         let rows = [
             Row(style: .Switch,
                 configuration: { [weak self] (cell: UITableViewCell, row: Row) in
-                    guard let cell = cell as? SwitchTableViewCell else {
-                        return
-                    }
+                    let cell = cell as! SwitchTableViewCell
                     cell.textLabel?.text = NSLocalizedString("Pin to Top", comment: "Note Options: Pin to Top")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handlePinToTop(sender:)), for: .primaryActionTriggered)
-                })
+                }
+            ),
+            Row(style: .Switch,
+                configuration: { [weak self] (cell: UITableViewCell, row: Row) in
+                    let cell = cell as! SwitchTableViewCell
+                    cell.textLabel?.text = NSLocalizedString("Markdown", comment: "Note Options: Toggle Markdown")
+                    cell.cellSwitch.addTarget(self, action: #selector(self?.handleMarkdown(sender:)), for: .primaryActionTriggered)
+                }
+            ),
+            Row(style: .Value1,
+                configuration: { (cell: UITableViewCell, row: Row) in
+                    let cell = cell as! Value1TableViewCell
+                    cell.textLabel?.text = NSLocalizedString("Share", comment: "Note Options: Show Share Options")
+                },
+                handler: { [weak self] in
+                    self?.handleShare()
+                }
+            ),
+            Row(style: .Value1,
+                configuration: { (cell: UITableViewCell, row: Row) in
+                    let cell = cell as! Value1TableViewCell
+                    cell.textLabel?.text = NSLocalizedString("History", comment: "Note Options: Show History")
+                },
+                handler: { [weak self] in
+                    self?.handleHistory()
+                }
+            )
+        ]
+        return Section(rows: rows)
+    }
+
+    /// Configures a section to display our link options in
+    fileprivate var linkSection: Section {
+        let rows = [
+            Row(style: .Switch,
+                configuration: { [weak self] (cell: UITableViewCell, row: Row) in
+                    let cell = cell as! SwitchTableViewCell
+                    cell.textLabel?.text = NSLocalizedString("Publish", comment: "Note Options: Publish")
+                    cell.cellSwitch.addTarget(self, action: #selector(self?.handlePublish(sender:)), for: .primaryActionTriggered)
+                }
+            ),
+            Row(style: .Value1,
+                configuration: { (cell: UITableViewCell, row: Row) in
+                    let cell = cell as! Value1TableViewCell
+                    cell.textLabel?.text = NSLocalizedString("Copy Link", comment: "Note Options: Copy Link")
+                    cell.textLabel?.textColor = .simplenoteGray20Color
+                },
+                handler: { [weak self] in
+                    self?.handleCopyLink()
+                }
+            )
+        ]
+        return Section(headerText: NSLocalizedString("Public Link", comment: "Note Options Header: Public Link"),
+                       footerText: NSLocalizedString("Publish your note to the web and generate a shareable URL", comment: "Note Options Footer: Publish your note to generate a URL"),
+                       rows: rows)
+    }
+
+    /// Configures a section to display our collaboration details
+    fileprivate var collaborationSection: Section {
+        let rows = [
+            Row(style: .Value1,
+                configuration: { (cell: UITableViewCell, row: Row) in
+                    let cell = cell as! Value1TableViewCell
+                    cell.textLabel?.text = NSLocalizedString("Collaborate", comment: "Note Options: Collaborate")
+                },
+                handler: { [weak self] in
+                    self?.handleCollaborate()
+                }
+            )
+        ]
+        return Section(rows: rows)
+    }
+
+    /// Configures a section to display our trash options
+    fileprivate var trashSection: Section {
+        let rows = [
+            Row(style: .Value1,
+                configuration: { (cell: UITableViewCell, row: Row) in
+                    let cell = cell as! Value1TableViewCell
+                    cell.textLabel?.text = NSLocalizedString("Move to Trash", comment: "Note Options: Move to Trash")
+                    cell.textLabel?.textColor = .simplenoteDestructiveActionColor
+            },
+                handler: { [weak self] in
+                    self?.handleMoveToTrash()
+                }
+            )
         ]
         return Section(rows: rows)
     }
@@ -106,7 +189,7 @@ class NoteOptionsViewController: UITableViewController {
         /// Determines what cell is used to render this row
         let style: Style
 
-        /// Called to set up this cell. You should do any view configuration here and assign tagets to elements such as switches.
+        /// Called to set up this cell. You should do any view configuration here and assign targets to elements such as switches.
         let configuration: ((UITableViewCell, Row) -> Void)?
 
         /// Called when this row is tapped. Optional.
@@ -135,7 +218,38 @@ class NoteOptionsViewController: UITableViewController {
     }
 
     // MARK: - Row Action Handling
-    @objc func handlePinToTop(sender: UISwitch) {
+    @objc
+    func handlePinToTop(sender: UISwitch) {
         ///Handle pinning logic here
+    }
+
+    @objc
+    func handleMarkdown(sender: UISwitch) {
+        ///Handle markdown logic here
+    }
+
+    func handleShare() {
+        ///Handle share logic here
+    }
+
+    func handleHistory() {
+        ///Handle history logic here
+    }
+
+    @objc
+    func handlePublish(sender: UISwitch) {
+        ///Handle publish logic here
+    }
+
+    func handleCopyLink() {
+        ///Handle copy link logic here
+    }
+
+    func handleCollaborate() {
+        ///Handle collaboration logic here
+    }
+
+    func handleMoveToTrash() {
+        ///Handle move to tash logic here
     }
 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -1,0 +1,126 @@
+//
+//  NoteOptionsViewController.swift
+//  Simplenote
+//
+//  Created by Matthew Cheetham on 11/08/2020.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import UIKit
+
+/// A class used to display options for the note that is currently being edited
+class NoteOptionsViewController: UITableViewController {
+
+    /// Array of `Section`s to display in the view.
+    /// Each `Section` has `Rows` that are used for display
+    fileprivate var sections: [Section] {
+        return [optionsSection]
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        registerTableCells()
+    }
+
+    // MARK: - Table helpers
+    /// Registers cell types that can be displayed by the note options view
+    func registerTableCells() {
+        for rowStyle in Row.Style.allCases {
+            tableView.register(rowStyle.cellType, forCellReuseIdentifier: rowStyle.rawValue)
+        }
+    }
+
+    // MARK: - Table view data source
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = sections[indexPath.section].rows[indexPath.row]
+        let cell = cellFor(row: row, at: indexPath)
+        row.configuration?(cell, row)
+        return cell
+    }
+
+    fileprivate func cellFor(row: Row, at indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.style.rawValue, for: indexPath)
+        return cell
+    }
+
+    // MARK: - Table view delegate
+
+    // MARK: - Table Sections
+    /// Configures a section to display our main options in
+    fileprivate var optionsSection: Section {
+        let rows = [
+            Row(style: .Switch,
+                configuration: { [weak self] (cell: UITableViewCell, row: Row) in
+                    guard let cell = cell as? SwitchTableViewCell else {
+                        return
+                    }
+                    cell.textLabel?.text = NSLocalizedString("Pin to Top", comment: "Note Options: Pin to Top")
+                    cell.cellSwitch.addTarget(self, action: #selector(self?.handlePinToTop(sender:)), for: .primaryActionTriggered)
+                })
+        ]
+        return Section(headerText: "hi", footerText: "hi", rows: rows)
+    }
+
+    // MARK: - Private Nested Classes
+    /// Contains all data required to render a `UITableView` section
+    fileprivate struct Section {
+        /// Optional text to display as standard header text above the `UITableView` section
+        let headerText: String?
+
+        /// Optional text to display as standard footer text below the `UITableView` section
+        let footerText: String?
+
+        /// Any rows to be displayed inside this `UITableView` section
+        let rows: [Row]
+
+        internal init(headerText: String?, footerText: String?, rows: [Row]) {
+            self.headerText = headerText
+            self.footerText = footerText
+            self.rows = rows
+        }
+    }
+
+    /// Contains all the data required to render a row
+    fileprivate struct Row {
+        /// Determines what cell is used to render this row
+        let style: Style
+        /// Called when this row is tapped. Optional.
+        let handler: (() -> Void)?
+        /// Called to set up this cell. You should do any view configuration here and assign tagets to elements such as switches.
+        let configuration: ((UITableViewCell, Row) -> Void)?
+
+        internal init(style: Style = .Value1, handler: (() -> Void)? = nil, configuration: ((UITableViewCell, Row) -> Void)? = nil) {
+            self.style = style
+            self.handler = handler
+            self.configuration = configuration
+        }
+
+        /// Defines a cell identifier that will be used to initialise a cell class
+        enum Style: String, CaseIterable {
+            case Value1 = "Value1CellIdentifier"
+            case Switch = "SwitchCellIdentifier"
+
+            var cellType: UITableViewCell.Type {
+                switch self {
+                case .Value1:
+                    return UITableViewCell.self
+                case .Switch:
+                    return SwitchTableViewCell.self
+                }
+            }
+        }
+    }
+
+    // MARK: - Row Action Handling
+    @objc func handlePinToTop(sender: UISwitch) {
+        ///Handle pinning logic here
+    }
+}

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -51,6 +51,14 @@ class NoteOptionsViewController: UITableViewController {
         return cell
     }
 
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section].headerText
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footerText
+    }
+
     // MARK: - Table view delegate
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let row = sections[indexPath.section].rows[indexPath.row]
@@ -71,7 +79,7 @@ class NoteOptionsViewController: UITableViewController {
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handlePinToTop(sender:)), for: .primaryActionTriggered)
                 })
         ]
-        return Section(headerText: "hi", footerText: "hi", rows: rows)
+        return Section(rows: rows)
     }
 
     // MARK: - Private Nested Classes
@@ -86,7 +94,7 @@ class NoteOptionsViewController: UITableViewController {
         /// Any rows to be displayed inside this `UITableView` section
         let rows: [Row]
 
-        internal init(headerText: String?, footerText: String?, rows: [Row]) {
+        internal init(headerText: String? = nil, footerText: String? = nil, rows: [Row]) {
             self.headerText = headerText
             self.footerText = footerText
             self.rows = rows

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -52,6 +52,11 @@ class NoteOptionsViewController: UITableViewController {
     }
 
     // MARK: - Table view delegate
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let row = sections[indexPath.section].rows[indexPath.row]
+        row.handler?()
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
 
     // MARK: - Table Sections
     /// Configures a section to display our main options in
@@ -92,15 +97,17 @@ class NoteOptionsViewController: UITableViewController {
     fileprivate struct Row {
         /// Determines what cell is used to render this row
         let style: Style
-        /// Called when this row is tapped. Optional.
-        let handler: (() -> Void)?
+
         /// Called to set up this cell. You should do any view configuration here and assign tagets to elements such as switches.
         let configuration: ((UITableViewCell, Row) -> Void)?
 
-        internal init(style: Style = .Value1, handler: (() -> Void)? = nil, configuration: ((UITableViewCell, Row) -> Void)? = nil) {
+        /// Called when this row is tapped. Optional.
+        let handler: (() -> Void)?
+
+        internal init(style: Style = .Value1, configuration: ((UITableViewCell, Row) -> Void)? = nil, handler: (() -> Void)? = nil) {
             self.style = style
-            self.handler = handler
             self.configuration = configuration
+            self.handler = handler
         }
 
         /// Defines a cell identifier that will be used to initialise a cell class

--- a/Simplenote/Classes/SPNavigationController.m
+++ b/Simplenote/Classes/SPNavigationController.m
@@ -69,7 +69,8 @@ static const NSInteger SPNavigationBarBackgroundPositionZ = -1000;
 - (void)refreshBlurTintColor
 {
     // We'll use different Bar Tint Colors, based on the presentation style
-    BOOL isModal = self.modalPresentationStyle == UIModalPresentationFormSheet;
+    BOOL isModal = (self.modalPresentationStyle == UIModalPresentationFormSheet ||
+                    self.modalPresentationStyle == UIModalPresentationPopover);
 
     self.navigationBarBackground.tintColorClosure = ^{
         return isModal ? [UIColor simplenoteNavigationBarModalBackgroundColor] : [UIColor simplenoteNavigationBarBackgroundColor];

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -156,6 +156,9 @@ extension SPNoteEditorViewController {
         let noteView = NoteOptionsViewController(style: .grouped)
         let noteNavigation = SPNavigationController(rootViewController: noteView)
         noteNavigation.displaysBlurEffect = true
+        noteNavigation.modalPresentationStyle = .popover
+        noteNavigation.popoverPresentationController?.sourceRect = view.convert(noteOptionsbutton.frame, from: noteOptionsbutton.superview)
+        noteNavigation.popoverPresentationController?.sourceView = view
         present(noteNavigation, animated: true, completion: nil)
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -144,3 +144,18 @@ extension SPNoteEditorViewController {
         noteEditorTextView.lockTagEditorPosition = locked
     }
 }
+
+// MARK: - Navigation button handling
+//
+extension SPNoteEditorViewController {
+
+    /// Presents the note options view
+    /// - Parameter button: The button that triggered the action
+    @objc
+    func handleNoteOptions(_ button: UIBarButtonItem) {
+        let noteView = NoteOptionsViewController(style: .grouped)
+        let noteNavigation = SPNavigationController(rootViewController: noteView)
+        noteNavigation.displaysBlurEffect = true
+        present(noteNavigation, animated: true, completion: nil)
+    }
+}

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -152,13 +152,13 @@ extension SPNoteEditorViewController {
     /// Presents the note options view
     /// - Parameter button: The button that triggered the action
     @objc
-    func handleNoteOptions(_ button: UIBarButtonItem) {
+    func handleNoteOptions(_ button: UIButton) {
         let noteView = NoteOptionsViewController(style: .grouped)
         let noteNavigation = SPNavigationController(rootViewController: noteView)
         noteNavigation.displaysBlurEffect = true
         noteNavigation.modalPresentationStyle = .popover
-        noteNavigation.popoverPresentationController?.sourceRect = view.convert(noteOptionsbutton.frame, from: noteOptionsbutton.superview)
-        noteNavigation.popoverPresentationController?.sourceView = view
+        noteNavigation.popoverPresentationController?.sourceRect = button.bounds
+        noteNavigation.popoverPresentationController?.sourceView = button
         noteNavigation.popoverPresentationController?.backgroundColor = .simplenoteNavigationBarModalBackgroundColor
         present(noteNavigation, animated: true, completion: nil)
     }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -159,6 +159,7 @@ extension SPNoteEditorViewController {
         noteNavigation.modalPresentationStyle = .popover
         noteNavigation.popoverPresentationController?.sourceRect = view.convert(noteOptionsbutton.frame, from: noteOptionsbutton.superview)
         noteNavigation.popoverPresentationController?.sourceView = view
+        noteNavigation.popoverPresentationController?.backgroundColor = .simplenoteNavigationBarModalBackgroundColor
         present(noteNavigation, animated: true, completion: nil)
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -65,6 +65,7 @@
 @property (nonatomic, strong) UIButton *checklistButton;
 @property (nonatomic, strong) UIButton *keyboardButton;
 @property (nonatomic, strong) UIButton *createNoteButton;
+@property (nonatomic, strong) UIButton *noteOptionsbutton;
 
 @property (nonatomic, strong) Note *currentNote;
 @property (nonatomic, strong) SPEditorTextView *noteEditorTextView;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -392,6 +392,13 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     CGFloat previousXOrigin = navigationButtonContainer.frame.size.width + trailingPadding;
     CGFloat buttonWidth = [self.theme floatForKey:@"barButtonWidth"];
     CGFloat buttonHeight = buttonWidth;
+
+    self.noteOptionsbutton.frame = CGRectMake(previousXOrigin - buttonWidth,
+                                              SPBarButtonYOriginAdjustment,
+                                              buttonWidth,
+                                              buttonHeight);
+
+    previousXOrigin = self.noteOptionsbutton.frame.origin.x;
     
     self.keyboardButton.frame = CGRectMake(previousXOrigin - buttonWidth,
                                            SPBarButtonYOriginAdjustment,
@@ -405,12 +412,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     
     previousXOrigin = self.createNoteButton.frame.origin.x;
 
-    self.noteOptionsbutton.frame = CGRectMake(previousXOrigin - buttonWidth,
-                                              SPBarButtonYOriginAdjustment,
-                                              buttonWidth,
-                                              buttonHeight);
-
-    previousXOrigin = self.noteOptionsbutton.frame.origin.x;
     
     self.actionButton.frame = CGRectMake(previousXOrigin - buttonWidth,
                                          SPBarButtonYOriginAdjustment,

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -486,6 +486,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     self.noteOptionsbutton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameEllipsis]
                                                 target:self
                                               selector:@selector(handleNoteOptions:)];
+    self.noteOptionsbutton.accessibilityLabel = NSLocalizedString(@"Options", @"Accessibility label on button that opens note options");
+    self.noteOptionsbutton.accessibilityHint = NSLocalizedString(@"Tap to open note options", @"Accessibility hint on button that opens note options");
     
     self.keyboardButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameHideKeyboard]
                                             target:self

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -404,6 +404,13 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                                              buttonHeight);
     
     previousXOrigin = self.createNoteButton.frame.origin.x;
+
+    self.noteOptionsbutton.frame = CGRectMake(previousXOrigin - buttonWidth,
+                                              SPBarButtonYOriginAdjustment,
+                                              buttonWidth,
+                                              buttonHeight);
+
+    previousXOrigin = self.noteOptionsbutton.frame.origin.x;
     
     self.actionButton.frame = CGRectMake(previousXOrigin - buttonWidth,
                                          SPBarButtonYOriginAdjustment,
@@ -475,6 +482,10 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                                              selector:@selector(newButtonAction:)];
     self.createNoteButton.accessibilityLabel = NSLocalizedString(@"New note", @"Label to create a new note");
     self.createNoteButton.accessibilityHint = NSLocalizedString(@"Create a new note", nil);
+
+    self.noteOptionsbutton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameEllipsis]
+                                                target:self
+                                              selector:@selector(handleNoteOptions:)];
     
     self.keyboardButton = [UIButton buttonWithImage:[UIImage imageWithName:UIImageNameHideKeyboard]
                                             target:self
@@ -485,9 +496,11 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     self.createNoteButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     self.actionButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     self.checklistButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
-    
+    self.noteOptionsbutton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
+
     [navigationButtonContainer addSubview:self.keyboardButton];
     [navigationButtonContainer addSubview:self.createNoteButton];
+    [navigationButtonContainer addSubview:self.noteOptionsbutton];
     [navigationButtonContainer addSubview:self.actionButton];
     [navigationButtonContainer addSubview:self.checklistButton];
     
@@ -963,6 +976,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         self.actionButton.alpha = 1.0;
         self.checklistButton.transform = CGAffineTransformIdentity;
         self.checklistButton.alpha = 1.0;
+        self.noteOptionsbutton.transform = CGAffineTransformIdentity;
+        self.noteOptionsbutton.alpha = 1.0;
         self.keyboardButton.alpha = 1.0;
         self.navigationController.navigationBar.transform = self->navigationBarTransform;
         self.navigationBarBackground.transform = CGAffineTransformIdentity;
@@ -1062,6 +1077,10 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     self.checklistButton.transform = CGAffineTransformConcat(CGAffineTransformMakeScale(scaleAmount, scaleAmount),
                                                      CGAffineTransformMakeTranslation(0, -yTransform / 2.0));
     self.checklistButton.alpha = alphaAmount;
+
+    self.noteOptionsbutton.transform = CGAffineTransformConcat(CGAffineTransformMakeScale(scaleAmount, scaleAmount),
+                                                             CGAffineTransformMakeTranslation(0, -yTransform / 2.0));
+    self.noteOptionsbutton.alpha = alphaAmount;
     
     
     self.navigationController.navigationBar.transform = navigationBarTransform;

--- a/Simplenote/Classes/SwitchTableViewCell.swift
+++ b/Simplenote/Classes/SwitchTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  SwitchTableViewCell.swift
+//  Simplenote
+//
+//  Created by Matthew Cheetham on 13/08/2020.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class SwitchTableViewCell: UITableViewCell {
+
+    var cellSwitch = UISwitch()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        accessoryView = cellSwitch
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/Simplenote/Classes/SwitchTableViewCell.swift
+++ b/Simplenote/Classes/SwitchTableViewCell.swift
@@ -29,5 +29,6 @@ class SwitchTableViewCell: UITableViewCell {
         backgroundColor = .simplenoteTableViewCellBackgroundColor
         selectedBackgroundView?.backgroundColor = .simplenoteLightBlueColor
         textLabel?.textColor = .simplenoteTextColor
+        selectionStyle = .none
     }
 }

--- a/Simplenote/Classes/SwitchTableViewCell.swift
+++ b/Simplenote/Classes/SwitchTableViewCell.swift
@@ -1,11 +1,3 @@
-//
-//  SwitchTableViewCell.swift
-//  Simplenote
-//
-//  Created by Matthew Cheetham on 13/08/2020.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
-
 import UIKit
 
 /// A UITableViewCell with it's `accessoryView` set to a `UISwitch`

--- a/Simplenote/Classes/SwitchTableViewCell.swift
+++ b/Simplenote/Classes/SwitchTableViewCell.swift
@@ -10,6 +10,7 @@ class SwitchTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupSwitch()
+        applyStyles()
     }
 
     required init?(coder: NSCoder) {
@@ -21,5 +22,12 @@ class SwitchTableViewCell: UITableViewCell {
         accessoryView = cellSwitch
         cellSwitch.onTintColor = .simplenoteSwitchOnTintColor
         cellSwitch.tintColor = .simplenoteSwitchTintColor
+    }
+
+    /// Applies custom theming to the cell
+    func applyStyles() {
+        backgroundColor = .simplenoteTableViewCellBackgroundColor
+        selectedBackgroundView?.backgroundColor = .simplenoteLightBlueColor
+        textLabel?.textColor = .simplenoteTextColor
     }
 }

--- a/Simplenote/Classes/SwitchTableViewCell.swift
+++ b/Simplenote/Classes/SwitchTableViewCell.swift
@@ -14,10 +14,16 @@ class SwitchTableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        accessoryView = cellSwitch
+        setupSwitch()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+
+    func setupSwitch() {
+        accessoryView = cellSwitch
+        cellSwitch.onTintColor = .simplenoteSwitchOnTintColor
+        cellSwitch.tintColor = .simplenoteSwitchTintColor
     }
 }

--- a/Simplenote/Classes/SwitchTableViewCell.swift
+++ b/Simplenote/Classes/SwitchTableViewCell.swift
@@ -8,8 +8,11 @@
 
 import UIKit
 
+/// A UITableViewCell with it's `accessoryView` set to a `UISwitch`
+/// Styled for Simplenote
 class SwitchTableViewCell: UITableViewCell {
 
+    /// A switch that is assigned to `accessoryView`
     var cellSwitch = UISwitch()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -21,6 +24,7 @@ class SwitchTableViewCell: UITableViewCell {
         super.init(coder: coder)
     }
 
+    /// Styles `cellSwitch` and adds it to the view
     func setupSwitch() {
         accessoryView = cellSwitch
         cellSwitch.onTintColor = .simplenoteSwitchOnTintColor

--- a/Simplenote/Classes/Value1TableViewCell.swift
+++ b/Simplenote/Classes/Value1TableViewCell.swift
@@ -5,9 +5,18 @@ class Value1TableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+        applyStyles()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+
+    /// Applies custom theming to the cell
+    func applyStyles() {
+        backgroundColor = .simplenoteTableViewCellBackgroundColor
+        selectedBackgroundView?.backgroundColor = .simplenoteLightBlueColor
+        textLabel?.textColor = .simplenoteTextColor
+        detailTextLabel?.textColor = UIColor.color(name: .tableViewDetailTextLabelColor)
     }
 }

--- a/Simplenote/Classes/Value1TableViewCell.swift
+++ b/Simplenote/Classes/Value1TableViewCell.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+/// A standard `UITableViewCell` set to `value1` style
 class Value1TableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/Simplenote/Classes/Value1TableViewCell.swift
+++ b/Simplenote/Classes/Value1TableViewCell.swift
@@ -15,7 +15,9 @@ class Value1TableViewCell: UITableViewCell {
     /// Applies custom theming to the cell
     func applyStyles() {
         backgroundColor = .simplenoteTableViewCellBackgroundColor
-        selectedBackgroundView?.backgroundColor = .simplenoteLightBlueColor
+        let selectedView = UIView(frame: bounds)
+        selectedView.backgroundColor = .simplenoteLightBlueColor
+        selectedBackgroundView = selectedView
         textLabel?.textColor = .simplenoteTextColor
         detailTextLabel?.textColor = UIColor.color(name: .tableViewDetailTextLabelColor)
     }

--- a/Simplenote/Classes/Value1TableViewCell.swift
+++ b/Simplenote/Classes/Value1TableViewCell.swift
@@ -1,11 +1,3 @@
-//
-//  Value1TableViewCell.swift
-//  Simplenote
-//
-//  Created by Matthew Cheetham on 15/08/2020.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
-
 import UIKit
 
 /// A standard `UITableViewCell` set to `value1` style

--- a/Simplenote/Classes/Value1TableViewCell.swift
+++ b/Simplenote/Classes/Value1TableViewCell.swift
@@ -1,0 +1,20 @@
+//
+//  Value1TableViewCell.swift
+//  Simplenote
+//
+//  Created by Matthew Cheetham on 15/08/2020.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class Value1TableViewCell: UITableViewCell {
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}


### PR DESCRIPTION
### Details
Adds a new `NoteOptionsViewController` containing the UI as part of the work for #763. This PR only contains the layout code and placeholder methods for handling interaction with the switches and tapped cells. Logic and behaviour will be in a future pull request. Eventually, this new view will replace the `SPActivityView` that currently serves these actions.

The views added are
1. `NoteOptionsViewController`
2. `SwitchTableViewCell`
3. `Value1TableViewCell`

### Screenshots
![Simulator Screen Shot - iPhone 11 Pro - 2020-08-15 at 12 40 23](https://user-images.githubusercontent.com/68430728/90311821-19d68900-def7-11ea-9c39-fff85bafeddf.png)
![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2020-08-15 at 12 39 57-2](https://user-images.githubusercontent.com/68430728/90311823-1ba04c80-def7-11ea-8ed9-ee653006b8da.png)

### Notes
There are nested classes for `Row` and `Section` which are used to render the view and can be easily moved around in the future with minimal effort (For consistency, I took this approach after looking through similar table views in WordPress and Simplenote).

After discussion with @jleandroperez I decided not to subclass `SPTableViewController` and instead set the few styles manually as there are only a few lines.

### Known Issues
Currently, the ellipsis icon is not compliant with the design, which has a circular border around it. I made attempts to add it programmatically but was having layout issues due to how the `SPOutsideTouchView` logic works. I'd be thankful for advice on how to go about the implementation if we want to avoid including a new asset that includes the circle.

### Test
> 1. Edit a note
> 2. Tap on the ellipsis icon in the top right
> 3. The new view is presented

Please check that this is visually correct on both iPhone and iPad against the supplied mocks in #763.

### Review
Please review the code and design against #763. 

### Release
> These changes do not require release notes.
