### PR TITLE
Fixing Text Selection: Mark I

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -165,18 +165,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self positionTagView];
 }
 
-- (CGFloat)tagsViewPadding
-{
-    return 2 * CGRectGetHeight(self.tagView.bounds);
-}
-
-- (UIEdgeInsets)adjustedContentInset
-{
-    UIEdgeInsets contentInsets = super.adjustedContentInset;
-    contentInsets.bottom += self.tagsViewPadding;
-    return contentInsets;
-}
-
 - (void)setTagView:(SPTagView *)tagView
 {
     if (_tagView) {

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -53,6 +53,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         self.verticalMoveLastCaretRect = CGRectZero;
 
         [self setupTagsEditor];
+        [self setupTextContainerInsets];
         [self setupGestureRecognizers];
         [self startListeningToNotifications];
         [self startObservingProperties];
@@ -62,6 +63,20 @@ NSInteger const ChecklistCursorAdjustment = 2;
     }
 
     return self;
+}
+
+- (void)setupTagsEditor
+{
+    self.tagView = [[SPTagView alloc] initWithFrame:CGRectMake(0, 0, 0, TagViewHeight)];
+    self.tagView.isAccessibilityElement = NO;
+    [self addSubview:self.tagView];
+}
+
+- (void)setupTextContainerInsets
+{
+    UIEdgeInsets containerInsets = self.textContainerInset;
+    containerInsets.top += TextViewTopInsets;
+    self.textContainerInset = containerInsets;
 }
 
 - (void)setupGestureRecognizers
@@ -76,13 +91,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
     tapGestureRecognizer.cancelsTouchesInView = NO;
     tapGestureRecognizer.delegate = recognizerDelegate;
     [self addGestureRecognizer:tapGestureRecognizer];
-}
-
-- (void)setupTagsEditor
-{
-    self.tagView = [[SPTagView alloc] initWithFrame:CGRectMake(0, 0, 0, TagViewHeight)];
-    self.tagView.isAccessibilityElement = NO;
-    [self addSubview:self.tagView];
 }
 
 - (void)startListeningToNotifications

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -173,6 +173,18 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self positionTagView];
 }
 
+- (CGFloat)tagsViewPadding
+{
+    return 2 * CGRectGetHeight(self.tagView.bounds);
+}
+
+- (UIEdgeInsets)adjustedContentInset
+{
+    UIEdgeInsets contentInsets = super.adjustedContentInset;
+    contentInsets.bottom += self.tagsViewPadding;
+    return contentInsets;
+}
+
 - (void)setTagView:(SPTagView *)tagView
 {
     if (_tagView) {

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -53,7 +53,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
         self.verticalMoveLastCaretRect = CGRectZero;
 
         [self setupTagsEditor];
-        [self setupTextContainerInsets];
         [self setupGestureRecognizers];
         [self startListeningToNotifications];
         [self startObservingProperties];
@@ -86,13 +85,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self addSubview:self.tagView];
 }
 
-- (void)setupTextContainerInsets
-{
-    UIEdgeInsets containerInsets = self.textContainerInset;
-    containerInsets.top += TextViewTopInsets;
-    containerInsets.bottom += TextViewBottomInsets;
-    self.textContainerInset = containerInsets;
-}
 
 - (void)startListeningToNotifications
 {

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -159,7 +159,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
 
     CGFloat paddingY    = self.contentInset.bottom + self.safeAreaInsets.bottom;
     CGFloat boundsMinY  = self.bounds.size.height - height + self.contentOffset.y - paddingY;
-    CGFloat contentMinY = self.contentSize.height - height + self.contentInset.top;
+    CGFloat contentMinY = self.contentSize.height + self.contentInset.top;
     CGFloat yOrigin     = self.lockTagEditorPosition ? boundsMinY : MAX(boundsMinY, contentMinY);
     CGFloat xOrigin     = self.safeAreaInsets.left;
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -10,8 +10,6 @@
 #import "SPTagView.h"
 #import "SPInteractiveTextStorage.h"
 #import "NSMutableAttributedString+Styling.h"
-#import "NSString+Attributed.h"
-#import "UIDevice+Extensions.h"
 #import "VSTheme+Extensions.h"
 #import "Simplenote-Swift.h"
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -17,6 +17,7 @@ NSString *const MarkdownUnchecked = @"- [ ]";
 NSString *const MarkdownChecked = @"- [x]";
 NSString *const TextAttachmentCharacterCode = @"\U0000fffc"; // Represents the glyph of an NSTextAttachment
 
+// TODO: Add intrinsicContentSize support to TagView
 CGFloat const TagViewHeight = 44;
 CGFloat const TextViewTopInsets = 8;
 CGFloat const TextViewBottomInsets = TagViewHeight * 2;

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -85,7 +85,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self addSubview:self.tagView];
 }
 
-
 - (void)startListeningToNotifications
 {
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -53,6 +53,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         self.verticalMoveLastCaretRect = CGRectZero;
 
         [self setupTagsEditor];
+        [self setupTextContainerInsets];
         [self setupGestureRecognizers];
         [self startListeningToNotifications];
         [self startObservingProperties];
@@ -85,6 +86,13 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self addSubview:self.tagView];
 }
 
+- (void)setupTextContainerInsets
+{
+    UIEdgeInsets containerInsets = self.textContainerInset;
+    containerInsets.top += TextViewTopInsets;
+    containerInsets.bottom += TextViewBottomInsets;
+    self.textContainerInset = containerInsets;
+}
 
 - (void)startListeningToNotifications
 {


### PR DESCRIPTION
### Fix
1. Fixes a faulty **TagsEditor Minimum Position.Y** calculation
2. Splits **SPEditorTextView**'s initializer

@eshurakov sir! you game for a quick PR?
Thanks in advance!

Ref. #921

### Test: Long Note
1. Open a long document
2. Press over the last row

- [x] Verify the Editor becomes the first responder
- [x] Verify that the Tags Editor gets dismissed **without covering the Tags Editor**

**Note:**
I've attached two videos that demo this glitch!

[Fixed.zip](https://github.com/Automattic/simplenote-ios/files/5478913/Fixed.zip)
[Broken.zip](https://github.com/Automattic/simplenote-ios/files/5478915/Broken.zip)


### Test: Short Note
1. Add a new note

- [x] Verify the Tags Editor is attached at the very bottom of the view
- [x] Verify that whenever the Editor becomes the First Responder the Tags Editor gets properly relocated

### Release
These changes do not require release notes.
