### PR TITLE
Bugfix: Tag Autocomplete

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -   Updated Navigation Bar's behavior #918
 -   Adjusted Notes List Metrics #929
 -   Fixed a bug that caused the Search Bar to look extra big #930
+-   Fixed a bug affecting Tags Autocomplete #964
 
 4.26
 -----

--- a/Simplenote/Classes/SPEditorTapRecognizerDelegate.swift
+++ b/Simplenote/Classes/SPEditorTapRecognizerDelegate.swift
@@ -16,6 +16,11 @@ class SPEditorTapRecognizerDelegate: NSObject, UIGestureRecognizerDelegate {
     @objc
     weak var parentTextView: UITextView?
 
+    /// View that, when interacted upon, should cause the recognizer to bail out
+    ///
+    @objc
+    weak var excludedView: UIView?
+
 
     /// TextView only performs linkification when the `editable` flag is disabled.
     /// We're allowing Edition by means of a TapGestureRecognizer, which also allows us to deal with Tap events performed over TextAttachments
@@ -33,6 +38,14 @@ class SPEditorTapRecognizerDelegate: NSObject, UIGestureRecognizerDelegate {
         }
 
         return textView.isFirstResponder == false
+    }
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        guard let excludedView = excludedView, let touchView = touch.view else {
+            return true
+        }
+
+        return touchView.isDescendant(of: excludedView) == false
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -71,6 +71,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
 
         SPEditorTapRecognizerDelegate *recognizerDelegate = [SPEditorTapRecognizerDelegate new];
         recognizerDelegate.parentTextView = self;
+        recognizerDelegate.excludedView = self.tagView;
         self.internalRecognizerDelegate = recognizerDelegate;
 
         UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self


### PR DESCRIPTION
### Fix
In this PR we're fixing the Tag Autocomplete mechanism.

@eshurakov Mind taking a peek at this one? (Thanks in advance!)

@codebykat Fixed!! Thanks for the heads up!!

Closes #286


### Test
1. Add a couple tags
2. Edit any of your notes
3. Press over the Tags Editor
4. Partially type any of the Tags added in (1)

- [x] Verify that pressing over any of the Autocomplete Tags inserts the full tag name in the Tags Editor

### Release
`RELEASE-NOTES.txt` was updated in 2df3bb8 with:
 
> Fixed a bug affecting Tags Autocomplete #964
