### PR TITLE
Editor: Drops direct ivar indirections

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -9,14 +9,9 @@
 
 @class Note;
 @class SPBlurEffectView;
-@class SPTextView;
 @class SPEditorTextView;
-@class SPOutsideTouchView;
 
 @interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {
-
-    SPOutsideTouchView *navigationButtonContainer;
-    
     UIBarButtonItem *nextSearchButton;
     UIBarButtonItem *prevSearchButton;
     UIBarButtonItem *doneSearchButton;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -1,9 +1,4 @@
 #import <UIKit/UIKit.h>
-#import "SPActionSheet.h"
-#import "SPActivityView.h"
-#import "SPTagView.h"
-#import "SPAddCollaboratorsViewController.h"
-#import "SPHorizontalPickerView.h"
 #import <Simperium/Simperium.h>
 
 
@@ -11,22 +6,13 @@
 @class SPBlurEffectView;
 @class SPEditorTextView;
 
-@interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {    
-    // sheets
-    SPActivityView *noteActivityView;
-    SPActionSheet *noteActionSheet;
-    SPActionSheet *versionActionSheet;
-    
-    SPHorizontalPickerView *versionPickerView;
-}
+@interface SPNoteEditorViewController : UIViewController  <SPBucketDelegate>
 
 // Navigation Bar
 @property (nonatomic, strong, readonly) SPBlurEffectView *navigationBarBackground;
 
-// Navigation Back Button
-@property (nonatomic, strong) UIButton *backButton;
-
 // Navigation Buttons
+@property (nonatomic, strong) UIButton *backButton;
 @property (nonatomic, strong) UIButton *actionButton;
 @property (nonatomic, strong) UIButton *checklistButton;
 @property (nonatomic, strong) UIButton *keyboardButton;
@@ -34,7 +20,6 @@
 
 @property (nonatomic, strong) Note *currentNote;
 @property (nonatomic, strong) SPEditorTextView *noteEditorTextView;
-@property (nonatomic, strong) SPTagView *tagView;
 @property (nonatomic, strong) NSString *searchString;
 
 // Voiceover
@@ -44,8 +29,10 @@
 @property (nonatomic, strong) NSArray *keyboardNotificationTokens;
 @property (nonatomic) BOOL isKeyboardVisible;
 
+// State
 @property (nonatomic, getter=isEditingNote) BOOL editingNote;
 @property (nonatomic, getter=isPreviewing) BOOL previewing;
+
 
 - (void)prepareToPopView;
 - (void)displayNote:(Note *)note;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -23,9 +23,7 @@
     BOOL bBlankNote;
     BOOL bModified;
     BOOL bDisableShrinkingNavigationBar;
-    BOOL bShouldDelete;
     BOOL bViewingVersions;
-    BOOL beditingTags;
     BOOL bActionSheetVisible;
     
     CGAffineTransform navigationBarTransform;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -14,8 +14,7 @@
 @class SPOutsideTouchView;
 
 @interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {
-    
-    CGAffineTransform navigationBarTransform;
+
     CGFloat scrollPosition;
     
     SPOutsideTouchView *navigationButtonContainer;
@@ -31,14 +30,8 @@
     
     SPHorizontalPickerView *versionPickerView;
     
-    BOOL bSearching;
-    NSInteger highlightedSearchResultIndex;
-    
-    UILabel *searchDetailLabel;
-    
     NSInteger currentVersion;
     NSMutableDictionary *noteVersionData;
-    
 }
 
 // Navigation Bar

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -14,11 +14,7 @@
 @class SPOutsideTouchView;
 
 @interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {
-    
-    // Other Objects
-    NSTimer *saveTimer;
-    NSTimer *guarenteedSaveTimer;
-    
+
     // BOOLS
     BOOL bBlankNote;
     BOOL bModified;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -14,13 +14,6 @@
 @class SPOutsideTouchView;
 
 @interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {
-
-    // BOOLS
-    BOOL bBlankNote;
-    BOOL bModified;
-    BOOL bDisableShrinkingNavigationBar;
-    BOOL bViewingVersions;
-    BOOL bActionSheetVisible;
     
     CGAffineTransform navigationBarTransform;
     CGFloat scrollPosition;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -15,8 +15,6 @@
 
 @interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {
 
-    CGFloat scrollPosition;
-    
     SPOutsideTouchView *navigationButtonContainer;
     
     UIBarButtonItem *nextSearchButton;
@@ -29,9 +27,6 @@
     SPActionSheet *versionActionSheet;
     
     SPHorizontalPickerView *versionPickerView;
-    
-    NSInteger currentVersion;
-    NSMutableDictionary *noteVersionData;
 }
 
 // Navigation Bar

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -11,11 +11,7 @@
 @class SPBlurEffectView;
 @class SPEditorTextView;
 
-@interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {
-    UIBarButtonItem *nextSearchButton;
-    UIBarButtonItem *prevSearchButton;
-    UIBarButtonItem *doneSearchButton;
-    
+@interface SPNoteEditorViewController : UIViewController  <SPActionSheetDelegate, SPActivityViewDelegate, UIActionSheetDelegate, SPTagViewDelegate, SPCollaboratorDelegate, SPHorizontalPickerViewDelegate, SPBucketDelegate> {    
     // sheets
     SPActivityView *noteActivityView;
     SPActionSheet *noteActionSheet;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -61,13 +61,17 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     BOOL bounceMarkdownPreviewOnActivityViewDismiss;
 }
 
-@property (nonatomic, strong) SPBlurEffectView          *navigationBarBackground;
-@property (nonatomic, strong) NSArray                   *searchResultRanges;
+// Timers
+@property (nonatomic, strong) NSTimer           *saveTimer;
+@property (nonatomic, strong) NSTimer           *guarenteedSaveTimer;
+
+@property (nonatomic, strong) SPBlurEffectView  *navigationBarBackground;
+@property (nonatomic, strong) NSArray           *searchResultRanges;
 
 // if a newly created tag is deleted within a certain time span,
 // the tag will be completely deleted - note just removed from the
 // current note. This helps prevent against tag spam by mistyping
-@property (nonatomic, strong) NSString                  *deletedTagBuffer;
+@property (nonatomic, strong) NSString          *deletedTagBuffer;
 
 @end
 
@@ -1083,21 +1087,21 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     bBlankNote = NO;
     bModified = YES;
     
-    [saveTimer invalidate];
-    saveTimer = [NSTimer scheduledTimerWithTimeInterval:2.0
-                                                 target:self
-                                               selector:@selector(saveAndSync:)
-                                               userInfo:nil
-                                                repeats:NO];
-    saveTimer.tolerance = 0.1;
+    [self.saveTimer invalidate];
+    self.saveTimer = [NSTimer scheduledTimerWithTimeInterval:2.0
+                                                      target:self
+                                                    selector:@selector(saveAndSync:)
+                                                    userInfo:nil
+                                                     repeats:NO];
+    self.saveTimer.tolerance = 0.1;
     
-    if (!guarenteedSaveTimer) {
-        guarenteedSaveTimer = [NSTimer scheduledTimerWithTimeInterval:21.0
-                                                               target:self
-                                                             selector:@selector(saveAndSync:)
-                                                             userInfo:nil
-                                                              repeats:NO];
-        guarenteedSaveTimer.tolerance = 1.0;
+    if (!self.guarenteedSaveTimer) {
+        self.guarenteedSaveTimer = [NSTimer scheduledTimerWithTimeInterval:21.0
+                                                                    target:self
+                                                                  selector:@selector(saveAndSync:)
+                                                                  userInfo:nil
+                                                                   repeats:NO];
+        self.guarenteedSaveTimer.tolerance = 1.0;
     }
     
     if([textView.text hasSuffix:@"\n"] && _noteEditorTextView.selectedRange.location == _noteEditorTextView.text.length) {
@@ -1191,11 +1195,11 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 - (void)cancelSaveTimers {
     
-    [saveTimer invalidate];
-	saveTimer = nil;
+    [self.saveTimer invalidate];
+    self.saveTimer = nil;
     
-    [guarenteedSaveTimer invalidate];
-    guarenteedSaveTimer = nil;
+    [self.guarenteedSaveTimer invalidate];
+    self.guarenteedSaveTimer = nil;
 }
 
 -(void)saveAndSync:(NSTimer *)timer

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -871,14 +871,9 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
                               // scroll to block
                               highlightFrame.origin.y += highlightFrame.size.height;
-                              [self.noteEditorTextView scrollRectToVisible:highlightFrame
-                                                      animated:YES];
-                              
-                              
+                              [self.noteEditorTextView scrollRectToVisible:highlightFrame animated:YES];
                           }];
     }
-    
-    
 }
 
 - (void)endSearching:(id)sender {
@@ -1281,9 +1276,9 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 - (void)didReceiveNewContent {
     
-	NSUInteger newLocation = [self newCursorLocation:_currentNote.content
-											 oldText:self.noteContentBeforeRemoteUpdate
-									 currentLocation:self.cursorLocationBeforeRemoteUpdate];
+    NSUInteger newLocation = [self newCursorLocation:_currentNote.content
+                                             oldText:self.noteContentBeforeRemoteUpdate
+                                     currentLocation:self.cursorLocationBeforeRemoteUpdate];
 	
 	_noteEditorTextView.attributedText = [_currentNote.content attributedString];
     [_noteEditorTextView processChecklists];
@@ -1996,7 +1991,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     }
     
     self.currentVersion = versionInt;
-	NSDictionary *versionData = [self.noteVersionData objectForKey:[NSNumber numberWithInteger:versionInt]];
+    NSDictionary *versionData = [self.noteVersionData objectForKey:[NSNumber numberWithInteger:versionInt]];
     NSLog(@"Loading version %ld: %@", (long)versionInt, versionData);
     
 	if (versionData != nil) {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -59,6 +59,9 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 @property (nonatomic, strong) SPOutsideTouchView    *navigationButtonContainer;
 @property (nonatomic, strong) SPBlurEffectView      *navigationBarBackground;
 @property (nonatomic, strong) UILabel               *searchDetailLabel;
+@property (nonatomic, strong) UIBarButtonItem       *nextSearchButton;
+@property (nonatomic, strong) UIBarButtonItem       *prevSearchButton;
+@property (nonatomic, strong) UIBarButtonItem       *doneSearchButton;
 
 // Timers
 @property (nonatomic, strong) NSTimer               *saveTimer;
@@ -509,10 +512,10 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     self.navigationItem.titleView = titleView;
     
     // setup search toolbar
-    doneSearchButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
-                                                                     target:self
-                                                                     action:@selector(endSearching:)];
-    doneSearchButton.width += 10.0;
+    self.doneSearchButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                                                                          target:self
+                                                                          action:@selector(endSearching:)];
+    self.doneSearchButton.width += 10.0;
     UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
                                                                                    target:nil
                                                                                    action:nil];
@@ -520,16 +523,16 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                                                                                    target:nil
                                                                                    action:nil];
 
-    nextSearchButton = [UIBarButtonItem barButtonWithImage:chevronRightImage
-                                            imageAlignment:UIBarButtonImageAlignmentRight
-                                                    target:self
-                                                  selector:@selector(highlightNextSearchResult:)];
-        nextSearchButton.width = 34.0;
-    prevSearchButton = [UIBarButtonItem barButtonWithImage:chevronLeftImage
-                                            imageAlignment:UIBarButtonImageAlignmentRight
-                                                    target:self
-                                                  selector:@selector(highlightPrevSearchResult:)];
-    prevSearchButton.width = 34.0;
+    self.nextSearchButton = [UIBarButtonItem barButtonWithImage:chevronRightImage
+                                                 imageAlignment:UIBarButtonImageAlignmentRight
+                                                         target:self
+                                                       selector:@selector(highlightNextSearchResult:)];
+    self.nextSearchButton.width = 34.0;
+    self.prevSearchButton = [UIBarButtonItem barButtonWithImage:chevronLeftImage
+                                                 imageAlignment:UIBarButtonImageAlignmentRight
+                                                         target:self
+                                                       selector:@selector(highlightPrevSearchResult:)];
+    self.prevSearchButton.width = 34.0;
     
     
     self.searchDetailLabel = [[UILabel alloc] init];
@@ -540,10 +543,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     self.searchDetailLabel.alpha = 0.0;
     UIBarButtonItem *detailButton = [[UIBarButtonItem alloc] initWithCustomView:self.searchDetailLabel];
     
-    
-    
-    [self setToolbarItems:@[doneSearchButton, flexibleSpace, detailButton, flexibleSpaceTwo, prevSearchButton, nextSearchButton] animated:NO];
-    
+
+    [self setToolbarItems:@[self.doneSearchButton, flexibleSpace, detailButton, flexibleSpaceTwo, self.prevSearchButton, self.nextSearchButton] animated:NO];
 }
 
 - (void)didReceiveVoiceOverNotification:(NSNotification *)notification
@@ -846,8 +847,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     if (index >= 0 && index < searchResultCount) {
         
         // enable or disbale search result puttons accordingly
-        prevSearchButton.enabled = index > 0;
-        nextSearchButton.enabled = index < searchResultCount - 1;
+        self.prevSearchButton.enabled = index > 0;
+        self.nextSearchButton.enabled = index < searchResultCount - 1;
         
         [_noteEditorTextView highlightRange:[(NSValue *)self.searchResultRanges[index] rangeValue]
                            animated:YES
@@ -867,7 +868,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 - (void)endSearching:(id)sender {
     
-    if ([sender isEqual:doneSearchButton])
+    if ([sender isEqual:self.doneSearchButton])
         [[SPAppDelegate sharedDelegate].noteListViewController endSearching];
     
     _noteEditorTextView.text = [_noteEditorTextView getPlainTextContent];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -55,11 +55,11 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                                         SPInteractivePushViewControllerProvider,
                                         SPInteractiveDismissableViewController,
                                         UIPopoverPresentationControllerDelegate>
-{
-    NSUInteger cursorLocationBeforeRemoteUpdate;
-    NSString *noteContentBeforeRemoteUpdate;
-    BOOL bounceMarkdownPreviewOnActivityViewDismiss;
-}
+
+// State
+@property (nonatomic, assign) NSUInteger        cursorLocationBeforeRemoteUpdate;
+@property (nonatomic, strong) NSString          *noteContentBeforeRemoteUpdate;
+@property (nonatomic, assign) BOOL              bounceMarkdownPreviewOnActivityViewDismiss;
 
 // Timers
 @property (nonatomic, strong) NSTimer           *saveTimer;
@@ -683,7 +683,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                     self.noteEditorTextView.hidden = NO;
                     [snapshot removeFromSuperview];
 
-                    self->bounceMarkdownPreviewOnActivityViewDismiss = NO;
+                    self.bounceMarkdownPreviewOnActivityViewDismiss = NO;
                 }];
             }];
         }];
@@ -729,7 +729,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 - (void)popoverPresentationControllerDidDismissPopover:(UIPopoverPresentationController *)popoverPresentationController
 {
-    if (bounceMarkdownPreviewOnActivityViewDismiss) {
+    if (self.bounceMarkdownPreviewOnActivityViewDismiss) {
         [self bounceMarkdownPreview];
     }
 }
@@ -1235,8 +1235,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 - (void)willReceiveNewContent {
     
-    cursorLocationBeforeRemoteUpdate = [_noteEditorTextView selectedRange].location;
-    noteContentBeforeRemoteUpdate = [_noteEditorTextView getPlainTextContent];
+    self.cursorLocationBeforeRemoteUpdate = [_noteEditorTextView selectedRange].location;
+    self.noteContentBeforeRemoteUpdate = [_noteEditorTextView getPlainTextContent];
 	
     if (_currentNote != nil && ![_noteEditorTextView.text isEqualToString:@""]) {
         _currentNote.content = [_noteEditorTextView getPlainTextContent];
@@ -1247,8 +1247,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 - (void)didReceiveNewContent {
     
 	NSUInteger newLocation = [self newCursorLocation:_currentNote.content
-											 oldText:noteContentBeforeRemoteUpdate
-									 currentLocation:cursorLocationBeforeRemoteUpdate];
+											 oldText:self.noteContentBeforeRemoteUpdate
+									 currentLocation:self.cursorLocationBeforeRemoteUpdate];
 	
 	_noteEditorTextView.attributedText = [_currentNote.content attributedString];
     [_noteEditorTextView processChecklists];
@@ -1533,7 +1533,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
             [self save];
 
             // If Markdown is being enabled and it was previously disabled
-            bounceMarkdownPreviewOnActivityViewDismiss = (enabled && ![[NSUserDefaults standardUserDefaults] boolForKey:kSimplenoteMarkdownDefaultKey]);
+            self.bounceMarkdownPreviewOnActivityViewDismiss = (enabled && ![[NSUserDefaults standardUserDefaults] boolForKey:kSimplenoteMarkdownDefaultKey]);
 
             // Update the global preference to use when creating new notes
             [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:kSimplenoteMarkdownDefaultKey];
@@ -1659,7 +1659,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     if ([actionSheet isEqual:versionActionSheet])
         versionActionSheet = nil;
 
-    if (bounceMarkdownPreviewOnActivityViewDismiss) {
+    if (self.bounceMarkdownPreviewOnActivityViewDismiss) {
         [self bounceMarkdownPreview];
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -56,6 +56,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                                         SPInteractiveDismissableViewController,
                                         UIPopoverPresentationControllerDelegate>
 // UIKit Components
+@property (nonatomic, strong) SPOutsideTouchView    *navigationButtonContainer;
 @property (nonatomic, strong) SPBlurEffectView      *navigationBarBackground;
 @property (nonatomic, strong) UILabel               *searchDetailLabel;
 
@@ -373,7 +374,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 - (void)sizeNavigationContainer {
     
     self.navigationItem.titleView.frame = CGRectMake(0, 0, MAX(self.view.frame.size.width, self.view.frame.size.height), SPCustomTitleViewHeight);
-    navigationButtonContainer.frame = self.navigationItem.titleView.bounds;
+    self.navigationButtonContainer.frame = self.navigationItem.titleView.bounds;
 
     BOOL isPad = [UIDevice isPad];
 
@@ -399,9 +400,9 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     self.backButton.frame = CGRectMake(leadingPadding,
                                        SPBarButtonYOriginAdjustment,
                                        self.backButton.frame.size.width,
-                                       navigationButtonContainer.frame.size.height);
+                                       self.navigationButtonContainer.frame.size.height);
     
-    CGFloat previousXOrigin = navigationButtonContainer.frame.size.width + trailingPadding;
+    CGFloat previousXOrigin = self.navigationButtonContainer.frame.size.width + trailingPadding;
     CGFloat buttonWidth = [self.theme floatForKey:@"barButtonWidth"];
     CGFloat buttonHeight = buttonWidth;
     
@@ -444,16 +445,16 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     SPOutsideTouchView *titleView = [[SPOutsideTouchView alloc] init];
     titleView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     
-    navigationButtonContainer = [[SPOutsideTouchView alloc] init];
-    navigationButtonContainer.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    [titleView addSubview:navigationButtonContainer];
+    self.navigationButtonContainer = [[SPOutsideTouchView alloc] init];
+    self.navigationButtonContainer.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [titleView addSubview:self.navigationButtonContainer];
     
     UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                                  action:@selector(navigationBarContainerTapped:)];
     tapGesture.numberOfTapsRequired = 1;
     tapGesture.numberOfTouchesRequired = 1;
     
-    [navigationButtonContainer addGestureRecognizer:tapGesture];
+    [self.navigationButtonContainer addGestureRecognizer:tapGesture];
     
     // back button
     self.backButton = [UIButton buttonWithType:UIButtonTypeSystem];
@@ -467,7 +468,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                         action:@selector(backButtonAction:)
               forControlEvents:UIControlEventTouchUpInside];
     
-    [navigationButtonContainer addSubview:self.backButton];
+    [self.navigationButtonContainer addSubview:self.backButton];
     
     
     // setup right buttons
@@ -498,10 +499,10 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     self.actionButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     self.checklistButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleHeight;
     
-    [navigationButtonContainer addSubview:self.keyboardButton];
-    [navigationButtonContainer addSubview:self.createNoteButton];
-    [navigationButtonContainer addSubview:self.actionButton];
-    [navigationButtonContainer addSubview:self.checklistButton];
+    [self.navigationButtonContainer addSubview:self.keyboardButton];
+    [self.navigationButtonContainer addSubview:self.createNoteButton];
+    [self.navigationButtonContainer addSubview:self.actionButton];
+    [self.navigationButtonContainer addSubview:self.checklistButton];
     
     [self sizeNavigationContainer];
 
@@ -1021,7 +1022,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     
     CGFloat navigationBarHeight = self.navigationController.navigationBar.bounds.size.height;
     
-    CGRect containerViewFrame = navigationButtonContainer.bounds;
+    CGRect containerViewFrame = self.navigationButtonContainer.bounds;
     containerViewFrame.size.height = navigationBarHeight;
     
     BOOL isPortrait = self.isViewHorizontallyCompact && !self.isViewVerticallyCompact;
@@ -1036,7 +1037,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     
     
     // apply transform to button container
-    CGFloat normalHeight = navigationButtonContainer.frame.size.height;
+    CGFloat normalHeight = self.navigationButtonContainer.frame.size.height;
     CGFloat desiredHeight = normalHeight - 24;
 
     CGFloat percentTransform = ABS(yTransform) / 24;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -64,13 +64,13 @@ CGFloat const SPSelectedAreaPadding                 = 20;
                                         UIActionSheetDelegate,
                                         UIPopoverPresentationControllerDelegate>
 // UIKit Components
-@property (nonatomic, strong) SPOutsideTouchView        *navigationButtonContainer;
 @property (nonatomic, strong) SPBlurEffectView          *navigationBarBackground;
+@property (nonatomic, strong) SPOutsideTouchView        *navigationButtonContainer;
 @property (nonatomic, strong) UILabel                   *searchDetailLabel;
+@property (nonatomic, strong) SPTagView                 *tagView;
 @property (nonatomic, strong) UIBarButtonItem           *nextSearchButton;
 @property (nonatomic, strong) UIBarButtonItem           *prevSearchButton;
 @property (nonatomic, strong) UIBarButtonItem           *doneSearchButton;
-@property (nonatomic, strong) SPTagView                 *tagView;
 
 // Sheets
 @property (nonatomic, strong) SPActivityView            *noteActivityView;
@@ -83,13 +83,13 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 @property (nonatomic, strong) NSTimer                   *guarenteedSaveTimer;
 
 // State
-@property (nonatomic, assign) BOOL                      bounceMarkdownPreviewOnActivityViewDismiss;
-@property (nonatomic, assign) BOOL                      blankNote;
-@property (nonatomic, assign) BOOL                      modified;
-@property (nonatomic, assign) BOOL                      disableShrinkingNavigationBar;
-@property (nonatomic, assign) BOOL                      viewingVersions;
 @property (nonatomic, assign) BOOL                      actionSheetVisible;
+@property (nonatomic, assign) BOOL                      blankNote;
+@property (nonatomic, assign) BOOL                      bounceMarkdownPreviewOnActivityViewDismiss;
+@property (nonatomic, assign) BOOL                      disableShrinkingNavigationBar;
+@property (nonatomic, assign) BOOL                      modified;
 @property (nonatomic, assign) BOOL                      searching;
+@property (nonatomic, assign) BOOL                      viewingVersions;
 
 // Remote Updates
 @property (nonatomic, assign) NSUInteger                cursorLocationBeforeRemoteUpdate;

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -8,6 +8,7 @@
 #import "SPNoteEditorViewController.h"
 #import "SPOptionsViewController.h"
 #import "SPTagsListViewController.h"
+#import "SPAddCollaboratorsViewController.h"
 
 #import "NSManagedObjectContext+CoreDataExtensions.h"
 #import "NSProcessInfo+Util.h"


### PR DESCRIPTION
### Details:
This PR does **not introduce new behavior**:
- Replaces old school **ivars** with actual ObjC properties
- Moves the protocol conformance list to the Editor's private category
- Drops direct ivar indirections: `self->_ivar` 🔥🔥
- Drops several dead properties

I just couldn't let go another day without dropping those `->_`!!

@aerych Sir!! may I bug you a biiiiit?
**Thank you!!!**


### Test
**Please** smoke test the editor:

- [x] Verify the Navigation Bar looks as expected
- [x] Verify you can swipe to dismiss
- [x] Verify you can swipe (from the right edge) to push Markdown Preview (on a Markdown-Enabled note)
- [x] Verify the top right New Note button adds a new document
- [x] Verify the top right `( i )` icon opens the Info Sheet
- [x] Verify that once the keyboard is onscreen, you can dismiss it with the navigation bar's Keyboard icon

### Test: Search
1. Open the Notes List
2. Press over the searchbar and type a keyword that yields results
3. Press over any of the Notes in your list

- [x] Verify that you can navigate across search results with the Search Bar located at the bottom
- [x] Verify the back button reads as `< Search`
- [x] Verify that pressing `Done` dismisses the Search Mode 

### Release
These changes do not require release notes.
