### PR TITLE
Remove canOpenURL check for https scheme

### DIFF
--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -581,10 +581,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             switch (indexPath.row) {
                 case SPOptionsHelpRowTitle: {
                     NSURL *url = [NSURL URLWithString:@"https://simplenote.com/help"];
-
-                    if ([[UIApplication sharedApplication] canOpenURL:url]) {
-                       [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
-                    }
+                    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 
                     break;
                 }


### PR DESCRIPTION
### Fix
In this PR we remove `canOpenURL` check for `https` urls. This check was preventing opening urls if default browser is not Safari.

@jleandroperez Quick one! Thanks.

Closes #963 

### Test
1. Change default browser
2. Open Simplenote -> Settings
3. Tap Help

- [x] Help page is opened in a browser from step 1

### Release

> These changes do not require release notes.
