### PR TITLE
Fixing Search Bar Height

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,8 @@
 -   New Note History interface #762
 -   New Note Options interface #763
 -   Updated Navigation Bar's behavior #918
--   Adjusted Notes List Metrics 
+-   Adjusted Notes List Metrics #929
+-   Fixed a bug that caused the Search Bar to look extra big #930
 
 4.26
 -----

--- a/Simplenote/Classes/UISearchBar+Simplenote.swift
+++ b/Simplenote/Classes/UISearchBar+Simplenote.swift
@@ -16,7 +16,6 @@ extension UISearchBar {
 
         // Apply font to search field by traversing subviews
         for textField in subviewsOfType(UITextField.self) {
-            textField.font = .systemFont(ofSize: 17.0)
             textField.textColor = .simplenoteTextColor
             textField.keyboardAppearance = SPUserInterface.isDark ? .dark : .default
         }


### PR DESCRIPTION
### Fix
In this PR we're dropping a workaround we had in place (allegedly for iOS 11 reasons), which is causing the SearchBar's Background to grow up to 56pt (rather than the expected standard 36pt).

@eshurakov Hacks are NOT cool!! 😂 

Closes #930

### Test
- [x] Verify the SearchBar looks huge in develop / iOS 14
- [x] Verify the SearchBar looks awesome in this branch!

### Release
`RELEASE-NOTES.txt` was updated in d3adb3ef with:
 
> Fixed a bug that caused the Search Bar to look extra big #930
