### PR TITLE
Nü Metrics: Mark I

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 -   New Note History interface #762
 -   New Note Options interface #763
+-   New Note Information interface #836
 -   Updated Navigation Bar's behavior #918
 -   Adjusted Notes List Metrics 
 

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		A6900346253D87060087D0D2 /* VersionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6900345253D87060087D0D2 /* VersionsController.swift */; };
 		A69F850F253EC2B2005140F2 /* SPCardConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F850E253EC2B2005140F2 /* SPCardConfigurable.swift */; };
 		A69F851D253EC877005140F2 /* UISlider+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */; };
+		A69F861C25408085005140F2 /* NoteInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F861A25408085005140F2 /* NoteInformationViewController.swift */; };
+		A69F861D25408085005140F2 /* NoteInformationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69F861B25408085005140F2 /* NoteInformationViewController.xib */; };
 		A6C0589424AD2B8F006BC572 /* SPNoteHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589224AD2B8F006BC572 /* SPNoteHistoryViewController.swift */; };
 		A6C0589524AD2B8F006BC572 /* SPNoteHistoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A6C0589324AD2B8F006BC572 /* SPNoteHistoryViewController.xib */; };
 		A6C0589924AD47CB006BC572 /* SPSnappingSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */; };
@@ -495,6 +497,8 @@
 		A6900345253D87060087D0D2 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
 		A69F850E253EC2B2005140F2 /* SPCardConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardConfigurable.swift; sourceTree = "<group>"; };
 		A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISlider+Simplenote.swift"; sourceTree = "<group>"; };
+		A69F861A25408085005140F2 /* NoteInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteInformationViewController.swift; sourceTree = "<group>"; };
+		A69F861B25408085005140F2 /* NoteInformationViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteInformationViewController.xib; sourceTree = "<group>"; };
 		A6C0589224AD2B8F006BC572 /* SPNoteHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPNoteHistoryViewController.swift; path = Classes/SPNoteHistoryViewController.swift; sourceTree = "<group>"; };
 		A6C0589324AD2B8F006BC572 /* SPNoteHistoryViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPNoteHistoryViewController.xib; path = Classes/SPNoteHistoryViewController.xib; sourceTree = "<group>"; };
 		A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPSnappingSlider.swift; sourceTree = "<group>"; };
@@ -1051,6 +1055,15 @@
 				A6900345253D87060087D0D2 /* VersionsController.swift */,
 			);
 			path = Controllers;
+			sourceTree = "<group>";
+		};
+		A69F861925407F80005140F2 /* Information */ = {
+			isa = PBXGroup;
+			children = (
+				A69F861A25408085005140F2 /* NoteInformationViewController.swift */,
+				A69F861B25408085005140F2 /* NoteInformationViewController.xib */,
+			);
+			path = Information;
 			sourceTree = "<group>";
 		};
 		A6C0589124AD2B00006BC572 /* Note History */ = {
@@ -1699,6 +1712,7 @@
 				B5A6846B23CE84B900398BBC /* Notes List */,
 				A6C0589124AD2B00006BC572 /* Note History */,
 				B537730D252E14AE00BC78C5 /* Options */,
+				A69F861925407F80005140F2 /* Information */,
 				E2F1497F179D8E1A00DC9690 /* Settings */,
 				E25C39CE17A41F3400B2591A /* SPAddCollaboratorsViewController.h */,
 				E25C39CF17A41F3400B2591A /* SPAddCollaboratorsViewController.m */,
@@ -1989,6 +2003,7 @@
 				B537732B252E176C00BC78C5 /* OptionsViewController.xib in Resources */,
 				B56A696222F9D53400B90398 /* SPAuthViewController.xib in Resources */,
 				B546BEA0234F6DA000A126DA /* SPTagHeaderView.xib in Resources */,
+				A69F861D25408085005140F2 /* NoteInformationViewController.xib in Resources */,
 				B513F2B62319A8F40021CFA4 /* SPNoteTableViewCell.xib in Resources */,
 				B5078A001C1F5595009F097A /* markdown-dark.css in Resources */,
 				B502311325129525002C3CDA /* SPDiagnosticsViewController.xib in Resources */,
@@ -2277,6 +2292,7 @@
 				B5B8AE7F1AB9F8BD0082775D /* UIDevice+Extensions.m in Sources */,
 				46A3C98017DFA81A002865AE /* UIImage+Colorization.m in Sources */,
 				B5E196BB230F522D00F5658A /* SPCredentials.swift in Sources */,
+				A69F861C25408085005140F2 /* NoteInformationViewController.swift in Sources */,
 				375D24BC21E01131007AB25A /* html_smartypants.c in Sources */,
 				46A3C98117DFA81A002865AE /* VSTheme.m in Sources */,
 				A6900346253D87060087D0D2 /* VersionsController.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		74F6638322BADD0300FA147E /* SharePresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638222BADD0300FA147E /* SharePresentationController.swift */; };
 		A681C72C254172B600F369C2 /* NoteMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C72B254172B600F369C2 /* NoteMetrics.swift */; };
 		A681C7342541772D00F369C2 /* NumberFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C7332541772D00F369C2 /* NumberFormatter+Simplenote.swift */; };
+		A681C73C2541AC8D00F369C2 /* HuggableTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */; };
 		A68ABCA624ABFA5800715EBD /* UIView+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */; };
 		A68ABCA824ABFB5300715EBD /* SPShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA724ABFB5300715EBD /* SPShadowView.swift */; };
 		A6900346253D87060087D0D2 /* VersionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6900345253D87060087D0D2 /* VersionsController.swift */; };
@@ -496,6 +497,7 @@
 		A22187FB12EF52A765E6D4EC /* Pods-SimplenoteTests.distribution appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution appstore.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution appstore.xcconfig"; sourceTree = "<group>"; };
 		A681C72B254172B600F369C2 /* NoteMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteMetrics.swift; sourceTree = "<group>"; };
 		A681C7332541772D00F369C2 /* NumberFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Simplenote.swift"; sourceTree = "<group>"; };
+		A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggableTableView.swift; sourceTree = "<group>"; };
 		A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Constraints.swift"; sourceTree = "<group>"; };
 		A68ABCA724ABFB5300715EBD /* SPShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPShadowView.swift; sourceTree = "<group>"; };
 		A6900345253D87060087D0D2 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
@@ -1563,6 +1565,7 @@
 				A68ABCA724ABFB5300715EBD /* SPShadowView.swift */,
 				A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */,
 				A6E1E7A724BE656D008A44BC /* SPCardView.swift */,
+				A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2358,6 +2361,7 @@
 				74388F4422CFFA30001C5EC0 /* UIViewController+Helpers.swift in Sources */,
 				46A3C99817DFA81A002865AE /* SPEntryListCell.m in Sources */,
 				B5E951E124FEDAD4004B10B8 /* UIPasteboard+Note.swift in Sources */,
+				A681C73C2541AC8D00F369C2 /* HuggableTableView.swift in Sources */,
 				46A3C99917DFA81A002865AE /* SPTransitionController.m in Sources */,
 				46A3C99A17DFA81A002865AE /* DTTwoPageViewController.m in Sources */,
 				B56A695B22F9CD4E00B90398 /* UINavigationBar+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		74F6637F22BADB5000FA147E /* ExtensionPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6637E22BADB5000FA147E /* ExtensionPresentationController.swift */; };
 		74F6638122BADBD200FA147E /* ExtensionPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638022BADBD200FA147E /* ExtensionPresentationAnimator.swift */; };
 		74F6638322BADD0300FA147E /* SharePresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638222BADD0300FA147E /* SharePresentationController.swift */; };
+		A681C72C254172B600F369C2 /* NoteMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C72B254172B600F369C2 /* NoteMetrics.swift */; };
 		A68ABCA624ABFA5800715EBD /* UIView+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */; };
 		A68ABCA824ABFB5300715EBD /* SPShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA724ABFB5300715EBD /* SPShadowView.swift */; };
 		A6900346253D87060087D0D2 /* VersionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6900345253D87060087D0D2 /* VersionsController.swift */; };
@@ -492,6 +493,7 @@
 		9F2210B2EE42B513C4C92372 /* Pods-Automattic-Simplenote.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		9F225454D6472EDCA812A4C5 /* Pods-Automattic-Simplenote.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		A22187FB12EF52A765E6D4EC /* Pods-SimplenoteTests.distribution appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution appstore.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution appstore.xcconfig"; sourceTree = "<group>"; };
+		A681C72B254172B600F369C2 /* NoteMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteMetrics.swift; sourceTree = "<group>"; };
 		A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Constraints.swift"; sourceTree = "<group>"; };
 		A68ABCA724ABFB5300715EBD /* SPShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPShadowView.swift; sourceTree = "<group>"; };
 		A6900345253D87060087D0D2 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
@@ -956,6 +958,7 @@
 				467D9C631788A54900785EF3 /* Tag.h */,
 				467D9C641788A54900785EF3 /* Tag.m */,
 				A6E1E79724B7D7B4008A44BC /* SPHistoryVersion.swift */,
+				A681C72B254172B600F369C2 /* NoteMetrics.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -2206,6 +2209,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A681C72C254172B600F369C2 /* NoteMetrics.swift in Sources */,
 				B53971A31AB8DCDC00B1A582 /* SPTracker.m in Sources */,
 				E215C793180B115C00AD36B5 /* SPNavigationController.m in Sources */,
 				B5DF734422A56E2800602CE7 /* UserDefaults+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		74F6638122BADBD200FA147E /* ExtensionPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638022BADBD200FA147E /* ExtensionPresentationAnimator.swift */; };
 		74F6638322BADD0300FA147E /* SharePresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F6638222BADD0300FA147E /* SharePresentationController.swift */; };
 		A681C72C254172B600F369C2 /* NoteMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C72B254172B600F369C2 /* NoteMetrics.swift */; };
+		A681C7342541772D00F369C2 /* NumberFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C7332541772D00F369C2 /* NumberFormatter+Simplenote.swift */; };
 		A68ABCA624ABFA5800715EBD /* UIView+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */; };
 		A68ABCA824ABFB5300715EBD /* SPShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA724ABFB5300715EBD /* SPShadowView.swift */; };
 		A6900346253D87060087D0D2 /* VersionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6900345253D87060087D0D2 /* VersionsController.swift */; };
@@ -494,6 +495,7 @@
 		9F225454D6472EDCA812A4C5 /* Pods-Automattic-Simplenote.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		A22187FB12EF52A765E6D4EC /* Pods-SimplenoteTests.distribution appstore.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution appstore.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution appstore.xcconfig"; sourceTree = "<group>"; };
 		A681C72B254172B600F369C2 /* NoteMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteMetrics.swift; sourceTree = "<group>"; };
+		A681C7332541772D00F369C2 /* NumberFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Simplenote.swift"; sourceTree = "<group>"; };
 		A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Constraints.swift"; sourceTree = "<group>"; };
 		A68ABCA724ABFB5300715EBD /* SPShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPShadowView.swift; sourceTree = "<group>"; };
 		A6900345253D87060087D0D2 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
@@ -1298,6 +1300,7 @@
 				A6E1E79924B7DB96008A44BC /* SPManagedObject+Version.swift */,
 				B52EF9FD24F69E4E0029DCCE /* UIMenuController+Simplenote.swift */,
 				A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */,
+				A681C7332541772D00F369C2 /* NumberFormatter+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2413,6 +2416,7 @@
 				375D24B121E01131007AB25A /* html5_blocks.c in Sources */,
 				B504D4DE23D2014200AEED27 /* IndexPath+Simplenote.swift in Sources */,
 				B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */,
+				A681C7342541772D00F369C2 /* NumberFormatter+Simplenote.swift in Sources */,
 				B59560E0251A46D500A06788 /* KeychainManager.swift in Sources */,
 				B52EF9FE24F69E4E0029DCCE /* UIMenuController+Simplenote.swift in Sources */,
 				46A3C9AF17DFA81A002865AE /* NSString+Condensing.m in Sources */,

--- a/Simplenote/Classes/DateFormatter+Simplenote.swift
+++ b/Simplenote/Classes/DateFormatter+Simplenote.swift
@@ -15,4 +15,11 @@ extension DateFormatter {
             return formatter
         }()
     }
+
+    static let dateTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
 }

--- a/Simplenote/Classes/DateFormatter+Simplenote.swift
+++ b/Simplenote/Classes/DateFormatter+Simplenote.swift
@@ -7,14 +7,12 @@ extension DateFormatter {
 
     /// Shared DateFormatters
     ///
-    struct Simplenote {
-        static let listDateFormatter: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.dateStyle = .short
-            formatter.timeStyle = .none
-            return formatter
-        }()
-    }
+    static let listDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .none
+        return formatter
+    }()
 
     static let dateTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -312,10 +312,10 @@ extension SPNoteEditorViewController: SPCardPresentationControllerDelegate {
 //
 extension SPNoteEditorViewController {
 
-    private func presentInformationController() {
-        let metrics = NoteInformationViewController()
-        metrics.configureToPresentAsCard(presentationDelegate: self)
-        present(metrics, animated: true, completion: nil)
+    private func presentInformationController(for note: Note) {
+        let information = NoteInformationViewController(note: note)
+        information.configureToPresentAsCard()
+        present(information, animated: true, completion: nil)
     }
 }
 
@@ -501,7 +501,12 @@ extension SPNoteEditorViewController {
 
     @objc
     private func noteInformationWasPressed(_ sender: UIBarButtonItem) {
-        presentInformationController()
+        guard let note = currentNote else {
+            assertionFailure()
+            return
+        }
+
+        presentInformationController(for: note)
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -35,6 +35,9 @@ extension SPNoteEditorViewController {
         checklistButton = UIBarButtonItem(image: .image(name: .checklist), style: .plain, target: self, action: #selector(insertChecklistAction(_:)))
         checklistButton.accessibilityLabel = NSLocalizedString("Inserts a new Checklist Item", comment: "Insert Checklist Button")
 
+        informationButton = UIBarButtonItem(image: .image(name: .info), style: .plain, target: self, action: #selector(noteInformationWasPressed(_:)))
+        informationButton.accessibilityLabel = NSLocalizedString("Information", comment: "Note Information Button (metrics + references)")
+
         createNoteButton = UIBarButtonItem(image: .image(name: .newNote), style: .plain, target: self, action: #selector(newButtonAction(_:)))
         createNoteButton.accessibilityLabel = NSLocalizedString("New note", comment: "Label to create a new note")
 
@@ -295,7 +298,7 @@ extension SPNoteEditorViewController: SPNoteHistoryControllerDelegate {
 }
 
 
-// MARK: - History Card transition delegate
+// MARK: - SPCardPresentationControllerDelegate
 //
 extension SPNoteEditorViewController: SPCardPresentationControllerDelegate {
 
@@ -305,6 +308,16 @@ extension SPNoteEditorViewController: SPCardPresentationControllerDelegate {
     }
 }
 
+// MARK: - Information
+//
+extension SPNoteEditorViewController {
+
+    private func presentInformationController() {
+        let metrics = NoteInformationViewController()
+        metrics.configureToPresentAsCard(presentationDelegate: self)
+        present(metrics, animated: true, completion: nil)
+    }
+}
 
 // MARK: - Private API(s)
 //
@@ -484,6 +497,11 @@ extension SPNoteEditorViewController {
         }
 
         presentOptionsController(for: note, from: sender)
+    }
+
+    @objc
+    private func noteInformationWasPressed(_ sender: UIBarButtonItem) {
+        presentInformationController()
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) UIBarButtonItem *checklistButton;
 @property (nonatomic, strong) UIBarButtonItem *keyboardButton;
 @property (nonatomic, strong) UIBarButtonItem *createNoteButton;
+@property (nonatomic, strong) UIBarButtonItem *informationButton;
 
 @property (nonatomic, strong) Note *currentNote;
 @property (nonatomic, strong) SPEditorTextView *noteEditorTextView;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -502,6 +502,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     }
 
     [buttons addObject:self.actionButton];
+    [buttons addObject:self.informationButton];
 
     if (self.isEditingNote) {
         [buttons addObject:self.checklistButton];

--- a/Simplenote/Classes/SPNoteHistoryViewController.xib
+++ b/Simplenote/Classes/SPNoteHistoryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -90,6 +90,7 @@
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="yP9-LW-2C9" firstAttribute="leading" secondItem="0Zh-yW-YrO" secondAttribute="leading" id="4Ey-om-Agv"/>
@@ -105,10 +106,20 @@
             </constraints>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="-259.4202898550725" y="-129.91071428571428"/>
         </view>
     </objects>
+    <designables>
+        <designable name="DfP-am-H0U">
+            <size key="intrinsicContentSize" width="-1" height="30"/>
+        </designable>
+        <designable name="TQJ-NT-WS8">
+            <size key="intrinsicContentSize" width="54" height="33"/>
+        </designable>
+        <designable name="obJ-JD-gy5">
+            <size key="intrinsicContentSize" width="16" height="22"/>
+        </designable>
+    </designables>
     <resources>
         <image name="icon_cross" width="16" height="16"/>
     </resources>

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -585,7 +585,7 @@ private extension SPNoteListViewController {
                 return nil
         }
 
-        return DateFormatter.Simplenote.listDateFormatter.string(from: date)
+        return DateFormatter.listDateFormatter.string(from: date)
     }
 }
 

--- a/Simplenote/HuggableTableView.swift
+++ b/Simplenote/HuggableTableView.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+// MARK: - HuggableTableView
+// Table View that wraps it's own content (tries to set it's own height to match the content)
+//
+class HuggableTableView: UITableView {
+
+    override var frame: CGRect {
+        didSet {
+            updateScrollState()
+        }
+    }
+
+    override var contentSize: CGSize {
+        didSet {
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    override func safeAreaInsetsDidChange() {
+        super.safeAreaInsetsDidChange()
+        invalidateIntrinsicContentSize()
+    }
+
+    override func invalidateIntrinsicContentSize() {
+        super.invalidateIntrinsicContentSize()
+        updateScrollState()
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var size = contentSize
+        size.height += safeAreaInsets.top + safeAreaInsets.bottom
+        return size
+    }
+
+    private func updateScrollState() {
+        isScrollEnabled = frame.size.height < intrinsicContentSize.height
+    }
+}

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -33,7 +33,15 @@ class NoteInformationViewController: UIViewController {
     }
 
     private func reloadData() {
+        let metrics = NoteMetrics(note: note)
 
+        rows = [
+            .metric(title: NSLocalizedString("Words", comment: "Number of words in the note"),
+                    value: NumberFormatter.decimalFormatter.string(for: metrics.numberOfWords)),
+
+            .metric(title: NSLocalizedString("Characters", comment: "Number of characters in the note"),
+                    value: NumberFormatter.decimalFormatter.string(for: metrics.numberOfChars))
+        ]
     }
 }
 
@@ -78,7 +86,7 @@ extension NoteInformationViewController: UITableViewDataSource {
         }
     }
 
-    private func configure(cell: Value1TableViewCell, withTitle title: String, value: String) {
+    private func configure(cell: Value1TableViewCell, withTitle title: String, value: String?) {
         cell.title = title
         cell.detailTextLabel?.text = value
     }
@@ -100,5 +108,5 @@ extension NoteInformationViewController {
 }
 
 private enum Row {
-    case metric(title: String, value: String)
+    case metric(title: String, value: String?)
 }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -36,6 +36,12 @@ class NoteInformationViewController: UIViewController {
         let metrics = NoteMetrics(note: note)
 
         rows = [
+            .metric(title: NSLocalizedString("Modified", comment: "Note Modification Date"),
+                    value: DateFormatter.dateTimeFormatter.string(from: metrics.modifiedDate)),
+
+            .metric(title: NSLocalizedString("Created", comment: "Note Creation Date"),
+                    value: DateFormatter.dateTimeFormatter.string(from: metrics.creationDate)),
+
             .metric(title: NSLocalizedString("Words", comment: "Number of words in the note"),
                     value: NumberFormatter.decimalFormatter.string(for: metrics.numberOfWords)),
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -1,0 +1,72 @@
+import UIKit
+import SimplenoteFoundation
+
+// MARK: - NoteInformationViewController
+//
+class NoteInformationViewController: UIViewController {
+    @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private weak var screenTitleLabel: UILabel!
+    @IBOutlet private weak var dismissButton: UIButton!
+
+    private var transitioningManager: UIViewControllerTransitioningDelegate?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTableView()
+    }
+
+    private func setupTableView() {
+        tableView.register(Value1TableViewCell.self, forCellReuseIdentifier: Value1TableViewCell.reuseIdentifier)
+    }
+}
+
+// MARK: - Handling button events
+//
+private extension NoteInformationViewController {
+    @IBAction func handleTapOnDismissButton() {
+        dismiss(animated: true, completion: nil)
+    }
+}
+
+// MARK: - UITableViewDelegate
+//
+extension NoteInformationViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+
+// MARK: - UITableViewDataSource
+//
+extension NoteInformationViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 0
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        fatalError()
+    }
+}
+
+// MARK: - Presentation
+//
+extension NoteInformationViewController {
+
+    /// Configure view controller to be presented as a card
+    ///
+    func configureToPresentAsCard(presentationDelegate: SPCardPresentationControllerDelegate) {
+        let transitioningManager = SPCardTransitioningManager()
+        transitioningManager.presentationDelegate = presentationDelegate
+        self.transitioningManager = transitioningManager
+
+        transitioningDelegate = transitioningManager
+        modalPresentationStyle = .custom
+    }
+}

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -13,6 +13,11 @@ class NoteInformationViewController: UIViewController {
     private let note: Note
     private var rows: [Row] = []
 
+    /// Designated initializer
+    ///
+    /// - Parameters:
+    ///     - note: Note
+    ///
     init(note: Note) {
         self.note = note
         super.init(nibName: nil, bundle: nil)
@@ -36,25 +41,16 @@ class NoteInformationViewController: UIViewController {
 
         reloadData()
     }
+}
 
-    private func configureViews() {
-        configureTableView()
-        screenTitleLabel.text = Localization.information
-
-        refreshStyle()
-    }
-
-    private func configureTableView() {
-        tableView.register(Value1TableViewCell.self, forCellReuseIdentifier: Value1TableViewCell.reuseIdentifier)
-        tableView.tableFooterView = UIView()
-    }
-
-    private func reloadData() {
+// MARK: - Data
+private extension NoteInformationViewController {
+    func reloadData() {
         rows = metricRows()
         tableView.reloadData()
     }
 
-    private func metricRows() -> [Row] {
+    func metricRows() -> [Row] {
         let metrics = NoteMetrics(note: note)
         return [
             .metric(title: Localization.modified,
@@ -70,10 +66,25 @@ class NoteInformationViewController: UIViewController {
                     value: NumberFormatter.decimalFormatter.string(for: metrics.numberOfChars))
         ]
     }
+}
 
-    private func configureAccessibility() {
+// MARK: - Configuration
+//
+private extension NoteInformationViewController {
+    func configureViews() {
+        configureTableView()
+        screenTitleLabel.text = Localization.information
+
+        refreshStyle()
+    }
+
+    func configureTableView() {
+        tableView.register(Value1TableViewCell.self, forCellReuseIdentifier: Value1TableViewCell.reuseIdentifier)
+        tableView.tableFooterView = UIView()
+    }
+
+    func configureAccessibility() {
         dismissButton.accessibilityLabel = Localization.dismissAccessibilityLabel
-
     }
 }
 
@@ -112,7 +123,6 @@ private extension NoteInformationViewController {
 // MARK: - UITableViewDelegate
 //
 extension NoteInformationViewController: UITableViewDelegate {
-
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
     }
@@ -122,7 +132,6 @@ extension NoteInformationViewController: UITableViewDelegate {
 // MARK: - UITableViewDataSource
 //
 extension NoteInformationViewController: UITableViewDataSource {
-
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -10,13 +10,30 @@ class NoteInformationViewController: UIViewController {
 
     private var transitioningManager: UIViewControllerTransitioningDelegate?
 
+    private let note: Note
+    private var rows: [Row] = []
+
+    init(note: Note) {
+        self.note = note
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTableView()
+        reloadData()
     }
 
     private func setupTableView() {
         tableView.register(Value1TableViewCell.self, forCellReuseIdentifier: Value1TableViewCell.reuseIdentifier)
+    }
+
+    private func reloadData() {
+
     }
 }
 
@@ -43,15 +60,27 @@ extension NoteInformationViewController: UITableViewDelegate {
 extension NoteInformationViewController: UITableViewDataSource {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 0
+        return 1
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 0
+        return rows.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        fatalError()
+        let row = rows[indexPath.row]
+
+        switch row {
+        case .metric(let title, let value):
+            let cell = tableView.dequeueReusableCell(ofType: Value1TableViewCell.self, for: indexPath)
+            configure(cell: cell, withTitle: title, value: value)
+            return cell
+        }
+    }
+
+    private func configure(cell: Value1TableViewCell, withTitle title: String, value: String) {
+        cell.title = title
+        cell.detailTextLabel?.text = value
     }
 }
 
@@ -61,12 +90,15 @@ extension NoteInformationViewController {
 
     /// Configure view controller to be presented as a card
     ///
-    func configureToPresentAsCard(presentationDelegate: SPCardPresentationControllerDelegate) {
+    func configureToPresentAsCard() {
         let transitioningManager = SPCardTransitioningManager()
-        transitioningManager.presentationDelegate = presentationDelegate
         self.transitioningManager = transitioningManager
 
         transitioningDelegate = transitioningManager
         modalPresentationStyle = .custom
     }
+}
+
+private enum Row {
+    case metric(title: String, value: String)
 }

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -5,7 +5,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -22,27 +21,25 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg">
-                    <rect key="frame" x="0.0" y="463" width="414" height="200"/>
-                    <constraints>
-                        <constraint firstAttribute="height" priority="999" constant="200" id="o96-z4-rfD"/>
-                    </constraints>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="263" width="414" height="400"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="dIp-Oc-ZbT"/>
                         <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
                     </connections>
                 </tableView>
                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
-                    <rect key="frame" x="20" y="60" width="374" height="387"/>
+                    <rect key="frame" x="20" y="60" width="374" height="187"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
-                            <rect key="frame" x="0.0" y="183.5" width="336" height="20.5"/>
+                            <rect key="frame" x="0.0" y="83.5" width="336" height="20.5"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7HZ-2J-9ef" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
-                            <rect key="frame" x="344" y="178.5" width="30" height="30"/>
+                            <rect key="frame" x="344" y="78.5" width="30" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="30" id="zYd-Xa-72n"/>
                                 <constraint firstAttribute="width" constant="30" id="zd7-TM-xEa"/>
@@ -61,7 +58,7 @@
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="qBv-kl-fOD" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="AXH-SH-eyF"/>
                 <constraint firstAttribute="trailingMargin" secondItem="qBv-kl-fOD" secondAttribute="trailing" id="HOZ-wS-Cap"/>
@@ -83,8 +80,5 @@
     </designables>
     <resources>
         <image name="icon_cross" width="16" height="16"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -33,16 +33,16 @@
                     </connections>
                 </tableView>
                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
-                    <rect key="frame" x="20" y="60" width="374" height="403"/>
+                    <rect key="frame" x="20" y="60" width="374" height="387"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
-                            <rect key="frame" x="0.0" y="191.5" width="336" height="20.5"/>
+                            <rect key="frame" x="0.0" y="183.5" width="336" height="20.5"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7HZ-2J-9ef" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
-                            <rect key="frame" x="344" y="186.5" width="30" height="30"/>
+                            <rect key="frame" x="344" y="178.5" width="30" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="30" id="zYd-Xa-72n"/>
                                 <constraint firstAttribute="width" constant="30" id="zd7-TM-xEa"/>
@@ -66,7 +66,7 @@
                 <constraint firstItem="qBv-kl-fOD" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="AXH-SH-eyF"/>
                 <constraint firstAttribute="trailingMargin" secondItem="qBv-kl-fOD" secondAttribute="trailing" id="HOZ-wS-Cap"/>
                 <constraint firstAttribute="bottom" secondItem="HfE-pa-isg" secondAttribute="bottom" id="KEK-Bi-Ygi"/>
-                <constraint firstItem="HfE-pa-isg" firstAttribute="top" secondItem="qBv-kl-fOD" secondAttribute="bottom" id="Kbi-ET-4A1"/>
+                <constraint firstItem="HfE-pa-isg" firstAttribute="top" secondItem="qBv-kl-fOD" secondAttribute="bottom" constant="16" id="Kbi-ET-4A1"/>
                 <constraint firstItem="qBv-kl-fOD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" id="Mdr-fB-E8P"/>
                 <constraint firstItem="HfE-pa-isg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="rSA-XM-wYj"/>
                 <constraint firstAttribute="trailing" secondItem="HfE-pa-isg" secondAttribute="trailing" id="wKC-dG-zlb"/>

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteInformationViewController" customModule="Simplenote" customModuleProvider="target">
+            <connections>
+                <outlet property="dismissButton" destination="7HZ-2J-9ef" id="rrw-yc-zdP"/>
+                <outlet property="screenTitleLabel" destination="9ul-2d-OoP" id="pZb-Nb-szF"/>
+                <outlet property="tableView" destination="HfE-pa-isg" id="5Gu-fK-38o"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg">
+                    <rect key="frame" x="0.0" y="463" width="414" height="200"/>
+                    <constraints>
+                        <constraint firstAttribute="height" priority="999" constant="200" id="o96-z4-rfD"/>
+                    </constraints>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="dIp-Oc-ZbT"/>
+                        <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
+                    </connections>
+                </tableView>
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
+                    <rect key="frame" x="20" y="60" width="374" height="403"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
+                            <rect key="frame" x="0.0" y="191.5" width="336" height="20.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7HZ-2J-9ef" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                            <rect key="frame" x="344" y="186.5" width="30" height="30"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="30" id="zYd-Xa-72n"/>
+                                <constraint firstAttribute="width" constant="30" id="zd7-TM-xEa"/>
+                            </constraints>
+                            <state key="normal" image="icon_cross"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                    <real key="value" value="15"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="handleTapOnDismissButton" destination="-1" eventType="touchUpInside" id="qgF-a7-uKd"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="qBv-kl-fOD" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="AXH-SH-eyF"/>
+                <constraint firstAttribute="trailingMargin" secondItem="qBv-kl-fOD" secondAttribute="trailing" id="HOZ-wS-Cap"/>
+                <constraint firstAttribute="bottom" secondItem="HfE-pa-isg" secondAttribute="bottom" id="KEK-Bi-Ygi"/>
+                <constraint firstItem="HfE-pa-isg" firstAttribute="top" secondItem="qBv-kl-fOD" secondAttribute="bottom" id="Kbi-ET-4A1"/>
+                <constraint firstItem="qBv-kl-fOD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" id="Mdr-fB-E8P"/>
+                <constraint firstItem="HfE-pa-isg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="rSA-XM-wYj"/>
+                <constraint firstAttribute="trailing" secondItem="HfE-pa-isg" secondAttribute="trailing" id="wKC-dG-zlb"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="-170" y="23"/>
+        </view>
+    </objects>
+    <designables>
+        <designable name="7HZ-2J-9ef">
+            <size key="intrinsicContentSize" width="16" height="22"/>
+        </designable>
+    </designables>
+    <resources>
+        <image name="icon_cross" width="16" height="16"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Simplenote/NoteMetrics.swift
+++ b/Simplenote/NoteMetrics.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// MARK: - NoteMetrics
+//
+struct NoteMetrics {
+
+    /// Returns the total number of characters
+    ///
+    let numberOfChars: Int
+
+    /// Returns the total number of words
+    ///
+    let numberOfWords: Int
+
+    /// Creation Date
+    ///
+    let creationDate: Date
+
+    /// Modification Date
+    ///
+    let modifiedDate: Date
+
+
+    /// Designed Initializer
+    /// - Parameter note: Note from which we should extract metrics
+    ///
+    init(note: Note) {
+        let content = ((note.content ?? "") as NSString)
+
+        numberOfChars = content.charCount
+        numberOfWords = content.wordCount
+        creationDate = note.creationDate
+        modifiedDate = note.modificationDate
+    }
+}

--- a/Simplenote/NumberFormatter+Simplenote.swift
+++ b/Simplenote/NumberFormatter+Simplenote.swift
@@ -3,6 +3,8 @@ import Foundation
 // MARK: - NumberFormatter Extension
 //
 extension NumberFormatter {
+    /// Number formatter with decimal style
+    ///
     static let decimalFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal

--- a/Simplenote/NumberFormatter+Simplenote.swift
+++ b/Simplenote/NumberFormatter+Simplenote.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+// MARK: - NumberFormatter Extension
+//
+extension NumberFormatter {
+    static let decimalFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
+}

--- a/Simplenote/SPCardPresentationController.swift
+++ b/Simplenote/SPCardPresentationController.swift
@@ -40,8 +40,9 @@ final class SPCardPresentationController: UIPresentationController {
         return gestureRecognizer
     }()
 
-    private var compactLayoutConstraints: [NSLayoutConstraint] = []
-    private var regularLayoutConstraints: [NSLayoutConstraint] = []
+    private var compactWidthLayoutConstraints: [NSLayoutConstraint] = []
+    private var regularWidthLayoutConstraints: [NSLayoutConstraint] = []
+    private var regularHeightLayoutConstraints: [NSLayoutConstraint] = []
 
     /// Transition interactor is set only during swipe to dismiss
     ///
@@ -109,10 +110,14 @@ extension SPCardPresentationController {
     }
 
     private func updateConstraints(for collection: UITraitCollection) {
-        NSLayoutConstraint.deactivate(compactLayoutConstraints + regularLayoutConstraints)
+        NSLayoutConstraint.deactivate(compactWidthLayoutConstraints + regularWidthLayoutConstraints + regularHeightLayoutConstraints)
 
-        let newConstraints = collection.horizontalSizeClass == .regular ? regularLayoutConstraints : compactLayoutConstraints
-        NSLayoutConstraint.activate(newConstraints)
+        let newWidthConstraints = collection.horizontalSizeClass == .regular ? regularWidthLayoutConstraints : compactWidthLayoutConstraints
+        NSLayoutConstraint.activate(newWidthConstraints)
+
+        if collection.verticalSizeClass == .regular {
+            NSLayoutConstraint.activate(regularHeightLayoutConstraints)
+        }
     }
 }
 
@@ -131,14 +136,18 @@ private extension SPCardPresentationController {
         cardView.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(cardView)
 
-        compactLayoutConstraints = [
+        compactWidthLayoutConstraints = [
             cardView.leadingAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.leadingAnchor),
             cardView.trailingAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.trailingAnchor),
         ]
 
-        regularLayoutConstraints = [
+        regularWidthLayoutConstraints = [
             cardView.leadingAnchor.constraint(equalTo: containerView.readableContentGuide.leadingAnchor),
             cardView.trailingAnchor.constraint(equalTo: containerView.readableContentGuide.trailingAnchor),
+        ]
+
+        regularHeightLayoutConstraints = [
+            cardView.topAnchor.constraint(greaterThanOrEqualTo: containerView.centerYAnchor),
         ]
 
         let heightConstraint = cardView.heightAnchor.constraint(equalToConstant: 0)
@@ -146,8 +155,7 @@ private extension SPCardPresentationController {
 
         NSLayoutConstraint.activate([
             cardView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-            cardView.topAnchor.constraint(greaterThanOrEqualTo: containerView.safeAreaLayoutGuide.topAnchor),
-            cardView.topAnchor.constraint(greaterThanOrEqualTo: containerView.centerYAnchor),
+            cardView.topAnchor.constraint(greaterThanOrEqualTo: containerView.safeAreaLayoutGuide.topAnchor, constant: 10),
             heightConstraint
         ])
 

--- a/Simplenote/SPCardPresentationController.swift
+++ b/Simplenote/SPCardPresentationController.swift
@@ -147,6 +147,7 @@ private extension SPCardPresentationController {
         NSLayoutConstraint.activate([
             cardView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
             cardView.topAnchor.constraint(greaterThanOrEqualTo: containerView.safeAreaLayoutGuide.topAnchor),
+            cardView.topAnchor.constraint(greaterThanOrEqualTo: containerView.centerYAnchor),
             heightConstraint
         ])
 

--- a/Simplenote/SPCardPresentationController.swift
+++ b/Simplenote/SPCardPresentationController.swift
@@ -155,7 +155,7 @@ private extension SPCardPresentationController {
 
         NSLayoutConstraint.activate([
             cardView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-            cardView.topAnchor.constraint(greaterThanOrEqualTo: containerView.safeAreaLayoutGuide.topAnchor, constant: 10),
+            cardView.topAnchor.constraint(greaterThanOrEqualTo: containerView.safeAreaLayoutGuide.topAnchor, constant: Constants.cardMinTopMargin),
             heightConstraint
         ])
 
@@ -293,4 +293,5 @@ private extension SPCardPresentationController {
 private struct Constants {
     static let dismissalPercentThreshold = CGFloat(0.3)
     static let dismissalVelocityThreshold = CGFloat(1600)
+    static let cardMinTopMargin = CGFloat(10.0)
 }

--- a/Simplenote/Value1TableViewCell.swift
+++ b/Simplenote/Value1TableViewCell.swift
@@ -14,6 +14,8 @@ class Value1TableViewCell: UITableViewCell {
         }
     }
 
+    /// Indicates if the row has clear background
+    ///
     var hasClearBackground = false {
         didSet {
             if oldValue != hasClearBackground {

--- a/Simplenote/Value1TableViewCell.swift
+++ b/Simplenote/Value1TableViewCell.swift
@@ -14,6 +14,14 @@ class Value1TableViewCell: UITableViewCell {
         }
     }
 
+    var hasClearBackground = false {
+        didSet {
+            if oldValue != hasClearBackground {
+                reloadBackgroundStyles()
+            }
+        }
+    }
+
     /// Wraps the TextLabel's Text Property
     ///
     var title: String? {
@@ -22,6 +30,17 @@ class Value1TableViewCell: UITableViewCell {
         }
         set {
             textLabel?.text = newValue
+        }
+    }
+
+    /// Wraps the DetailTextLabel's Text Property
+    ///
+    var value: String? {
+        get {
+            detailTextLabel?.text
+        }
+        set {
+            detailTextLabel?.text = newValue
         }
     }
 
@@ -56,13 +75,15 @@ private extension Value1TableViewCell {
         let selectedView = UIView(frame: bounds)
         selectedView.backgroundColor = .simplenoteLightBlueColor
 
-        backgroundColor = .simplenoteTableViewCellBackgroundColor
+        backgroundColor = hasClearBackground ? .clear : .simplenoteTableViewCellBackgroundColor
         selectedBackgroundView = selectedView
     }
 
     func reloadTextStyles() {
         let textColor: UIColor = selectable ? .simplenoteTextColor : .simplenotePlaceholderTextColor
+        let detailTextColor: UIColor = selectable ? .simplenoteSecondaryTextColor : .simplenotePlaceholderTextColor
         textLabel?.textColor = textColor
+        detailTextLabel?.textColor = detailTextColor
         imageView?.tintColor = textColor
         selectionStyle = selectable ? .default : .none
     }


### PR DESCRIPTION
New Note Information card showing metrics (and later also interlink references)

@jleandroperez Please take a look when you have time. Thanks!

### Test (note)
1. Open a note

- [x] Check that there is a `(i)` button in the navigation bar

### Test (information card)

1. Open a note
2. Tap on the `(i)` button in the navigation bar

- [x] Information card is visible (also try when from is in landscape)
- [x] Information card shows Modified date, Created date, Words and Characters counts
- [x] Can be dismissed by tapping on `X`
- [x] Can be dismissed by tapping outside of the card
- [x] Can be dismissed by swiping the card down

### Release
Added in https://github.com/Automattic/simplenote-ios/pull/939/commits/5e35f83ac53cd1d9d7b49183350f9c0df95c75c7

> New Note Information interface #836
