### PR TITLE
Fixing Text Selection: Mark III

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 4.28
 -----
 -   Fixed a bug that affected Text Selection #973
- 
 -   Fixed a bug that toggled Edition while dragging the Editor #972
 
 4.27

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -168,8 +168,9 @@ NSInteger const ChecklistCursorAdjustment = 2;
     CGFloat width       = self.bounds.size.width - self.safeAreaInsets.left - self.safeAreaInsets.right;
     CGFloat height      = CGRectGetHeight(self.tagView.frame);
 
-    // When the Keyboard is absent we'll always honor the Safe Area Insets
-    CGFloat paddingY    = MAX(self.contentInset.bottom, self.safeAreaInsets.bottom);
+    /// When the keyboard is presented, we're explicitly removing the bottom safeAreaInsets: TextView automatically accounts for them.
+    /// For that reason, when positioning the TagView we'd need to add them manually
+    CGFloat paddingY    = self.contentInset.bottom + self.safeAreaInsets.bottom;
     CGFloat boundsMinY  = self.bounds.size.height - height + self.contentOffset.y - paddingY;
     CGFloat contentMinY = self.contentSize.height + self.textContainerInset.top - self.textContainerInset.bottom;
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -141,7 +141,6 @@ extension SPNoteEditorViewController: KeyboardObservable {
         let newKeyboardIsVisible    = newKeyboardHeight != .zero
         let animationOptions        = UIView.AnimationOptions(arrayLiteral: .beginFromCurrentState, .init(rawValue: curve))
         let adjustedBottomInsets    = newKeyboardFloats ? .zero : newKeyboardHeight
-        let adjustedIndicatorInsets = max(newKeyboardHeight - view.safeAreaInsets.bottom, .zero)
 
         guard noteEditorTextView.contentInset.bottom != adjustedBottomInsets else {
             return
@@ -155,7 +154,7 @@ extension SPNoteEditorViewController: KeyboardObservable {
 
         UIViewPropertyAnimator.runningPropertyAnimator(withDuration: duration, delay: .zero, options: animationOptions, animations: {
             self.noteEditorTextView.contentInset.bottom = adjustedBottomInsets
-            self.noteEditorTextView.scrollIndicatorInsets.bottom = adjustedIndicatorInsets
+            self.noteEditorTextView.scrollIndicatorInsets.bottom = adjustedBottomInsets
         }, completion: { _ in
             self.noteEditorTextView.enableScrollSmoothening = false
         })

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -133,6 +133,7 @@ extension SPNoteEditorViewController: KeyboardObservable {
     /// Updates the Editor's Bottom Insets
     ///
     /// - Note: Floating Keyboard results in `contentInset.bottom = .zero`
+    /// - Note: When the keyboard is visible, we'll substract the `safeAreaInsets.bottom`, since the TextView already considers that gap.
     /// - Note: We're explicitly turning on / off `enableScrollSmoothening`, since it's proven to be a nightmare when UIAutoscroll is involved.
     ///
     private func updateBottomInsets(keyboardFrame: CGRect, duration: TimeInterval, curve: UInt) {
@@ -140,7 +141,8 @@ extension SPNoteEditorViewController: KeyboardObservable {
         let newKeyboardFloats       = keyboardFrame.maxY < view.frame.height
         let newKeyboardIsVisible    = newKeyboardHeight != .zero
         let animationOptions        = UIView.AnimationOptions(arrayLiteral: .beginFromCurrentState, .init(rawValue: curve))
-        let adjustedBottomInsets    = newKeyboardFloats ? .zero : newKeyboardHeight
+        let editorBottomInsets      = newKeyboardFloats ? .zero : newKeyboardHeight
+        let adjustedBottomInsets    = max(editorBottomInsets - view.safeAreaInsets.bottom, .zero)
 
         guard noteEditorTextView.contentInset.bottom != adjustedBottomInsets else {
             return


### PR DESCRIPTION
### Fix
In this PR we're (further) adjusting the Autoscroll Behavior, so that **only partially visible lines** cause the TextView to autoscroll.

@eshurakov **Last round!!!** Please LMK if this time autoscroll feels right. I *think* this is what we were after.

Thanks in advance!!

Closes #921

### Test: Regressions
- [x] Verify dragging the cursor all over works as expected (and it's not impossible to control!)
- [x] Verify that scrolling all the way down and pressing over the Tags Editor does not cause the Scroll Offset to jump
- [x] Verify that the Tags Editor is placed above the App Switcher (in a short note!)
- [x] Verify that dismissing the Keyboard restores the default bottom insets
- [ ] Verify that the Scroll Indicator clips right before the area where Tags Editor begin
- [x] Verify that pressing over the Tags Editor area brings up the keyboard, and applies a bottom inset

### Test: Search
1. Launch the app on an iPhone device
2. Enter a search keyword that yields any results
3. Press over any search result
4. Scroll all the way down, until the Tags Editor is revealed
5. Press Done to dismiss

- [x] Verify that Keyword Matches are properly highlighted (and that they don't look off!)
- [x] Verify that the Search Bar is dismissed with an animation
- [x] Verify that the Tags Editor is relocated with an animation, smooothly!

### Test: Voiceover
1. Launch Simplenote on a device with Safe Area (iPhone X / 11)
2. Add a note with (lots) of text, so that it causes scroll
3. Enable voiceover (hey siri voiceover on!)

- [x]  Verify that the Tags View now shows up locked at the bottom

### Test: iPad
1. Launch Simplenote on an iPad Device
2. Toggle a Split Keyboard

- [x]  Verify that text shows up all over, and does not clip above the Keyboard
- [x]  Verify that switching to floating keyboard and moving it all over does not cause the Text to disappear

### Release
These changes do not require release notes.
