### PR TITLE
Dropping VSTheme: Mark III

### DIFF
--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -10,6 +10,7 @@
 #import "SPTagView.h"
 #import "SPInteractiveTextStorage.h"
 #import "NSMutableAttributedString+Styling.h"
+#import "VSThemeManager.h"
 #import "VSTheme+Extensions.h"
 #import "Simplenote-Swift.h"
 

--- a/Simplenote/Classes/SPEntryListCell.m
+++ b/Simplenote/Classes/SPEntryListCell.m
@@ -7,10 +7,10 @@
 //
 
 #import "SPEntryListCell.h"
-#import "VSThemeManager.h"
 #import "Simplenote-Swift.h"
 
 
+static CGFloat const EntryListCellSidePadding = 15;
 
 @implementation SPEntryListCell
 
@@ -57,29 +57,22 @@
     CGFloat primaryLabelHeight = primaryLabel.font.lineHeight;
     CGFloat secondaryLabelHeight = secondaryLabel.text.length > 0 ? secondaryLabel.font.lineHeight : 0;
     CGFloat cellHeight = self.bounds.size.height;
-    CGFloat padding = [self.theme floatForKey:@"collaboratorCellSidePadding"];
     
-    
-    checkmarkImageView.frame = CGRectMake(self.bounds.size.width - checkmarkImageView.bounds.size.width - padding,
+    checkmarkImageView.frame = CGRectMake(self.bounds.size.width - checkmarkImageView.bounds.size.width - EntryListCellSidePadding,
                                           (cellHeight - checkmarkImageView.bounds.size.height) / 2.0,
                                           checkmarkImageView.frame.size.width,
                                           checkmarkImageView.frame.size.height);
     
-    primaryLabel.frame = CGRectMake(padding,
+    primaryLabel.frame = CGRectMake(EntryListCellSidePadding,
                                     (cellHeight - (primaryLabelHeight + secondaryLabelHeight)) / 2.0,
-                                    checkmarkImageView.frame.origin.x - 2 * padding,
+                                    checkmarkImageView.frame.origin.x - 2 * EntryListCellSidePadding,
                                     primaryLabelHeight);
     
-    secondaryLabel.frame = CGRectMake(padding,
+    secondaryLabel.frame = CGRectMake(EntryListCellSidePadding,
                                     primaryLabelHeight + primaryLabel.frame.origin.y,
-                                    checkmarkImageView.frame.origin.x - 2 * padding,
+                                    checkmarkImageView.frame.origin.x - 2 * EntryListCellSidePadding,
                                     secondaryLabelHeight);
     
-}
-
-- (VSTheme *)theme {
-    
-    return [[VSThemeManager sharedManager] theme];
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated

--- a/Simplenote/Classes/SPEntryListViewController.m
+++ b/Simplenote/Classes/SPEntryListViewController.m
@@ -7,23 +7,20 @@
 //
 
 #import "SPEntryListViewController.h"
-#import "VSThemeManager.h"
 #import "Simplenote-Swift.h"
 #import "SPEntryListCell.h"
 #import "SPEntryListAutoCompleteCell.h"
 
 static NSString *cellIdentifier = @"primaryCell";
 static NSString *autoCompleteCellIdentifier = @"autoCompleteCell";
+static CGFloat const EntryListTextFieldSidePadding = 15;
+static CGFloat const EntryListCellHeight = 44;
 
 @implementation SPEntryListViewController
 
-- (void)dealloc {
+- (void)dealloc
+{
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
-- (VSTheme *)theme {
-    
-    return [[VSThemeManager sharedManager] theme];
 }
 
 - (void)viewDidLoad {
@@ -46,14 +43,13 @@ static NSString *autoCompleteCellIdentifier = @"autoCompleteCell";
     entryFieldBackground = [[UIView alloc] initWithFrame:CGRectMake(0,
                                                                     yOrigin,
                                                                     self.view.frame.size.width,
-                                                                    [self.theme floatForKey:@"collaboratorCellHeight"])];
+                                                                    EntryListCellHeight)];
     entryFieldBackground.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
     [self.view addSubview:entryFieldBackground];
     
-    CGFloat padding = [self.theme floatForKey:@"collaboratorCellSidePadding"];
-    entryTextField = [[SPTextField alloc] initWithFrame:CGRectMake(padding,
+    entryTextField = [[SPTextField alloc] initWithFrame:CGRectMake(EntryListTextFieldSidePadding,
                                                                    0,
-                                                                   entryFieldBackground.frame.size.width - 2 * padding,
+                                                                   entryFieldBackground.frame.size.width - 2 * EntryListTextFieldSidePadding,
                                                                    entryFieldBackground.frame.size.height)];
     entryTextField.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
     entryTextField.keyboardType = UIKeyboardTypeEmailAddress;
@@ -77,7 +73,7 @@ static NSString *autoCompleteCellIdentifier = @"autoCompleteCell";
     primaryTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, yOrigin + entryTextField.frame.size.height,
                                                                      self.view.frame.size.width, self.view.frame.size.height - (yOrigin + entryTextField.frame.size.height))
                                                     style:UITableViewStyleGrouped];
-    primaryTableView.rowHeight = [self.theme floatForKey:@"collaboratorCellHeight"];
+    primaryTableView.rowHeight = EntryListCellHeight;
     primaryTableView.delegate = self;
     primaryTableView.dataSource = self;
     primaryTableView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -6,7 +6,6 @@
 #pragma mark - External
 
 #import <Simperium/Simperium.h>
-#import "VSThemeManager.h"
 
 
 #pragma mark - Simplenote-Y


### PR DESCRIPTION
### Fix
In this PR we're dropping VSTheme usage in the Collaboration ViewController / Cell.

We're only focusing on wiring Constants, please note that this entire component is up for a full rewrite :fire:

@eshurakov Almost there!! (Thank youu!)
Ref. #481

### Test
1. Open any note
2. Press over the top right `...` button
3. Press over `Collaborate`
4. Press over `Add a new collaborator...`
5. Type any keyword that yields results

- [x] Verify the "Autocomplete Cells" looks (exactly!) like the way they do in the AppStore version
- [x] Verify that after pressing any of the search results an actual collaborator cell is added

### Release
These changes do not require release notes.
