### PR TITLE
Nü Note Options: Mark IV

### DIFF
--- a/Simplenote/Classes/OptionsViewController.swift
+++ b/Simplenote/Classes/OptionsViewController.swift
@@ -6,7 +6,6 @@ import SimplenoteFoundation
 // MARK: - OptionsControllerDelegate
 //
 protocol OptionsControllerDelegate: class {
-    func optionsControllerDidPressCollaborate(_ sender: OptionsViewController)
     func optionsControllerDidPressHistory(_ sender: OptionsViewController)
     func optionsControllerDidPressShare(_ sender: OptionsViewController)
     func optionsControllerDidPressTrash(_ sender: OptionsViewController)
@@ -374,7 +373,7 @@ private extension OptionsViewController {
 
     @IBAction
     func collaborateWasPressed() {
-        delegate?.optionsControllerDidPressCollaborate(self)
+
     }
 
     @IBAction

--- a/Simplenote/Classes/OptionsViewController.swift
+++ b/Simplenote/Classes/OptionsViewController.swift
@@ -21,10 +21,6 @@ class OptionsViewController: UIViewController {
     ///
     @IBOutlet private var tableView: UITableView!
 
-    /// Note for which we'll render the current Options
-    ///
-    private let note: Note
-
     /// EntityObserver: Allows us to listen to changes applied to the associated entity
     ///
     private lazy var entityObserver = EntityObserver(context: SPAppDelegate.shared().managedObjectContext, object: note)
@@ -41,6 +37,10 @@ class OptionsViewController: UIViewController {
     /// Indicates if the Markdown flag was Enabled
     ///
     private var markdownWasEnabled = false
+
+    /// Note for which we'll render the current Options
+    ///
+    let note: Note
 
     /// OptionsController's Delegate
     ///

--- a/Simplenote/Classes/OptionsViewController.swift
+++ b/Simplenote/Classes/OptionsViewController.swift
@@ -373,7 +373,7 @@ private extension OptionsViewController {
 
     @IBAction
     func collaborateWasPressed() {
-
+        NSLog("Collab!")
     }
 
     @IBAction

--- a/Simplenote/Classes/OptionsViewController.swift
+++ b/Simplenote/Classes/OptionsViewController.swift
@@ -3,6 +3,17 @@ import UIKit
 import SimplenoteFoundation
 
 
+// MARK: - OptionsControllerDelegate
+//
+protocol OptionsControllerDelegate: class {
+    func optionsControllerDidPressCollaborate(_ sender: OptionsViewController)
+    func optionsControllerDidPressHistory(_ sender: OptionsViewController)
+    func optionsControllerDidPressShare(_ sender: OptionsViewController)
+    func optionsControllerDidPressTrash(_ sender: OptionsViewController)
+    func optionsControllerDidDismiss(_ sender: OptionsViewController, markdownWasEnabled: Bool)
+}
+
+
 // MARK: - OptionsViewController
 //
 class OptionsViewController: UIViewController {
@@ -32,10 +43,9 @@ class OptionsViewController: UIViewController {
     ///
     private var markdownWasEnabled = false
 
-    /// Closure to be executed on dismissal.
-    /// - Note: We'll pass over a Boolean indicating if Markdown flaghas been enabled
+    /// OptionsController's Delegate
     ///
-    var onDismiss: ((Bool) -> Void)?
+    weak var delegate: OptionsControllerDelegate?
 
 
     /// Designated Initializer
@@ -64,7 +74,7 @@ class OptionsViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        onDismiss?(markdownWasEnabled)
+        delegate?.optionsControllerDidDismiss(self, markdownWasEnabled: markdownWasEnabled)
     }
 }
 
@@ -343,12 +353,12 @@ private extension OptionsViewController {
 
     @IBAction
     func shareWasPressed() {
-        NSLog("Share!")
+        delegate?.optionsControllerDidPressShare(self)
     }
 
     @IBAction
     func historyWasPressed() {
-        NSLog("History!")
+        delegate?.optionsControllerDidPressHistory(self)
     }
 
     @IBAction
@@ -364,12 +374,12 @@ private extension OptionsViewController {
 
     @IBAction
     func collaborateWasPressed() {
-        NSLog("Collab!")
+        delegate?.optionsControllerDidPressCollaborate(self)
     }
 
     @IBAction
     func trashWasPressed() {
-        NSLog("Trash!")
+        delegate?.optionsControllerDidPressTrash(self)
     }
 
     @IBAction

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -280,6 +280,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
         // Wait a bit until the Dismiss Animation concludes. `dismiss(:completion)` takes too long!
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
             self.delete(note: sender.note)
+            self.backButtonAction(sender)
         }
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -223,7 +223,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
         sender.dismiss(animated: true, completion: nil)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
-            self.shareNoteContentAction()
+            self.presentShareController()
         }
     }
 
@@ -231,7 +231,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
         sender.dismiss(animated: true, completion: nil)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
-            self.addCollaboratorsAction()
+            self.presentCollaboratorsController()
         }
     }
 
@@ -239,7 +239,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
         sender.dismiss(animated: true, completion: nil)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
-            self.viewVersionAction()
+            self.presentHistoryController()
         }
     }
 
@@ -275,6 +275,22 @@ extension SPNoteEditorViewController {
         }
 
         presentNoteOptions(for: note, from: sender)
+    }
+
+    @IBAction
+    func presentShareController() {
+        guard let note = currentNote, let activityController = UIActivityViewController(note: note) else {
+            return
+        }
+
+        activityController.modalPresentationStyle = .popover
+
+        let presentationController = activityController.popoverPresentationController
+        presentationController?.sourceRect = actionButton.bounds
+        presentationController?.sourceView = actionButton
+
+        present(activityController, animated: true, completion: nil)
+        SPTracker.trackEditorNoteContentShared()
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -256,7 +256,9 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
             return
         }
 
-        bounceMarkdownPreviewAfterDelay()
+        DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
+            self.bounceMarkdownPreview()
+        }
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -227,14 +227,6 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
         }
     }
 
-    func optionsControllerDidPressCollaborate(_ sender: OptionsViewController) {
-        sender.dismiss(animated: true, completion: nil)
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
-            self.presentCollaboratorsController()
-        }
-    }
-
     func optionsControllerDidPressHistory(_ sender: OptionsViewController) {
         sender.dismiss(animated: true, completion: nil)
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -251,6 +251,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
     func optionsControllerDidPressShare(_ sender: OptionsViewController) {
         sender.dismiss(animated: true, completion: nil)
 
+        // Wait a bit until the Dismiss Animation concludes. `dismiss(:completion)` takes too long!
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
             self.presentShareController(for: sender.note, from: self.actionButton)
         }
@@ -259,6 +260,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
     func optionsControllerDidPressHistory(_ sender: OptionsViewController) {
         sender.dismiss(animated: true, completion: nil)
 
+        // Wait a bit until the Dismiss Animation concludes. `dismiss(:completion)` takes too long!
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
             self.presentHistoryController()
         }
@@ -267,6 +269,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
     func optionsControllerDidPressTrash(_ sender: OptionsViewController) {
         sender.dismiss(animated: true, completion: nil)
 
+        // Wait a bit until the Dismiss Animation concludes. `dismiss(:completion)` takes too long!
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
             self.trashWasPressed(self)
         }
@@ -277,7 +280,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
             return
         }
 
-        // Let's wait a bit until the Dismiss Animation concludes
+        // Wait a bit until the Dismiss Animation concludes. `dismiss(:completion)` takes too long!
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
             self.bounceMarkdownPreview()
         }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -213,6 +213,21 @@ private extension SPNoteEditorViewController {
 
         SPTracker.trackEditorActivitiesAccessed()
     }
+
+    func presentShareController(for note: Note) {
+        guard let activityController = UIActivityViewController(note: note) else {
+            return
+        }
+
+        activityController.modalPresentationStyle = .popover
+
+        let presentationController = activityController.popoverPresentationController
+        presentationController?.sourceRect = actionButton.bounds
+        presentationController?.sourceView = actionButton
+
+        present(activityController, animated: true, completion: nil)
+        SPTracker.trackEditorNoteContentShared()
+    }
 }
 
 
@@ -224,7 +239,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
         sender.dismiss(animated: true, completion: nil)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
-            self.presentShareController()
+            self.presentShareController(for: sender.note)
         }
     }
 
@@ -269,22 +284,6 @@ extension SPNoteEditorViewController {
         }
 
         presentNoteOptions(for: note, from: sender)
-    }
-
-    @IBAction
-    func presentShareController() {
-        guard let note = currentNote, let activityController = UIActivityViewController(note: note) else {
-            return
-        }
-
-        activityController.modalPresentationStyle = .popover
-
-        let presentationController = activityController.popoverPresentationController
-        presentationController?.sourceRect = actionButton.bounds
-        presentationController?.sourceView = actionButton
-
-        present(activityController, animated: true, completion: nil)
-        SPTracker.trackEditorNoteContentShared()
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreSpotlight
 
 
 // MARK: - Interface Initialization
@@ -231,6 +232,18 @@ private extension SPNoteEditorViewController {
 }
 
 
+// MARK: - Services
+//
+extension SPNoteEditorViewController {
+
+    func delete(note: Note) {
+        SPTracker.trackEditorNoteDeleted()
+        SPObjectManager.shared().trashNote(note)
+        CSSearchableIndex.default().deleteSearchableNote(note)
+    }
+}
+
+
 // MARK: - OptionsControllerDelegate
 //
 extension SPNoteEditorViewController: OptionsControllerDelegate {
@@ -255,7 +268,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
         sender.dismiss(animated: true, completion: nil)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
-            self.trashNoteAction()
+            self.trashWasPressed(self)
         }
     }
 
@@ -284,6 +297,16 @@ extension SPNoteEditorViewController {
         }
 
         presentOptionsController(for: note, from: sender)
+    }
+
+    @IBAction
+    func trashWasPressed(_ sender: Any) {
+        guard let note = currentNote else {
+            assertionFailure()
+            return
+        }
+
+        delete(note: note)
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -214,7 +214,7 @@ private extension SPNoteEditorViewController {
         SPTracker.trackEditorActivitiesAccessed()
     }
 
-    func presentShareController(for note: Note) {
+    func presentShareController(for note: Note, from sourceView: UIView) {
         guard let activityController = UIActivityViewController(note: note) else {
             return
         }
@@ -222,8 +222,8 @@ private extension SPNoteEditorViewController {
         activityController.modalPresentationStyle = .popover
 
         let presentationController = activityController.popoverPresentationController
-        presentationController?.sourceRect = actionButton.bounds
-        presentationController?.sourceView = actionButton
+        presentationController?.sourceRect = sourceView.bounds
+        presentationController?.sourceView = sourceView
 
         present(activityController, animated: true, completion: nil)
         SPTracker.trackEditorNoteContentShared()
@@ -239,7 +239,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
         sender.dismiss(animated: true, completion: nil)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
-            self.presentShareController(for: sender.note)
+            self.presentShareController(for: sender.note, from: self.actionButton)
         }
     }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -210,6 +210,7 @@ private extension SPNoteEditorViewController {
 
     func presentOptionsController(for note: Note, from sourceView: UIView) {
         let optionsViewController = OptionsViewController(note: note)
+        optionsViewController.delegate = self
 
         let navigationController = SPNavigationController(rootViewController: optionsViewController)
         navigationController.configureAsPopover(sourceView: sourceView)

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -279,7 +279,7 @@ extension SPNoteEditorViewController: OptionsControllerDelegate {
 
         // Wait a bit until the Dismiss Animation concludes. `dismiss(:completion)` takes too long!
         DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
-            self.trashWasPressed(self)
+            self.delete(note: sender.note)
         }
     }
 }
@@ -297,16 +297,6 @@ extension SPNoteEditorViewController {
         }
 
         presentOptionsController(for: note, from: sender)
-    }
-
-    @IBAction
-    func trashWasPressed(_ sender: Any) {
-        guard let note = currentNote else {
-            assertionFailure()
-            return
-        }
-
-        delete(note: note)
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -231,11 +231,7 @@ private extension SPNoteEditorViewController {
             return
         }
 
-        activityController.modalPresentationStyle = .popover
-
-        let presentationController = activityController.popoverPresentationController
-        presentationController?.sourceRect = sourceView.bounds
-        presentationController?.sourceView = sourceView
+        activityController.configureAsPopover(sourceView: sourceView)
 
         present(activityController, animated: true, completion: nil)
         SPTracker.trackEditorNoteContentShared()

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -197,13 +197,7 @@ private extension SPNoteEditorViewController {
 
     func presentNoteOptions(for note: Note, from sourceView: UIView) {
         let optionsViewController = OptionsViewController(note: note)
-        optionsViewController.onDismiss = { [weak self] markdownWasEnabled in
-            guard markdownWasEnabled else {
-                return
-            }
-
-            self?.bounceMarkdownPreviewAfterDelay()
-        }
+        optionsViewController.delegate = self
 
         let navigationController = SPNavigationController(rootViewController: optionsViewController)
         navigationController.displaysBlurEffect = true
@@ -218,6 +212,51 @@ private extension SPNoteEditorViewController {
         present(navigationController, animated: true, completion: nil)
 
         SPTracker.trackEditorActivitiesAccessed()
+    }
+}
+
+
+// MARK: - OptionsControllerDelegate
+//
+extension SPNoteEditorViewController: OptionsControllerDelegate {
+    func optionsControllerDidPressShare(_ sender: OptionsViewController) {
+        sender.dismiss(animated: true, completion: nil)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
+            self.shareNoteContentAction()
+        }
+    }
+
+    func optionsControllerDidPressCollaborate(_ sender: OptionsViewController) {
+        sender.dismiss(animated: true, completion: nil)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
+            self.addCollaboratorsAction()
+        }
+    }
+
+    func optionsControllerDidPressHistory(_ sender: OptionsViewController) {
+        sender.dismiss(animated: true, completion: nil)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
+            self.viewVersionAction()
+        }
+    }
+
+    func optionsControllerDidPressTrash(_ sender: OptionsViewController) {
+        sender.dismiss(animated: true, completion: nil)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + UIKitConstants.animationDelayShort) {
+            self.trashNoteAction()
+        }
+    }
+
+    func optionsControllerDidDismiss(_ sender: OptionsViewController, markdownWasEnabled: Bool) {
+        guard markdownWasEnabled else {
+            return
+        }
+
+        bounceMarkdownPreviewAfterDelay()
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -46,7 +46,6 @@
 - (void)didReceiveVersion:(NSString *)version data:(NSDictionary *)data;
 - (void)didDeleteCurrentNote;
 
-- (void)presentCollaboratorsController;
 - (void)presentHistoryController;
 - (void)trashNoteAction;
 

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -46,6 +46,11 @@
 - (void)didReceiveVersion:(NSString *)version data:(NSDictionary *)data;
 - (void)didDeleteCurrentNote;
 
+- (void)addCollaboratorsAction;
+- (void)viewVersionAction;
+- (void)trashNoteAction;
+- (void)shareNoteContentAction;
+
 - (void)resetNavigationBarToIdentityWithAnimation:(BOOL)animated completion:(void (^)())completion;
 
 - (void)save;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -35,6 +35,8 @@
 
 
 - (void)prepareToPopView;
+- (void)backButtonAction:(id)sender;
+
 - (void)displayNote:(Note *)note;
 - (void)setSearchString:(NSString *)string;
 - (void)clearNote;
@@ -47,7 +49,6 @@
 - (void)didDeleteCurrentNote;
 
 - (void)presentHistoryController;
-- (void)trashNoteAction;
 
 - (void)resetNavigationBarToIdentityWithAnimation:(BOOL)animated completion:(void (^)())completion;
 

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -39,7 +39,7 @@
 - (void)setSearchString:(NSString *)string;
 - (void)clearNote;
 - (void)endEditing;
-- (void)bounceMarkdownPreviewAfterDelay;
+- (void)bounceMarkdownPreview;
 
 - (void)willReceiveNewContent;
 - (void)didReceiveNewContent;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -46,10 +46,9 @@
 - (void)didReceiveVersion:(NSString *)version data:(NSDictionary *)data;
 - (void)didDeleteCurrentNote;
 
-- (void)addCollaboratorsAction;
-- (void)viewVersionAction;
+- (void)presentCollaboratorsController;
+- (void)presentHistoryController;
 - (void)trashNoteAction;
-- (void)shareNoteContentAction;
 
 - (void)resetNavigationBarToIdentityWithAnimation:(BOOL)animated completion:(void (^)())completion;
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1416,14 +1416,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 #pragma mark Note Actions
 
-- (CGRect)presentationRectForActionButton {
-    
-    return [self.view convertRect:self.actionButton.frame
-                         fromView:self.actionButton.superview];
-    
-}
-
-- (void)addCollaboratorsAction
+- (void)presentCollaboratorsController
 {    
     [SPTracker trackEditorCollaboratorsAccessed];
 	   
@@ -1441,7 +1434,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     
 }
 
-- (void)viewVersionAction
+- (void)presentHistoryController
 {
     // check reachability status
     if (![[SPAppDelegate sharedDelegate].simperium.authenticator connected]) {
@@ -1505,31 +1498,28 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 {
     [SPTracker trackEditorNoteDeleted];
 
+    // create a snapshot before the animation
+    UIView *snapshot = [_noteEditorTextView snapshotViewAfterScreenUpdates:NO];
+    snapshot.frame = _noteEditorTextView.frame;
+    [self.view addSubview:snapshot];
+
     [[SPObjectManager sharedManager] trashNote:_currentNote];
     [[CSSearchableIndex defaultSearchableIndex] deleteSearchableNote:_currentNote];
-    [self backButtonAction:nil];
-}
 
-- (void)shareNoteContentAction
-{
-    if (_currentNote.content == nil) {
-        return;
-    }
+    [self clearNote];
 
-    [self save];
+    [UIView animateWithDuration:0.25
+                     animations:^{
 
-    [SPTracker trackEditorNoteContentShared];
+                         snapshot.transform = CGAffineTransformMakeTranslation(0, -snapshot.frame.size.height);
+                         snapshot.alpha = 0.0;
 
-    UIActivityViewController *acv = [[UIActivityViewController alloc] initWithNote:_currentNote];
+                     } completion:^(BOOL finished) {
 
-    if ([UIDevice isPad]) {
-        acv.modalPresentationStyle = UIModalPresentationPopover;
-        acv.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
-        acv.popoverPresentationController.sourceRect = [self presentationRectForActionButton];
-        acv.popoverPresentationController.sourceView = self.view;
-    }
+                         [snapshot removeFromSuperview];
+                         [self backButtonAction:nil];
 
-    [self presentViewController:acv animated:YES completion:nil];
+                     }];
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -673,11 +673,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     [self.view endEditing:YES];
 }
 
-- (void)bounceMarkdownPreviewAfterDelay
-{
-    [self performSelector:@selector(bounceMarkdownPreview) withObject:nil afterDelay:UIKitConstants.animationDelayShort];
-}
-
 // Bounces a snapshot of the text view to hint to the user how to access
 // the Markdown preview.
 - (void)bounceMarkdownPreview

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1510,15 +1510,11 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
     [UIView animateWithDuration:0.25
                      animations:^{
-
                          snapshot.transform = CGAffineTransformMakeTranslation(0, -snapshot.frame.size.height);
-                         snapshot.alpha = 0.0;
-
+                         snapshot.alpha = UIKitConstants.alpha0_0;
                      } completion:^(BOOL finished) {
-
                          [snapshot removeFromSuperview];
                          [self backButtonAction:nil];
-
                      }];
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1428,7 +1428,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     
 }
 
-- (void)addCollaboratorsAction:(id)sender
+- (void)addCollaboratorsAction
 {    
     [SPTracker trackEditorCollaboratorsAccessed];
 	   
@@ -1446,8 +1446,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     
 }
 
-- (void)viewVersionAction:(id)sender {
-    
+- (void)viewVersionAction
+{
     // check reachability status
     if (![[SPAppDelegate sharedDelegate].simperium.authenticator connected]) {
 
@@ -1506,33 +1506,37 @@ CGFloat const SPSelectedAreaPadding                 = 20;
     return minVersion;
 }
 
-- (void)trashNoteAction:(id)sender {
-
+- (void)trashNoteAction
+{
     [SPTracker trackEditorNoteDeleted];
 
-    // create a snapshot before the animation
-    UIView *snapshot = [_noteEditorTextView snapshotViewAfterScreenUpdates:NO];
-    snapshot.frame = _noteEditorTextView.frame;
-    [self.view addSubview:snapshot];
-    
     [[SPObjectManager sharedManager] trashNote:_currentNote];
     [[CSSearchableIndex defaultSearchableIndex] deleteSearchableNote:_currentNote];
-    
-    [self clearNote];
-    
-    [UIView animateWithDuration:0.25
-                     animations:^{
-                         
-                         snapshot.transform = CGAffineTransformMakeTranslation(0, -snapshot.frame.size.height);
-                         snapshot.alpha = 0.0;
-                         
-                     } completion:^(BOOL finished) {
-                         
-                         [snapshot removeFromSuperview];
-                         [self backButtonAction:nil];
-                         
-                     }];
+    [self backButtonAction:nil];
 }
+
+- (void)shareNoteContentAction
+{
+    if (_currentNote.content == nil) {
+        return;
+    }
+
+    [self save];
+
+    [SPTracker trackEditorNoteContentShared];
+
+    UIActivityViewController *acv = [[UIActivityViewController alloc] initWithNote:_currentNote];
+
+    if ([UIDevice isPad]) {
+        acv.modalPresentationStyle = UIModalPresentationPopover;
+        acv.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
+        acv.popoverPresentationController.sourceRect = [self presentationRectForActionButton];
+        acv.popoverPresentationController.sourceView = self.view;
+    }
+
+    [self presentViewController:acv animated:YES completion:nil];
+}
+
 
 #pragma mark SPHorizontalPickerView delegate methods
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1479,28 +1479,11 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 {
     [SPTracker trackEditorNoteDeleted];
 
-    // create a snapshot before the animation
-    UIView *snapshot = [_noteEditorTextView snapshotViewAfterScreenUpdates:NO];
-    snapshot.frame = _noteEditorTextView.frame;
-    [self.view addSubview:snapshot];
-
     [[SPObjectManager sharedManager] trashNote:_currentNote];
     [[CSSearchableIndex defaultSearchableIndex] deleteSearchableNote:_currentNote];
 
     [self clearNote];
-
-    [UIView animateWithDuration:0.25
-                     animations:^{
-
-                         snapshot.transform = CGAffineTransformMakeTranslation(0, -snapshot.frame.size.height);
-                         snapshot.alpha = 0.0;
-
-                     } completion:^(BOOL finished) {
-
-                         [snapshot removeFromSuperview];
-                         [self backButtonAction:nil];
-
-                     }];
+    [self backButtonAction:nil];
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -598,7 +598,8 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 }
 
 
-- (void)backButtonAction:(id)sender {
+- (void)backButtonAction:(id)sender
+{
     
     // this is to disable the swipe gesture while restoring to a previous version
     if (self.viewingVersions) {
@@ -1473,17 +1474,6 @@ CGFloat const SPSelectedAreaPadding                 = 20;
         minVersion = 1;
     
     return minVersion;
-}
-
-- (void)trashNoteAction
-{
-    [SPTracker trackEditorNoteDeleted];
-
-    [[SPObjectManager sharedManager] trashNote:_currentNote];
-    [[CSSearchableIndex defaultSearchableIndex] deleteSearchableNote:_currentNote];
-
-    [self clearNote];
-    [self backButtonAction:nil];
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -1416,7 +1416,7 @@ CGFloat const SPSelectedAreaPadding                 = 20;
 
 #pragma mark Note Actions
 
-- (void)presentCollaboratorsController
+- (void)addCollaboratorsAction:(id)sender
 {    
     [SPTracker trackEditorCollaboratorsAccessed];
 	   


### PR DESCRIPTION
### 🛑  Important
Don't merge until #906 #907 #909 and #910 are ready: everything must be merged in a single shot!

### Details:
In this PR we're wiring support for few missing Note Option Actions:

- Share
- History
- Trash

@aerych Sir!! can I trouble you with this one?
Thanks in advance!!

Ref. #763

### Test
1. Log into your account
2. Open any note
3. Press over the top `( i )` button

- [x] Verify pressing **Share** dismisses the Options and presents the Share Sheet
- [x] Verify pressing **History** dismisses the Options and presents the History Slider
- [x] Verify pressing **Trash** dismisses both, Options and the Editor, and trashes the Note
- [x] Verify the same works super on an iPad device please!!

### Release
These changes do not require release notes.
