### PR TITLE
Fixing Tags Edition

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -   Fixed a stability issue in the Notes Editor
 -   Swiping a Note in the List now reveals the Copy Internal Link Action
 -   Long Pressing over an Internal Link now pushes the target Note
+-   Fixed a bug that affected Tag Edition with non ASCII keyboards
 
 4.23
 -----

--- a/Simplenote/Classes/SPTagListViewCell.xib
+++ b/Simplenote/Classes/SPTagListViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,9 +27,9 @@
                                 </constraints>
                             </imageView>
                             <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jm9-sw-6Ik">
-                                <rect key="frame" x="34" y="1.5" width="354" height="21"/>
+                                <rect key="frame" x="34" y="1" width="354" height="22"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="alphabet" returnKeyType="done"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done"/>
                             </textField>
                         </subviews>
                     </stackView>


### PR DESCRIPTION
### Fix
In this PR we're fixing a glitch that prevented non western keyboards from showing up, when editing a Tag.

Closes #841

@danielebogo Sir!! Can I bug you yeeet again?
Thanks in advance!!

### Test
1. In the Settings app, go to General > Keyboard > Keyboards > Add New Keyboard and add a non-Latin keyboard to your device (e.g. Arabic).
2. Open the Simplenote app.
3. Open the Editor and confirm you can switch between keyboards using the globe icon.
4. Open the Notes List and select "Edit" next to Tags.
5. Tap into a tag name field to bring up the keyboard.
6. Try switching between keyboards 

- [  ] Verify the Arabic keyboard shows up correctly!

### Release
`RELEASE-NOTES.txt` was updated in f3a521d with:
 
> Fixed a bug that affected Tag Edition with non ASCII keyboards
