### PR TITLE
Keychain: Silencing "No password" error

### DIFF
--- a/Simplenote/Classes/KeychainManager.swift
+++ b/Simplenote/Classes/KeychainManager.swift
@@ -41,8 +41,12 @@ struct KeychainItemWrapper {
         mutating get {
             do {
                 return try item.readPassword()
+
+            } catch KeychainError.noPassword {
+                return nil
+
             } catch {
-                NSLog("Error Reading Keychain Item \(item.service).\(item.account)")
+                NSLog("Error Reading Keychain Item \(item.service).\(item.account): \(error)")
                 return nil
             }
         }

--- a/Simplenote/KeychainPasswordItem.swift
+++ b/Simplenote/KeychainPasswordItem.swift
@@ -9,18 +9,17 @@
 import Foundation
 
 
+enum KeychainError: Error {
+    case noPassword
+    case unexpectedPasswordData
+    case unexpectedItemData
+    case unhandledError(status: OSStatus)
+}
+
 /// Ref. https://developer.apple.com/library/content/samplecode/GenericKeychain/Listings/GenericKeychain_KeychainPasswordItem_swift.html
 ///
 struct KeychainPasswordItem {
-    // MARK: Types
-    
-    enum KeychainError: Error {
-        case noPassword
-        case unexpectedPasswordData
-        case unexpectedItemData
-        case unhandledError(status: OSStatus)
-    }
-    
+
     // MARK: Properties
     
     let service: String


### PR DESCRIPTION
### Fix
In this PR we prevent printing out errors in console whenever there are no stored Keychain Passwords (PIN Lock)

@eshurakov Thanks in advance!!

### Test
1. Launch the app
2. Log into your account

- [x] Verify no `Error Reading Keychain Item` error shows up in the console anymore!

### Release
These changes do not require release notes.
