### PR TITLE
Add Help Link

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.26
 -----
+-   Added a link to help in Settings and About #894
  
 4.25
 -----

--- a/Simplenote/Classes/SPAboutViewController.swift
+++ b/Simplenote/Classes/SPAboutViewController.swift
@@ -289,6 +289,7 @@ private enum Constants {
     static let titles: [String] = [
         NSLocalizedString("Blog", comment: "The Simplenote blog"),
         "Twitter",
+        NSLocalizedString("Get Help", comment: "FAQ or contact us"),
         NSLocalizedString("Apps", comment: "Other Simplenote apps"),
         NSLocalizedString("Contribute", comment: "Contribute to the Simplenote apps on github"),
         NSLocalizedString("Work With Us", comment: "Work at Automattic")
@@ -297,6 +298,7 @@ private enum Constants {
     static let descriptions: [String] = [
         "simplenote.com/blog",
         "@simplenoteapp",
+        "FAQ or contact us",
         "simplenote.com",
         "GitHub.com",
         NSLocalizedString("Are you a developer? Automattic is hiring.", comment: "Automattic hiring description")
@@ -305,6 +307,7 @@ private enum Constants {
     static let urls: [URL] = [
         URL(string: "https://simplenote.com/blog")!,
         URL(string: "https://twitter.com/simplenoteapp")!,
+        URL(string: "https://simplenote.com/help")!,
         URL(string: "https://simplenote.com")!,
         URL(string: "https://github.com/automattic/simplenote-ios")!,
         URL(string: "https://automattic.com/work-with-us")!

--- a/Simplenote/Classes/SPAboutViewController.swift
+++ b/Simplenote/Classes/SPAboutViewController.swift
@@ -298,7 +298,7 @@ private enum Constants {
     static let descriptions: [String] = [
         "simplenote.com/blog",
         "@simplenoteapp",
-        NSLocalizedString("FAQ or contact us", "Get Help Description Label"),
+        NSLocalizedString("FAQ or contact us", comment: "Get Help Description Label"),```
         "simplenote.com",
         "GitHub.com",
         NSLocalizedString("Are you a developer? Automattic is hiring.", comment: "Automattic hiring description")

--- a/Simplenote/Classes/SPAboutViewController.swift
+++ b/Simplenote/Classes/SPAboutViewController.swift
@@ -298,7 +298,7 @@ private enum Constants {
     static let descriptions: [String] = [
         "simplenote.com/blog",
         "@simplenoteapp",
-        NSLocalizedString("FAQ or contact us", comment: "Get Help Description Label"),```
+        NSLocalizedString("FAQ or contact us", comment: "Get Help Description Label"),
         "simplenote.com",
         "GitHub.com",
         NSLocalizedString("Are you a developer? Automattic is hiring.", comment: "Automattic hiring description")

--- a/Simplenote/Classes/SPAboutViewController.swift
+++ b/Simplenote/Classes/SPAboutViewController.swift
@@ -298,7 +298,7 @@ private enum Constants {
     static let descriptions: [String] = [
         "simplenote.com/blog",
         "@simplenoteapp",
-        "FAQ or contact us",
+        NSLocalizedString("FAQ or contact us", "Get Help Description Label"),
         "simplenote.com",
         "GitHub.com",
         NSLocalizedString("Are you a developer? Automattic is hiring.", comment: "Automattic hiring description")

--- a/Simplenote/Classes/SPOptionsViewController.m
+++ b/Simplenote/Classes/SPOptionsViewController.m
@@ -52,8 +52,9 @@ typedef NS_ENUM(NSInteger, SPOptionsViewSections) {
     SPOptionsViewSectionsSecurity       = 3,
     SPOptionsViewSectionsAccount        = 4,
     SPOptionsViewSectionsAbout          = 5,
-    SPOptionsViewSectionsDebug          = 6,
-    SPOptionsViewSectionsCount          = 7
+    SPOptionsViewSectionsHelp           = 6,
+    SPOptionsViewSectionsDebug          = 7,
+    SPOptionsViewSectionsCount          = 8
 };
 
 typedef NS_ENUM(NSInteger, SPOptionsAccountRow) {
@@ -89,6 +90,11 @@ typedef NS_ENUM(NSInteger, SPOptionsSecurityRow) {
 typedef NS_ENUM(NSInteger, SPOptionsAboutRow) {
     SPOptionsAboutRowTitle              = 0,
     SPOptionsAboutRowCount              = 1
+};
+
+typedef NS_ENUM(NSInteger, SPOptionsHelpRow) {
+    SPOptionsHelpRowTitle              = 0,
+    SPOptionsHelpRowCount              = 1
 };
 
 typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
@@ -247,9 +253,13 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
         case SPOptionsViewSectionsAccount: {
             return SPOptionsAccountRowCount;
         }
-
+            
         case SPOptionsViewSectionsAbout: {
             return SPOptionsAboutRowCount;
+        }
+            
+        case SPOptionsViewSectionsHelp: {
+            return SPOptionsHelpRowCount;
         }
             
         case SPOptionsViewSectionsDebug: {
@@ -457,6 +467,16 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             }
             
             break;
+        } case SPOptionsViewSectionsHelp: {
+            
+            switch (indexPath.row) {
+                case SPOptionsHelpRowTitle: {
+                    cell.textLabel.text = NSLocalizedString(@"Help", @"Display help web page");
+                    break;
+                }
+            }
+            
+            break;
         } case SPOptionsViewSectionsDebug: {
 
             switch (indexPath.row) {
@@ -560,6 +580,20 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     SPAboutViewController *aboutController = [[SPAboutViewController alloc] init];
                     aboutController.modalPresentationStyle = UIModalPresentationFormSheet;
                     [[self navigationController] presentViewController:aboutController animated:YES completion:nil];
+                    break;
+                }
+            }
+            
+            break;
+        } case SPOptionsViewSectionsHelp: {
+            switch (indexPath.row) {
+                case SPOptionsHelpRowTitle: {
+                    NSURL *url = [NSURL URLWithString:@"https://simplenote.com/help"];
+
+                    if ([[UIApplication sharedApplication] canOpenURL:url]) {
+                       [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+                    }
+
                     break;
                 }
             }


### PR DESCRIPTION
### Fix
Add a link to help in **_Settings_** and **_About_**, which directs to https://simplenote.com/help on the web.  See the screenshots below for illustration.

![simplenote_ios_help](https://user-images.githubusercontent.com/3827611/94051873-700bd700-fd95-11ea-81cf-a357669d62e2.png)

### Test
1. Open navigation drawer.
2. Tap ***Settings*** item in navigation drawer.
3. Notice **_Help_** under **_About_** item.
4. Tap **_Help_** under **_About_** item.
5. Notice [Simplenote Help page](https://simplenote.com/help/) is shown.
6. Tap back arrow in navigation bar.
7. Tap **_About_** item.
8. Notice **_Get Help_** item with **_FAQ or contact us_** summary.
9. Tap **_Get Help_** item.
10. Notice [Simplenote Help page](https://simplenote.com/help/) is shown.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in e0b4e81 with:
> Added a link to help in Settings and About #894