### PR TITLE
Fixing Email Validation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+4.25
+-----
+-   Fixed a bug that prevented adding collaborators with email addresses that contain new TLDs
+
 4.24
 -----
 -   Fixed a stability issue in the Notes Editor

--- a/Simplenote/Classes/NSString+Metadata.h
+++ b/Simplenote/Classes/NSString+Metadata.h
@@ -3,8 +3,5 @@
 
 // Removes pin and tags
 - (NSArray *)stringArray;
-// Search for a complete word. Does not match substrings of words. Requires fullWord be present
-// and no surrounding alphanumeric characters.
-- (BOOL)containsEmailAddress;
 
 @end

--- a/Simplenote/Classes/NSString+Metadata.m
+++ b/Simplenote/Classes/NSString+Metadata.m
@@ -17,11 +17,4 @@
 	return list;
 }
 
-- (BOOL)containsEmailAddress {
-    NSString *regEx = @"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}";
-    
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", regEx];
-    return [predicate evaluateWithObject:self];
-}
-
 @end

--- a/Simplenote/Classes/NSString+Simplenote.swift
+++ b/Simplenote/Classes/NSString+Simplenote.swift
@@ -35,4 +35,12 @@ extension NSString {
     var isValidTagName: Bool {
         byEncodingAsTagHash.count <= SimplenoteConstants.maximumTagLength
     }
+
+    /// Indicates if the receiver contains a valid email address
+    ///
+    @objc
+    var isValidEmailAddress: Bool {
+        let predicate = NSPredicate.predicateForEmailValidation()
+        return predicate.evaluate(with: self)
+    }
 }

--- a/Simplenote/Classes/Note.m
+++ b/Simplenote/Classes/Note.m
@@ -9,6 +9,7 @@
 #import "NSString+Condensing.h"
 #import "NSString+Metadata.h"
 #import "JSONKit+Simplenote.h"
+#import "Simplenote-Swift.h"
 
 
 @interface Note (PrimitiveAccessors)
@@ -414,7 +415,7 @@ SEL notifySelector;
 
     emailTagsArray = [NSMutableArray arrayWithCapacity:2];
     for (NSString *tag in tagsArray) {
-        if ([tag containsEmailAddress])
+        if ([tag isValidEmailAddress])
             [emailTagsArray addObject:tag];
     }
 }

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.m
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.m
@@ -219,7 +219,7 @@
 {
     // make sure email address is actually an email address
     person.email = [person.email stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    if (![person.email containsEmailAddress]) {
+    if (![person.email isValidEmailAddress]) {
         return;
     }
     
@@ -241,7 +241,7 @@
 - (void)processTextInField
 {
     NSString *email = entryTextField.text;
-    if (email.containsEmailAddress == false) {
+    if (email.isValidEmailAddress == false) {
         return;
     }
 

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -147,7 +147,7 @@
     }
     
     // Make sure email addresses don't get added as proper tags
-    if ([tagName containsEmailAddress]) {
+    if ([tagName isValidEmailAddress]) {
         return nil;
     }
 

--- a/Simplenote/Classes/SPTagStub.h
+++ b/Simplenote/Classes/SPTagStub.h
@@ -8,13 +8,11 @@
 #import <Foundation/Foundation.h>
 
 
-@interface SPTagStub : NSObject {
-}
-
+@interface SPTagStub : NSObject
 
 #pragma mark - Constructor
-- (id)initWithTag:(NSString *)aTag;
-- (id)initWithTag:(NSString *)aTag displayText:(NSString *)aDisplayText;
+- (instancetype)initWithTag:(NSString *)aTag;
+- (instancetype)initWithTag:(NSString *)aTag displayText:(NSString *)aDisplayText;
 
 
 #pragma mark - Properties

--- a/Simplenote/Classes/SPTagStub.m
+++ b/Simplenote/Classes/SPTagStub.m
@@ -7,28 +7,29 @@
 
 #import "SPTagStub.h"
 #import "NSString+Metadata.h"
+#import "Simplenote-Swift.h"
+
 
 @implementation SPTagStub
 
-
 #pragma mark - Constructor
 
-- (id)initWithTag:(NSString *)aTag {
+- (instancetype)initWithTag:(NSString *)aTag {
     self = [super init];
     if (self) {
         self.tag = aTag;
         self.displayText = nil;
-        self.isEmailTag = [aTag containsEmailAddress];
+        self.isEmailTag = [aTag isValidEmailAddress];
     }
     return self;
 }
 
-- (id)initWithTag:(NSString *)aTag displayText:(NSString *)aDisplayText {
+- (instancetype)initWithTag:(NSString *)aTag displayText:(NSString *)aDisplayText {
     self = [super init];
     if (self) {
         self.tag = aTag;
         self.displayText = aDisplayText;
-        self.isEmailTag = [aTag containsEmailAddress];
+        self.isEmailTag = [aTag isValidEmailAddress];
     }
     return self;
 }

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -144,7 +144,7 @@
     
     for (NSString *tag in tagNames) {
         
-        if (![tag containsEmailAddress])
+        if (![tag isValidEmailAddress])
             [self newTagPillWithString:tag];
     }
     
@@ -364,7 +364,7 @@
     
     // there may be multiple tags
     NSString *name = addTagField.text;
-    BOOL containsEmailAddress = [name containsEmailAddress];
+    BOOL containsEmailAddress = [name isValidEmailAddress];
     
 
     if (name.length > 0 && [self.tagDelegate tagView:self shouldCreateTagName:name] && !containsEmailAddress) {

--- a/SimplenoteTests/NSPredicateEmailTests.swift
+++ b/SimplenoteTests/NSPredicateEmailTests.swift
@@ -27,6 +27,10 @@ class NSPredicateEmailTests: XCTestCase {
         let predicate = NSPredicate.predicateForEmailValidation()
         XCTAssertFalse(predicate.evaluate(with: "j@j..com"))
         XCTAssertFalse(predicate.evaluate(with: "j@j.com...ar"))
+        XCTAssertFalse(predicate.evaluate(with: "@test"))
+        XCTAssertFalse(predicate.evaluate(with: "@test.com"))
+        XCTAssertFalse(predicate.evaluate(with: "test.com"))
+        XCTAssertFalse(predicate.evaluate(with: "test.test.coffee"))
     }
 
     /// Verifies that `predicateForEmailValidation` evaluates true when the email is well formed
@@ -36,5 +40,14 @@ class NSPredicateEmailTests: XCTestCase {
         XCTAssertTrue(predicate.evaluate(with: "j@j.com"))
         XCTAssertTrue(predicate.evaluate(with: "something@seriouslynotrealbutvalidsimplenote.blog"))
         XCTAssertTrue(predicate.evaluate(with: "something@seriouslynotrealbutvalidsimplenote.blog.ar"))
+    }
+
+    /// Verifies that `predicateForEmailValidation` returns  *true* when the email contains a New / Non Standard TLD
+    ///
+    func testPredicateForEmailValidationEvaluatesTrueWhenStringContainsNewTLDs() {
+        let predicate = NSPredicate.predicateForEmailValidation()
+        XCTAssertTrue(predicate.evaluate(with: "test@test.coffee"))
+        XCTAssertTrue(predicate.evaluate(with: "test@test.email"))
+        XCTAssertTrue(predicate.evaluate(with: "test@test.education"))
     }
 }

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -56,4 +56,22 @@ class NSStringSimplenoteTests: XCTestCase {
         XCTAssertEqual(hashA, hashC)
         XCTAssertEqual(hashB, hashC)
     }
+
+    /// Verifies that `isValidEmailAddress` returns  *true* when the receiver contains an email address with a non-standard TLD
+    ///
+    func testIsValidEmailAddressReturnsTrueWhenStringContainsNewTLDs() {
+        XCTAssertTrue("test@test.coffee".isValidEmailAddress)
+        XCTAssertTrue("test@test.email".isValidEmailAddress)
+        XCTAssertTrue("test@test.education".isValidEmailAddress)
+    }
+
+    /// Verifies that `isValidEmailAddress` returns  **false** whenever the receiver does not contain a valid email address
+    ///
+    func testIsValidEmailAddressReturnsFalseForMalformedEmails() {
+        XCTAssertFalse("@test".isValidEmailAddress)
+        XCTAssertFalse("@test.com".isValidEmailAddress)
+        XCTAssertFalse("test.com".isValidEmailAddress)
+        XCTAssertFalse("test.test.coffee".isValidEmailAddress)
+    }
+
 }

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -56,22 +56,4 @@ class NSStringSimplenoteTests: XCTestCase {
         XCTAssertEqual(hashA, hashC)
         XCTAssertEqual(hashB, hashC)
     }
-
-    /// Verifies that `isValidEmailAddress` returns  *true* when the receiver contains an email address with a non-standard TLD
-    ///
-    func testIsValidEmailAddressReturnsTrueWhenStringContainsNewTLDs() {
-        XCTAssertTrue("test@test.coffee".isValidEmailAddress)
-        XCTAssertTrue("test@test.email".isValidEmailAddress)
-        XCTAssertTrue("test@test.education".isValidEmailAddress)
-    }
-
-    /// Verifies that `isValidEmailAddress` returns  **false** whenever the receiver does not contain a valid email address
-    ///
-    func testIsValidEmailAddressReturnsFalseForMalformedEmails() {
-        XCTAssertFalse("@test".isValidEmailAddress)
-        XCTAssertFalse("@test.com".isValidEmailAddress)
-        XCTAssertFalse("test.com".isValidEmailAddress)
-        XCTAssertFalse("test.test.coffee".isValidEmailAddress)
-    }
-
 }


### PR DESCRIPTION
### Fix
In this PR we're unifying the Email Validation routines, so that new TLDs are supported by the collaboration functionality.

Closes #832 
@aerych Sir!! you game for a quick PR?

Thanks in advance!!

### Test
1. Open any note
2. Press over the top right `( i )` icon
3. Press over `Collaborate`

- [ ] Verify you can add an email with a new (long) TLD, such as `test@test.coffee`

### Release
`RELEASE-NOTES.txt` was updated in 8ece212 with:
 
> Fixed a bug that prevented adding collaborators with email addresses that contain new TLDs
