### PR TITLE
Dropping VSTheme: Mark I

### DIFF
--- a/External/DTPinLock/DTPinLockController.m
+++ b/External/DTPinLock/DTPinLockController.m
@@ -10,7 +10,6 @@
 #import "DTPinDigitView.h"
 #import "DTPinErrorView.h"
 #import <LocalAuthentication/LocalAuthentication.h>
-#import "VSThemeManager.h"
 #import "Simplenote-Swift.h"
 
 #define MARGIN_SIDES 23.0

--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -8,7 +8,6 @@
 
 #import "SPMarkdownParser.h"
 #import "html.h"
-#import "VSThemeManager.h"
 #import "Simplenote-Swift.h"
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -16,7 +16,6 @@
 #import "NSMutableAttributedString+Styling.h"
 #import "NSString+Search.h"
 #import "UIDevice+Extensions.h"
-#import "VSThemeManager.h"
 
 #import <StoreKit/StoreKit.h>
 #import <Simperium/Simperium.h>

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -2,7 +2,6 @@
 #import "SPAppDelegate.h"
 #import "SPConstants.h"
 #import "DTPinLockController.h"
-#import "VSThemeManager.h"
 #import "StatusChecker.h"
 #import "SPTracker.h"
 #import "SPDebugViewController.h"

--- a/Simplenote/Classes/SPTagEntryField.m
+++ b/Simplenote/Classes/SPTagEntryField.m
@@ -8,7 +8,8 @@
 
 #import "SPTagEntryField.h"
 #import "Simplenote-Swift.h"
-#import "VSThemeManager.h"
+
+CGFloat const TagEntryFieldPadding = 40;
 
 @implementation SPTagEntryField
 
@@ -45,11 +46,6 @@
     return self;
 }
 
-- (VSTheme *)theme
-{    
-    return [[VSThemeManager sharedManager] theme];
-}
-
 - (void)setText:(NSString *)text
 {
     [super setText:text];
@@ -68,7 +64,7 @@
     
     CGRect frame = self.frame;
     
-    frame.size.width += 8 * [self.theme floatForKey:@"tagViewItemPadding"];
+    frame.size.width += 2 * TagEntryFieldPadding;
     frame.size.height = self.frame.size.height;
     
     self.frame = frame;

--- a/Simplenote/Classes/SPTagPill.h
+++ b/Simplenote/Classes/SPTagPill.h
@@ -9,12 +9,14 @@
 #import <UIKit/UIKit.h>
 @class SPTagStub;
 
+
+extern CGVector const TagPillSpacing;
+
 @interface SPTagPill : UIButton {
     
     id target;
     SEL deletionAction;
 }
-
 
 - (instancetype)initWithTagStub:(SPTagStub *)tagStub target:(id)target action:(SEL)action deletionAction:(SEL)deletionAction;
 

--- a/Simplenote/Classes/SPTagPill.m
+++ b/Simplenote/Classes/SPTagPill.m
@@ -10,6 +10,8 @@
 #import "SPTagStub.h"
 #import "Simplenote-Swift.h"
 
+CGVector const TagPillSpacing = {15, 10};
+
 @interface SPTagPill ()
 
 @property (nonatomic) BOOL performDeletionAction;
@@ -23,7 +25,7 @@
 - (id)initWithTagStub:(SPTagStub *)tagStub target:(id)t action:(SEL)a deletionAction:(SEL)da {
     
     self = [self init];
-    
+
     if (self) {
         
         [self setTitle:tagStub.tag forState:UIControlStateNormal];
@@ -51,14 +53,8 @@
     [super sizeToFit];
     
     CGRect frame = self.frame;
-    frame.size.width += 2 * [self.theme floatForKey:@"tagViewItemSideSpacing"];
+    frame.size.width += 2 * TagPillSpacing.dx;
     self.frame = frame;
-}
-
-
-- (VSTheme *)theme {
-    
-    return [[VSThemeManager sharedManager] theme];
 }
 
 - (UIColor *)color {
@@ -76,8 +72,8 @@
     
     if (!_deletionOverlayView) {
         
-        CGFloat horizontalSpacing = [self.theme floatForKey:@"tagViewItemSideSpacing"];
-        CGFloat verticalSpacing = 10.0;
+        CGFloat horizontalSpacing = TagPillSpacing.dx;
+        CGFloat verticalSpacing = TagPillSpacing.dy;
         
         _deletionOverlayView = [[UIView alloc] initWithFrame:CGRectMake(horizontalSpacing / 2.0,
                                                                         verticalSpacing / 2.0,

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -7,7 +7,6 @@
 //
 
 #import "SPTagView.h"
-#import "VSThemeManager.h"
 #import "SPTagStub.h"
 #import <Simperium/Simperium.h>
 #import "SPAppDelegate.h"
@@ -135,11 +134,6 @@
     
     bounds.origin.y -= bounds.size.height;
     autoCompleteScrollView.frame = bounds;
-}
-
-- (VSTheme *)theme {
-    
-    return [[VSThemeManager sharedManager] theme];
 }
 
 - (BOOL)setupWithTagNames:(NSArray *)tagNames {

--- a/Simplenote/Classes/SPTagView.m
+++ b/Simplenote/Classes/SPTagView.m
@@ -91,7 +91,7 @@
 - (void)layoutSubviews
 {
     CGFloat xOrigin = 0.0;
-    CGFloat spacing = [self.theme floatForKey:@"tagViewItemSideSpacing"];
+    CGFloat spacing = TagPillSpacing.dx;
     
     // position tags
     for (UIView *view in tagPills) {
@@ -409,14 +409,12 @@
     if (_activeDeletionPill) {
         return;
     }
-    
-    CGFloat spacing = [self.theme floatForKey:@"tagViewItemSpacing"];
-    
+
     if (tagScrollView.contentSize.width > tagScrollView.bounds.size.width &&
-        addTagField.frame.origin.x + addTagField.frame.size.width+ 2 * spacing - tagScrollView.contentOffset.x > tagScrollView.bounds.size.width) {
+        addTagField.frame.origin.x + addTagField.frame.size.width - tagScrollView.contentOffset.x > tagScrollView.bounds.size.width) {
 
         CGPoint offset = CGPointMake(MIN(tagScrollView.contentSize.width - tagScrollView.bounds.size.width,
-                                         addTagField.frame.origin.x + addTagField.frame.size.width + 2 * spacing - tagScrollView.bounds.size.width),
+                                         addTagField.frame.origin.x + addTagField.frame.size.width - tagScrollView.bounds.size.width),
                                      0);
         
         [tagScrollView setContentOffset:offset animated:animated];

--- a/Simplenote/Classes/SPTagsListViewController.m
+++ b/Simplenote/Classes/SPTagsListViewController.m
@@ -6,7 +6,6 @@
 #import "SPTagListViewCell.h"
 #import "Tag.h"
 
-#import "VSThemeManager.h"
 #import <Simperium/Simperium.h>
 #import "Simplenote-Swift.h"
 

--- a/Simplenote/Classes/SPTextView.m
+++ b/Simplenote/Classes/SPTextView.m
@@ -9,10 +9,14 @@
 
 #import "SPTextView.h"
 #import <CoreFoundation/CFStringTokenizer.h>
-#import "VSThemeManager.h"
 #import "NSString+Search.h"
 #import "SPInteractiveTextStorage.h"
 #import "Simplenote-Swift.h"
+
+
+CGFloat const TextViewHighlightHorizontalPadding = 3;
+CGFloat const TextViewHighlightCornerRadius = 3;
+
 
 @implementation SPTextView
 
@@ -109,11 +113,8 @@
 
 - (UIView *)createHighlightViewForAttributedString:(NSAttributedString *)attributedString frame:(CGRect)frame {
 
-    VSTheme *theme = [[VSThemeManager sharedManager] theme];
-    CGFloat horizontalPadding = [theme floatForKey:@"searchHighlightHorizontalPadding"];
-
-    frame.size.width += 2 * horizontalPadding;
-    frame.origin.x -= horizontalPadding;
+    frame.size.width += 2 * TextViewHighlightHorizontalPadding;
+    frame.origin.x -= TextViewHighlightHorizontalPadding;
     
     UILabel *highlightLabel = [[UILabel alloc] initWithFrame:frame];
     
@@ -128,7 +129,7 @@
     
     highlightLabel.textAlignment = NSTextAlignmentCenter;
     highlightLabel.backgroundColor = [UIColor simplenoteEditorSearchHighlightSelectedColor];
-    highlightLabel.layer.cornerRadius = [theme floatForKey:@"searhHighlightCornerRadius"];
+    highlightLabel.layer.cornerRadius = TextViewHighlightCornerRadius;
     highlightLabel.clipsToBounds = YES;
     highlightLabel.layer.shouldRasterize = YES;
     highlightLabel.layer.rasterizationScale = [[UIScreen mainScreen] scale];

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -22,8 +22,6 @@
 #import "SPRatingsHelper.h"
 #import "WPAuthHandler.h"
 
-#import "VSThemeManager.h"
-#import "VSTheme.h"
 #import "DTPinLockController.h"
 #import "SPTracker.h"
 


### PR DESCRIPTION
### Fix
In this PR we're dropping (part of the) remaining VSTheme integrations.

Ref. #481

cc @eshurakov (Thanks in advance!!)

### Test: Tags Editor
1. Launch Simplenote
2. Open any note

- [x] Verify the **Tag...** TextField (at the bottom) looks great!
- [x] Verify the **Tag Pills** (at the bottom) also look great!

### Test: Search
1. Launch Simplenote
2. Enter a Search Keyword that yields at least one result
3. Press over any row

- [x] Verify the Keywords are properly highlighted
- [x] Verify the Highlight Overlay has rounded corners!


### Release
These changes do not require release notes.
