### PR TITLE
Fix highlight when search query contains multiple words

### DIFF
--- a/Simplenote/Classes/NSString+Search.m
+++ b/Simplenote/Classes/NSString+Search.m
@@ -55,8 +55,10 @@
 
     return [self wordRangesFilteredWithBlock:^BOOL(NSString *word) {
         for (NSString *term in termsArray) {
-            return ([word rangeOfString:term
-                                options:NSCaseInsensitiveSearch|NSDiacriticInsensitiveSearch].location != NSNotFound);
+            if ([word rangeOfString:term
+                            options:NSCaseInsensitiveSearch|NSDiacriticInsensitiveSearch].location != NSNotFound) {
+                return YES;
+            }
         }
         return NO;
     }];


### PR DESCRIPTION
### Fix
This PR fixes words highlights when search query contains multiple words.
It got broken here: https://github.com/Automattic/simplenote-ios/commit/bdbec61ad31c2832eac80fca3ce6ad7c78c5cfc1

@jleandroperez Please take a look when you have time! Thanks :-)

### Test (List)
1. Open notes list
2. Search for several words

- [x] Check that all words are highlighted

### Test (Note)
1. Open notes list
2. Search for several words
3. Open one of the notes

- [x] Check that all words are highlighted

### Release
> These changes do not require release notes.
