### PR TITLE
Updates Dependencies + CI Xcode12 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   Test:
     executor:
       name: ios/default
-      xcode-version: "11.6.0"
+      xcode-version: "12.0"
     steps:
       - git/shallow-checkout
       - fix-path
@@ -40,7 +40,7 @@ jobs:
       - run: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
       # END: Swift Package Manager Workaround
       - ios/test:
-          xcode-version: "11.6.0"
+          xcode-version: "12.0"
           workspace: Simplenote.xcworkspace
           scheme: Simplenote
           device: iPhone 11
@@ -48,7 +48,7 @@ jobs:
   Installable Build:
     executor:
       name: ios/default
-      xcode-version: "11.6.0"
+      xcode-version: "12.0"
     steps:
       - git/shallow-checkout
       - ios/install-dependencies:
@@ -76,7 +76,7 @@ jobs:
   Release Build:
     executor:
       name: ios/default
-      xcode-version: "11.6.0"
+      xcode-version: "12.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:

--- a/Podfile
+++ b/Podfile
@@ -18,12 +18,12 @@ abstract_target 'Automattic' do
 		# Third Party
 		#
 		pod 'Gridicons', '~> 0.18'
-		pod 'AppCenter', '~> 2.3.0'
-		pod 'AppCenter/Distribute', '~> 2.3.0'
+		pod 'AppCenter', '~> 2.5.1'
+		pod 'AppCenter/Distribute', '~> 2.5.1'
 
 		# Automattic
 		#
-		pod 'Automattic-Tracks-iOS', '~> 0.5'
+		pod 'Automattic-Tracks-iOS', '~> 0.5.1'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
 		pod 'Simperium', '~> 1.0'
 		pod 'WordPress-Ratings-iOS', '0.0.2'

--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ abstract_target 'Automattic' do
 
 		# Automattic
 		#
-		pod 'Automattic-Tracks-iOS', '~> 0.5.1'
+		pod 'Automattic-Tracks-iOS', '~> 0.6'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
 		pod 'Simperium', '~> 1.0'
 		pod 'WordPress-Ratings-iOS', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,11 +9,11 @@ PODS:
     - AppCenter/Core
   - AppCenter/Distribute (2.5.3):
     - AppCenter/Core
-  - Automattic-Tracks-iOS (0.5.1):
+  - Automattic-Tracks-iOS (0.6.0):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
     - Sentry (~> 4)
-    - Sodium (~> 0.8.0)
+    - Sodium-Fork (= 0.8.2)
     - UIDeviceIdentifier (~> 1)
   - CocoaLumberjack (3.7.0):
     - CocoaLumberjack/Core (= 3.7.0)
@@ -34,7 +34,7 @@ PODS:
   - Simperium/SocketTrust (1.0.0)
   - Simperium/SPReachability (1.0.0)
   - Simperium/SSKeychain (1.0.0)
-  - Sodium (0.8.0)
+  - Sodium-Fork (0.8.2)
   - UIDeviceIdentifier (1.5.0)
   - WordPress-Ratings-iOS (0.0.2)
   - ZIPFoundation (0.9.11)
@@ -42,7 +42,7 @@ PODS:
 DEPENDENCIES:
   - AppCenter (~> 2.5.1)
   - AppCenter/Distribute (~> 2.5.1)
-  - Automattic-Tracks-iOS (~> 0.5.1)
+  - Automattic-Tracks-iOS (~> 0.6)
   - Gridicons (~> 0.18)
   - Simperium (~> 1.0)
   - WordPress-Ratings-iOS (= 0.0.2)
@@ -57,24 +57,24 @@ SPEC REPOS:
     - Reachability
     - Sentry
     - Simperium
-    - Sodium
+    - Sodium-Fork
     - UIDeviceIdentifier
     - WordPress-Ratings-iOS
     - ZIPFoundation
 
 SPEC CHECKSUMS:
   AppCenter: 765ff38c4d360fc5ec61b61a8be24d74cd6d4d83
-  Automattic-Tracks-iOS: ac2cf9d8332fef72cf3e6de7b14012e7a0672676
+  Automattic-Tracks-iOS: c525679cbf91ac8bcbcbed01bdaa564867173182
   CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   Simperium: fa0feb6e86de4e93d0d07704b59a0a7aebd7d5a7
-  Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
+  Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 9d5d9514beec4282249693de8e03e9902abf1948
+PODFILE CHECKSUM: 89dff66327b71b6e3fbef5704ad88eb94cb36bc7
 
 COCOAPODS: 1.7.5

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - AppCenter (2.3.0):
-    - AppCenter/Analytics (= 2.3.0)
-    - AppCenter/Crashes (= 2.3.0)
-  - AppCenter/Analytics (2.3.0):
+  - AppCenter (2.5.3):
+    - AppCenter/Analytics (= 2.5.3)
+    - AppCenter/Crashes (= 2.5.3)
+  - AppCenter/Analytics (2.5.3):
     - AppCenter/Core
-  - AppCenter/Core (2.3.0)
-  - AppCenter/Crashes (2.3.0):
+  - AppCenter/Core (2.5.3)
+  - AppCenter/Crashes (2.5.3):
     - AppCenter/Core
-  - AppCenter/Distribute (2.3.0):
+  - AppCenter/Distribute (2.5.3):
     - AppCenter/Core
   - Automattic-Tracks-iOS (0.5.1):
     - CocoaLumberjack (~> 3)
@@ -40,9 +40,9 @@ PODS:
   - ZIPFoundation (0.9.11)
 
 DEPENDENCIES:
-  - AppCenter (~> 2.3.0)
-  - AppCenter/Distribute (~> 2.3.0)
-  - Automattic-Tracks-iOS (~> 0.5)
+  - AppCenter (~> 2.5.1)
+  - AppCenter/Distribute (~> 2.5.1)
+  - Automattic-Tracks-iOS (~> 0.5.1)
   - Gridicons (~> 0.18)
   - Simperium (~> 1.0)
   - WordPress-Ratings-iOS (= 0.0.2)
@@ -63,7 +63,7 @@ SPEC REPOS:
     - ZIPFoundation
 
 SPEC CHECKSUMS:
-  AppCenter: 9784d2fc998c9bd0b8fbaf4fb9ed69526d12ce1a
+  AppCenter: 765ff38c4d360fc5ec61b61a8be24d74cd6d4d83
   Automattic-Tracks-iOS: ac2cf9d8332fef72cf3e6de7b14012e7a0672676
   CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
@@ -75,6 +75,6 @@ SPEC CHECKSUMS:
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 95e97b56dcfc5dd8ee75870e9b1be11b1a5cbe47
+PODFILE CHECKSUM: 9d5d9514beec4282249693de8e03e9902abf1948
 
 COCOAPODS: 1.7.5

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 		B594C3EE2501E24C006D3A78 /* UINavigationController+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B594C3ED2501E24C006D3A78 /* UINavigationController+Simplenote.swift */; };
 		B59560E0251A46D500A06788 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59560DF251A46D500A06788 /* KeychainManager.swift */; };
 		B599839A2514EC790037B129 /* KeychainPasswordItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD30471FC4CFA2008D0B78 /* KeychainPasswordItem.swift */; };
+		B59CACFC2541E05400958330 /* SimplenoteInterlinks in Frameworks */ = {isa = PBXBuildFile; productRef = B59CACFB2541E05400958330 /* SimplenoteInterlinks */; };
 		B59FFB43231851C700567627 /* UIGestureRecognizer+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59FFB42231851C700567627 /* UIGestureRecognizer+Simplenote.swift */; };
 		B5A6166F2150855300CBE47B /* Preferences.m in Sources */ = {isa = PBXBuildFile; fileRef = B594E61321508247001577EE /* Preferences.m */; };
 		B5A6846D23CE84D400398BBC /* NotesListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A6846C23CE84D400398BBC /* NotesListController.swift */; };
@@ -846,6 +847,7 @@
 				46A3C9B417DFA81A002865AE /* libicucore.dylib in Frameworks */,
 				B5BAF9ED24E4D0D2000917C0 /* SimplenoteFoundation in Frameworks */,
 				46A3C9B517DFA81A002865AE /* CoreFoundation.framework in Frameworks */,
+				B59CACFC2541E05400958330 /* SimplenoteInterlinks in Frameworks */,
 				46A3C9B617DFA81A002865AE /* SystemConfiguration.framework in Frameworks */,
 				46A3C9B717DFA81A002865AE /* CoreData.framework in Frameworks */,
 				46A3C9B817DFA81A002865AE /* CFNetwork.framework in Frameworks */,
@@ -1812,6 +1814,7 @@
 			packageProductDependencies = (
 				B5BAF9EC24E4D0D2000917C0 /* SimplenoteFoundation */,
 				B50D2FB524E6DFAC00163FC3 /* SimplenoteSearch */,
+				B59CACFB2541E05400958330 /* SimplenoteInterlinks */,
 			);
 			productName = Simplenote;
 			productReference = 46A3C9D717DFA81A002865AE /* Simplenote.app */;
@@ -1949,6 +1952,7 @@
 			packageReferences = (
 				B5BAF9EB24E4D0D2000917C0 /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */,
 				B50D2FB424E6DFAC00163FC3 /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */,
+				B59CACFA2541E05400958330 /* XCRemoteSwiftPackageReference "SimplenoteInterlinks-Swift" */,
 			);
 			productRefGroup = E29ADD3917848E8500E55842 /* Products */;
 			projectDirPath = "";
@@ -4017,7 +4021,15 @@
 			repositoryURL = "git@github.com:Automattic/SimplenoteSearch-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.1.0;
+			};
+		};
+		B59CACFA2541E05400958330 /* XCRemoteSwiftPackageReference "SimplenoteInterlinks-Swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "git@github.com:Automattic/SimplenoteInterlinks-Swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 		B5BAF9EB24E4D0D2000917C0 /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */ = {
@@ -4025,7 +4037,7 @@
 			repositoryURL = "git@github.com:Automattic/SimplenoteFoundation-Swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -4035,6 +4047,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B50D2FB424E6DFAC00163FC3 /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */;
 			productName = SimplenoteSearch;
+		};
+		B59CACFB2541E05400958330 /* SimplenoteInterlinks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B59CACFA2541E05400958330 /* XCRemoteSwiftPackageReference "SimplenoteInterlinks-Swift" */;
+			productName = SimplenoteInterlinks;
 		};
 		B5BAF9EC24E4D0D2000917C0 /* SimplenoteFoundation */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,17 @@
         "repositoryURL": "git@github.com:Automattic/SimplenoteFoundation-Swift.git",
         "state": {
           "branch": null,
-          "revision": "c5938f97ba6c041ae4c0f4030493f628f2263a41",
-          "version": "1.0.0"
+          "revision": "150e363b46f7c0d479a474c2c0a8d00648bbab97",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "SimplenoteInterlinks",
+        "repositoryURL": "git@github.com:Automattic/SimplenoteInterlinks-Swift.git",
+        "state": {
+          "branch": null,
+          "revision": "be3827a5bf05c5349ed62126c3e1dc60a2a6cee6",
+          "version": "1.1.0"
         }
       },
       {
@@ -15,8 +24,8 @@
         "repositoryURL": "git@github.com:Automattic/SimplenoteSearch-Swift.git",
         "state": {
           "branch": null,
-          "revision": "c594338829e8fb8954fad8743508b135da17b132",
-          "version": "1.0.0"
+          "revision": "a0f72ae7441d0311c41b47dfa4046bc9e23823bf",
+          "version": "1.1.0"
         }
       }
     ]


### PR DESCRIPTION
### Details:
In this PR we're updating several dependencies:

- **SimplenoteFoundation**
- **SimplenoteSearch**
- We're also integrating **SimplenoteInterlinking**
- Updated **AutomatticTracks** and **AppCenter**
- Bumped up the CI's Xcode version

@eshurakov A quick one if you don't mind sir!

/cc @mokagio Sir! we're bumping up CircleCI to Xcode 12 in this PR. Had to map Tracks 0.6 to fix **THAT** Sodium issue!

Thank youu!!

### Test
- [ ] Verify the app builds correctly please!

### Release
These changes do not require release notes.
