### PR TITLE
List: Contextual Menu Previewing Style

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -542,6 +542,12 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self refreshNavigationBarButtons];
 }
 
+- (void)setPreviewing:(BOOL)previewing
+{
+    _previewing = previewing;
+    [self refreshStyle];
+}
+
 
 #pragma mark - UIPopoverPresentationControllerDelegate
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -119,7 +119,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
         // Apply the current style right away!
         [self startListeningToThemeNotifications];
-        [self applyStyle];
+        [self refreshStyle];
     }
     
     return self;
@@ -139,7 +139,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     return [[VSThemeManager sharedManager] theme];
 }
 
-- (void)applyStyle
+- (void)refreshStyle
 {    
     UIFont *bodyFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     UIFont *headlineFont = [UIFont preferredFontFor:UIFontTextStyleTitle1 weight:UIFontWeightBold];
@@ -251,7 +251,7 @@ CGFloat const SPSelectedAreaPadding = 20;
         [self.noteEditorTextView endEditing:YES];
     }
 
-    [self applyStyle];
+    [self refreshStyle];
 }
 
 - (void)highlightSearchResultsIfNeeded
@@ -319,7 +319,7 @@ CGFloat const SPSelectedAreaPadding = 20;
         //
         // Ref. https://github.com/Automattic/simplenote-ios/issues/599
         //
-        [self applyStyle];
+        [self refreshStyle];
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -134,8 +134,8 @@ CGFloat const SPSelectedAreaPadding = 20;
     _noteEditorTextView.checklistsFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
 }
 
-- (VSTheme *)theme {
-    
+- (VSTheme *)theme
+{
     return [[VSThemeManager sharedManager] theme];
 }
 
@@ -533,14 +533,12 @@ CGFloat const SPSelectedAreaPadding = 20;
 - (void)setEditingNote:(BOOL)editingNote
 {
     _editingNote = editingNote;
-    
     [self refreshNavigationBarButtons];
 }
 
 - (void)setIsKeyboardVisible:(BOOL)isKeyboardVisible
 {
     _isKeyboardVisible = isKeyboardVisible;
-
     [self refreshNavigationBarButtons];
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -149,8 +149,6 @@ CGFloat const SPSelectedAreaPadding = 20;
     paragraphStyle.lineSpacing = bodyFont.lineHeight * [self.theme floatForKey:@"noteBodyLineHeightPercentage"];
 
     _tagView = _noteEditorTextView.tagView;
-    [_tagView applyStyle];
-
 
     self.noteEditorTextView.checklistsFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
     self.noteEditorTextView.checklistsTintColor = [UIColor simplenoteNoteBodyPreviewColor];
@@ -165,7 +163,6 @@ CGFloat const SPSelectedAreaPadding = 20;
     self.bottomView.backgroundColor = backgroundColor;
     self.view.backgroundColor = backgroundColor;
 
-    _noteEditorTextView.interactiveTextStorage.tokens = @{
     self.noteEditorTextView.interactiveTextStorage.tokens = @{
         SPDefaultTokenName : @{
                 NSFontAttributeName : bodyFont,

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -151,18 +151,22 @@ CGFloat const SPSelectedAreaPadding = 20;
     _tagView = _noteEditorTextView.tagView;
     [_tagView applyStyle];
 
-    self.bottomView.backgroundColor = [UIColor simplenoteBackgroundColor];
 
     self.noteEditorTextView.checklistsFont = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
     self.noteEditorTextView.checklistsTintColor = [UIColor simplenoteNoteBodyPreviewColor];
-    self.noteEditorTextView.backgroundColor = [UIColor simplenoteBackgroundColor];
-    self.noteEditorTextView.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
 
-    UIColor *backgroundColor = [UIColor simplenoteBackgroundColor];
+    UIKeyboardAppearance keyboardAppearance = SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault;
+    self.noteEditorTextView.keyboardAppearance = keyboardAppearance;
+    self.tagView.keyboardAppearance = keyboardAppearance;
+
+    UIColor *backgroundColor = self.previewing ? [UIColor simplenoteBackgroundPreviewColor] : [UIColor simplenoteBackgroundColor];
     self.noteEditorTextView.backgroundColor = backgroundColor;
+    self.tagView.backgroundColor = backgroundColor;
+    self.bottomView.backgroundColor = backgroundColor;
     self.view.backgroundColor = backgroundColor;
 
     _noteEditorTextView.interactiveTextStorage.tokens = @{
+    self.noteEditorTextView.interactiveTextStorage.tokens = @{
         SPDefaultTokenName : @{
                 NSFontAttributeName : bodyFont,
                 NSForegroundColorAttributeName : fontColor,

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -662,6 +662,11 @@ private extension SPNoteListViewController {
             self?.share(note: note)
         }
 
+        let pinTitle = note.pinned ? ActionTitle.unpin : ActionTitle.pin
+        let pin = UIAction(title: pinTitle, image: .image(name: .pin)) { [weak self] _ in
+            self?.togglePinnedState(note: note)
+        }
+
         /// NOTE:
         /// iOS 13 exhibits a broken animation when performing a Delete OP from a ContextMenu.
         /// Since this appears to be fixed in iOS 14, quick workaround is: remove Delete from the Contextual Actions for iOS 13.
@@ -669,14 +674,14 @@ private extension SPNoteListViewController {
         /// Ref.: https://github.com/Automattic/simplenote-ios/pull/902/files
         ///
         guard #available(iOS 14.0, *) else {
-            return UIMenu(title: "", children: [copy, share])
+            return UIMenu(title: "", children: [share, copy, pin])
         }
 
         let delete = UIAction(title: ActionTitle.delete, image: .image(name: .trash), attributes: .destructive) { [weak self] _ in
             self?.delete(note: note)
         }
 
-        return UIMenu(title: "", children: [copy, share, delete])
+        return UIMenu(title: "", children: [share, copy, pin, delete])
     }
 }
 
@@ -835,8 +840,10 @@ extension SPNoteListViewController {
 private enum ActionTitle {
     static let cancel = NSLocalizedString("Cancel", comment: "Dismissing an interface")
     static let copyLink = NSLocalizedString("Copy Link", comment: "Copies Link to a Note")
-    static let delete = NSLocalizedString("Delete", comment: "Deletes a note")
+    static let delete = NSLocalizedString("Move to Trash", comment: "Deletes a note")
+    static let pin = NSLocalizedString("Pin to Top", comment: "Pins a note")
     static let share = NSLocalizedString("Share...", comment: "Shares a note")
+    static let unpin = NSLocalizedString("Unpin", comment: "Unpins a note")
 }
 
 private enum Constants {

--- a/Simplenote/Classes/SPTagView.h
+++ b/Simplenote/Classes/SPTagView.h
@@ -40,6 +40,7 @@
 }
 
 @property (nonatomic, weak) id<SPTagViewDelegate> tagDelegate;
+@property (nonatomic, assign) UIKeyboardAppearance keyboardAppearance;
 
 - (void)scrollEntryFieldToVisible:(BOOL)animated;
 - (void)clearAllTags;

--- a/Simplenote/Classes/SPTagView.h
+++ b/Simplenote/Classes/SPTagView.h
@@ -45,6 +45,5 @@
 - (void)scrollEntryFieldToVisible:(BOOL)animated;
 - (void)clearAllTags;
 - (BOOL)setupWithTagNames:(NSArray *)tagNames;
-- (void)applyStyle;
 
 @end

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -62,17 +62,16 @@
         tagPills = [NSMutableArray array];
 
         [self ensureRightToLeftSupportIsInitialized];
-        [self applyStyle];
     }
     
     return self;
 }
 
-- (void)applyStyle
+- (void)setBackgroundColor:(UIColor *)backgroundColor
 {
-    self.backgroundColor = [UIColor simplenoteBackgroundColor];
-    autoCompleteScrollView.backgroundColor = [UIColor simplenoteBackgroundColor];
-    addTagField.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
+    [super setBackgroundColor:backgroundColor];
+    autoCompleteScrollView.backgroundColor = backgroundColor;
+}
 
 - (UIKeyboardAppearance)keyboardAppearance
 {

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -73,6 +73,15 @@
     self.backgroundColor = [UIColor simplenoteBackgroundColor];
     autoCompleteScrollView.backgroundColor = [UIColor simplenoteBackgroundColor];
     addTagField.keyboardAppearance = (SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault);
+
+- (UIKeyboardAppearance)keyboardAppearance
+{
+    return addTagField.keyboardAppearance;
+}
+
+- (void)setKeyboardAppearance:(UIKeyboardAppearance)keyboardAppearance
+{
+    addTagField.keyboardAppearance = keyboardAppearance;
 }
 
 - (BOOL)isFirstResponder

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -210,6 +210,11 @@ extension UIColor {
     }
 
     @objc
+    static var simplenoteBackgroundPreviewColor: UIColor {
+        UIColor(lightColor: .white, darkColor: .darkGray1)
+    }
+
+    @objc
     static var simplenoteModalOverlayColor: UIColor {
         UIColor(studioColor: .black).withAlphaComponent(UIKitConstants.alpha0_4)
     }


### PR DESCRIPTION
### Details:
In this PR we're:

- Updating the Editor's "Preview" Style (dark mode only)
- Adding a new Contextual Menu option to Pin / Unpin

@eshurakov Sir!! bugging you with yet another PR!
Thanks in advance!!

Closes #927

### Test: Style
1. Launch Simplenote in an iOS 13/14 device
2. Switch to Dark Mode
3. Access the Notes List
4. Long press over any note

- [x] Verify the Preview Window shows the editor with a slightly gray background
- [x] Verify that if you tap over the Editor Preview, the Editor gets pushed, and the BG switches to Black
- [x] Please test the same in iOS 12 (use 3d Touch instead of long press!)

### Test: Contextual Actions
1. Access the Notes List
2. Long press over any of your notes

- [x] Verify there's a new action that reads `Pin to Top` or `Unpin` (depending on the note's state)
- [x] Verify that pressing over such new action toggles the Pinned State

### Release
These changes do not require release notes.
