### PR TITLE
Fixing Text Selection: Mark II

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.28
 -----
+-   Fixed a bug that affected Text Selection #973
  
 4.27
 -----

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -22,15 +22,6 @@
 @property (nonatomic, strong) UIFont *checklistsFont;
 @property (nonatomic, strong) UIColor *checklistsTintColor;
 
-/// Allows you to set `contentInset.bottom`
-///
-@property (nonatomic, assign) CGFloat bottomContentInset;
-
-/// Allows you to set `scrollIndicatorInsets` while considering (automatically) an extra padding, to be allocated by the TagsEditor
-///
-@property (nonatomic, assign) CGFloat bottomScrollerInset;
-
-
 - (void)scrollToBottomWithAnimation:(BOOL)animated;
 - (void)scrollToTop;
 - (void)processChecklists;

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -22,6 +22,15 @@
 @property (nonatomic, strong) UIFont *checklistsFont;
 @property (nonatomic, strong) UIColor *checklistsTintColor;
 
+/// Allows you to set `contentInset.bottom`
+///
+@property (nonatomic, assign) CGFloat bottomContentInset;
+
+/// Allows you to set `scrollIndicatorInsets` while considering (automatically) an extra padding, to be allocated by the TagsEditor
+///
+@property (nonatomic, assign) CGFloat bottomScrollerInset;
+
+
 - (void)scrollToBottomWithAnimation:(BOOL)animated;
 - (void)scrollToTop;
 - (void)processChecklists;

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -172,9 +172,11 @@ NSInteger const ChecklistCursorAdjustment = 2;
     CGFloat width       = self.bounds.size.width - self.safeAreaInsets.left - self.safeAreaInsets.right;
     CGFloat height      = CGRectGetHeight(self.tagView.frame);
 
-    CGFloat paddingY    = self.contentInset.bottom + self.safeAreaInsets.bottom;
+    // When the Keyboard is absent we'll always honor the Safe Area Insets
+    CGFloat paddingY    = MAX(self.contentInset.bottom, self.safeAreaInsets.bottom);
     CGFloat boundsMinY  = self.bounds.size.height - height + self.contentOffset.y - paddingY;
     CGFloat contentMinY = self.contentSize.height + self.textContainerInset.top - self.textContainerInset.bottom;
+
     CGFloat yOrigin     = self.lockTagEditorPosition ? boundsMinY : MAX(boundsMinY, contentMinY);
     CGFloat xOrigin     = self.safeAreaInsets.left;
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -19,11 +19,12 @@ NSString *const TextAttachmentCharacterCode = @"\U0000fffc"; // Represents the g
 
 // TODO: Add intrinsicContentSize support to TagView
 CGFloat const TagViewHeight = 44;
+
 CGFloat const TextViewContanerInsetsTop = 8;
 CGFloat const TextViewContanerInsetsBottom = TagViewHeight * 2;
-CGFloat const TextViewScrollerInsetsBottom = TagViewHeight;
 
-CGFloat const TextViewDefaultBottomScrollInset = 0;
+CGFloat const TextViewScrollerExtraInsetsBottom = TagViewHeight;
+CGFloat const TextViewScrollerDefaultBottomInset = 0;
 
 // One unicode character plus a space
 NSInteger const ChecklistCursorAdjustment = 2;
@@ -53,7 +54,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         self.alwaysBounceHorizontal = NO;
         self.alwaysBounceVertical = YES;
         self.scrollEnabled = YES;
-        self.bottomScrollerInset = TextViewDefaultBottomScrollInset;
+        self.bottomScrollerInset = TextViewScrollerDefaultBottomInset;
         self.verticalMoveStartCaretRect = CGRectZero;
         self.verticalMoveLastCaretRect = CGRectZero;
 
@@ -266,13 +267,13 @@ NSInteger const ChecklistCursorAdjustment = 2;
 - (void)setBottomScrollerInset:(CGFloat)bottomInset
 {
     UIEdgeInsets updated = self.scrollIndicatorInsets;
-    updated.bottom = bottomInset + TextViewScrollerInsetsBottom;
+    updated.bottom = bottomInset + TextViewScrollerExtraInsetsBottom;
     self.scrollIndicatorInsets = updated;
 }
 
 - (CGFloat)bottomScrollerInset
 {
-    return self.scrollIndicatorInsets.bottom - TextViewScrollerInsetsBottom;
+    return self.scrollIndicatorInsets.bottom - TextViewScrollerExtraInsetsBottom;
 }
 
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -174,7 +174,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
 
     CGFloat paddingY    = self.contentInset.bottom + self.safeAreaInsets.bottom;
     CGFloat boundsMinY  = self.bounds.size.height - height + self.contentOffset.y - paddingY;
-    CGFloat contentMinY = self.contentSize.height + self.contentInset.top;
+    CGFloat contentMinY = self.contentSize.height + self.textContainerInset.top - self.textContainerInset.bottom;
     CGFloat yOrigin     = self.lockTagEditorPosition ? boundsMinY : MAX(boundsMinY, contentMinY);
     CGFloat xOrigin     = self.safeAreaInsets.left;
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -19,8 +19,9 @@ NSString *const TextAttachmentCharacterCode = @"\U0000fffc"; // Represents the g
 
 // TODO: Add intrinsicContentSize support to TagView
 CGFloat const TagViewHeight = 44;
-CGFloat const TextViewTopInsets = 8;
-CGFloat const TextViewBottomInsets = TagViewHeight * 2;
+CGFloat const TextViewTopContainerInset = 8;
+CGFloat const TextViewBottomContainerInset = TagViewHeight * 2;
+CGFloat const TextViewBottomScrollerInset = TagViewHeight;
 
 // One unicode character plus a space
 NSInteger const ChecklistCursorAdjustment = 2;
@@ -76,7 +77,8 @@ NSInteger const ChecklistCursorAdjustment = 2;
 - (void)setupTextContainerInsets
 {
     UIEdgeInsets containerInsets = self.textContainerInset;
-    containerInsets.top += TextViewTopInsets;
+    containerInsets.top += TextViewTopContainerInset;
+    containerInsets.bottom += TextViewBottomContainerInset;
     self.textContainerInset = containerInsets;
 }
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -180,18 +180,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self positionTagView];
 }
 
-- (CGFloat)tagsViewPadding
-{
-    return 2 * CGRectGetHeight(self.tagView.bounds);
-}
-
-- (UIEdgeInsets)adjustedContentInset
-{
-    UIEdgeInsets contentInsets = super.adjustedContentInset;
-    contentInsets.bottom += self.tagsViewPadding;
-    return contentInsets;
-}
-
 - (void)setTagView:(SPTagView *)tagView
 {
     if (_tagView) {

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -23,9 +23,6 @@ CGFloat const TagViewHeight = 44;
 CGFloat const TextViewContanerInsetsTop = 8;
 CGFloat const TextViewContanerInsetsBottom = TagViewHeight * 2;
 
-CGFloat const TextViewScrollerExtraInsetsBottom = TagViewHeight;
-CGFloat const TextViewScrollerDefaultBottomInset = 0;
-
 // One unicode character plus a space
 NSInteger const ChecklistCursorAdjustment = 2;
 
@@ -54,7 +51,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
         self.alwaysBounceHorizontal = NO;
         self.alwaysBounceVertical = YES;
         self.scrollEnabled = YES;
-        self.bottomScrollerInset = TextViewScrollerDefaultBottomInset;
         self.verticalMoveStartCaretRect = CGRectZero;
         self.verticalMoveLastCaretRect = CGRectZero;
 
@@ -254,33 +250,6 @@ NSInteger const ChecklistCursorAdjustment = 2;
     CGFloat yOffset = self.bounds.origin.y - self.contentInset.top;
     CGPoint scrollOffset = CGPointMake(0, yOffset);
     [self setContentOffset:scrollOffset animated:NO];
-}
-
-
-#pragma mark - Properties
-
-- (void)setBottomContentInset:(CGFloat)bottomInset
-{
-    UIEdgeInsets updated = self.contentInset;
-    updated.bottom = bottomInset;
-    self.contentInset = updated;
-}
-
-- (CGFloat)bottomContentInset
-{
-    return self.contentInset.bottom;
-}
-
-- (void)setBottomScrollerInset:(CGFloat)bottomInset
-{
-    UIEdgeInsets updated = self.scrollIndicatorInsets;
-    updated.bottom = bottomInset + TextViewScrollerExtraInsetsBottom;
-    self.scrollIndicatorInsets = updated;
-}
-
-- (CGFloat)bottomScrollerInset
-{
-    return self.scrollIndicatorInsets.bottom - TextViewScrollerExtraInsetsBottom;
 }
 
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -243,7 +243,35 @@ NSInteger const ChecklistCursorAdjustment = 2;
     [self setContentOffset:scrollOffset animated:NO];
 }
 
-#pragma mark Notifications
+
+#pragma mark - Properties
+
+- (void)setBottomContentInset:(CGFloat)bottomInset
+{
+    UIEdgeInsets updated = self.contentInset;
+    updated.bottom = bottomInset;
+    self.contentInset = updated;
+}
+
+- (CGFloat)bottomContentInset
+{
+    return self.contentInset.bottom;
+}
+
+- (void)setBottomScrollerInset:(CGFloat)bottomInset
+{
+    UIEdgeInsets updated = self.scrollIndicatorInsets;
+    updated.bottom = bottomInset + TextViewBottomScrollerInset;
+    self.scrollIndicatorInsets = updated;
+}
+
+- (CGFloat)bottomScrollerInset
+{
+    return self.scrollIndicatorInsets.bottom - TextViewBottomScrollerInset;
+}
+
+
+#pragma mark - Notifications
 
 - (void)didEndEditing:(NSNotification *)notification
 {

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -228,17 +228,22 @@ NSInteger const ChecklistCursorAdjustment = 2;
     /// Notes:
     /// -   We consider `adjusted bottom inset` because that's how we inject the Tags Editor padding!
     /// -   And we don't consider `adjusted top insets` since that deals with navbar overlaps, and doesn't affect our calculations.
-    if (self.contentSize.height <= self.bounds.size.height - self.contentInset.top - self.adjustedContentInset.bottom) {
+
+    CGFloat visibleHeight = self.bounds.size.height
+                                - self.textContainerInset.top
+                                - self.textContainerInset.bottom
+                                - self.contentInset.bottom;
+    if (self.contentSize.height <= visibleHeight) {
         return;
     }
 
     CGFloat yOffset = self.contentSize.height + self.adjustedContentInset.bottom - self.bounds.size.height;
-    CGPoint scrollOffset = CGPointMake(0, yOffset);
 
-    if (self.contentOffset.y == scrollOffset.y) {
+    if (self.contentOffset.y == yOffset) {
         return;
     }
 
+    CGPoint scrollOffset = CGPointMake(0, yOffset);
     [self setContentOffset:scrollOffset animated:animated];
 }
 

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -19,9 +19,11 @@ NSString *const TextAttachmentCharacterCode = @"\U0000fffc"; // Represents the g
 
 // TODO: Add intrinsicContentSize support to TagView
 CGFloat const TagViewHeight = 44;
-CGFloat const TextViewTopContainerInset = 8;
-CGFloat const TextViewBottomContainerInset = TagViewHeight * 2;
-CGFloat const TextViewBottomScrollerInset = TagViewHeight;
+CGFloat const TextViewContanerInsetsTop = 8;
+CGFloat const TextViewContanerInsetsBottom = TagViewHeight * 2;
+CGFloat const TextViewScrollerInsetsBottom = TagViewHeight;
+
+CGFloat const TextViewDefaultBottomScrollInset = 0;
 
 // One unicode character plus a space
 NSInteger const ChecklistCursorAdjustment = 2;
@@ -51,6 +53,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
         self.alwaysBounceHorizontal = NO;
         self.alwaysBounceVertical = YES;
         self.scrollEnabled = YES;
+        self.bottomScrollerInset = TextViewDefaultBottomScrollInset;
         self.verticalMoveStartCaretRect = CGRectZero;
         self.verticalMoveLastCaretRect = CGRectZero;
 
@@ -77,8 +80,8 @@ NSInteger const ChecklistCursorAdjustment = 2;
 - (void)setupTextContainerInsets
 {
     UIEdgeInsets containerInsets = self.textContainerInset;
-    containerInsets.top += TextViewTopContainerInset;
-    containerInsets.bottom += TextViewBottomContainerInset;
+    containerInsets.top += TextViewContanerInsetsTop;
+    containerInsets.bottom += TextViewContanerInsetsBottom;
     self.textContainerInset = containerInsets;
 }
 
@@ -263,13 +266,13 @@ NSInteger const ChecklistCursorAdjustment = 2;
 - (void)setBottomScrollerInset:(CGFloat)bottomInset
 {
     UIEdgeInsets updated = self.scrollIndicatorInsets;
-    updated.bottom = bottomInset + TextViewBottomScrollerInset;
+    updated.bottom = bottomInset + TextViewScrollerInsetsBottom;
     self.scrollIndicatorInsets = updated;
 }
 
 - (CGFloat)bottomScrollerInset
 {
-    return self.scrollIndicatorInsets.bottom - TextViewBottomScrollerInset;
+    return self.scrollIndicatorInsets.bottom - TextViewScrollerInsetsBottom;
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -155,8 +155,8 @@ extension SPNoteEditorViewController: KeyboardObservable {
         self.noteEditorTextView.enableScrollSmoothening = true
 
         UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: .zero, options: animationOptions, animations: {
-            self.noteEditorTextView.contentInset.bottom = adjustedBottomInsets
-            self.noteEditorTextView.scrollIndicatorInsets.bottom = adjustedBottomInsets
+            self.noteEditorTextView.bottomContentInset = adjustedBottomInsets
+            self.noteEditorTextView.bottomScrollerInset = adjustedBottomInsets
         }, completion: { _ in
             self.noteEditorTextView.enableScrollSmoothening = false
         })

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -141,6 +141,7 @@ extension SPNoteEditorViewController: KeyboardObservable {
         let newKeyboardIsVisible    = newKeyboardHeight != .zero
         let animationOptions        = UIView.AnimationOptions(arrayLiteral: .beginFromCurrentState, .init(rawValue: curve))
         let adjustedBottomInsets    = newKeyboardFloats ? .zero : newKeyboardHeight
+        let adjustedIndicatorInsets = max(newKeyboardHeight - view.safeAreaInsets.bottom, .zero)
 
         guard noteEditorTextView.contentInset.bottom != adjustedBottomInsets else {
             return
@@ -153,8 +154,8 @@ extension SPNoteEditorViewController: KeyboardObservable {
         self.noteEditorTextView.enableScrollSmoothening = true
 
         UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: .zero, options: animationOptions, animations: {
-            self.noteEditorTextView.bottomContentInset = adjustedBottomInsets
-            self.noteEditorTextView.bottomScrollerInset = adjustedBottomInsets
+            self.noteEditorTextView.contentInset.bottom = adjustedBottomInsets
+            self.noteEditorTextView.scrollIndicatorInsets.bottom = adjustedIndicatorInsets
         }, completion: { _ in
             self.noteEditorTextView.enableScrollSmoothening = false
         })

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -133,7 +133,6 @@ extension SPNoteEditorViewController: KeyboardObservable {
     /// Updates the Editor's Bottom Insets
     ///
     /// - Note: Floating Keyboard results in `contentInset.bottom = .zero`
-    /// - Note: When the keyboard is visible, we'll substract the `safeAreaInsets.bottom`, since the TextView already considers that gap.
     /// - Note: We're explicitly turning on / off `enableScrollSmoothening`, since it's proven to be a nightmare when UIAutoscroll is involved.
     ///
     private func updateBottomInsets(keyboardFrame: CGRect, duration: TimeInterval, curve: UInt) {
@@ -141,8 +140,7 @@ extension SPNoteEditorViewController: KeyboardObservable {
         let newKeyboardFloats       = keyboardFrame.maxY < view.frame.height
         let newKeyboardIsVisible    = newKeyboardHeight != .zero
         let animationOptions        = UIView.AnimationOptions(arrayLiteral: .beginFromCurrentState, .init(rawValue: curve))
-        let editorBottomInsets      = newKeyboardFloats ? .zero : newKeyboardHeight
-        let adjustedBottomInsets    = max(editorBottomInsets - view.safeAreaInsets.bottom, .zero)
+        let adjustedBottomInsets    = newKeyboardFloats ? .zero : newKeyboardHeight
 
         guard noteEditorTextView.contentInset.bottom != adjustedBottomInsets else {
             return

--- a/Simplenote/Classes/SPTextView.m
+++ b/Simplenote/Classes/SPTextView.m
@@ -56,7 +56,7 @@
     [self clearHighlights:animated];
     
     highlightViews = [NSMutableArray arrayWithCapacity:range.length];
-    
+
     [self.layoutManager enumerateLineFragmentsForGlyphRange:range
                                                  usingBlock:^(CGRect rect, CGRect usedRect, NSTextContainer *textContainer, NSRange glyphRange, BOOL *stop) {
                                                      
@@ -67,7 +67,8 @@
                                                      
                                                      CGRect highlightRect = [self.layoutManager boundingRectForGlyphRange:highlightRange
                                                                                                           inTextContainer:textContainer];
-                                                     
+                                                     highlightRect.origin.y += self.textContainerInset.top;
+
                                                      if (block)
                                                          block(highlightRect);
                                                      
@@ -107,17 +108,12 @@
 }
 
 - (UIView *)createHighlightViewForAttributedString:(NSAttributedString *)attributedString frame:(CGRect)frame {
-    
-    frame.origin.y += 8;
-    
+
     VSTheme *theme = [[VSThemeManager sharedManager] theme];
     CGFloat horizontalPadding = [theme floatForKey:@"searchHighlightHorizontalPadding"];
-    CGFloat verticalPadding = [theme floatForKey:@"searchHighlightVerticalPadding"];
-    
+
     frame.size.width += 2 * horizontalPadding;
     frame.origin.x -= horizontalPadding;
-    frame.size.height += 2 * verticalPadding;
-    frame.origin.y -= verticalPadding;
     
     UILabel *highlightLabel = [[UILabel alloc] initWithFrame:frame];
     


### PR DESCRIPTION
### Fix
In this PR we're fixing a glitch that caused the TextView's scroll offset to jump when pressing anywhere in the last ~5 lines of text.

@eshurakov May I bug you with this one?
**Small PR**... looots of things to check (apologies about that!!)

Ref #921

### Test: Selection
1. Open a long document
2. Tap anywhere to reveal the keyboard
3. Tap anywhere at the bottom of the visible text

 - [x] Verify that the contentOffset doesn't get pushed upwards **unlesss it's the last 1-2 lines!**

**Note**
Please compare the behavior against develop: the Content Offset jumps when pressing the last ~5 lines!


### Test: Regressions
- [x] Verify dragging the cursor all over works as expected (and it's not impossible to control!)
- [x] Verify that scrolling all the way down and pressing over the Tags Editor does not cause the Scroll Offset to jump
- [x] Verify that the Tags Editor is placed above the App Switcher (in a short note!)
- [x] Verify that dismissing the Keyboard restores the default bottom insets
- [x] Verify that the Scroll Indicator clips right before the area where Tags Editor begin
- [x] Verify that pressing over the Tags Editor area brings up the keyboard, and applies a bottom inset

### Test: Search
1. Launch the app on an iPhone device
2. Enter a search keyword that yields any results
3. Press over any search result
4. Scroll all the way down, until the Tags Editor is revealed
5. Press Done to dismiss

- [ ] Verify that Keyword Matches are properly highlighted (and that they don't look off!)
- [x] Verify that the Search Bar is dismissed with an animation
- [x] Verify that the Tags Editor is relocated with an animation, smooothly!

### Test: Voiceover
1. Launch Simplenote on a device with Safe Area (iPhone X / 11)
2. Add a note with (lots) of text, so that it causes scroll
3. Enable voiceover (hey siri voiceover on!)

- [x]  Verify that the Tags View now shows up locked at the bottom

### Test: iPad
1. Launch Simplenote on an iPad Device
2. Toggle a Split Keyboard

- [x]  Verify that text shows up all over, and does not clip above the Keyboard
- [x]  Verify that switching to floating keyboard and moving it all over does not cause the Text to disappear


### Release
`RELEASE-NOTES.txt` was updated in 1428131 with:
 
> Fixed a bug that affected Text Selection #973
