### PR TITLE
TagList: Updates Separator Behavior

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.28
 -----
+-   Tags List now extend to the edge of the screen, in landscape mode #989
 -   Fixed a bug that affected Text Selection #973
 -   Fixed a bug that toggled Edition while dragging the Editor #972
 

--- a/Simplenote/Classes/SPTagHeaderView.xib
+++ b/Simplenote/Classes/SPTagHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,11 +26,12 @@
                     <state key="normal" title="Button"/>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="HJL-3a-kMx"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="aHp-el-CsD" secondAttribute="bottom" constant="5" id="9NS-Yr-ko2"/>
                 <constraint firstItem="FwE-o8-Mhf" firstAttribute="top" secondItem="t2U-RY-Ulw" secondAttribute="top" constant="5" id="HtV-gc-dUn"/>
-                <constraint firstItem="aHp-el-CsD" firstAttribute="leading" secondItem="t2U-RY-Ulw" secondAttribute="leading" constant="16" id="Kac-Yu-sTd"/>
+                <constraint firstItem="aHp-el-CsD" firstAttribute="leading" secondItem="HJL-3a-kMx" secondAttribute="leading" constant="16" id="Kac-Yu-sTd"/>
                 <constraint firstItem="HJL-3a-kMx" firstAttribute="bottom" secondItem="FwE-o8-Mhf" secondAttribute="bottom" constant="5" id="LAc-OD-rdq"/>
                 <constraint firstAttribute="trailing" secondItem="FwE-o8-Mhf" secondAttribute="trailing" constant="16" id="XsG-YJ-tsE"/>
                 <constraint firstItem="FwE-o8-Mhf" firstAttribute="centerY" secondItem="t2U-RY-Ulw" secondAttribute="centerY" id="hnq-Tl-QsJ"/>
@@ -38,7 +39,6 @@
                 <constraint firstItem="FwE-o8-Mhf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="aHp-el-CsD" secondAttribute="trailing" constant="10" id="nZZ-mB-RMj"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="HJL-3a-kMx"/>
             <connections>
                 <outlet property="actionButton" destination="FwE-o8-Mhf" id="YNd-cV-4oq"/>
                 <outlet property="titleLabel" destination="aHp-el-CsD" id="uxr-qy-pBU"/>

--- a/Simplenote/Classes/TagListViewController.xib
+++ b/Simplenote/Classes/TagListViewController.xib
@@ -46,7 +46,7 @@
                 <constraint firstAttribute="trailing" secondItem="dMw-N6-gUa" secondAttribute="trailing" id="WwN-pP-oJT"/>
                 <constraint firstAttribute="bottom" secondItem="zpC-BW-MFx" secondAttribute="bottom" id="ZZY-IF-D93"/>
                 <constraint firstAttribute="bottom" secondItem="dMw-N6-gUa" secondAttribute="bottom" id="h4I-wd-bbB"/>
-                <constraint firstItem="dMw-N6-gUa" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="pfu-gA-vNg"/>
+                <constraint firstItem="dMw-N6-gUa" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="pfu-gA-vNg"/>
                 <constraint firstAttribute="trailing" secondItem="zpC-BW-MFx" secondAttribute="trailing" id="v6n-hw-aVx"/>
                 <constraint firstItem="dMw-N6-gUa" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="z1r-bb-Try"/>
             </constraints>

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -77,6 +77,7 @@ private extension TagListViewController {
     func configureTableView() {
         tableView.register(SPTagListViewCell.loadNib(), forCellReuseIdentifier: SPTagListViewCell.reuseIdentifier)
 
+        tableView.separatorInsetReference = .fromAutomaticInsets
         if #available(iOS 13.0, *) {
             tableView.automaticallyAdjustsScrollIndicatorInsets = false
         }
@@ -274,6 +275,7 @@ extension TagListViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         cell.isSelected = shouldSelectCell(at: indexPath)
+        cell.adjustSeparatorWidth(width: .full)
     }
 
     func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -76,8 +76,8 @@ private extension TagListViewController {
 
     func configureTableView() {
         tableView.register(SPTagListViewCell.loadNib(), forCellReuseIdentifier: SPTagListViewCell.reuseIdentifier)
-
         tableView.separatorInsetReference = .fromAutomaticInsets
+
         if #available(iOS 13.0, *) {
             tableView.automaticallyAdjustsScrollIndicatorInsets = false
         }


### PR DESCRIPTION
### Fix
In this PR we're updating the Tags List:

- Cells now extend to the full width
- Separators have been adjusted as well!

cc @eshurakov (Thanks in advance!!)
Closes #604

### Test
1. Launch the app on an iPhone device
2. Grab the device in landscape

- [x] Verify the Cell Highlight extends to the whole screen (regardless of the safe area)
- [x] Verify the Header Separators extend to the whole screen
- [x] Verify the Cell Separators start where the text does
- [x] Verify the Cell(s) Text looks great
- [x] Verify the Header's Text looks great
- [x] Verify Portrait mode looks unchanged!
- [x] Verify this also looks great on an iPad device please!

### Release
`RELEASE-NOTES.txt` was updated in 13823a4 with:
 
> Tags List now extend to the edge of the screen, in landscape mode #989

### Screenshots
![Separators](https://user-images.githubusercontent.com/1195260/98392386-aeeca800-2036-11eb-8d49-b706102ff8fa.jpg)
