### PR TITLE
Fixing Text Selection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 4.23
 -----
- 
+
+4.22.1
+------
+-   Fixed a bug that caused text selection to unexpectedly scroll to the top (or bottom) of the document
+
 4.22
 -----
 -   Fixed several layout issues that affected the Editor

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -94,12 +94,12 @@ extension SPNoteEditorViewController: KeyboardObservable {
     ///
     /// - Note: Floating Keyboard results in `contentInset.bottom = .zero`
     /// - Note: When the keyboard is visible, we'll substract the `safeAreaInsets.bottom`, since the TextView already considers that gap.
+    /// - Note: We're explicitly turning on / off `enableScrollSmoothening`, since it's proven to be a nightmare when UIAutoscroll is involved.
     ///
     private func updateBottomInsets(keyboardFrame: CGRect, duration: TimeInterval, curve: UInt) {
         let newKeyboardHeight       = keyboardFrame.intersection(noteEditorTextView.frame).height
         let newKeyboardFloats       = keyboardFrame.maxY < view.frame.height
         let newKeyboardIsVisible    = newKeyboardHeight != .zero
-
         let animationOptions        = UIView.AnimationOptions(arrayLiteral: .beginFromCurrentState, .init(rawValue: curve))
         let editorBottomInsets      = newKeyboardFloats ? .zero : newKeyboardHeight
         let adjustedBottomInsets    = max(editorBottomInsets - view.safeAreaInsets.bottom, .zero)
@@ -108,10 +108,14 @@ extension SPNoteEditorViewController: KeyboardObservable {
             isKeyboardVisible = newKeyboardIsVisible
         }
 
+        self.noteEditorTextView.enableScrollSmoothening = true
+
         UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: .zero, options: animationOptions, animations: {
             self.noteEditorTextView.contentInset.bottom = adjustedBottomInsets
             self.noteEditorTextView.scrollIndicatorInsets.bottom = adjustedBottomInsets
-        }, completion: nil)
+        }, completion: { _ in
+            self.noteEditorTextView.enableScrollSmoothening = false
+        })
     }
 }
 

--- a/Simplenote/Classes/SPTextView.h
+++ b/Simplenote/Classes/SPTextView.h
@@ -14,7 +14,15 @@
     NSMutableArray *highlightViews;
 }
 
+/// Interactive Storage: Custom formatting over the Header.
+///
 @property (nonatomic, retain, nonnull) SPInteractiveTextStorage *interactiveTextStorage;
+
+/// Indicates if the `setContentOffset:animated` API should apply our custom animation
+/// - Note: We'd want to use this only for Keyboard-Animation matching purposes.
+/// - Important: Apparently the superclass implementation has a special handling when `UIAutoscroll` (private class) is involved.
+///
+@property (nonatomic, assign) BOOL enableScrollSmoothening;
 
 - (void)highlightSubstringsMatching:(NSString * _Nonnull)keywords color:(UIColor * _Nonnull)color;
 - (void)highlightRange:(NSRange)range animated:(BOOL)animated withBlock:(void (^_Nonnull)(CGRect highlightFrame))block;

--- a/Simplenote/Classes/SPTextView.m
+++ b/Simplenote/Classes/SPTextView.m
@@ -200,8 +200,8 @@
 
 - (void)setContentOffset:(CGPoint)contentOffset animated:(BOOL)animated
 {
-    if (!animated) {
-        [self setContentOffset:contentOffset];
+    if (!self.enableScrollSmoothening || !animated) {
+        [super setContentOffset:contentOffset animated:animated];
         return;
     }
 


### PR DESCRIPTION
### Fix
In this PR we're updating our TextView supersmooth animation, and making sure it's only enabled for Keyboard-Y events.

As far as I can tell, the superclass implementation would appear to have a special behavior, whenever `UIAutoscroll` (private class) is involved, which is out of the question for us.

@aerych sir!! mind taking a look?
Thanks in advance!!

Ref. #842

### Test
1. Open a long note
2. Double tap over any word
- [x] Verify expanding the selected text upwards / downwards works as expected

**Important:** I've spotted a glitch in which the autoscroll wouldn't follow to the Heading / bottom of the document. Addressing that in a follow up, for atomicity's sake!

### Release
`RELEASE-NOTES.txt` was updated in 7edfc20 with:

> Fixed a bug that caused text selection to unexpectedly scroll to the top (or bottom) of the document
