### PR TITLE
Nü Metrics: Mark II

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		A6E1E7A224BDE456008A44BC /* SPCardPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1E7A124BDE456008A44BC /* SPCardPresentationAnimator.swift */; };
 		A6E1E7A424BDE472008A44BC /* SPCardPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1E7A324BDE472008A44BC /* SPCardPresentationController.swift */; };
 		A6E1E7A824BE656D008A44BC /* SPCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1E7A724BE656D008A44BC /* SPCardView.swift */; };
+		A6FDF73E2542BDE100415C87 /* NoteInformationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6FDF73D2542BDE100415C87 /* NoteInformationController.swift */; };
 		B502311325129525002C3CDA /* SPDiagnosticsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B502311225129525002C3CDA /* SPDiagnosticsViewController.xib */; };
 		B504D4DE23D2014200AEED27 /* IndexPath+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504D4DD23D2014200AEED27 /* IndexPath+Simplenote.swift */; };
 		B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 17C421CE1BE0BAB100752B56 /* SPInteractivePushPopAnimationController.m */; };
@@ -518,6 +519,7 @@
 		A6E1E7A124BDE456008A44BC /* SPCardPresentationAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardPresentationAnimator.swift; sourceTree = "<group>"; };
 		A6E1E7A324BDE472008A44BC /* SPCardPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardPresentationController.swift; sourceTree = "<group>"; };
 		A6E1E7A724BE656D008A44BC /* SPCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardView.swift; sourceTree = "<group>"; };
+		A6FDF73D2542BDE100415C87 /* NoteInformationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteInformationController.swift; sourceTree = "<group>"; };
 		A774E3E4F5041D36FBE400BD /* Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution adhoc.xcconfig"; sourceTree = "<group>"; };
 		AE066B9C23C9166D41F1A732 /* Pods-SimplenoteTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B303123B163A5C7805D10DC7 /* Pods-Automattic-Simplenote.distribution adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.distribution adhoc.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.distribution adhoc.xcconfig"; sourceTree = "<group>"; };
@@ -1071,6 +1073,7 @@
 			children = (
 				A69F861A25408085005140F2 /* NoteInformationViewController.swift */,
 				A69F861B25408085005140F2 /* NoteInformationViewController.xib */,
+				A6FDF73D2542BDE100415C87 /* NoteInformationController.swift */,
 			);
 			path = Information;
 			sourceTree = "<group>";
@@ -2337,6 +2340,7 @@
 				B5E3F3982539F1E900271AEA /* SPTextView.m in Sources */,
 				B5185CFB23427F2F0060145A /* SearchDisplayController.swift in Sources */,
 				B524AE0F2352BE9200EA11D4 /* UITableView+Simplenote.swift in Sources */,
+				A6FDF73E2542BDE100415C87 /* NoteInformationController.swift in Sources */,
 				B5E951E624FEE2A8004B10B8 /* Note+Links.swift in Sources */,
 				B5D982D022F8643300C37C29 /* SPTextInputView.swift in Sources */,
 				B5476BBD23D8A71D000E7723 /* UIFont+Simplenote.swift in Sources */,

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -312,19 +312,46 @@ extension SPNoteEditorViewController: SPCardPresentationControllerDelegate {
 //
 extension SPNoteEditorViewController {
 
-    private func presentInformationController(for note: Note, from barButtonItem: UIBarButtonItem) {
-        let information = NoteInformationViewController(note: note)
+    /// Present information controller
+    /// - Parameters:
+    ///     - note: Note
+    ///     - barButtonItem: Bar button item to be used as a popover target
+    ///
+    @objc
+    func presentInformationController(for note: Note, from barButtonItem: UIBarButtonItem) {
+        let informationViewController = NoteInformationViewController(note: note)
 
         let presentAsPopover = UIDevice.sp_isPad() && traitCollection.horizontalSizeClass == .regular
 
         if presentAsPopover {
-            let navigationController = SPNavigationController(rootViewController: information)
+            let navigationController = SPNavigationController(rootViewController: informationViewController)
             navigationController.configureAsPopover(barButtonItem: barButtonItem)
             navigationController.displaysBlurEffect = true
+            self.informationViewController = navigationController
             present(navigationController, animated: true, completion: nil)
         } else {
-            information.configureToPresentAsCard()
-            present(information, animated: true, completion: nil)
+            informationViewController.configureToPresentAsCard()
+            self.informationViewController = informationViewController
+            present(informationViewController, animated: true, completion: nil)
+        }
+    }
+
+    /// Dismiss and present information controller.
+    /// Called when horizontal size class changes
+    ///
+    @objc
+    func updateInformationControllerPresentation() {
+        guard let informationViewController = self.informationViewController else {
+            return
+        }
+
+        informationViewController.dismiss(animated: false) { [weak self] in
+            guard let self = self,
+                  let note = self.currentNote,
+                  let informationButton = self.informationButton else {
+                return
+            }
+            self.presentInformationController(for: note, from: informationButton)
         }
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -312,10 +312,20 @@ extension SPNoteEditorViewController: SPCardPresentationControllerDelegate {
 //
 extension SPNoteEditorViewController {
 
-    private func presentInformationController(for note: Note) {
+    private func presentInformationController(for note: Note, from barButtonItem: UIBarButtonItem) {
         let information = NoteInformationViewController(note: note)
-        information.configureToPresentAsCard()
-        present(information, animated: true, completion: nil)
+
+        let presentAsPopover = UIDevice.sp_isPad() && traitCollection.horizontalSizeClass == .regular
+
+        if presentAsPopover {
+            let navigationController = SPNavigationController(rootViewController: information)
+            navigationController.configureAsPopover(barButtonItem: barButtonItem)
+            navigationController.displaysBlurEffect = true
+            present(navigationController, animated: true, completion: nil)
+        } else {
+            information.configureToPresentAsCard()
+            present(information, animated: true, completion: nil)
+        }
     }
 }
 
@@ -506,7 +516,7 @@ extension SPNoteEditorViewController {
             return
         }
 
-        presentInformationController(for: note)
+        presentInformationController(for: note, from: sender)
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -25,6 +25,9 @@
 // History
 @property (nonatomic, weak) UIViewController *historyViewController;
 
+// Information
+@property (nonatomic, weak) UIViewController *informationViewController;
+
 // Voiceover
 @property (nonatomic, strong) UIView *bottomView;
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -296,6 +296,10 @@ CGFloat const SPSelectedAreaPadding = 20;
 {
     [super traitCollectionDidChange:previousTraitCollection];
 
+    if (self.traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass) {
+        [self updateInformationControllerPresentation];
+    }
+
     if (@available(iOS 13.0, *)) {
         if (self.traitCollection.userInterfaceStyle == previousTraitCollection.userInterfaceStyle) {
             return;

--- a/Simplenote/Information/NoteInformationController.swift
+++ b/Simplenote/Information/NoteInformationController.swift
@@ -64,7 +64,7 @@ private extension NoteInformationController {
 //
 private extension NoteInformationController {
     func allRows() -> [Row] {
-        return self.metricRows()
+        return metricRows()
     }
 
     func metricRows() -> [Row] {

--- a/Simplenote/Information/NoteInformationController.swift
+++ b/Simplenote/Information/NoteInformationController.swift
@@ -34,7 +34,7 @@ final class NoteInformationController {
 
     /// Note changes observer
     ///
-    private var noteChangesObserver: EntityObserver?
+    private lazy var noteChangesObserver = EntityObserver(context: mainContext, object: note)
 
     private let note: Note
 
@@ -52,12 +52,11 @@ final class NoteInformationController {
 //
 private extension NoteInformationController {
     func startListeningForChanges() {
-        noteChangesObserver = EntityObserver(context: mainContext, object: note)
-        noteChangesObserver?.delegate = self
+        noteChangesObserver.delegate = self
     }
 
     func stopListeningForChanges() {
-        noteChangesObserver = nil
+        noteChangesObserver.delegate = nil
     }
 }
 

--- a/Simplenote/Information/NoteInformationController.swift
+++ b/Simplenote/Information/NoteInformationController.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+final class NoteInformationController {
+
+    /// Row
+    ///
+    enum Row {
+        /// Metric row
+        ///
+        case metric(title: String, value: String?)
+    }
+
+    /// Observer sends changes in rows
+    /// When assigned, it sends current state
+    ///
+    var observer: (([Row]) -> Void)? {
+        didSet {
+            observer?(allRows())
+        }
+    }
+
+    private let note: Note
+
+    /// Designated initializer
+    ///
+    /// - Parameters:
+    ///     - note: Note
+    ///
+    init(note: Note) {
+        self.note = note
+    }
+
+    private func allRows() -> [Row] {
+        return self.metricRows()
+    }
+
+    private func metricRows() -> [Row] {
+        let metrics = NoteMetrics(note: note)
+        return [
+            .metric(title: Localization.modified,
+                    value: DateFormatter.dateTimeFormatter.string(from: metrics.modifiedDate)),
+
+            .metric(title: Localization.created,
+                    value: DateFormatter.dateTimeFormatter.string(from: metrics.creationDate)),
+
+            .metric(title: Localization.words,
+                    value: NumberFormatter.decimalFormatter.string(for: metrics.numberOfWords)),
+
+            .metric(title: Localization.characters,
+                    value: NumberFormatter.decimalFormatter.string(for: metrics.numberOfChars))
+        ]
+    }
+}
+
+private struct Localization {
+    static let modified = NSLocalizedString("Modified", comment: "Note Modification Date")
+    static let created = NSLocalizedString("Created", comment: "Note Creation Date")
+    static let words = NSLocalizedString("Words", comment: "Number of words in the note")
+    static let characters = NSLocalizedString("Characters", comment: "Number of characters in the note")
+}

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -109,8 +109,12 @@ private extension NoteInformationViewController {
     func configureHeaderLayoutMargins() {
         headerStackView.isLayoutMarginsRelativeArrangement = true
 
+        var layoutMargins = Consts.headerExtraLayoutMargins
+        layoutMargins.left += tableView.layoutMargins.left
+        layoutMargins.right += tableView.layoutMargins.right
+
         // Sync layout margins with table view so labels are aligned
-        headerStackView.layoutMargins = UIEdgeInsets(top: 16, left: tableView.layoutMargins.left, bottom: 0.0, right: tableView.layoutMargins.right)
+        headerStackView.layoutMargins = layoutMargins
     }
 
     func removeHeaderViewIfNeeded() {
@@ -239,4 +243,8 @@ private struct Localization {
     static let information = NSLocalizedString("Information", comment: "Card title showing information about the note (metrics, references)")
     static let done = NSLocalizedString("Done", comment: "Dismisses the Note Information UI")
     static let dismissAccessibilityLabel = NSLocalizedString("Dismiss Information", comment: "Accessibility label describing a button used to dismiss an information view of the note")
+}
+
+private struct Consts {
+    static let headerExtraLayoutMargins = UIEdgeInsets(top: 16.0, left: 0.0, bottom: 0.0, right: 0.0)
 }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -7,6 +7,7 @@ final class NoteInformationViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet private weak var screenTitleLabel: UILabel!
     @IBOutlet private weak var dismissButton: UIButton!
+    @IBOutlet private weak var headerStackView: UIStackView!
 
     private var transitioningManager: UIViewControllerTransitioningDelegate?
 
@@ -45,13 +46,22 @@ final class NoteInformationViewController: UIViewController {
 
         configureViews()
         configureAccessibility()
+        configureNavigation()
+
+        refreshPreferredSize()
 
         startListeningToNotifications()
         startListeningForControllerChanges()
     }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        configureHeaderLayoutMargins()
+    }
 }
 
 // MARK: - Controller
+//
 private extension NoteInformationViewController {
     func startListeningForControllerChanges() {
         controller.observer = { [weak self] rows in
@@ -62,15 +72,27 @@ private extension NoteInformationViewController {
     func update(with rows: [NoteInformationController.Row]) {
         self.rows = rows
         tableView.reloadData()
+
+        refreshPreferredSize()
     }
 }
 
 // MARK: - Configuration
 //
 private extension NoteInformationViewController {
+    func configureNavigation() {
+        title = Localization.information
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Localization.done,
+                                                            style: .done,
+                                                            target: self,
+                                                            action: #selector(handleTapOnDismissButton))
+    }
+
     func configureViews() {
         configureTableView()
         screenTitleLabel.text = Localization.information
+
+        removeHeaderViewIfNeeded()
 
         refreshStyle()
     }
@@ -82,6 +104,25 @@ private extension NoteInformationViewController {
 
     func configureAccessibility() {
         dismissButton.accessibilityLabel = Localization.dismissAccessibilityLabel
+    }
+
+    func configureHeaderLayoutMargins() {
+        headerStackView.isLayoutMarginsRelativeArrangement = true
+
+        // Sync layout margins with table view so labels are aligned
+        headerStackView.layoutMargins = UIEdgeInsets(top: 16, left: tableView.layoutMargins.left, bottom: 0.0, right: tableView.layoutMargins.right)
+    }
+
+    func removeHeaderViewIfNeeded() {
+        guard navigationController != nil else {
+            return
+        }
+
+        headerStackView.isHidden = true
+    }
+
+    func refreshPreferredSize() {
+        preferredContentSize = tableView.intrinsicContentSize
     }
 }
 
@@ -196,5 +237,6 @@ extension NoteInformationViewController {
 
 private struct Localization {
     static let information = NSLocalizedString("Information", comment: "Card title showing information about the note (metrics, references)")
+    static let done = NSLocalizedString("Done", comment: "Dismisses the Note Information UI")
     static let dismissAccessibilityLabel = NSLocalizedString("Dismiss Information", comment: "Accessibility label describing a button used to dismiss an information view of the note")
 }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -152,6 +152,7 @@ extension NoteInformationViewController: UITableViewDataSource {
     }
 
     private func configure(cell: Value1TableViewCell, withTitle title: String, value: String?) {
+        cell.selectionStyle = .none
         cell.hasClearBackground = true
         cell.title = title
         cell.detailTextLabel?.text = value

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -94,6 +94,7 @@ private extension NoteInformationViewController {
     func refreshStyle() {
         styleScreenTitleLabel()
         styleDismissButton()
+        styleTableView()
     }
 
     func styleScreenTitleLabel() {
@@ -109,6 +110,10 @@ private extension NoteInformationViewController {
         dismissButton.setBackgroundImage(UIColor.simplenoteCardDismissButtonHighlightedBackgroundColor.dynamicImageRepresentation(), for: .highlighted)
 
         dismissButton.tintColor = .simplenoteCardDismissButtonTintColor
+    }
+
+    func styleTableView() {
+        tableView.separatorColor = .simplenoteDividerColor
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -11,6 +11,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteInformationViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
                 <outlet property="dismissButton" destination="7HZ-2J-9ef" id="rrw-yc-zdP"/>
+                <outlet property="headerStackView" destination="qBv-kl-fOD" id="eEl-cs-unx"/>
                 <outlet property="screenTitleLabel" destination="9ul-2d-OoP" id="pZb-Nb-szF"/>
                 <outlet property="tableView" destination="HfE-pa-isg" id="5Gu-fK-38o"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -21,52 +22,54 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="263" width="414" height="400"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <connections>
-                        <outlet property="dataSource" destination="-1" id="dIp-Oc-ZbT"/>
-                        <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
-                    </connections>
-                </tableView>
-                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
-                    <rect key="frame" x="20" y="60" width="374" height="187"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="9hs-LD-rni">
+                    <rect key="frame" x="0.0" y="44" width="414" height="619"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
-                            <rect key="frame" x="0.0" y="83.5" width="336" height="20.5"/>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7HZ-2J-9ef" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
-                            <rect key="frame" x="344" y="78.5" width="30" height="30"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="30" id="zYd-Xa-72n"/>
-                                <constraint firstAttribute="width" constant="30" id="zd7-TM-xEa"/>
-                            </constraints>
-                            <state key="normal" image="icon_cross"/>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                    <real key="value" value="15"/>
-                                </userDefinedRuntimeAttribute>
-                            </userDefinedRuntimeAttributes>
+                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="203"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
+                                    <rect key="frame" x="0.0" y="91.5" width="376" height="20.5"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7HZ-2J-9ef" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                                    <rect key="frame" x="384" y="86.5" width="30" height="30"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="30" id="zYd-Xa-72n"/>
+                                        <constraint firstAttribute="width" constant="30" id="zd7-TM-xEa"/>
+                                    </constraints>
+                                    <state key="normal" image="icon_cross"/>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                            <real key="value" value="15"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                    <connections>
+                                        <action selector="handleTapOnDismissButton" destination="-1" eventType="touchUpInside" id="qgF-a7-uKd"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                        <tableView clipsSubviews="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="219" width="414" height="400"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <connections>
-                                <action selector="handleTapOnDismissButton" destination="-1" eventType="touchUpInside" id="qgF-a7-uKd"/>
+                                <outlet property="dataSource" destination="-1" id="dIp-Oc-ZbT"/>
+                                <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
                             </connections>
-                        </button>
+                        </tableView>
                     </subviews>
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="qBv-kl-fOD" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="AXH-SH-eyF"/>
-                <constraint firstAttribute="trailingMargin" secondItem="qBv-kl-fOD" secondAttribute="trailing" id="HOZ-wS-Cap"/>
-                <constraint firstAttribute="bottom" secondItem="HfE-pa-isg" secondAttribute="bottom" id="KEK-Bi-Ygi"/>
-                <constraint firstItem="HfE-pa-isg" firstAttribute="top" secondItem="qBv-kl-fOD" secondAttribute="bottom" constant="16" id="Kbi-ET-4A1"/>
-                <constraint firstItem="qBv-kl-fOD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" id="Mdr-fB-E8P"/>
-                <constraint firstItem="HfE-pa-isg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="rSA-XM-wYj"/>
-                <constraint firstAttribute="trailing" secondItem="HfE-pa-isg" secondAttribute="trailing" id="wKC-dG-zlb"/>
+                <constraint firstItem="9hs-LD-rni" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="1Jc-dZ-rp6"/>
+                <constraint firstItem="9hs-LD-rni" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Ixl-Rz-z1H"/>
+                <constraint firstAttribute="trailing" secondItem="9hs-LD-rni" secondAttribute="trailing" id="XkJ-f0-nW0"/>
+                <constraint firstAttribute="bottom" secondItem="9hs-LD-rni" secondAttribute="bottom" id="Ysh-TV-19V"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>


### PR DESCRIPTION
This PR is a follow up to #939 adds the following fixes and improvements to the Information Card:
- separator color now has the right color and based on the theme
- displayed metrics are updated when note is updated
- on iPad Info Card is displayed as a Popover for regular width class and as a card for compact width class
- loading and handling of data is extracted to a separate class `NoteInformationController`

@jleandroperez Would you mind taking a look? Thank you!

![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-10-23 at 14 24 53](https://user-images.githubusercontent.com/54751/97007106-2bfd2500-1541-11eb-966a-718729d3d9f3.png)
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-10-23 at 14 25 24](https://user-images.githubusercontent.com/54751/97007114-2e5f7f00-1541-11eb-9b17-053b2971a90a.png)

### Test (Updates)
1. Open Note A on Device A
2. Open Note A on Device B
3. Open Info card on Device B
4. Change Note A on Device A

- [x] Observe that words and characters counters are updated on Device B

### Test (iPad)
1. Open a note
2. Open Info Card (Tap on (i) button on the nav bar)

- [x] Info Card opens as a popover

### Test (iPad, Split Screen)
1. Enter Split Screen
2. Resize Simplenote app so that it takes half screen or less
3. Open a note
4. Open Info Card (Tap on (i) button on the nav bar)

- [x] Info Card opens as a card

### Release

> These changes do not require release notes.
