### PR TITLE
Fixing New Note Action

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 -   Fixed a bug that affected Text Selection #973
 -   Fixed a bug that toggled Edition while dragging the Editor #972
+-   Fixed an issue that caused changes not to be persisted immediately #996
 
 4.27
 -----

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -780,6 +780,14 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self cancelSaveTimers];
 }
 
+- (void)saveIfNeeded
+{
+    if (self.currentNote == nil || self.modified == NO) {
+        return;
+    }
+
+    [self save];
+}
 
 - (void)save
 {
@@ -857,7 +865,9 @@ CGFloat const SPSelectedAreaPadding = 20;
     [_tagView endEditing:YES];
 }
 
-- (void)newButtonAction:(id)sender {
+- (void)newButtonAction:(id)sender
+{
+    [self saveIfNeeded];
 
     if (self.currentNote.isBlank) {
         [_noteEditorTextView becomeFirstResponder];


### PR DESCRIPTION
### Fix
In this PR we're ensuring pending changes are persisted whenever the **New Note** Action Button is pressed.

@eshurakov Mind taking a look at this one?
Thank youuuu!!

Closes #811
Closes #993

### Test
1. Add a new note
2. Type `1234`
3. **Quickly** press `+` to add a new note

- [x] Verify that the Editor is cleared out **immediately**
- [x] Verify that the changes edited in (2) were persited

### Release
`RELEASE-NOTES.txt` was updated in 2500261 with:
 
> Fixed an issue that caused changes not to be persisted immediately #996
