### PR TITLE
New Note Options Logic

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -62,7 +62,7 @@
 		46A3C96317DFA81A002865AE /* NSString+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 467D9C771788D0FF00785EF3 /* NSString+Metadata.m */; };
 		46A3C96417DFA81A002865AE /* SPVersionPickerViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = E2ACA88217A7728E00EF801C /* SPVersionPickerViewCell.m */; };
 		46A3C96517DFA81A002865AE /* SPActivityView.m in Sources */ = {isa = PBXBuildFile; fileRef = E22BCDF61794F53600A17ED2 /* SPActivityView.m */; };
-		46A3C96617DFA81A002865AE /* SPAcitivitySafari.m in Sources */ = {isa = PBXBuildFile; fileRef = E283709917D7B46300AB562D /* SPAcitivitySafari.m */; };
+		46A3C96617DFA81A002865AE /* SPActivitySafari.m in Sources */ = {isa = PBXBuildFile; fileRef = E283709917D7B46300AB562D /* SPActivitySafari.m */; };
 		46A3C96717DFA81A002865AE /* NSManagedObjectContext+CoreDataExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = E22A17CF17A2E1CE00383575 /* NSManagedObjectContext+CoreDataExtensions.m */; };
 		46A3C96A17DFA81A002865AE /* SPTagStub.m in Sources */ = {isa = PBXBuildFile; fileRef = E277B5FA179F714C0095CD24 /* SPTagStub.m */; };
 		46A3C96C17DFA81A002865AE /* SPOptionsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E26AC90F179DA25F00C4BFB6 /* SPOptionsViewController.m */; };
@@ -768,8 +768,8 @@
 		E277B5FF17A063020095CD24 /* SPTagEntryField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPTagEntryField.h; path = Classes/SPTagEntryField.h; sourceTree = "<group>"; };
 		E277B60017A063020095CD24 /* SPTagEntryField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPTagEntryField.m; path = Classes/SPTagEntryField.m; sourceTree = "<group>"; };
 		E280453D180DAE0200670073 /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		E283709817D7B46300AB562D /* SPAcitivitySafari.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPAcitivitySafari.h; path = Classes/SPAcitivitySafari.h; sourceTree = "<group>"; };
-		E283709917D7B46300AB562D /* SPAcitivitySafari.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPAcitivitySafari.m; path = Classes/SPAcitivitySafari.m; sourceTree = "<group>"; };
+		E283709817D7B46300AB562D /* SPActivitySafari.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPActivitySafari.h; path = Classes/SPActivitySafari.h; sourceTree = "<group>"; };
+		E283709917D7B46300AB562D /* SPActivitySafari.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPActivitySafari.m; path = Classes/SPActivitySafari.m; sourceTree = "<group>"; };
 		E28A760D178CBE6D008659DE /* SPNoteEditorViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPNoteEditorViewController.h; path = Classes/SPNoteEditorViewController.h; sourceTree = "<group>"; };
 		E28A760E178CBE6D008659DE /* SPNoteEditorViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = SPNoteEditorViewController.m; path = Classes/SPNoteEditorViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		E2911E7C17B49F4600F13AD9 /* DTPinDigitView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DTPinDigitView.h; path = DTPinLock/DTPinDigitView.h; sourceTree = "<group>"; };
@@ -954,8 +954,8 @@
 				B5AEC38523FAE70600D24221 /* Note+List.swift */,
 				E25C39D417A42C4900B2591A /* PersonTag.h */,
 				E25C39D517A42C4900B2591A /* PersonTag.m */,
-				E283709817D7B46300AB562D /* SPAcitivitySafari.h */,
-				E283709917D7B46300AB562D /* SPAcitivitySafari.m */,
+				E283709817D7B46300AB562D /* SPActivitySafari.h */,
+				E283709917D7B46300AB562D /* SPActivitySafari.m */,
 				E277B5F9179F714C0095CD24 /* SPTagStub.h */,
 				E277B5FA179F714C0095CD24 /* SPTagStub.m */,
 				467D9C631788A54900785EF3 /* Tag.h */,
@@ -2203,7 +2203,7 @@
 				46A3C96517DFA81A002865AE /* SPActivityView.m in Sources */,
 				B5E4082B235DDFC800D4E1DF /* ColorStudio.swift in Sources */,
 				B552AB8724B8E75E00E5E115 /* SPNoteEditorViewController+Extensions.swift in Sources */,
-				46A3C96617DFA81A002865AE /* SPAcitivitySafari.m in Sources */,
+				46A3C96617DFA81A002865AE /* SPActivitySafari.m in Sources */,
 				B5BE05461AB7522F002417BF /* JSONKit+Simplenote.m in Sources */,
 				B5095DC924632E3300812711 /* SimplenoteConstants.swift in Sources */,
 				B56E763422BD394C00C5AA47 /* UIImage+Simplenote.swift in Sources */,

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -13,6 +13,10 @@ class NoteOptionsViewController: UITableViewController {
     /// The note from the editor that we will change settings for
     fileprivate var note: Note
 
+    /// The delegate to notify about
+    /// chaanges made here
+    weak var delegate: NoteOptionsViewControllerDelegate?
+
     init(with note: Note) {
         self.note = note
         super.init(style: .grouped)
@@ -264,6 +268,7 @@ class NoteOptionsViewController: UITableViewController {
     func handleMarkdown(sender: UISwitch) {
         note.markdown = sender.isOn
         save()
+        delegate?.didToggleMarkdown(toggle: sender, sender: self)
     }
 
     func handleShare(from indexPath: IndexPath) {
@@ -319,4 +324,10 @@ class NoteOptionsViewController: UITableViewController {
         SPTracker.trackEditorNoteEdited()
         CSSearchableIndex.default().indexSearchableNote(note)
     }
+}
+
+// MARK: - Action protocol
+//
+protocol NoteOptionsViewControllerDelegate: class {
+    func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController)
 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -11,17 +11,17 @@ final class NoteOptionsViewController: UITableViewController {
     }
 
     /// The note from the editor that we will change settings for
-    private var note: Note
+    private let note: Note
 
     /// The delegate to notify about
     /// chaanges made here
     weak var delegate: NoteOptionsViewControllerDelegate?
 
     /// Formats number of collaborators to respect locales
-    private var collaboratorNumberFormatter = NumberFormatter()
+    private let collaboratorNumberFormatter = NumberFormatter()
 
     /// Activity indicator that displays when note is publishing or unpublishing
-    private var publishActivityIndicator = UIActivityIndicatorView(style: SPUserInterface.isDark ? .white : .gray)
+    private let publishActivityIndicator = UIActivityIndicatorView(style: SPUserInterface.isDark ? .white : .gray)
 
     /// Initialises the options view for a specific note
     /// - Parameter note: The note to configure options for

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -21,7 +21,7 @@ final class NoteOptionsViewController: UITableViewController {
     private let collaboratorNumberFormatter = NumberFormatter()
 
     /// Activity indicator that displays when note is publishing or unpublishing
-    private let publishActivityIndicator = UIActivityIndicatorView(style: SPUserInterface.isDark ? .white : .gray)
+    private let publishActivityIndicator = UIActivityIndicatorView(style: .white)
 
     /// Initialises the options view for a specific note
     /// - Parameter note: The note to configure options for
@@ -57,6 +57,7 @@ final class NoteOptionsViewController: UITableViewController {
     func setupViewStyles() {
         tableView.backgroundColor = .simplenoteTableViewBackgroundColor
         tableView.separatorColor = .simplenoteDividerColor
+        publishActivityIndicator.color = UIColor.color(name: .tableViewDetailTextLabelColor)
     }
 
     // MARK: - Table helpers

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -25,11 +25,8 @@ final class NoteOptionsViewController: UITableViewController {
     /// Determines if a note is currently awaiting publishing
     /// changes to synchronise
     private var noteIsChangingPublishState: Bool {
-        if (note.published && note.publishURL.isEmpty ||
-            !note.published && !note.publishURL.isEmpty) {
-            return true
-        }
-        return false
+        (note.published && note.publishURL.isEmpty ||
+        !note.published && !note.publishURL.isEmpty)
     }
 
     /// The delegate to notify about
@@ -357,7 +354,7 @@ final class NoteOptionsViewController: UITableViewController {
 
         note.published = sender.isOn
 
-        if (noteIsChangingPublishState) {
+        if noteIsChangingPublishState {
             publishActivityIndicator.startAnimating()
         } else {
             publishActivityIndicator.stopAnimating()

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -298,6 +298,12 @@ final class NoteOptionsViewController: UITableViewController {
         sender.accessibilityHint = note.pinned ?
             NSLocalizedString("Unpin note", comment: "Action to mark a note as unpinned") :
             NSLocalizedString("Pin note", comment: "Action to mark a note as pinned")
+
+        if sender.isOn {
+            SPTracker.trackEditorNotePinned()
+        } else {
+            SPTracker.trackEditorNoteUnpinned()
+        }
     }
 
     @objc
@@ -309,6 +315,12 @@ final class NoteOptionsViewController: UITableViewController {
         sender.accessibilityHint = note.markdown ?
             NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode") :
             NSLocalizedString("Enable Markdown formatting", comment: "Accessibility hint for enabling markdown mode")
+
+        if sender.isOn {
+            SPTracker.trackEditorNoteMarkdownEnabled()
+        } else {
+            SPTracker.trackEditorNoteMarkdownDisabled()
+        }
     }
 
     func handleShare(from indexPath: IndexPath) {
@@ -404,6 +416,7 @@ final class NoteOptionsViewController: UITableViewController {
     }
 
     func handleMoveToTrash() {
+        SPTracker.trackEditorNoteDeleted()
         delegate?.didTapMoveToTrash(sender: self)
     }
 

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -169,7 +169,8 @@ class NoteOptionsViewController: UITableViewController {
                     cell.accessibilityHint = NSLocalizedString("Tap to copy link", comment: "Accessibility hint on cell that copies public URL of note")
                     cell.isUserInteractionEnabled = !note.publishURL.isEmpty
 
-                    if note.published && note.publishURL.isEmpty {
+                    if (note.published && note.publishURL.isEmpty ||
+                        !note.published && !note.publishURL.isEmpty) {
                         let activityIndicator = UIActivityIndicatorView(style: .gray)
                         activityIndicator.startAnimating()
                         cell.accessoryView = activityIndicator

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -402,7 +402,9 @@ final class NoteOptionsViewController: UITableViewController {
     // MARK: - Navigation button handling
     @objc
     func handleDone(button: UIBarButtonItem) {
-        dismiss(animated: true)
+        dismiss(animated: true) { [popoverPresentationController] in
+            popoverPresentationController?.delegate?.popoverPresentationControllerDidDismissPopover?(popoverPresentationController!)
+        }
     }
 
     // MARK: - Note saving

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -338,9 +338,7 @@ final class NoteOptionsViewController: UITableViewController {
             presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
             presentationController?.sourceView = tableView
         }
-        present(activityVC,
-                animated: true,
-                completion: nil)
+        present(activityVC, animated: true, completion: nil)
     }
 
     func handleHistory() {
@@ -388,9 +386,7 @@ final class NoteOptionsViewController: UITableViewController {
             presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
             presentationController?.sourceView = tableView
         }
-        present(activityViewController,
-                animated: true,
-                completion: nil)
+        present(activityViewController, animated: true, completion: nil)
     }
 
     func handleCollaborate(from indexPath: IndexPath) {
@@ -411,9 +407,7 @@ final class NoteOptionsViewController: UITableViewController {
             presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
             presentationController?.sourceView = tableView
         }
-        present(navController,
-                animated: true,
-                completion: nil)
+        present(navController, animated: true, completion: nil)
     }
 
     func handleMoveToTrash() {

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -1,6 +1,15 @@
 import UIKit
 import CoreSpotlight
 
+// MARK: - Action protocol
+//
+/// A protocol to pass row actions to the parent view controller for handling
+protocol NoteOptionsViewControllerDelegate: class {
+    func didToggleMarkdown()
+    func didTapHistory(sender: NoteOptionsViewController)
+    func didTapMoveToTrash(sender: NoteOptionsViewController)
+}
+
 /// A class used to display options for the note that is currently being edited
 final class NoteOptionsViewController: UITableViewController {
 
@@ -428,15 +437,6 @@ final class NoteOptionsViewController: UITableViewController {
         }
         present(viewController, animated: true, completion: nil)
     }
-}
-
-// MARK: - Action protocol
-//
-/// A protocol to pass row actions to the parent view controller for handling
-protocol NoteOptionsViewControllerDelegate: class {
-    func didToggleMarkdown()
-    func didTapHistory(sender: NoteOptionsViewController)
-    func didTapMoveToTrash(sender: NoteOptionsViewController)
 }
 
 // MARK: - Collaboration handling

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -9,6 +9,18 @@ class NoteOptionsViewController: UITableViewController {
         return [optionsSection, linkSection, collaborationSection, trashSection]
     }
 
+    /// The note from the editor that we will change settings for
+    fileprivate var note: Note
+
+    init(with note: Note) {
+        self.note = note
+        super.init(style: .grouped)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("This view cannot be initialised through Storyboards")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         title = NSLocalizedString("Options", comment: "Note Options: Title")

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -305,14 +305,12 @@ final class NoteOptionsViewController: UITableViewController {
         note.pinned = sender.isOn
         save()
 
-        sender.accessibilityHint = note.pinned ?
-            NSLocalizedString("Unpin note", comment: "Action to mark a note as unpinned") :
-            NSLocalizedString("Pin note", comment: "Action to mark a note as pinned")
-
         if sender.isOn {
             SPTracker.trackEditorNotePinned()
+            sender.accessibilityHint = NSLocalizedString("Unpin note", comment: "Action to mark a note as unpinned")
         } else {
             SPTracker.trackEditorNoteUnpinned()
+            sender.accessibilityHint = NSLocalizedString("Pin note", comment: "Action to mark a note as pinned")
         }
     }
 
@@ -322,14 +320,12 @@ final class NoteOptionsViewController: UITableViewController {
         save()
         delegate?.didToggleMarkdown()
 
-        sender.accessibilityHint = note.markdown ?
-            NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode") :
-            NSLocalizedString("Enable Markdown formatting", comment: "Accessibility hint for enabling markdown mode")
-
         if sender.isOn {
             SPTracker.trackEditorNoteMarkdownEnabled()
+            sender.accessibilityHint = NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode")
         } else {
             SPTracker.trackEditorNoteMarkdownDisabled()
+            sender.accessibilityHint = NSLocalizedString("Enable Markdown formatting", comment: "Accessibility hint for enabling markdown mode")
         }
     }
 
@@ -350,8 +346,10 @@ final class NoteOptionsViewController: UITableViewController {
     func handlePublish(sender: UISwitch) {
         if sender.isOn {
             SPTracker.trackEditorNotePublished()
+            sender.accessibilityHint = NSLocalizedString("Unpublish note", comment: "Action which unpublishes a note")
         } else {
             SPTracker.trackEditorNoteUnpublished()
+            sender.accessibilityHint = NSLocalizedString("Publish note", comment: "Action which published a note to a web page")
         }
 
         note.published = sender.isOn
@@ -363,10 +361,6 @@ final class NoteOptionsViewController: UITableViewController {
         }
 
         save()
-
-        sender.accessibilityHint = note.published ?
-            NSLocalizedString("Unpublish note", comment: "Action which unpublishes a note") :
-            NSLocalizedString("Publish note", comment: "Action which published a note to a web page")
     }
 
     func handleCopyLink(from indexPath: IndexPath) {

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -143,7 +143,7 @@ final class NoteOptionsViewController: UITableViewController {
                 configuration: { (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Share", comment: "Note Options: Show Share Options")
-                    cell.accessibilityHint = NSLocalizedString("share-accessibility-hint", comment: "Accessibility hint on share button")
+                    cell.accessibilityHint = NSLocalizedString("Tap to open share options", comment: "Accessibility hint on cell that activates share sheet")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleShare(from: indexPath)
@@ -153,7 +153,7 @@ final class NoteOptionsViewController: UITableViewController {
                 configuration: { (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("History", comment: "Note Options: Show History")
-                    cell.accessibilityHint = NSLocalizedString("history-accessibility-hint", comment: "Accessibility hint on button which shows the history of a notew")
+                    cell.accessibilityHint = NSLocalizedString("Tap to open history", comment: "Accessibility hint on cell that opens note history view")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleHistory()
@@ -210,7 +210,7 @@ final class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Collaborate", comment: "Note Options: Collaborate")
                     cell.detailTextLabel?.text = collaboratorNumberFormatter.string(from: NSNumber(value: note.emailTagsArray.count))
-                    cell.accessibilityHint = NSLocalizedString("collaborate-accessibility-hint", comment: "Accessibility hint on button which shows the current collaborators on a note")
+                    cell.accessibilityHint = NSLocalizedString("Tap to open collaboration menu", comment: "Accessibility hint on cell that opens collaboration menu")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleCollaborate(from: indexPath)
@@ -228,7 +228,7 @@ final class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Move to Trash", comment: "Note Options: Move to Trash")
                     cell.textLabel?.textColor = .simplenoteDestructiveActionColor
-                    cell.accessibilityHint = NSLocalizedString("trash-accessibility-hint", comment: "Accessibility hint on button which moves a note to the trash")
+                    cell.accessibilityHint = NSLocalizedString("Tap to move this note to trash", comment: "Accessibility hint on cell that moves a note to trash")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleMoveToTrash()

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -86,7 +86,7 @@ class NoteOptionsViewController: UITableViewController {
     // MARK: - Table view delegate
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let row = sections[indexPath.section].rows[indexPath.row]
-        row.handler?()
+        row.handler?(indexPath)
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
@@ -116,8 +116,8 @@ class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.text = NSLocalizedString("Share", comment: "Note Options: Show Share Options")
                     cell.accessibilityHint = NSLocalizedString("Tap to open share options", comment: "Accessibility hint on cell that activates share sheet")
                 },
-                handler: { [weak self] in
-                    self?.handleShare()
+                handler: { [weak self] (indexPath: IndexPath) in
+                    self?.handleShare(from: indexPath)
                 }
             ),
             Row(style: .Value1,
@@ -126,7 +126,7 @@ class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.text = NSLocalizedString("History", comment: "Note Options: Show History")
                     cell.accessibilityHint = NSLocalizedString("Tap to open history", comment: "Accessibility hint on cell that opens note history view")
                 },
-                handler: { [weak self] in
+                handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleHistory()
                 }
             )
@@ -153,7 +153,7 @@ class NoteOptionsViewController: UITableViewController {
                     cell.accessibilityHint = NSLocalizedString("Tap to copy link", comment: "Accessibility hint on cell that copies public URL of note")
                     cell.isUserInteractionEnabled = false
                 },
-                handler: { [weak self] in
+                handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleCopyLink()
                 }
             )
@@ -172,7 +172,7 @@ class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.text = NSLocalizedString("Collaborate", comment: "Note Options: Collaborate")
                     cell.accessibilityLabel = NSLocalizedString("Tap to open collaboration menu", comment: "Accessibility hint on cell that opens collaboration menu")
                 },
-                handler: { [weak self] in
+                handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleCollaborate()
                 }
             )
@@ -190,7 +190,7 @@ class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.textColor = .simplenoteDestructiveActionColor
                     cell.accessibilityHint = NSLocalizedString("Tap to move this note to trash", comment: "Accessibility hint on cell that moves a note to trash")
                 },
-                handler: { [weak self] in
+                handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleMoveToTrash()
                 }
             )
@@ -226,9 +226,9 @@ class NoteOptionsViewController: UITableViewController {
         let configuration: ((UITableViewCell, Row) -> Void)?
 
         /// Called when this row is tapped. Optional.
-        let handler: (() -> Void)?
+        let handler: ((IndexPath) -> Void)?
 
-        internal init(style: Style = .Value1, configuration: ((UITableViewCell, Row) -> Void)? = nil, handler: (() -> Void)? = nil) {
+        internal init(style: Style = .Value1, configuration: ((UITableViewCell, Row) -> Void)? = nil, handler: ((IndexPath) -> Void)? = nil) {
             self.style = style
             self.configuration = configuration
             self.handler = handler
@@ -261,8 +261,21 @@ class NoteOptionsViewController: UITableViewController {
         ///Handle markdown logic here
     }
 
-    func handleShare() {
-        ///Handle share logic here
+    func handleShare(from indexPath: IndexPath) {
+        guard let activityVC = UIActivityViewController(note: note) else {
+            return
+        }
+        SPTracker.trackEditorNoteContentShared()
+
+        if UIDevice.sp_isPad() {
+            activityVC.modalPresentationStyle = .popover
+
+            let presentationController = activityVC.popoverPresentationController
+            presentationController?.permittedArrowDirections = .any
+            presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
+            presentationController?.sourceView = tableView
+        }
+        present(activityVC, animated: true, completion: nil)
     }
 
     func handleHistory() {

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -176,7 +176,7 @@ class NoteOptionsViewController: UITableViewController {
                     }
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
-                    self?.handleCopyLink()
+                    self?.handleCopyLink(from: indexPath)
                 }
             )
         ]
@@ -324,8 +324,24 @@ class NoteOptionsViewController: UITableViewController {
         tableView.reloadRows(at: [IndexPath(item: 1, section: 1)], with: .automatic)
     }
 
-    func handleCopyLink() {
-        ///Handle copy link logic here
+    func handleCopyLink(from indexPath: IndexPath) {
+        guard !note.publishURL.isEmpty, let publishURL = URL(string: kSimplenotePublishURL + note.publishURL) else {
+            return
+        }
+
+        SPTracker.trackEditorPublishedUrlPressed()
+
+        let activityViewController = UIActivityViewController(activityItems: [publishURL],
+                                                              applicationActivities: [SPActivitySafari()])
+        if UIDevice.sp_isPad() {
+            activityViewController.modalPresentationStyle = .popover
+
+            let presentationController = activityViewController.popoverPresentationController
+            presentationController?.permittedArrowDirections = .any
+            presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
+            presentationController?.sourceView = tableView
+        }
+        present(activityViewController, animated: true, completion: nil)
     }
 
     func handleCollaborate() {

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -310,7 +310,7 @@ class NoteOptionsViewController: UITableViewController {
     }
 
     func handleMoveToTrash() {
-        ///Handle move to tash logic here
+        delegate?.didTapMoveToTrash(sender: self)
     }
 
     // MARK: - Navigation button handling
@@ -336,4 +336,5 @@ protocol NoteOptionsViewControllerDelegate: class {
     func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController)
     func didTapHistory(sender: NoteOptionsViewController)
     func didTapCollaborators(sender: NoteOptionsViewController)
+    func didTapMoveToTrash(sender: NoteOptionsViewController)
 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -320,7 +320,7 @@ final class NoteOptionsViewController: UITableViewController {
     func handleMarkdown(sender: UISwitch) {
         note.markdown = sender.isOn
         save()
-        delegate?.didToggleMarkdown(toggle: sender, sender: self)
+        delegate?.didToggleMarkdown()
 
         sender.accessibilityHint = note.markdown ?
             NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode") :
@@ -438,7 +438,7 @@ final class NoteOptionsViewController: UITableViewController {
 //
 /// A protocol to pass row actions to the parent view controller for handling
 protocol NoteOptionsViewControllerDelegate: class {
-    func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController)
+    func didToggleMarkdown()
     func didTapHistory(sender: NoteOptionsViewController)
     func didTapMoveToTrash(sender: NoteOptionsViewController)
 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -221,7 +221,7 @@ final class NoteOptionsViewController: UITableViewController {
                 configuration: { [note, collaboratorNumberFormatter] (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Collaborate", comment: "Note Options: Collaborate")
-                    cell.detailTextLabel?.text = collaboratorNumberFormatter.string(from: NSNumber(value: note.emailTagsArray.count))
+                    cell.detailTextLabel?.text = note.emailTagsArray.count > 0 ? collaboratorNumberFormatter.string(from: NSNumber(value: note.emailTagsArray.count)) : nil
                     cell.accessibilityHint = NSLocalizedString("Tap to open collaboration menu", comment: "Accessibility hint on cell that opens collaboration menu")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import CoreSpotlight
 
 /// A class used to display options for the note that is currently being edited
-class NoteOptionsViewController: UITableViewController {
+final class NoteOptionsViewController: UITableViewController {
 
     /// Array of `Section`s to display in the view.
     /// Each `Section` has `Rows` that are used for display
@@ -11,7 +11,7 @@ class NoteOptionsViewController: UITableViewController {
     }
 
     /// The note from the editor that we will change settings for
-    fileprivate var note: Note
+    private var note: Note
 
     /// The delegate to notify about
     /// chaanges made here

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -23,6 +23,8 @@ class NoteOptionsViewController: UITableViewController {
     /// Activity indicator that displays when note is publishing or unpublishing
     private var publishActivityIndicator = UIActivityIndicatorView(style: SPUserInterface.isDark ? .white : .gray)
 
+    /// Initialises the options view for a specific note
+    /// - Parameter note: The note to configure options for
     init(with note: Note) {
         self.note = note
         super.init(style: .grouped)
@@ -65,6 +67,8 @@ class NoteOptionsViewController: UITableViewController {
         }
     }
 
+    /// Called by the presenting view when Simperium
+    /// has delivered updates for the `note`
     @objc
     public func didReceiveNoteUpdate() {
         tableView.reloadData()
@@ -344,7 +348,7 @@ class NoteOptionsViewController: UITableViewController {
         } else {
             publishActivityIndicator.stopAnimating()
         }
-        
+
         save()
 
         sender.accessibilityHint = note.published ?
@@ -399,6 +403,7 @@ class NoteOptionsViewController: UITableViewController {
 
 // MARK: - Action protocol
 //
+/// A protocol to pass row actions to the parent view controller for handling
 protocol NoteOptionsViewControllerDelegate: class {
     func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController)
     func didTapHistory(sender: NoteOptionsViewController)

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -289,7 +289,7 @@ class NoteOptionsViewController: UITableViewController {
     }
 
     func handleHistory() {
-        ///Handle history logic here
+        delegate?.didTapHistory(sender: self)
     }
 
     @objc
@@ -330,4 +330,5 @@ class NoteOptionsViewController: UITableViewController {
 //
 protocol NoteOptionsViewControllerDelegate: class {
     func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController)
+    func didTapHistory(sender: NoteOptionsViewController)
 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -17,6 +17,9 @@ class NoteOptionsViewController: UITableViewController {
     /// chaanges made here
     weak var delegate: NoteOptionsViewControllerDelegate?
 
+    /// Formats number of collaborators to respect locales
+    private var collaboratorNumberFormatter = NumberFormatter()
+
     init(with note: Note) {
         self.note = note
         super.init(style: .grouped)
@@ -174,9 +177,10 @@ class NoteOptionsViewController: UITableViewController {
     fileprivate var collaborationSection: Section {
         let rows = [
             Row(style: .Value1,
-                configuration: { (cell: UITableViewCell, row: Row) in
+                configuration: { [note, collaboratorNumberFormatter] (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Collaborate", comment: "Note Options: Collaborate")
+                    cell.detailTextLabel?.text = collaboratorNumberFormatter.string(from: NSNumber(value: note.emailTagsArray.count))
                     cell.accessibilityLabel = NSLocalizedString("Tap to open collaboration menu", comment: "Accessibility hint on cell that opens collaboration menu")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
@@ -302,7 +306,7 @@ class NoteOptionsViewController: UITableViewController {
     }
 
     func handleCollaborate() {
-        ///Handle collaboration logic here
+        delegate?.didTapCollaborators(sender: self)
     }
 
     func handleMoveToTrash() {
@@ -331,4 +335,5 @@ class NoteOptionsViewController: UITableViewController {
 protocol NoteOptionsViewControllerDelegate: class {
     func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController)
     func didTapHistory(sender: NoteOptionsViewController)
+    func didTapCollaborators(sender: NoteOptionsViewController)
 }

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -140,10 +140,9 @@ final class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.text = NSLocalizedString("Pin to Top", comment: "Note Options: Pin to Top")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handlePinToTop(sender:)), for: .primaryActionTriggered)
                     cell.cellSwitch.accessibilityLabel = NSLocalizedString("Pin toggle", comment: "Switch which marks a note as pinned or unpinned")
-                    cell.cellSwitch.accessibilityHint = note.pinned ?
-                        NSLocalizedString("Unpin note", comment: "Action to mark a note as unpinned") :
-                        NSLocalizedString("Pin note", comment: "Action to mark a note as pinned")
+                    cell.cellSwitch.accessibilityIdentifier = "note-options-pin-switch"
                     cell.cellSwitch.isOn = note.pinned
+                    self?.updateAccessibilityHint(for: cell.cellSwitch)
                 }
             ),
             Row(style: .Switch,
@@ -152,10 +151,9 @@ final class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.text = NSLocalizedString("Markdown", comment: "Note Options: Toggle Markdown")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handleMarkdown(sender:)), for: .primaryActionTriggered)
                     cell.cellSwitch.accessibilityLabel = NSLocalizedString("Markdown toggle", comment: "Switch which marks a note as using Markdown formatting or not")
-                    cell.cellSwitch.accessibilityHint = note.markdown ?
-                        NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode") :
-                        NSLocalizedString("Enable Markdown formatting", comment: "Accessibility hint for enabling markdown mode")
+                    cell.cellSwitch.accessibilityIdentifier = "note-options-markdown-switch"
                     cell.cellSwitch.isOn = note.markdown
+                    self?.updateAccessibilityHint(for: cell.cellSwitch)
                 }
             ),
             Row(style: .Value1,
@@ -191,10 +189,9 @@ final class NoteOptionsViewController: UITableViewController {
                     cell.textLabel?.text = NSLocalizedString("Publish", comment: "Note Options: Publish")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handlePublish(sender:)), for: .primaryActionTriggered)
                     cell.cellSwitch.accessibilityLabel = NSLocalizedString("Publish toggle", comment: "Switch which marks a note as published or unpublished")
-                    cell.cellSwitch.accessibilityHint = note.published ?
-                        NSLocalizedString("Unpublish note", comment: "Action which unpublishes a note") :
-                        NSLocalizedString("Publish note", comment: "Action which published a note to a web page")
+                    cell.cellSwitch.accessibilityIdentifier = "note-options-publish-switch"
                     cell.cellSwitch.isOn = note.published
+                    self?.updateAccessibilityHint(for: cell.cellSwitch)
                 }
             ),
             Row(style: .Value1,
@@ -316,11 +313,10 @@ final class NoteOptionsViewController: UITableViewController {
 
         if sender.isOn {
             SPTracker.trackEditorNotePinned()
-            sender.accessibilityHint = NSLocalizedString("Unpin note", comment: "Action to mark a note as unpinned")
         } else {
             SPTracker.trackEditorNoteUnpinned()
-            sender.accessibilityHint = NSLocalizedString("Pin note", comment: "Action to mark a note as pinned")
         }
+        updateAccessibilityHint(for: sender)
     }
 
     @objc
@@ -331,11 +327,10 @@ final class NoteOptionsViewController: UITableViewController {
 
         if sender.isOn {
             SPTracker.trackEditorNoteMarkdownEnabled()
-            sender.accessibilityHint = NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode")
         } else {
             SPTracker.trackEditorNoteMarkdownDisabled()
-            sender.accessibilityHint = NSLocalizedString("Enable Markdown formatting", comment: "Accessibility hint for enabling markdown mode")
         }
+        updateAccessibilityHint(for: sender)
     }
 
     func handleShare(from indexPath: IndexPath) {
@@ -355,11 +350,10 @@ final class NoteOptionsViewController: UITableViewController {
     func handlePublish(sender: UISwitch) {
         if sender.isOn {
             SPTracker.trackEditorNotePublished()
-            sender.accessibilityHint = NSLocalizedString("Unpublish note", comment: "Action which unpublishes a note")
         } else {
             SPTracker.trackEditorNoteUnpublished()
-            sender.accessibilityHint = NSLocalizedString("Publish note", comment: "Action which published a note to a web page")
         }
+        updateAccessibilityHint(for: sender)
 
         note.published = sender.isOn
 
@@ -400,6 +394,36 @@ final class NoteOptionsViewController: UITableViewController {
     func handleMoveToTrash() {
         SPTracker.trackEditorNoteDeleted()
         delegate?.didTapMoveToTrash(sender: self)
+    }
+
+    // MARK: - Row updates
+
+    /// Updates the accessibility hint based on switch state
+    /// - Parameter rowSwitch: The switch that has changed state
+    func updateAccessibilityHint(for rowSwitch: UISwitch) {
+
+        switch rowSwitch.accessibilityIdentifier {
+        case "note-options-pin-switch":
+            if rowSwitch.isOn {
+                rowSwitch.accessibilityHint = NSLocalizedString("Unpin note", comment: "Action to mark a note as unpinned")
+            } else {
+                rowSwitch.accessibilityHint = NSLocalizedString("Pin note", comment: "Action to mark a note as pinned")
+            }
+        case "note-options-markdown-switch":
+            if rowSwitch.isOn {
+                rowSwitch.accessibilityHint = NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode")
+            } else {
+                rowSwitch.accessibilityHint = NSLocalizedString("Enable Markdown formatting", comment: "Accessibility hint for enabling markdown mode")
+            }
+        case "note-options-publish-switch":
+            if rowSwitch.isOn {
+                rowSwitch.accessibilityHint = NSLocalizedString("Unpublish note", comment: "Action which unpublishes a note")
+            } else {
+                rowSwitch.accessibilityHint = NSLocalizedString("Publish note", comment: "Action which published a note to a web page")
+            }
+        default:
+            return
+        }
     }
 
     // MARK: - Navigation button handling

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -430,7 +430,6 @@ class NoteOptionsViewController: UITableViewController {
 protocol NoteOptionsViewControllerDelegate: class {
     func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController)
     func didTapHistory(sender: NoteOptionsViewController)
-    func didTapCollaborators(sender: NoteOptionsViewController)
     func didTapMoveToTrash(sender: NoteOptionsViewController)
 }
 

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -5,7 +5,7 @@ import CoreSpotlight
 //
 /// A protocol to pass row actions to the parent view controller for handling
 protocol NoteOptionsViewControllerDelegate: class {
-    func didToggleMarkdown()
+    func didToggleMarkdown(state: Bool)
     func didTapHistory(sender: NoteOptionsViewController)
     func didTapMoveToTrash(sender: NoteOptionsViewController)
 }
@@ -320,7 +320,7 @@ final class NoteOptionsViewController: UITableViewController {
     func handleMarkdown(sender: UISwitch) {
         note.markdown = sender.isOn
         save()
-        delegate?.didToggleMarkdown()
+        delegate?.didToggleMarkdown(state: sender.isOn)
 
         if sender.isOn {
             SPTracker.trackEditorNoteMarkdownEnabled()

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -112,7 +112,10 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! SwitchTableViewCell
                     cell.textLabel?.text = NSLocalizedString("Pin to Top", comment: "Note Options: Pin to Top")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handlePinToTop(sender:)), for: .primaryActionTriggered)
-                    cell.cellSwitch.accessibilityHint = NSLocalizedString("Tap to toggle pin to top", comment: "Accessibility hint for toggling pin to top")
+                    cell.cellSwitch.accessibilityLabel = NSLocalizedString("Pin toggle", comment: "Switch which marks a note as pinned or unpinned")
+                    cell.cellSwitch.accessibilityHint = note.pinned ?
+                        NSLocalizedString("Unpin note", comment: "Action to mark a note as unpinned") :
+                        NSLocalizedString("Pin note", comment: "Action to mark a note as pinned")
                     cell.cellSwitch.isOn = note.pinned
                 }
             ),
@@ -121,7 +124,10 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! SwitchTableViewCell
                     cell.textLabel?.text = NSLocalizedString("Markdown", comment: "Note Options: Toggle Markdown")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handleMarkdown(sender:)), for: .primaryActionTriggered)
-                    cell.cellSwitch.accessibilityHint = NSLocalizedString("Tap to toggle markdown mode", comment: "Accessibility hint for toggling markdown mode")
+                    cell.cellSwitch.accessibilityLabel = NSLocalizedString("Markdown toggle", comment: "Switch which marks a note as using Markdown formatting or not")
+                    cell.cellSwitch.accessibilityHint = note.markdown ?
+                        NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode") :
+                        NSLocalizedString("Enable Markdown formatting", comment: "Accessibility hint for enabling markdown mode")
                     cell.cellSwitch.isOn = note.markdown
                 }
             ),
@@ -129,7 +135,7 @@ class NoteOptionsViewController: UITableViewController {
                 configuration: { (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Share", comment: "Note Options: Show Share Options")
-                    cell.accessibilityHint = NSLocalizedString("Tap to open share options", comment: "Accessibility hint on cell that activates share sheet")
+                    cell.accessibilityHint = NSLocalizedString("share-accessibility-hint", comment: "Accessibility hint on share button")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleShare(from: indexPath)
@@ -139,7 +145,7 @@ class NoteOptionsViewController: UITableViewController {
                 configuration: { (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("History", comment: "Note Options: Show History")
-                    cell.accessibilityHint = NSLocalizedString("Tap to open history", comment: "Accessibility hint on cell that opens note history view")
+                    cell.accessibilityHint = NSLocalizedString("history-accessibility-hint", comment: "Accessibility hint on button which shows the history of a notew")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleHistory()
@@ -157,7 +163,10 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! SwitchTableViewCell
                     cell.textLabel?.text = NSLocalizedString("Publish", comment: "Note Options: Publish")
                     cell.cellSwitch.addTarget(self, action: #selector(self?.handlePublish(sender:)), for: .primaryActionTriggered)
-                    cell.cellSwitch.accessibilityHint = NSLocalizedString("Tap to toggle publish state", comment: "Accessibility hint on switch that toggles publish state")
+                    cell.cellSwitch.accessibilityLabel = NSLocalizedString("Publish toggle", comment: "Switch which marks a note as published or unpublished")
+                    cell.cellSwitch.accessibilityHint = note.published ?
+                        NSLocalizedString("Unpublish note", comment: "Action which unpublishes a note") :
+                        NSLocalizedString("Publish note", comment: "Action which published a note to a web page")
                     cell.cellSwitch.isOn = note.published
                 }
             ),
@@ -194,7 +203,7 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Collaborate", comment: "Note Options: Collaborate")
                     cell.detailTextLabel?.text = collaboratorNumberFormatter.string(from: NSNumber(value: note.emailTagsArray.count))
-                    cell.accessibilityLabel = NSLocalizedString("Tap to open collaboration menu", comment: "Accessibility hint on cell that opens collaboration menu")
+                    cell.accessibilityHint = NSLocalizedString("collaborate-accessibility-hint", comment: "Accessibility hint on button which shows the current collaborators on a note")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleCollaborate()
@@ -212,7 +221,7 @@ class NoteOptionsViewController: UITableViewController {
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Move to Trash", comment: "Note Options: Move to Trash")
                     cell.textLabel?.textColor = .simplenoteDestructiveActionColor
-                    cell.accessibilityHint = NSLocalizedString("Tap to move this note to trash", comment: "Accessibility hint on cell that moves a note to trash")
+                    cell.accessibilityHint = NSLocalizedString("trash-accessibility-hint", comment: "Accessibility hint on button which moves a note to the trash")
                 },
                 handler: { [weak self] (indexPath: IndexPath) in
                     self?.handleMoveToTrash()
@@ -279,6 +288,10 @@ class NoteOptionsViewController: UITableViewController {
     func handlePinToTop(sender: UISwitch) {
         note.pinned = sender.isOn
         save()
+
+        sender.accessibilityHint = note.pinned ?
+            NSLocalizedString("Unpin note", comment: "Action to mark a note as unpinned") :
+            NSLocalizedString("Pin note", comment: "Action to mark a note as pinned")
     }
 
     @objc
@@ -286,6 +299,10 @@ class NoteOptionsViewController: UITableViewController {
         note.markdown = sender.isOn
         save()
         delegate?.didToggleMarkdown(toggle: sender, sender: self)
+
+        sender.accessibilityHint = note.markdown ?
+            NSLocalizedString("Disable Markdown formatting", comment: "Accessibility hint for disabling markdown mode") :
+            NSLocalizedString("Enable Markdown formatting", comment: "Accessibility hint for enabling markdown mode")
     }
 
     func handleShare(from indexPath: IndexPath) {
@@ -323,6 +340,10 @@ class NoteOptionsViewController: UITableViewController {
         // To prevent the publish switch snapping on/off we manually
         // reload the link row to show the indicator
         tableView.reloadRows(at: [IndexPath(item: 1, section: 1)], with: .automatic)
+
+        sender.accessibilityHint = note.published ?
+            NSLocalizedString("Unpublish note", comment: "Action which unpublishes a note") :
+            NSLocalizedString("Publish note", comment: "Action which published a note to a web page")
     }
 
     func handleCopyLink(from indexPath: IndexPath) {

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -13,6 +13,16 @@ final class NoteOptionsViewController: UITableViewController {
     /// The note from the editor that we will change settings for
     private let note: Note
 
+    /// Determines if a note is currently awaiting publishing
+    /// changes to synchronise
+    private var noteIsChangingPublishState: Bool {
+        if (note.published && note.publishURL.isEmpty ||
+            !note.published && !note.publishURL.isEmpty) {
+            return true
+        }
+        return false
+    }
+
     /// The delegate to notify about
     /// chaanges made here
     weak var delegate: NoteOptionsViewControllerDelegate?
@@ -179,7 +189,7 @@ final class NoteOptionsViewController: UITableViewController {
                 }
             ),
             Row(style: .Value1,
-                configuration: { [publishActivityIndicator, note] (cell: UITableViewCell, row: Row) in
+                configuration: { [noteIsChangingPublishState, publishActivityIndicator, note] (cell: UITableViewCell, row: Row) in
                     let cell = cell as! Value1TableViewCell
                     cell.textLabel?.text = NSLocalizedString("Copy Link", comment: "Note Options: Copy Link")
                     cell.textLabel?.textColor = !note.publishURL.isEmpty ? .simplenoteTextColor : .simplenoteGray20Color
@@ -187,8 +197,7 @@ final class NoteOptionsViewController: UITableViewController {
                     cell.isUserInteractionEnabled = !note.publishURL.isEmpty
                     cell.accessoryView = publishActivityIndicator
 
-                    if (note.published && note.publishURL.isEmpty ||
-                        !note.published && !note.publishURL.isEmpty) {
+                    if (noteIsChangingPublishState) {
                         publishActivityIndicator.startAnimating()
                     }
                 },
@@ -355,8 +364,7 @@ final class NoteOptionsViewController: UITableViewController {
 
         note.published = sender.isOn
 
-        if (note.published && note.publishURL.isEmpty ||
-            !note.published && !note.publishURL.isEmpty) {
+        if (noteIsChangingPublishState) {
             publishActivityIndicator.startAnimating()
         } else {
             publishActivityIndicator.stopAnimating()

--- a/Simplenote/Classes/NoteOptionsViewController.swift
+++ b/Simplenote/Classes/NoteOptionsViewController.swift
@@ -339,15 +339,7 @@ final class NoteOptionsViewController: UITableViewController {
         }
         SPTracker.trackEditorNoteContentShared()
 
-        if UIDevice.sp_isPad() {
-            activityVC.modalPresentationStyle = .popover
-
-            let presentationController = activityVC.popoverPresentationController
-            presentationController?.permittedArrowDirections = .any
-            presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
-            presentationController?.sourceView = tableView
-        }
-        present(activityVC, animated: true, completion: nil)
+        presentPopover(viewController: activityVC, from: indexPath)
     }
 
     func handleHistory() {
@@ -386,15 +378,7 @@ final class NoteOptionsViewController: UITableViewController {
 
         let activityViewController = UIActivityViewController(activityItems: [publishURL],
                                                               applicationActivities: [SPActivitySafari()])
-        if UIDevice.sp_isPad() {
-            activityViewController.modalPresentationStyle = .popover
-
-            let presentationController = activityViewController.popoverPresentationController
-            presentationController?.permittedArrowDirections = .any
-            presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
-            presentationController?.sourceView = tableView
-        }
-        present(activityViewController, animated: true, completion: nil)
+        presentPopover(viewController: activityViewController, from: indexPath)
     }
 
     func handleCollaborate(from indexPath: IndexPath) {
@@ -407,15 +391,7 @@ final class NoteOptionsViewController: UITableViewController {
         let navController = SPNavigationController(rootViewController: collaboratorView)
         navController.displaysBlurEffect = true
 
-        if UIDevice.sp_isPad() {
-            navController.modalPresentationStyle = .popover
-
-            let presentationController = navController.popoverPresentationController
-            presentationController?.permittedArrowDirections = .any
-            presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
-            presentationController?.sourceView = tableView
-        }
-        present(navController, animated: true, completion: nil)
+        presentPopover(viewController: navController, from: indexPath)
     }
 
     func handleMoveToTrash() {
@@ -437,6 +413,24 @@ final class NoteOptionsViewController: UITableViewController {
         SPAppDelegate.shared().save()
         SPTracker.trackEditorNoteEdited()
         CSSearchableIndex.default().indexSearchableNote(note)
+    }
+
+    // MARK: - Navigation helpers
+    /// Presents a view controller as a popover from the provided index path on iPad
+    /// on iOS this will be presented modally
+    /// - Parameters:
+    ///   - viewController: The view controller to present
+    ///   - indexPath: The index path to present from
+    func presentPopover(viewController: UIViewController, from indexPath: IndexPath) {
+        if UIDevice.sp_isPad() {
+            viewController.modalPresentationStyle = .popover
+
+            let presentationController = viewController.popoverPresentationController
+            presentationController?.permittedArrowDirections = .any
+            presentationController?.sourceRect = tableView.rectForRow(at: indexPath)
+            presentationController?.sourceView = tableView
+        }
+        present(viewController, animated: true, completion: nil)
     }
 }
 

--- a/Simplenote/Classes/SPActivitySafari.h
+++ b/Simplenote/Classes/SPActivitySafari.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface SPAcitivitySafari : UIActivity
+@interface SPActivitySafari : UIActivity
 {
     NSURL *openURL;
 }

--- a/Simplenote/Classes/SPActivitySafari.m
+++ b/Simplenote/Classes/SPActivitySafari.m
@@ -6,9 +6,9 @@
 //
 //
 
-#import "SPAcitivitySafari.h"
+#import "SPActivitySafari.h"
 
-@implementation SPAcitivitySafari
+@implementation SPActivitySafari
 
 - (NSString *)activityType
 {

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.h
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.h
@@ -28,6 +28,6 @@
 
 @property (nonatomic, weak) id<SPCollaboratorDelegate> collaboratorDelegate;
 
-- (void)setupWithCollaborators:(NSArray *)collaborators;
+- (void)setupWithCollaborators:(NSArray<NSString *> *)collaborators;
 
 @end

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.m
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.m
@@ -104,7 +104,7 @@
     entryTextField.placeholder = NSLocalizedString(@"Add a new collaborator...", @"Noun - collaborators are other Simplenote users who you chose to share a note with");
 }
 
-- (void)setupWithCollaborators:(NSArray *)collaborators
+- (void)setupWithCollaborators:(NSArray<NSString *> *)collaborators
 {
     NSMutableSet *merged = [NSMutableSet set];
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -202,13 +202,13 @@ extension SPNoteEditorViewController: UIPopoverPresentationControllerDelegate {
 // MARK: - Note options delegate
 //
 extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
-    func didToggleMarkdown() {
+    func didToggleMarkdown(state: Bool) {
 
         // If Markdown is being enabled and it was previously disabled
-        bounceMarkdownPreviewOnActivityViewDismiss = currentNote.markdown && !UserDefaults.standard.bool(forKey: kSimplenoteMarkdownDefaultKey)
+        bounceMarkdownPreviewOnActivityViewDismiss = state && !UserDefaults.standard.bool(forKey: kSimplenoteMarkdownDefaultKey)
 
         // Update the global preference to use when creating new notes
-        UserDefaults.standard.set(currentNote.markdown, forKey: kSimplenoteMarkdownDefaultKey)
+        UserDefaults.standard.set(state, forKey: kSimplenoteMarkdownDefaultKey)
     }
 
     func didTapHistory(sender: NoteOptionsViewController) {

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -196,13 +196,13 @@ extension SPNoteEditorViewController: UIPopoverPresentationControllerDelegate {
 // MARK: - Note options delegate
 //
 extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
-    func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController) {
+    func didToggleMarkdown() {
 
         // If Markdown is being enabled and it was previously disabled
-        bounceMarkdownPreviewOnActivityViewDismiss = toggle.isOn && !UserDefaults.standard.bool(forKey: kSimplenoteMarkdownDefaultKey)
+        bounceMarkdownPreviewOnActivityViewDismiss = currentNote.markdown && !UserDefaults.standard.bool(forKey: kSimplenoteMarkdownDefaultKey)
 
         // Update the global preference to use when creating new notes
-        UserDefaults.standard.set(toggle.isOn, forKey: kSimplenoteMarkdownDefaultKey)
+        UserDefaults.standard.set(currentNote.markdown, forKey: kSimplenoteMarkdownDefaultKey)
     }
 
     func didTapHistory(sender: NoteOptionsViewController) {

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -193,7 +193,7 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
     func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController) {
 
         // If Markdown is being enabled and it was previously disabled
-        bounceMarkdownPreviewOnActivityViewDismiss = toggle.isOn && UserDefaults.standard.bool(forKey: kSimplenoteMarkdownDefaultKey)
+        bounceMarkdownPreviewOnActivityViewDismiss = toggle.isOn && !UserDefaults.standard.bool(forKey: kSimplenoteMarkdownDefaultKey)
 
         // Update the global preference to use when creating new notes
         UserDefaults.standard.set(toggle.isOn, forKey: kSimplenoteMarkdownDefaultKey)

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -153,7 +153,7 @@ extension SPNoteEditorViewController {
     /// - Parameter button: The button that triggered the action
     @objc
     func handleNoteOptions(_ button: UIButton) {
-        let noteView = NoteOptionsViewController(style: .grouped)
+        let noteView = NoteOptionsViewController(with: currentNote)
         let noteNavigation = SPNavigationController(rootViewController: noteView)
         noteNavigation.displaysBlurEffect = true
         noteNavigation.modalPresentationStyle = .popover

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -203,4 +203,9 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
         sender.dismiss(animated: true, completion: nil)
         addCollaboratorsAction(sender)
     }
+
+    func didTapMoveToTrash(sender: NoteOptionsViewController) {
+        sender.dismiss(animated: true, completion: nil)
+        trashNoteAction(self)
+    }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -153,6 +153,13 @@ extension SPNoteEditorViewController {
     /// - Parameter button: The button that triggered the action
     @objc
     func handleNoteOptions(_ button: UIButton) {
+
+        save()
+        endEditing(button)
+        tagView.endEditing(true)
+
+        SPTracker.trackEditorActivitiesAccessed()
+
         let noteView = NoteOptionsViewController(with: currentNote)
         noteView.delegate = self
         let noteNavigation = SPNavigationController(rootViewController: noteView)

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -169,7 +169,6 @@ extension SPNoteEditorViewController {
 // MARK: - Popover presentation delegate
 //
 extension SPNoteEditorViewController: UIPopoverPresentationControllerDelegate {
-
     public func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
         if bounceMarkdownPreviewOnActivityViewDismiss {
             self.bounceMarkdownPreview()
@@ -214,6 +213,8 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
 // MARK: - Note options state handling
 //
 extension SPNoteEditorViewController {
+    /// A convenience variable for accessing the currently presented note options view
+    /// This is used to pass on note updates from Simperium
     @objc var presentedNoteOptionsViewcontroller: NoteOptionsViewController? {
         return (presentedViewController as? SPNavigationController)?.topViewController as? NoteOptionsViewController
     }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -191,7 +191,12 @@ extension SPNoteEditorViewController: UIPopoverPresentationControllerDelegate {
 //
 extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
     func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController) {
-        bounceMarkdownPreviewOnActivityViewDismiss = toggle.isOn
+
+        // If Markdown is being enabled and it was previously disabled
+        bounceMarkdownPreviewOnActivityViewDismiss = toggle.isOn && UserDefaults.standard.bool(forKey: kSimplenoteMarkdownDefaultKey)
+
+        // Update the global preference to use when creating new notes
+        UserDefaults.standard.set(toggle.isOn, forKey: kSimplenoteMarkdownDefaultKey)
     }
 
     func didTapHistory(sender: NoteOptionsViewController) {

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -195,8 +195,9 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
     }
 
     func didTapHistory(sender: NoteOptionsViewController) {
-        sender.dismiss(animated: true, completion: nil)
-        viewVersionAction(sender)
+        sender.dismiss(animated: true) { [weak self] in
+            self?.viewVersionAction(sender)
+        }
     }
 
     func didTapCollaborators(sender: NoteOptionsViewController) {

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -154,12 +154,43 @@ extension SPNoteEditorViewController {
     @objc
     func handleNoteOptions(_ button: UIButton) {
         let noteView = NoteOptionsViewController(with: currentNote)
+        noteView.delegate = self
         let noteNavigation = SPNavigationController(rootViewController: noteView)
         noteNavigation.displaysBlurEffect = true
         noteNavigation.modalPresentationStyle = .popover
         noteNavigation.popoverPresentationController?.sourceRect = button.bounds
         noteNavigation.popoverPresentationController?.sourceView = button
         noteNavigation.popoverPresentationController?.backgroundColor = .simplenoteNavigationBarModalBackgroundColor
+        noteNavigation.popoverPresentationController?.delegate = self
         present(noteNavigation, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Popover presentation delegate
+//
+extension SPNoteEditorViewController: UIPopoverPresentationControllerDelegate {
+
+    public func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
+        if bounceMarkdownPreviewOnActivityViewDismiss {
+            self.bounceMarkdownPreview()
+        }
+    }
+
+    // The `SPActivityView` and `SPPopoverContainerViewController` breaks when transitioning from a popover to a modal-style
+    // presentation, so we'll tell it not to change its presentation if the
+    // view's size class changes.
+    public func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        if controller.presentedViewController is SPPopoverContainerViewController {
+            return .none
+        }
+        return .popover
+    }
+}
+
+// MARK: - Note options delegate
+//
+extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
+    func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController) {
+        bounceMarkdownPreviewOnActivityViewDismiss = toggle.isOn
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -184,7 +184,7 @@ extension SPNoteEditorViewController {
 extension SPNoteEditorViewController: UIPopoverPresentationControllerDelegate {
     public func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
         if bounceMarkdownPreviewOnActivityViewDismiss {
-            self.bounceMarkdownPreview()
+            bounceMarkdownPreview()
         }
     }
 
@@ -228,7 +228,7 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
 extension SPNoteEditorViewController {
     /// A convenience variable for accessing the currently presented note options view
     /// This is used to pass on note updates from Simperium
-    @objc var presentedNoteOptionsViewcontroller: NoteOptionsViewController? {
+    @objc var presentedNoteOptionsViewController: NoteOptionsViewController? {
         return (presentedViewController as? SPNavigationController)?.topViewController as? NoteOptionsViewController
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -205,11 +205,6 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
         }
     }
 
-    func didTapCollaborators(sender: NoteOptionsViewController) {
-        sender.dismiss(animated: true, completion: nil)
-        addCollaboratorsAction(sender)
-    }
-
     func didTapMoveToTrash(sender: NoteOptionsViewController) {
         sender.dismiss(animated: true, completion: nil)
         trashNoteAction(self)

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -193,4 +193,9 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
     func didToggleMarkdown(toggle: UISwitch, sender: NoteOptionsViewController) {
         bounceMarkdownPreviewOnActivityViewDismiss = toggle.isOn
     }
+
+    func didTapHistory(sender: NoteOptionsViewController) {
+        sender.dismiss(animated: true, completion: nil)
+        viewVersionAction(sender)
+    }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -209,3 +209,11 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
         trashNoteAction(self)
     }
 }
+
+// MARK: - Note options state handling
+//
+extension SPNoteEditorViewController {
+    @objc var presentedNoteOptionsViewcontroller: NoteOptionsViewController? {
+        return (presentedViewController as? SPNavigationController)?.topViewController as? NoteOptionsViewController
+    }
+}

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -198,4 +198,9 @@ extension SPNoteEditorViewController: NoteOptionsViewControllerDelegate {
         sender.dismiss(animated: true, completion: nil)
         viewVersionAction(sender)
     }
+
+    func didTapCollaborators(sender: NoteOptionsViewController) {
+        sender.dismiss(animated: true, completion: nil)
+        addCollaboratorsAction(sender)
+    }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -159,7 +159,13 @@ extension SPNoteEditorViewController {
         tagView.endEditing(true)
 
         SPTracker.trackEditorActivitiesAccessed()
+        presentNoteOptions(from: button)
+    }
 
+    /// Presents a new note options view from a given `UIButton`
+    /// This is presented as a popover on iPad
+    /// - Parameter button: The button to anchor the popover to
+    func presentNoteOptions(from button: UIButton) {
         let noteView = NoteOptionsViewController(with: currentNote)
         noteView.delegate = self
         let noteNavigation = SPNavigationController(rootViewController: noteView)

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -82,6 +82,8 @@
 @property (nonatomic, getter=isEditingNote) BOOL editingNote;
 @property (nonatomic, getter=isPreviewing) BOOL previewing;
 
+@property (nonatomic) BOOL bounceMarkdownPreviewOnActivityViewDismiss;
+
 - (void)prepareToPopView;
 - (void)updateNote:(Note *)note;
 - (void)setSearchString:(NSString *)string;
@@ -91,6 +93,8 @@
 - (void)didReceiveNewContent;
 - (void)didReceiveVersion:(NSString *)version data:(NSDictionary *)data;
 - (void)didDeleteCurrentNote;
+
+- (void)bounceMarkdownPreview;
 
 - (void)resetNavigationBarToIdentityWithAnimation:(BOOL)animated completion:(void (^)())completion;
 

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -99,6 +99,7 @@
 - (void)resetNavigationBarToIdentityWithAnimation:(BOOL)animated completion:(void (^)())completion;
 
 - (void)save;
+- (void)endEditing:(id)sender;
 
 - (void)viewVersionAction:(id)sender;
 - (void)addCollaboratorsAction:(id)sender;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -100,4 +100,6 @@
 
 - (void)save;
 
+- (void)viewVersionAction:(id)sender;
+
 @end

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -101,5 +101,6 @@
 - (void)save;
 
 - (void)viewVersionAction:(id)sender;
+- (void)addCollaboratorsAction:(id)sender;
 
 @end

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -102,5 +102,6 @@
 
 - (void)viewVersionAction:(id)sender;
 - (void)addCollaboratorsAction:(id)sender;
+- (void)trashNoteAction:(id)sender;
 
 @end

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1272,6 +1272,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 		[_tagView setupWithTagNames:tags];
     }
     [self updatePublishUI];
+    [self.presentedNoteOptionsViewcontroller didReceiveNoteUpdate];
 }
 
 - (void)didReceiveVersion:(NSString *)version data:(NSDictionary *)data {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1272,7 +1272,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 		[_tagView setupWithTagNames:tags];
     }
     [self updatePublishUI];
-    [self.presentedNoteOptionsViewcontroller didReceiveNoteUpdate];
+    [self.presentedNoteOptionsViewController didReceiveNoteUpdate];
 }
 
 - (void)didReceiveVersion:(NSString *)version data:(NSDictionary *)data {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -711,7 +711,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                     self.noteEditorTextView.hidden = NO;
                     [snapshot removeFromSuperview];
 
-                    self->_bounceMarkdownPreviewOnActivityViewDismiss = NO;
+                    self.bounceMarkdownPreviewOnActivityViewDismiss = NO;
                 }];
             }];
         }];
@@ -1546,7 +1546,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
             [self save];
 
             // If Markdown is being enabled and it was previously disabled
-            _bounceMarkdownPreviewOnActivityViewDismiss = (enabled && ![[NSUserDefaults standardUserDefaults] boolForKey:kSimplenoteMarkdownDefaultKey]);
+            self.bounceMarkdownPreviewOnActivityViewDismiss = (enabled && ![[NSUserDefaults standardUserDefaults] boolForKey:kSimplenoteMarkdownDefaultKey]);
 
             // Update the global preference to use when creating new notes
             [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kSimplenoteMarkdownDefaultKey];
@@ -1672,7 +1672,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     if ([actionSheet isEqual:versionActionSheet])
         versionActionSheet = nil;
 
-    if (_bounceMarkdownPreviewOnActivityViewDismiss) {
+    if (self.bounceMarkdownPreviewOnActivityViewDismiss) {
         [self bounceMarkdownPreview];
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -25,7 +25,7 @@
 #import "NSString+Search.h"
 #import "SPTextView.h"
 #import "NSString+Attributed.h"
-#import "SPAcitivitySafari.h"
+#import "SPActivitySafari.h"
 #import "SPNavigationController.h"
 #import "SPMarkdownPreviewViewController.h"
 #import "UIDevice+Extensions.h"
@@ -1746,7 +1746,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     
     NSURL *publishURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", kSimplenotePublishURL, _currentNote.publishURL]];
     
-    SPAcitivitySafari *safariActivity = [[SPAcitivitySafari alloc] init];
+    SPActivitySafari *safariActivity = [[SPActivitySafari alloc] init];
     
     UIActivityViewController *acv = [[UIActivityViewController alloc] initWithActivityItems:@[publishURL]
                                                                       applicationActivities:@[safariActivity]];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -58,7 +58,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 {
     NSUInteger cursorLocationBeforeRemoteUpdate;
     NSString *noteContentBeforeRemoteUpdate;
-    BOOL bounceMarkdownPreviewOnActivityViewDismiss;
 }
 
 @property (nonatomic, strong) SPBlurEffectView          *navigationBarBackground;
@@ -712,7 +711,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                     self.noteEditorTextView.hidden = NO;
                     [snapshot removeFromSuperview];
 
-                    self->bounceMarkdownPreviewOnActivityViewDismiss = NO;
+                    self->_bounceMarkdownPreviewOnActivityViewDismiss = NO;
                 }];
             }];
         }];
@@ -751,24 +750,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     _isKeyboardVisible = isKeyboardVisible;
 
     [self refreshNavigationBarButtons];
-}
-
-
-#pragma mark - UIPopoverPresentationControllerDelegate
-
-- (void)popoverPresentationControllerDidDismissPopover:(UIPopoverPresentationController *)popoverPresentationController
-{
-    if (bounceMarkdownPreviewOnActivityViewDismiss) {
-        [self bounceMarkdownPreview];
-    }
-}
-
-// The activity sheet breaks when transitioning from a popover to a modal-style
-// presentation, so we'll tell it not to change its presentation if the
-// view's size class changes.
-- (UIModalPresentationStyle)adaptivePresentationStyleForPresentationController:(UIPresentationController *)controller
-{
-    return UIModalPresentationNone;
 }
 
 #pragma mark - SPInteractivePushViewControllerProvider (Markdown Preview)
@@ -1564,7 +1545,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
             [self save];
 
             // If Markdown is being enabled and it was previously disabled
-            bounceMarkdownPreviewOnActivityViewDismiss = (enabled && ![[NSUserDefaults standardUserDefaults] boolForKey:kSimplenoteMarkdownDefaultKey]);
+            _bounceMarkdownPreviewOnActivityViewDismiss = (enabled && ![[NSUserDefaults standardUserDefaults] boolForKey:kSimplenoteMarkdownDefaultKey]);
 
             // Update the global preference to use when creating new notes
             [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kSimplenoteMarkdownDefaultKey];
@@ -1690,7 +1671,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     if ([actionSheet isEqual:versionActionSheet])
         versionActionSheet = nil;
 
-    if (bounceMarkdownPreviewOnActivityViewDismiss) {
+    if (_bounceMarkdownPreviewOnActivityViewDismiss) {
         [self bounceMarkdownPreview];
     }
 }

--- a/Simplenote/Classes/Value1TableViewCell.swift
+++ b/Simplenote/Classes/Value1TableViewCell.swift
@@ -21,4 +21,12 @@ class Value1TableViewCell: UITableViewCell {
         textLabel?.textColor = .simplenoteTextColor
         detailTextLabel?.textColor = UIColor.color(name: .tableViewDetailTextLabelColor)
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        applyStyles()
+        textLabel?.text = nil
+        detailTextLabel?.text = nil
+        accessoryView = nil
+    }
 }

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -29,7 +29,9 @@
 #import "SPNoteEditorViewController.h"
 #import "SPTracker.h"
 #import "WPAuthHandler.h"
-
+#import "SPNavigationController.h"
+#import "SPPopoverContainerViewController.h"
+#import "SPActivitySafari.h"
 
 #pragma mark - Extensions
 
@@ -39,5 +41,3 @@
 #import "NSString+Condensing.h"
 #import "NSTextStorage+Highlight.h"
 #import "Simperium+Simplenote.h"
-#import "SPNavigationController.h"
-#import "SPPopoverContainerViewController.h"

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -40,3 +40,4 @@
 #import "NSTextStorage+Highlight.h"
 #import "Simperium+Simplenote.h"
 #import "SPNavigationController.h"
+#import "SPPopoverContainerViewController.h"


### PR DESCRIPTION
### Details
This PR is part of the work required for #763 and will join the work in #851 when merged. It adds the logic for handling each of the table rows in the new note options view and their switches. This includes:
1. Pin to top 
2. Markdown
3. Share note
4. History
5. Publishing
6. Link copying
7. Collaboration handling
8. Trash

I've replaced some of the accessibility localisation strings that I had set with some of the ones from the existing view as they serve the same purpose and creating new strings would be a time waste. 

This PR also renames `SPAcitivitySafari` to `SPActivitySafari` which I believe was a typo.

### Screenshots
![Simulator Screen Shot - iPad Pro (12 9-inch) - 2020-08-22 at 12 11 09](https://user-images.githubusercontent.com/68430728/90954916-cae9a000-e470-11ea-95b5-424a1ec9a556.png)

### Notes
I took the liberty of adding a loading indicator to the public link row as it seemed sensible to show that something was happening while the sync happens. I have tested running two simulators and toggling the switches on both and they are reflected on both devices quickly.

### Issues & Questions
1. The designs show an alert that displays at the bottom of the view if the note fails to publish. With the current publish mechanism I can see no way to subscribe to error notifications. If there is no internet connection then it looks like Simperium queues the action and waits for a connection before syncing. If any other type of error occurs, it doesn't look like the there is a way of getting details passed back from the save operation as there is no closure or completion block for the action.

2. I have not yet removed all of the legacy methods that this code replaces. It adds several hundred lines of deletion so will be moved to a separate request to avoid sending this over 500LOC

3. I've been unable to fully test the publishing behaviour as I'm currently using the demo credentials which I don't believe allows me to publish. I may need setting up with some proper credentials to test this one on.

4. I've been considering moving the collaboration view logic into the note options view. It would mean presenting another popover from our current one but I feel that the UX would feel nicer. You would edit your collaborators and be able to see the count increase in the options view. Currently, the options view is dismissed in favour of a modal view for collaboration.

### Feedback
Any feedback on this code is very welcome. 

