### PR TITLE
Enabling Interlinking

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,8 @@
 4.25
 -----
--   Fixed a bug that prevented adding collaborators with email addresses that contain new TLDs
--   Swiping a Note in the List now reveals the Copy Internal Link Action
--   Long Pressing over an Internal Link now pushes the target Note
+-   Fixed a bug that prevented adding collaborators with email addresses that contain new TLDs #872
+-   Swiping a Note in the List now reveals the Copy Internal Link Action #864
+-   Long Pressing over an Internal Link now pushes the target Note #868
 
 4.24
 -----

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -610,12 +610,12 @@ private extension SPNoteListViewController {
                 self?.togglePinnedState(note: note)
                 completion(true)
             },
-/*
+
             UIContextualAction(style: .normal, image: .image(name: .link), backgroundColor: .simplenoteTertiaryActionColor) { [weak self] (_, _, completion) in
                 self?.copyInterlink(to: note)
                 completion(true)
             },
-*/
+
             UIContextualAction(style: .normal, image: .image(name: .share), backgroundColor: .simplenoteQuaternaryActionColor) { [weak self] (_, _, completion) in
                 self?.share(note: note)
                 completion(true)


### PR DESCRIPTION
### Details:
In this PR we're enabling Interlinking, for final release. We've disabled the `Copy Internal Link` feature in 4.24 (PR #873), in order to sync the launch with the other platforms.

@danielebogo May I trouble you with this one sir?
Thanks a looot in advance!

Ref. #863

### Test
1. Launch Simplenote
2. Swipe over any Note

- [x] Verify that 4 actions show up: There should be a Link Icon (which copies the selected note interlink)

### Release
These changes do not require release notes.
