### PR TITLE
Disables Interlinking Support

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,11 +1,11 @@
 4.25
 -----
- 
+-   Swiping a Note in the List now reveals the Copy Internal Link Action
+-   Long Pressing over an Internal Link now pushes the target Note
+
 4.24
 -----
 -   Fixed a stability issue in the Notes Editor
--   Swiping a Note in the List now reveals the Copy Internal Link Action
--   Long Pressing over an Internal Link now pushes the target Note
 -   Fixed a bug that affected Tag Edition with non ASCII keyboards
 
 4.23

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -610,12 +610,12 @@ private extension SPNoteListViewController {
                 self?.togglePinnedState(note: note)
                 completion(true)
             },
-
+/*
             UIContextualAction(style: .normal, image: .image(name: .link), backgroundColor: .simplenoteTertiaryActionColor) { [weak self] (_, _, completion) in
                 self?.copyInterlink(to: note)
                 completion(true)
             },
-
+*/
             UIContextualAction(style: .normal, image: .image(name: .share), backgroundColor: .simplenoteQuaternaryActionColor) { [weak self] (_, _, completion) in
                 self?.share(note: note)
                 completion(true)


### PR DESCRIPTION
### Fix
Disables Interlinking Support in 4.24. Pushed to 4.25, in order to sync the launch with other platforms.

@aerych sir!! Can I bug you with this one?
Thanks in advance!!

### Test
1. Launch Simplenote
2. Swipe over any Note

- [x] Verify that only three actions show up: There should be **no action** with a Link Icon

### Release
These changes do not require release notes.
