### PR TITLE
Convert text to markdown when copying to pasteboard

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		A69F851D253EC877005140F2 /* UISlider+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */; };
 		A69F861C25408085005140F2 /* NoteInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F861A25408085005140F2 /* NoteInformationViewController.swift */; };
 		A69F861D25408085005140F2 /* NoteInformationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69F861B25408085005140F2 /* NoteInformationViewController.xib */; };
+		A6BBDA3E25502FE3005C8343 /* NSAttributedStringToMarkdownConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BBDA3D25502FE3005C8343 /* NSAttributedStringToMarkdownConverter.swift */; };
+		A6BBDA46255034E6005C8343 /* SPEditorTextView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BBDA45255034E6005C8343 /* SPEditorTextView+Simplenote.swift */; };
 		A6C0589424AD2B8F006BC572 /* SPNoteHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589224AD2B8F006BC572 /* SPNoteHistoryViewController.swift */; };
 		A6C0589524AD2B8F006BC572 /* SPNoteHistoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A6C0589324AD2B8F006BC572 /* SPNoteHistoryViewController.xib */; };
 		A6C0589924AD47CB006BC572 /* SPSnappingSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */; };
@@ -510,6 +512,8 @@
 		A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISlider+Simplenote.swift"; sourceTree = "<group>"; };
 		A69F861A25408085005140F2 /* NoteInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteInformationViewController.swift; sourceTree = "<group>"; };
 		A69F861B25408085005140F2 /* NoteInformationViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteInformationViewController.xib; sourceTree = "<group>"; };
+		A6BBDA3D25502FE3005C8343 /* NSAttributedStringToMarkdownConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringToMarkdownConverter.swift; sourceTree = "<group>"; };
+		A6BBDA45255034E6005C8343 /* SPEditorTextView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPEditorTextView+Simplenote.swift"; sourceTree = "<group>"; };
 		A6C0589224AD2B8F006BC572 /* SPNoteHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPNoteHistoryViewController.swift; path = Classes/SPNoteHistoryViewController.swift; sourceTree = "<group>"; };
 		A6C0589324AD2B8F006BC572 /* SPNoteHistoryViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPNoteHistoryViewController.xib; path = Classes/SPNoteHistoryViewController.xib; sourceTree = "<group>"; };
 		A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPSnappingSlider.swift; sourceTree = "<group>"; };
@@ -1173,6 +1177,7 @@
 				B5E3F3962539F1E900271AEA /* SPTextView.m */,
 				E21F57B717C1244E001F02D3 /* SPEditorTextView.h */,
 				E21F57B817C1244E001F02D3 /* SPEditorTextView.m */,
+				A6BBDA45255034E6005C8343 /* SPEditorTextView+Simplenote.swift */,
 				B52E2B142537480A0074509A /* SPEditorTapRecognizerDelegate.swift */,
 			);
 			name = Editor;
@@ -1453,6 +1458,7 @@
 				74F454EC22DD4BC0000C66DB /* KeyboardObservable.swift */,
 				B5185CFA23427F2F0060145A /* SearchDisplayController.swift */,
 				B531090723D0B685002B0998 /* SPSimpleTextPrintFormatter.swift */,
+				A6BBDA3D25502FE3005C8343 /* NSAttributedStringToMarkdownConverter.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -2260,6 +2266,7 @@
 				B5796549250684EC00DFD6F7 /* EditorFactory.swift in Sources */,
 				B5476BB223D88F49000E7723 /* SPTagTableViewCell.swift in Sources */,
 				B52AC186233587F8007B2E75 /* UITraitCollection+Simplenote.swift in Sources */,
+				A6BBDA3E25502FE3005C8343 /* NSAttributedStringToMarkdownConverter.swift in Sources */,
 				B56A696922F9D57200B90398 /* NSMutableAttributedString+Simplenote.swift in Sources */,
 				B535F2E72399BFB600C1DDCA /* SPRatingsPromptView.swift in Sources */,
 				B5D982D222F8644000C37C29 /* SPSquaredButton.swift in Sources */,
@@ -2348,6 +2355,7 @@
 				B524AE0F2352BE9200EA11D4 /* UITableView+Simplenote.swift in Sources */,
 				A6FDF73E2542BDE100415C87 /* NoteInformationController.swift in Sources */,
 				B5E951E624FEE2A8004B10B8 /* Note+Links.swift in Sources */,
+				A6BBDA46255034E6005C8343 /* SPEditorTextView+Simplenote.swift in Sources */,
 				B5D982D022F8643300C37C29 /* SPTextInputView.swift in Sources */,
 				B5476BBD23D8A71D000E7723 /* UIFont+Simplenote.swift in Sources */,
 				B52BB75022CFD18F0042C162 /* UIActivity+Simplenote.swift in Sources */,

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -25,7 +25,6 @@
 - (void)scrollToBottomWithAnimation:(BOOL)animated;
 - (void)scrollToTop;
 - (void)processChecklists;
-- (NSString *)getPlainTextContent;
 - (void)insertOrRemoveChecklist;
 
 /// iOS 13.0 + 13.1 had an usability issue that rendered link interactions within a UITextView next to impossible.

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -389,23 +389,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
                            allowsMultiplePerLine:NO];
 }
 
-// Processes content of note editor, and replaces special string attachments with their plain
-// text counterparts. Currently supports markdown checklists.
-- (NSString *)getPlainTextContent
-{
-    NSMutableAttributedString *adjustedString = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
-    // Replace checkbox images with their markdown syntax equivalent
-    [adjustedString enumerateAttribute:NSAttachmentAttributeName inRange:[adjustedString.string rangeOfString:adjustedString.string] options:0 usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop) {
-        if ([value isKindOfClass:[SPTextAttachment class]]) {
-            SPTextAttachment *attachment = (SPTextAttachment *)value;
-            NSString *checkboxMarkdown = attachment.isChecked ? MarkdownChecked : MarkdownUnchecked;
-            [adjustedString replaceCharactersInRange:range withString:checkboxMarkdown];
-        }
-    }];
-    
-    return adjustedString.string;
-}
-
 - (void)insertOrRemoveChecklist
 {
     NSRange lineRange = [self.text lineRangeForRange:self.selectedRange];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -560,7 +560,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 - (UIViewController *)nextViewControllerForInteractivePush
 {
     SPMarkdownPreviewViewController *previewViewController = [SPMarkdownPreviewViewController new];
-    previewViewController.markdownText = [self.noteEditorTextView getPlainTextContent];
+    previewViewController.markdownText = [self.noteEditorTextView plainText];
     
     return previewViewController;
 }
@@ -653,7 +653,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     if ([sender isEqual:self.doneSearchButton])
         [[SPAppDelegate sharedDelegate].noteListViewController endSearching];
     
-    _noteEditorTextView.text = [_noteEditorTextView getPlainTextContent];
+    _noteEditorTextView.text = [_noteEditorTextView plainText];
     [_noteEditorTextView processChecklists];
     
     _searchString = nil;
@@ -835,7 +835,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 	if (self.modified || _currentNote.deleted == YES)
 	{
         // Update note
-        _currentNote.content = [_noteEditorTextView getPlainTextContent];
+        _currentNote.content = [_noteEditorTextView plainText];
         _currentNote.modificationDate = [NSDate date];
 
         // Force an update of the note's content preview in case only tags changed
@@ -854,10 +854,10 @@ CGFloat const SPSelectedAreaPadding = 20;
 - (void)willReceiveNewContent {
     
     self.cursorLocationBeforeRemoteUpdate = [_noteEditorTextView selectedRange].location;
-    self.noteContentBeforeRemoteUpdate = [_noteEditorTextView getPlainTextContent];
+    self.noteContentBeforeRemoteUpdate = [_noteEditorTextView plainText];
 	
     if (_currentNote != nil && ![_noteEditorTextView.text isEqualToString:@""]) {
-        _currentNote.content = [_noteEditorTextView getPlainTextContent];
+        _currentNote.content = [_noteEditorTextView plainText];
         [[SPAppDelegate sharedDelegate].simperium saveWithoutSyncing];
     }
 }

--- a/Simplenote/NSAttributedStringToMarkdownConverter.swift
+++ b/Simplenote/NSAttributedStringToMarkdownConverter.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+
+// MARK: - NSAttributedString to Markdown Converter
+//
+struct NSAttributedStringToMarkdownConverter {
+
+    /// Markdown replacement for "Unchecked Checklist"
+    ///
+    private static let unchecked = "- [ ]"
+
+    /// Markdown replacement for "Checked Checklist"
+    ///
+    private static let checked = "- [x]"
+
+
+    /// Returns the NSString representation of a given NSAttributedString.
+    ///
+    static func convert(string: NSAttributedString) -> String {
+        let fullRange = NSRange(location: 0, length: string.length)
+        let adjusted = NSMutableAttributedString(attributedString: string)
+        adjusted.enumerateAttribute(.attachment, in: fullRange, options: .reverse) { (value, range, _) in
+            guard let attachment = value as? SPTextAttachment else {
+                return
+            }
+
+            let markdown = attachment.isChecked ? checked : unchecked
+            adjusted.replaceCharacters(in: range, with: markdown)
+        }
+
+        return adjusted.string
+    }
+}

--- a/Simplenote/SPEditorTextView+Simplenote.swift
+++ b/Simplenote/SPEditorTextView+Simplenote.swift
@@ -4,9 +4,29 @@ import Foundation
 //
 extension SPEditorTextView {
 
-    /// Processes content of note editor, and replaces special string attachments with their plain text counterparts. Currently supports markdown checklists.
+    /// Text with attachments converted to markdown
     @objc
     var plainText: String {
         return NSAttributedStringToMarkdownConverter.convert(string: attributedText)
+    }
+
+    /// Selected text with attachments converted to markdown
+    var plainSelectedText: String? {
+        guard selectedRange.location != NSNotFound else {
+            return nil
+        }
+
+        let selectedAttributedText = attributedText.attributedSubstring(from: selectedRange)
+        return NSAttributedStringToMarkdownConverter.convert(string: selectedAttributedText)
+    }
+
+    open override func copy(_ sender: Any?) {
+        UIPasteboard.general.string = plainSelectedText
+    }
+
+    open override func cut(_ sender: Any?) {
+        let text = plainSelectedText
+        super.cut(sender)
+        UIPasteboard.general.string = text
     }
 }

--- a/Simplenote/SPEditorTextView+Simplenote.swift
+++ b/Simplenote/SPEditorTextView+Simplenote.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+// MARK: - SPEditorTextView
+//
+extension SPEditorTextView {
+
+    /// Processes content of note editor, and replaces special string attachments with their plain text counterparts. Currently supports markdown checklists.
+    @objc
+    var plainText: String {
+        return NSAttributedStringToMarkdownConverter.convert(string: attributedText)
+    }
+}


### PR DESCRIPTION
### Fix
This PR fixes copy-pasting of checklists.

@jleandroperez Mind taking a look? Thanks! :-)

Closes #968 

### Test
1. Copy/cut text with checklist
2. Paste text with checklist

- [ ] Check that pasted checklist is identical to copied checklist
