### PR TITLE
Editor: Preventing edition during drag OP(s)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.28
 -----
- 
+-   Fixed a bug that toggled Edition while dragging the Editor #972
+
 4.27
 -----
 -   New Note History interface #762

--- a/Simplenote/Classes/SPEditorTapRecognizerDelegate.swift
+++ b/Simplenote/Classes/SPEditorTapRecognizerDelegate.swift
@@ -32,6 +32,10 @@ class SPEditorTapRecognizerDelegate: NSObject, UIGestureRecognizerDelegate {
             return true
         }
 
+        if textView.isDragging {
+            return false
+        }
+
         let characterIndex = gestureRecognizer.characterIndex(in: textView)
         if textView.attachment(ofType: SPTextAttachment.self, at: characterIndex) != nil {
             return true


### PR DESCRIPTION
### Fix
In this PR we're preventing the Editor from becoming active while there's a Drag Operation going on.

**Note:** 
I've tried skipping when `isDecelerating` evaluates true, but the UX ends up quite bad: you need to wait until the UIScrollView ends up moving entirely.

cc @eshurakov Mind taking a peek at this one?
Thanks in advance!

Closes #972

### Test
1. Open a long document
2. Begin dragging the Editor
3. Release your finger

- [x] Verify the Editor does not become the First Responder

### Release
`RELEASE-NOTES.txt` was updated in 4862d1b with:
 
> Fixed a bug that toggled Edition while dragging the Editor #972
