### PR TITLE
Snackbar: First steps at potential implementation

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 		46A3C9C417DFA81A002865AE /* Simplenote-DB5.plist in Resources */ = {isa = PBXBuildFile; fileRef = E2FCA5F21789118A00FC229D /* Simplenote-DB5.plist */; };
 		4A4A4BC825593FC400876C29 /* Snackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A4BC725593FC400876C29 /* Snackbar.swift */; };
 		4A4A4BD02559541100876C29 /* SnackbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A4BCF2559541100876C29 /* SnackbarViewController.swift */; };
-		4A4A4BD82559545400876C29 /* SnackbarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A4A4BD72559545400876C29 /* SnackbarView.xib */; };
+		4A4A4BE62559585300876C29 /* SnackbarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A4A4BE52559585300876C29 /* SnackbarView.xib */; };
 		74388F4422CFFA30001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
 		74388F4622CFFA8B001C5EC0 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */; };
 		74388F4722CFFAB6001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
@@ -484,7 +484,7 @@
 		46A3C9DC17DFA866002865AE /* Simplenote-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Simplenote-Info.plist"; sourceTree = "<group>"; };
 		4A4A4BC725593FC400876C29 /* Snackbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snackbar.swift; sourceTree = "<group>"; };
 		4A4A4BCF2559541100876C29 /* SnackbarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackbarViewController.swift; sourceTree = "<group>"; };
-		4A4A4BD72559545400876C29 /* SnackbarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SnackbarView.xib; sourceTree = "<group>"; };
+		4A4A4BE52559585300876C29 /* SnackbarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SnackbarView.xib; sourceTree = "<group>"; };
 		593EA1C08A9F76E3833C3E80 /* Pods-SimplenoteTests.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		697B9622931545E466B5E186 /* Pods-Automattic-SimplenoteShare.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		6AE4CF60906DA6D08F64E5B3 /* Pods-Automattic-Simplenote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.release.xcconfig"; sourceTree = "<group>"; };
@@ -1701,7 +1701,7 @@
 				B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */,
 				4A4A4BC725593FC400876C29 /* Snackbar.swift */,
 				4A4A4BCF2559541100876C29 /* SnackbarViewController.swift */,
-				4A4A4BD72559545400876C29 /* SnackbarView.xib */,
+				4A4A4BE52559585300876C29 /* SnackbarView.xib */,
 			);
 			path = Simplenote;
 			sourceTree = "<group>";
@@ -2028,7 +2028,7 @@
 				B56A695822F9CD1500B90398 /* SPOnboardingViewController.xib in Resources */,
 				A6C0589524AD2B8F006BC572 /* SPNoteHistoryViewController.xib in Resources */,
 				B5EB1EFE1C205A800080A1B3 /* Icons.xcassets in Resources */,
-				4A4A4BD82559545400876C29 /* SnackbarView.xib in Resources */,
+				4A4A4BE62559585300876C29 /* SnackbarView.xib in Resources */,
 				B53929492398642800ACEE00 /* SPRatingsPromptView.xib in Resources */,
 				B537732B252E176C00BC78C5 /* OptionsViewController.xib in Resources */,
 				B56A696222F9D53400B90398 /* SPAuthViewController.xib in Resources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		46A3C9C217DFA81A002865AE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E29ADD4417848E8500E55842 /* InfoPlist.strings */; };
 		46A3C9C317DFA81A002865AE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E29ADD4D17848E8500E55842 /* Images.xcassets */; };
 		46A3C9C417DFA81A002865AE /* Simplenote-DB5.plist in Resources */ = {isa = PBXBuildFile; fileRef = E2FCA5F21789118A00FC229D /* Simplenote-DB5.plist */; };
+		4A4A4BC825593FC400876C29 /* Snackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A4BC725593FC400876C29 /* Snackbar.swift */; };
 		74388F4422CFFA30001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
 		74388F4622CFFA8B001C5EC0 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */; };
 		74388F4722CFFAB6001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
@@ -479,6 +480,7 @@
 		467D9C7F1788D47500785EF3 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		46A3C9D717DFA81A002865AE /* Simplenote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Simplenote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		46A3C9DC17DFA866002865AE /* Simplenote-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Simplenote-Info.plist"; sourceTree = "<group>"; };
+		4A4A4BC725593FC400876C29 /* Snackbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snackbar.swift; sourceTree = "<group>"; };
 		593EA1C08A9F76E3833C3E80 /* Pods-SimplenoteTests.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		697B9622931545E466B5E186 /* Pods-Automattic-SimplenoteShare.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		6AE4CF60906DA6D08F64E5B3 /* Pods-Automattic-Simplenote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.release.xcconfig"; sourceTree = "<group>"; };
@@ -1693,6 +1695,7 @@
 				E29ADD4A17848E8500E55842 /* SPAppDelegate.h */,
 				E29ADD4B17848E8500E55842 /* SPAppDelegate.m */,
 				B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */,
+				4A4A4BC725593FC400876C29 /* Snackbar.swift */,
 			);
 			path = Simplenote;
 			sourceTree = "<group>";
@@ -2422,6 +2425,7 @@
 				B575736C232D454300443C2E /* UIColor+Helpers.swift in Sources */,
 				37E55A6721BF2B1800F14241 /* SPTextAttachment.swift in Sources */,
 				A69F850F253EC2B2005140F2 /* SPCardConfigurable.swift in Sources */,
+				4A4A4BC825593FC400876C29 /* Snackbar.swift in Sources */,
 				B5BE05541AB75C3B002417BF /* Settings.m in Sources */,
 				B58039862322D4F90083C916 /* UIView+ImageRepresentation.swift in Sources */,
 				46A3C9AD17DFA81A002865AE /* VSThemeLoader.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		46A3C9C317DFA81A002865AE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E29ADD4D17848E8500E55842 /* Images.xcassets */; };
 		46A3C9C417DFA81A002865AE /* Simplenote-DB5.plist in Resources */ = {isa = PBXBuildFile; fileRef = E2FCA5F21789118A00FC229D /* Simplenote-DB5.plist */; };
 		4A4A4BC825593FC400876C29 /* Snackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A4BC725593FC400876C29 /* Snackbar.swift */; };
+		4A4A4BD02559541100876C29 /* SnackbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A4BCF2559541100876C29 /* SnackbarViewController.swift */; };
+		4A4A4BD82559545400876C29 /* SnackbarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A4A4BD72559545400876C29 /* SnackbarView.xib */; };
 		74388F4422CFFA30001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
 		74388F4622CFFA8B001C5EC0 /* NSObject+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4522CFFA8B001C5EC0 /* NSObject+Helpers.swift */; };
 		74388F4722CFFAB6001C5EC0 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74388F4322CFFA30001C5EC0 /* UIViewController+Helpers.swift */; };
@@ -481,6 +483,8 @@
 		46A3C9D717DFA81A002865AE /* Simplenote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Simplenote.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		46A3C9DC17DFA866002865AE /* Simplenote-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Simplenote-Info.plist"; sourceTree = "<group>"; };
 		4A4A4BC725593FC400876C29 /* Snackbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snackbar.swift; sourceTree = "<group>"; };
+		4A4A4BCF2559541100876C29 /* SnackbarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnackbarViewController.swift; sourceTree = "<group>"; };
+		4A4A4BD72559545400876C29 /* SnackbarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SnackbarView.xib; sourceTree = "<group>"; };
 		593EA1C08A9F76E3833C3E80 /* Pods-SimplenoteTests.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		697B9622931545E466B5E186 /* Pods-Automattic-SimplenoteShare.distribution internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution internal.xcconfig"; sourceTree = "<group>"; };
 		6AE4CF60906DA6D08F64E5B3 /* Pods-Automattic-Simplenote.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.release.xcconfig"; sourceTree = "<group>"; };
@@ -1696,6 +1700,8 @@
 				E29ADD4B17848E8500E55842 /* SPAppDelegate.m */,
 				B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */,
 				4A4A4BC725593FC400876C29 /* Snackbar.swift */,
+				4A4A4BCF2559541100876C29 /* SnackbarViewController.swift */,
+				4A4A4BD72559545400876C29 /* SnackbarView.xib */,
 			);
 			path = Simplenote;
 			sourceTree = "<group>";
@@ -2022,6 +2028,7 @@
 				B56A695822F9CD1500B90398 /* SPOnboardingViewController.xib in Resources */,
 				A6C0589524AD2B8F006BC572 /* SPNoteHistoryViewController.xib in Resources */,
 				B5EB1EFE1C205A800080A1B3 /* Icons.xcassets in Resources */,
+				4A4A4BD82559545400876C29 /* SnackbarView.xib in Resources */,
 				B53929492398642800ACEE00 /* SPRatingsPromptView.xib in Resources */,
 				B537732B252E176C00BC78C5 /* OptionsViewController.xib in Resources */,
 				B56A696222F9D53400B90398 /* SPAuthViewController.xib in Resources */,
@@ -2264,6 +2271,7 @@
 				B5476BB223D88F49000E7723 /* SPTagTableViewCell.swift in Sources */,
 				B52AC186233587F8007B2E75 /* UITraitCollection+Simplenote.swift in Sources */,
 				B56A696922F9D57200B90398 /* NSMutableAttributedString+Simplenote.swift in Sources */,
+				4A4A4BD02559541100876C29 /* SnackbarViewController.swift in Sources */,
 				B535F2E72399BFB600C1DDCA /* SPRatingsPromptView.swift in Sources */,
 				B5D982D222F8644000C37C29 /* SPSquaredButton.swift in Sources */,
 				A6E1E7A824BE656D008A44BC /* SPCardView.swift in Sources */,

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -319,6 +319,12 @@ extension SPNoteEditorViewController {
     ///
     @objc
     func presentInformationController(for note: Note, from barButtonItem: UIBarButtonItem) {
+		
+		let snackbar = Snackbar(message: "Some message")
+		print(snackbar)
+		snackbar.show()
+		return
+		
         let informationViewController = NoteInformationViewController(note: note)
 
         let presentAsPopover = UIDevice.sp_isPad() && traitCollection.horizontalSizeClass == .regular

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -320,15 +320,6 @@ extension SPNoteEditorViewController {
     @objc
     func presentInformationController(for note: Note, from barButtonItem: UIBarButtonItem) {
 
-        let snackbar = Snackbar(message: "Hello!", actionTitle: "Do it!") {
-            print("Callback code executed!")
-        }
-        
-//        let snackbar = Snackbar(message: "Yoyo!")
-        print(snackbar)
-        snackbar.show()
-        return
-
         let informationViewController = NoteInformationViewController(note: note)
 
         let presentAsPopover = UIDevice.sp_isPad() && traitCollection.horizontalSizeClass == .regular
@@ -538,6 +529,10 @@ extension SPNoteEditorViewController {
 
     @IBAction
     func noteOptionsWasPressed(_ sender: UIBarButtonItem) {
+        
+        displaySnackbarWithAction()
+        return
+        
         guard let note = currentNote else {
             assertionFailure()
             return
@@ -548,12 +543,30 @@ extension SPNoteEditorViewController {
 
     @objc
     private func noteInformationWasPressed(_ sender: UIBarButtonItem) {
+        
+        displaySnackbar()
+        return
+        
         guard let note = currentNote else {
             assertionFailure()
             return
         }
 
         presentInformationController(for: note, from: sender)
+    }
+    
+    func displaySnackbar() {
+        
+        let snackbar = Snackbar(message: "Simple snackbar")
+        snackbar.show()
+    }
+    
+    func displaySnackbarWithAction() {
+        
+        let snackbar = Snackbar(message: "Snackbar with action!", actionTitle: "Boom!") {
+            print("Callback code executed!")
+        }
+        snackbar.show()
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -320,7 +320,11 @@ extension SPNoteEditorViewController {
     @objc
     func presentInformationController(for note: Note, from barButtonItem: UIBarButtonItem) {
 
-        let snackbar = Snackbar(message: "Some message")
+        let snackbar = Snackbar(message: "Hello!", actionTitle: "Do it!") {
+            print("Callback code executed!")
+        }
+        
+//        let snackbar = Snackbar(message: "Yoyo!")
         print(snackbar)
         snackbar.show()
         return

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -319,12 +319,12 @@ extension SPNoteEditorViewController {
     ///
     @objc
     func presentInformationController(for note: Note, from barButtonItem: UIBarButtonItem) {
-		
-		let snackbar = Snackbar(message: "Some message")
-		print(snackbar)
-		snackbar.show()
-		return
-		
+
+        let snackbar = Snackbar(message: "Some message")
+        print(snackbar)
+        snackbar.show()
+        return
+
         let informationViewController = NoteInformationViewController(note: note)
 
         let presentAsPopover = UIDevice.sp_isPad() && traitCollection.horizontalSizeClass == .regular

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -10,9 +10,9 @@ import Foundation
 
 class Snackbar {
     
-    private var message: String
+    fileprivate let message: String
     
-    init(message: String = "Test message") {
+    init(message: String) {
         self.message = message
     }
     
@@ -81,13 +81,14 @@ class SnackbarPresenter {
     private func prepareViewFromXIB() -> UIView {
         
         let vc = SnackbarViewController()
-        let view = vc.view!
         
+        let view = vc.view!
         let frame = view.frame
         let newFrame = CGRect(x: 0, y: 0, width: frame.width - 30, height: frame.height)
         vc.view.frame = newFrame
         
         viewController = vc
+        vc.messageLabel.text = snackbar?.message
         
         return view
     }

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -112,19 +112,43 @@ class SnackbarPresenter {
 			view.center.y = view.center.y - offset - viewHeight
 		}) { _ in
 			print("Animation complete.")
+			
+			// Using the delay param results in the UIButton not receiving inputs.
+			// Using the asyncAfter allows the button to work correctly.
+			
+//			self.removeView(view)
+			self.removeViewAsync(view)
+		}
+	}
+	
+	func removeView(_ view: UIView) {
+		
+		// Results in action button not working.
+		UIView.animate(withDuration: 0.66, delay: 2.4, options: []) {
+			view.alpha = 0
+		} completion: { (Bool) in
+			view.removeFromSuperview()
+			print("Done fade.")
 
-			DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-				print("Hiding snackbar")
+			self.snackbar = nil
+			self.viewController = nil
+		}
+	}
+	
+	func removeViewAsync(_ view: UIView) {
+		
+		// Allows action button to accept inputs.
+		DispatchQueue.main.asyncAfter(deadline: .now() + 2.4) {
+			print("Hiding snackbar")
 
-				UIView.animate(withDuration: 0.66, delay: 0.0, options: []) {
-					view.alpha = 0
-				} completion: { (Bool) in
-					view.removeFromSuperview()
-					print("Done fade.")
-					
-					self.snackbar = nil
-					self.viewController = nil
-				}
+			UIView.animate(withDuration: 0.66, delay: 0.0, options: []) {
+				view.alpha = 0
+			} completion: { (Bool) in
+				view.removeFromSuperview()
+				print("Done fade.")
+
+				self.snackbar = nil
+				self.viewController = nil
 			}
 		}
 	}

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -12,8 +12,6 @@ class Snackbar {
 	
 	var message: String
 	
-	static var presenter = SnackbarPresenter()
-	
 	init(message: String = "Test message") {
 		self.message = message
 	}
@@ -24,14 +22,19 @@ class Snackbar {
 	
 	func show() {
 		print("Displaying snackbar")
-		Snackbar.presenter.present(self)
+		SnackbarPresenter.shared.present(self)
 	}
 }
 
 class SnackbarPresenter {
 	
+	static let shared = SnackbarPresenter()
+	
 	var snackbar: Snackbar?
 	var viewController: SnackbarViewController?
+	
+	// Prevent use outside the shared instance.
+	private init() {}
 	
 	deinit {
 		print("SnackbarPresenter deinit")

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -9,147 +9,147 @@
 import Foundation
 
 class Snackbar {
-	
-	private var message: String
-	
-	init(message: String = "Test message") {
-		self.message = message
-	}
-	
-	deinit {
-		print("Snackbar deinit")
-	}
-	
-	func show() {
-		print("Displaying snackbar")
-		SnackbarPresenter.shared.present(self)
-	}
+    
+    private var message: String
+    
+    init(message: String = "Test message") {
+        self.message = message
+    }
+    
+    deinit {
+        print("Snackbar deinit")
+    }
+    
+    func show() {
+        print("Displaying snackbar")
+        SnackbarPresenter.shared.present(self)
+    }
 }
 
-class SnackbarPresenter {
-	
-	static let shared = SnackbarPresenter()
-	
-	private var snackbar: Snackbar?
-	private var viewController: SnackbarViewController?
-	
-	// Prevent use outside the shared instance.
-	private init() {}
-	
-	deinit {
-		print("SnackbarPresenter deinit")
-		// Should never happen
-	}
-	
-	func present(_ sender: Snackbar) {
-		guard snackbar == nil else {
-			print("Already presenting. Please wait.")
-			return
-		}
-		
-		snackbar = sender
-		
-//		let snackView = prepareView()
-		let snackView = prepareViewFromXIB()
-		presentView(snackView)
-		
-		// Puts the view onscreen and returns.
-	}
-	
-	private func prepareView() -> UIView {
-		
-		// Prep a test view for display.
-		// Limit to 80% of the host window.
-		
-		let window = UIApplication.shared.keyWindow!
-		let width: CGFloat = window.frame.size.width * 0.8
-		let height: CGFloat = 60 // Should come from text size?
-		
-		let rect = CGRect(x: 0, y: 0, width: width, height: height)
-		let view = UIView(frame: rect)
-		view.backgroundColor = .lightGray
-		view.layer.cornerRadius = rect.height / 2
-		
-		return view
-	}
-	
-	private func prepareViewFromXIB() -> UIView {
-		
-		let vc = SnackbarViewController()
-		let view = vc.view!
-		
-		let frame = view.frame
-		let newFrame = CGRect(x: 0, y: 0, width: frame.width - 30, height: frame.height)
-		vc.view.frame = newFrame
-		
-		viewController = vc
-		
-		return view
-	}
+    class SnackbarPresenter {
 
-	private func presentView(_ view: UIView) {
-		
-		// Determine where the view goes in the host window.
-		
-		let window = UIApplication.shared.keyWindow!
-		
-		window.addSubview(view)
-		
-		// View center should be window width / 2 and window height - offset - (view height / 2)
-		
-		let viewHeight = view.frame.height
-		let offset: CGFloat = 50 // Magic number alert!
-		view.center.x = window.frame.size.width / 2
-		view.center.y = window.frame.size.height - offset - (viewHeight / 2.0) // Half the view height + the gap from view to screen edge.
-		print(view.center)
-		print(window.frame.height)
-		
-		// Now push the view down offscreen.
-		view.center.y = view.center.y + offset + viewHeight
-		print(view.center.y)
-		
-		UIView.animate(withDuration: 0.2, delay: 0.0, options: [], animations: {
-			view.center.y = view.center.y - offset - viewHeight
-		}) { _ in
-			print("Animation complete.")
-			
-			// Using the delay param results in the UIButton not receiving inputs.
-			// Using the asyncAfter allows the button to work correctly.
-			
-//			self.removeView(view)
-			self.removeViewAsync(view)
-		}
-	}
+    static let shared = SnackbarPresenter()
+
+    private var snackbar: Snackbar?
+    private var viewController: SnackbarViewController?
+
+    // Prevent use outside the shared instance.
+    private init() {}
+
+    deinit {
+        print("SnackbarPresenter deinit")
+        // Should never happen
+    }
+
+    func present(_ sender: Snackbar) {
+        guard snackbar == nil else {
+            print("Already presenting. Please wait.")
+            return
+        }
+        
+        snackbar = sender
+        
+    //		let snackView = prepareView()
+        let snackView = prepareViewFromXIB()
+        presentView(snackView)
+        
+        // Puts the view onscreen and returns.
+    }
+
+    private func prepareView() -> UIView {
+        
+        // Prep a test view for display.
+        // Limit to 80% of the host window.
+        
+        let window = UIApplication.shared.keyWindow!
+        let width: CGFloat = window.frame.size.width * 0.8
+        let height: CGFloat = 60 // Should come from text size?
+        
+        let rect = CGRect(x: 0, y: 0, width: width, height: height)
+        let view = UIView(frame: rect)
+        view.backgroundColor = .lightGray
+        view.layer.cornerRadius = rect.height / 2
+        
+        return view
+    }
+
+    private func prepareViewFromXIB() -> UIView {
+        
+        let vc = SnackbarViewController()
+        let view = vc.view!
+        
+        let frame = view.frame
+        let newFrame = CGRect(x: 0, y: 0, width: frame.width - 30, height: frame.height)
+        vc.view.frame = newFrame
+        
+        viewController = vc
+        
+        return view
+    }
+
+    private func presentView(_ view: UIView) {
+        
+        // Determine where the view goes in the host window.
+        
+        let window = UIApplication.shared.keyWindow!
+        
+        window.addSubview(view)
+        
+        // View center should be window width / 2 and window height - offset - (view height / 2)
+        
+        let viewHeight = view.frame.height
+        let offset: CGFloat = 50 // Magic number alert!
+        view.center.x = window.frame.size.width / 2
+        view.center.y = window.frame.size.height - offset - (viewHeight / 2.0) // Half the view height + the gap from view to screen edge.
+        print(view.center)
+        print(window.frame.height)
+        
+        // Now push the view down offscreen.
+        view.center.y = view.center.y + offset + viewHeight
+        print(view.center.y)
+        
+        UIView.animate(withDuration: 0.2, delay: 0.0, options: [], animations: {
+            view.center.y = view.center.y - offset - viewHeight
+        }) { _ in
+            print("Animation complete.")
+            
+            // Using the delay param results in the UIButton not receiving inputs.
+            // Using the asyncAfter allows the button to work correctly.
+            
+    //			self.removeView(view)
+            self.removeViewAsync(view)
+        }
+    }
+
+    private func removeView(_ view: UIView) {
+        
+        // Results in action button not working.
+        UIView.animate(withDuration: 0.66, delay: 2.4, options: []) {
+            view.alpha = 0
+        } completion: { (Bool) in
+            view.removeFromSuperview()
+            print("Done fade.")
+
+            self.snackbar = nil
+            self.viewController = nil
+        }
+    }
 	
-	private func removeView(_ view: UIView) {
-		
-		// Results in action button not working.
-		UIView.animate(withDuration: 0.66, delay: 2.4, options: []) {
-			view.alpha = 0
-		} completion: { (Bool) in
-			view.removeFromSuperview()
-			print("Done fade.")
+    private func removeViewAsync(_ view: UIView) {
+        
+        // Allows action button to accept inputs.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.4) {
+            print("Hiding snackbar")
 
-			self.snackbar = nil
-			self.viewController = nil
-		}
-	}
-	
-	private func removeViewAsync(_ view: UIView) {
-		
-		// Allows action button to accept inputs.
-		DispatchQueue.main.asyncAfter(deadline: .now() + 2.4) {
-			print("Hiding snackbar")
+            UIView.animate(withDuration: 0.66, delay: 0.0, options: []) {
+                view.alpha = 0
+            } completion: { (Bool) in
+                view.removeFromSuperview()
+                print("Done fade.")
 
-			UIView.animate(withDuration: 0.66, delay: 0.0, options: []) {
-				view.alpha = 0
-			} completion: { (Bool) in
-				view.removeFromSuperview()
-				print("Done fade.")
-
-				self.snackbar = nil
-				self.viewController = nil
-			}
-		}
-	}
+                self.snackbar = nil
+                self.viewController = nil
+            }
+        }
+    }
 }

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -45,9 +45,51 @@ class SnackbarPresenter {
 		
 		snackbar = sender
 		
+		let snackView = prepareView()
+		positionView(snackView)
+		
 		DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
 			print("Hiding snackbar")
+			
+			snackView.removeFromSuperview()
 			self.snackbar = nil
 		}
+	}
+	
+	func prepareView() -> UIView {
+		
+		// Prep a test view for display.
+		// Limit to 80% of the host window.
+		
+		let window = UIApplication.shared.keyWindow!
+		let width: CGFloat = window.frame.size.width * 0.8
+		let height: CGFloat = 60 // Should come from text size?
+		
+		let rect = CGRect(x: 0, y: 0, width: width, height: height)
+		let view = UIView(frame: rect)
+		view.backgroundColor = .lightGray
+		view.layer.cornerRadius = rect.height / 2
+		
+		return view
+	}
+	
+	func positionView(_ view: UIView) {
+		
+		// Determine where the view goes in the host window.
+		
+		let window = UIApplication.shared.keyWindow!
+		
+		window.addSubview(view)
+		
+		// View center should be window width / 2 and window height - offset - (view height / 2)
+		
+		let offset: CGFloat = 70 // Magic number alert!
+		let viewHeight = view.frame.height
+		view.center.x = window.frame.size.width / 2
+		view.center.y = window.frame.size.height - offset - (viewHeight / 2.0)
+		print(view.center)
+		
+		// Now push the view down offscreen.
+//		view.center.y = view.center.y + offset + (viewHeight / 2.0)
 	}
 }

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -46,14 +46,9 @@ class SnackbarPresenter {
 		snackbar = sender
 		
 		let snackView = prepareView()
-		positionView(snackView)
+		presentView(snackView)
 		
-		DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-			print("Hiding snackbar")
-			
-			snackView.removeFromSuperview()
-			self.snackbar = nil
-		}
+		// Puts the view onscreen and returns.
 	}
 	
 	func prepareView() -> UIView {
@@ -73,7 +68,7 @@ class SnackbarPresenter {
 		return view
 	}
 	
-	func positionView(_ view: UIView) {
+	func presentView(_ view: UIView) {
 		
 		// Determine where the view goes in the host window.
 		
@@ -83,13 +78,34 @@ class SnackbarPresenter {
 		
 		// View center should be window width / 2 and window height - offset - (view height / 2)
 		
-		let offset: CGFloat = 70 // Magic number alert!
 		let viewHeight = view.frame.height
+		let offset: CGFloat = 50 // Magic number alert!
 		view.center.x = window.frame.size.width / 2
-		view.center.y = window.frame.size.height - offset - (viewHeight / 2.0)
+		view.center.y = window.frame.size.height - offset - (viewHeight / 2.0) // Half the view height + the gap from view to screen edge.
 		print(view.center)
+		print(window.frame.height)
 		
 		// Now push the view down offscreen.
-//		view.center.y = view.center.y + offset + (viewHeight / 2.0)
+		view.center.y = view.center.y + offset + viewHeight
+		print(view.center.y)
+		
+		UIView.animate(withDuration: 0.2, delay: 0.0, options: [], animations: {
+			view.center.y = view.center.y - offset - viewHeight
+		}) { _ in
+			print("Animation complete.")
+
+			DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+				print("Hiding snackbar")
+
+				UIView.animate(withDuration: 0.66, delay: 0.0, options: []) {
+					view.alpha = 0
+				} completion: { (Bool) in
+					view.removeFromSuperview()
+					print("Done fade.")
+					
+					self.snackbar = nil
+				}
+			}
+		}
 	}
 }

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -26,13 +26,18 @@ class Snackbar {
     }
 }
 
-    class SnackbarPresenter {
+class SnackbarPresenter {
 
     static let shared = SnackbarPresenter()
 
     private var snackbar: Snackbar?
     private var viewController: SnackbarViewController?
 
+    // TODO: Switch to UIKitConstants here.
+    /// Only in use during testing so we have extra time to play with the action button.
+    /// Should use UIKitConstants.animationLongDuration.
+    private let animationDurationLongTest = TimeInterval(2.4)
+    
     // Prevent use outside the shared instance.
     private init() {}
 
@@ -108,7 +113,7 @@ class Snackbar {
         view.center.y = view.center.y + offset + viewHeight
         print(view.center.y)
         
-        UIView.animate(withDuration: 0.2, delay: 0.0, options: [], animations: {
+        UIView.animate(withDuration: UIKitConstants.animationShortDuration, delay: UIKitConstants.animationDelayZero, options: [], animations: {
             view.center.y = view.center.y - offset - viewHeight
         }) { _ in
             print("Animation complete.")
@@ -124,8 +129,8 @@ class Snackbar {
     private func removeView(_ view: UIView) {
         
         // Results in action button not working.
-        UIView.animate(withDuration: 0.66, delay: 2.4, options: []) {
-            view.alpha = 0
+        UIView.animate(withDuration: UIKitConstants.animationLongDuration, delay: animationDurationLongTest, options: []) {
+            view.alpha = UIKitConstants.alpha0_0
         } completion: { (Bool) in
             view.removeFromSuperview()
             print("Done fade.")
@@ -137,12 +142,12 @@ class Snackbar {
 	
     private func removeViewAsync(_ view: UIView) {
         
-        // Allows action button to accept inputs.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.4) {
+        /// Allows action button to accept inputs.
+        DispatchQueue.main.asyncAfter(deadline: .now() + animationDurationLongTest) {
             print("Hiding snackbar")
 
-            UIView.animate(withDuration: 0.66, delay: 0.0, options: []) {
-                view.alpha = 0
+            UIView.animate(withDuration: UIKitConstants.animationLongDuration, delay: UIKitConstants.animationDelayZero, options: []) {
+                view.alpha = UIKitConstants.alpha0_0
             } completion: { (Bool) in
                 view.removeFromSuperview()
                 print("Done fade.")

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -1,0 +1,53 @@
+//
+//  Snackbar.swift
+//  Simplenote
+//
+//  Created by Kevin LaCoste on 2020-11-09.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import Foundation
+
+class Snackbar {
+	
+	var message: String
+	
+	static var presenter = SnackbarPresenter()
+	
+	init(message: String = "Test message") {
+		self.message = message
+	}
+	
+	deinit {
+		print("Snackbar deinit")
+	}
+	
+	func show() {
+		print("Displaying snackbar")
+		Snackbar.presenter.present(self)
+	}
+}
+
+class SnackbarPresenter {
+	
+	var snackbar: Snackbar?
+	
+	deinit {
+		print("SnackbarPresenter deinit")
+		// Should never happen
+	}
+	
+	func present(_ sender: Snackbar) {
+		guard snackbar == nil else {
+			print("Already presenting. Please wait.")
+			return
+		}
+		
+		snackbar = sender
+		
+		DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+			print("Hiding snackbar")
+			self.snackbar = nil
+		}
+	}
+}

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -3,9 +3,19 @@ import Foundation
 class Snackbar {
     
     fileprivate let message: String
+    fileprivate let actionTitle: String?
+    fileprivate let actionCompletion: (() -> Void)?
     
     init(message: String) {
         self.message = message
+        self.actionTitle = nil
+        self.actionCompletion = nil
+    }
+    
+    init(message: String, actionTitle: String, actionCompletion: @escaping () -> Void) {
+        self.message = message
+        self.actionTitle = actionTitle
+        self.actionCompletion = actionCompletion
     }
     
     deinit {
@@ -47,6 +57,7 @@ class SnackbarPresenter: SnackbarViewControllerDelegate {
         }
         
         snackbar = sender
+        wasActionTapped = false
         
 //        let snackView = prepareView()
         let snackView = prepareViewFromXIB()
@@ -146,7 +157,11 @@ class SnackbarPresenter: SnackbarViewControllerDelegate {
         } completion: { (Bool) in
             view.removeFromSuperview()
             print("Done fade.")
-
+            
+            if self.wasActionTapped, let completion = self.snackbar?.actionCompletion {
+                completion()
+            }
+            
             self.snackbar = nil
             self.viewController = nil
         }

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -31,6 +31,7 @@ class Snackbar {
 class SnackbarPresenter {
 	
 	var snackbar: Snackbar?
+	var viewController: SnackbarViewController?
 	
 	deinit {
 		print("SnackbarPresenter deinit")
@@ -45,7 +46,8 @@ class SnackbarPresenter {
 		
 		snackbar = sender
 		
-		let snackView = prepareView()
+//		let snackView = prepareView()
+		let snackView = prepareViewFromXIB()
 		presentView(snackView)
 		
 		// Puts the view onscreen and returns.
@@ -68,6 +70,20 @@ class SnackbarPresenter {
 		return view
 	}
 	
+	func prepareViewFromXIB() -> UIView {
+		
+		let vc = SnackbarViewController()
+		let view = vc.view!
+		
+		let frame = view.frame
+		let newFrame = CGRect(x: 0, y: 0, width: frame.width - 30, height: frame.height)
+		vc.view.frame = newFrame
+		
+		viewController = vc
+		
+		return view
+	}
+
 	func presentView(_ view: UIView) {
 		
 		// Determine where the view goes in the host window.
@@ -104,6 +120,7 @@ class SnackbarPresenter {
 					print("Done fade.")
 					
 					self.snackbar = nil
+					self.viewController = nil
 				}
 			}
 		}

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -1,11 +1,3 @@
-//
-//  Snackbar.swift
-//  Simplenote
-//
-//  Created by Kevin LaCoste on 2020-11-09.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
-
 import Foundation
 
 class Snackbar {

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -31,16 +31,14 @@ class Snackbar {
 class SnackbarPresenter: SnackbarViewControllerDelegate {
     
     static let shared = SnackbarPresenter()
+    
+    private let DurationShort = 1.5
+    private let DurationLong = 2.75
 
     private var snackbar: Snackbar?
     private var viewController: SnackbarViewController?
     
     private var wasActionTapped = false
-
-    // TODO: Switch to UIKitConstants here.
-    /// Only in use during testing so we have extra time to play with the action button.
-    /// Should use UIKitConstants.animationLongDuration.
-    private let animationDurationLongTest = TimeInterval(2.4)
     
     // Prevent use outside the shared instance.
     private init() {}
@@ -147,7 +145,10 @@ class SnackbarPresenter: SnackbarViewControllerDelegate {
     private func removeViewAfterTimeout(_ view: UIView) {
         print("Starting countdown to fade...")
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + animationDurationLongTest) {
+        let duration = (snackbar?.actionTitle != nil) ? DurationLong : DurationShort
+        print(duration)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
             if !self.wasActionTapped {
                 print("Hiding snackbar after timeout...")
                 self.removeViewNow(view)

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -86,15 +86,21 @@ class SnackbarPresenter: SnackbarViewControllerDelegate {
     private func prepareViewFromXIB() -> UIView {
         
         let vc = SnackbarViewController()
-        vc.delegate = self
         
         let view = vc.view!
         let frame = view.frame
         let newFrame = CGRect(x: 0, y: 0, width: frame.width - 30, height: frame.height)
         vc.view.frame = newFrame
         
+        let snack = snackbar!
+        vc.configureMessageLabel(message: snack.message)
+        
+        if let title = snack.actionTitle {
+            vc.configureActionButton(title: title)
+            vc.delegate = self
+        }
+        
         viewController = vc
-        vc.messageLabel.text = snackbar?.message
         
         return view
     }

--- a/Simplenote/Snackbar.swift
+++ b/Simplenote/Snackbar.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class Snackbar {
 	
-	var message: String
+	private var message: String
 	
 	init(message: String = "Test message") {
 		self.message = message
@@ -30,8 +30,8 @@ class SnackbarPresenter {
 	
 	static let shared = SnackbarPresenter()
 	
-	var snackbar: Snackbar?
-	var viewController: SnackbarViewController?
+	private var snackbar: Snackbar?
+	private var viewController: SnackbarViewController?
 	
 	// Prevent use outside the shared instance.
 	private init() {}
@@ -56,7 +56,7 @@ class SnackbarPresenter {
 		// Puts the view onscreen and returns.
 	}
 	
-	func prepareView() -> UIView {
+	private func prepareView() -> UIView {
 		
 		// Prep a test view for display.
 		// Limit to 80% of the host window.
@@ -73,7 +73,7 @@ class SnackbarPresenter {
 		return view
 	}
 	
-	func prepareViewFromXIB() -> UIView {
+	private func prepareViewFromXIB() -> UIView {
 		
 		let vc = SnackbarViewController()
 		let view = vc.view!
@@ -87,7 +87,7 @@ class SnackbarPresenter {
 		return view
 	}
 
-	func presentView(_ view: UIView) {
+	private func presentView(_ view: UIView) {
 		
 		// Determine where the view goes in the host window.
 		
@@ -121,7 +121,7 @@ class SnackbarPresenter {
 		}
 	}
 	
-	func removeView(_ view: UIView) {
+	private func removeView(_ view: UIView) {
 		
 		// Results in action button not working.
 		UIView.animate(withDuration: 0.66, delay: 2.4, options: []) {
@@ -135,7 +135,7 @@ class SnackbarPresenter {
 		}
 	}
 	
-	func removeViewAsync(_ view: UIView) {
+	private func removeViewAsync(_ view: UIView) {
 		
 		// Allows action button to accept inputs.
 		DispatchQueue.main.asyncAfter(deadline: .now() + 2.4) {

--- a/Simplenote/SnackbarView.xib
+++ b/Simplenote/SnackbarView.xib
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SnackbarViewController" customModule="Simplenote" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="fBD-vH-rjc"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="374" height="70"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qbw-cJ-GD8">
+                    <rect key="frame" x="10" y="10" width="354" height="50"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="Qbw-cJ-GD8" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="9uG-xT-hAm"/>
+                <constraint firstAttribute="bottom" secondItem="Qbw-cJ-GD8" secondAttribute="bottom" constant="10" id="KHl-V1-8LP"/>
+                <constraint firstItem="Qbw-cJ-GD8" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="10" id="gBY-Cp-m7M"/>
+                <constraint firstAttribute="trailing" secondItem="Qbw-cJ-GD8" secondAttribute="trailing" constant="10" id="qb9-BD-86n"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="108.69565217391305" y="143.97321428571428"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Simplenote/SnackbarView.xib
+++ b/Simplenote/SnackbarView.xib
@@ -29,7 +29,7 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" pointerInteraction="YES" id="ONv-6m-bm2">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="ONv-6m-bm2">
                             <rect key="frame" x="224.5" y="0.0" width="149.5" height="70"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>

--- a/Simplenote/SnackbarView.xib
+++ b/Simplenote/SnackbarView.xib
@@ -10,6 +10,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SnackbarViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
+                <outlet property="actionButton" destination="ONv-6m-bm2" id="MBQ-cv-BdN"/>
+                <outlet property="messageLabel" destination="80l-s1-xzf" id="j6V-9h-E90"/>
                 <outlet property="view" destination="iN0-l3-epB" id="fBD-vH-rjc"/>
             </connections>
         </placeholder>
@@ -18,19 +20,33 @@
             <rect key="frame" x="0.0" y="0.0" width="374" height="70"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qbw-cJ-GD8">
-                    <rect key="frame" x="10" y="10" width="354" height="50"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="z6P-d2-fN8">
+                    <rect key="frame" x="0.0" y="0.0" width="374" height="70"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Some message" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="80l-s1-xzf">
+                            <rect key="frame" x="0.0" y="0.0" width="224.5" height="70"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" pointerInteraction="YES" id="ONv-6m-bm2">
+                            <rect key="frame" x="224.5" y="0.0" width="149.5" height="70"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                            <state key="normal" title="Action title"/>
+                            <connections>
+                                <action selector="actionButtonTapped:" destination="-1" eventType="touchUpInside" id="goo-o8-clU"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                </stackView>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="Qbw-cJ-GD8" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="9uG-xT-hAm"/>
-                <constraint firstAttribute="bottom" secondItem="Qbw-cJ-GD8" secondAttribute="bottom" constant="10" id="KHl-V1-8LP"/>
-                <constraint firstItem="Qbw-cJ-GD8" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="10" id="gBY-Cp-m7M"/>
-                <constraint firstAttribute="trailing" secondItem="Qbw-cJ-GD8" secondAttribute="trailing" constant="10" id="qb9-BD-86n"/>
+                <constraint firstAttribute="bottom" secondItem="z6P-d2-fN8" secondAttribute="bottom" id="Jdu-au-5eF"/>
+                <constraint firstItem="z6P-d2-fN8" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="RPe-8N-R2Y"/>
+                <constraint firstItem="z6P-d2-fN8" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="jOl-ob-6Ex"/>
+                <constraint firstAttribute="trailing" secondItem="z6P-d2-fN8" secondAttribute="trailing" id="jsr-th-rze"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>

--- a/Simplenote/SnackbarView.xib
+++ b/Simplenote/SnackbarView.xib
@@ -4,15 +4,19 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SnackbarViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
-                <outlet property="actionButton" destination="ONv-6m-bm2" id="MBQ-cv-BdN"/>
-                <outlet property="messageLabel" destination="80l-s1-xzf" id="j6V-9h-E90"/>
-                <outlet property="view" destination="iN0-l3-epB" id="fBD-vH-rjc"/>
+                <outlet property="actionButton" destination="p4z-Wa-YOi" id="zA2-Mx-hQD"/>
+                <outlet property="activeMessageLabel" destination="u1z-wp-wCn" id="vsD-Ju-ney"/>
+                <outlet property="activeSnackView" destination="3MS-fc-fpW" id="pRj-lz-GHJ"/>
+                <outlet property="simpleMessageLabel" destination="Kqd-h0-whe" id="efd-hf-Sq8"/>
+                <outlet property="simpleSnackView" destination="63y-ri-B8D" id="mUk-Xu-NOH"/>
+                <outlet property="view" destination="2Ss-HJ-A54" id="p8B-3A-l6o"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -53,10 +57,115 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="108.69565217391305" y="143.97321428571428"/>
         </view>
+        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="2Ss-HJ-A54">
+            <rect key="frame" x="0.0" y="0.0" width="344" height="278"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3MS-fc-fpW">
+                    <rect key="frame" x="57" y="64" width="230" height="52.5"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p4z-Wa-YOi">
+                            <rect key="frame" x="153" y="11" width="49" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="3LF-vp-HIU"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                            <state key="normal" title="Button"/>
+                            <connections>
+                                <action selector="actionButtonTapped:" destination="-1" eventType="touchUpInside" id="TbZ-La-JjO"/>
+                            </connections>
+                        </button>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Some message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u1z-wp-wCn">
+                            <rect key="frame" x="28" y="16" width="117" height="20.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                    <constraints>
+                        <constraint firstItem="u1z-wp-wCn" firstAttribute="top" secondItem="3MS-fc-fpW" secondAttribute="top" constant="16" id="ClR-cf-6ms"/>
+                        <constraint firstItem="u1z-wp-wCn" firstAttribute="leading" secondItem="3MS-fc-fpW" secondAttribute="leading" constant="28" id="Gnm-pf-702"/>
+                        <constraint firstAttribute="bottom" secondItem="u1z-wp-wCn" secondAttribute="bottom" constant="16" id="I4u-T6-pGg"/>
+                        <constraint firstItem="p4z-Wa-YOi" firstAttribute="leading" secondItem="u1z-wp-wCn" secondAttribute="trailing" constant="8" symbolic="YES" id="Jji-TS-xfo"/>
+                        <constraint firstAttribute="trailing" secondItem="p4z-Wa-YOi" secondAttribute="trailing" constant="28" id="ZMW-9W-Z8n"/>
+                        <constraint firstItem="p4z-Wa-YOi" firstAttribute="firstBaseline" secondItem="u1z-wp-wCn" secondAttribute="firstBaseline" id="gOE-j6-rN8"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="63y-ri-B8D">
+                    <rect key="frame" x="85.5" y="178" width="173" height="52.5"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Some message" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kqd-h0-whe">
+                            <rect key="frame" x="28" y="16" width="117" height="20.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                    <constraints>
+                        <constraint firstItem="Kqd-h0-whe" firstAttribute="top" secondItem="63y-ri-B8D" secondAttribute="top" constant="16" id="F2Y-1k-Tgg"/>
+                        <constraint firstItem="Kqd-h0-whe" firstAttribute="leading" secondItem="63y-ri-B8D" secondAttribute="leading" constant="28" id="KYd-Gb-I6j"/>
+                        <constraint firstAttribute="trailing" secondItem="Kqd-h0-whe" secondAttribute="trailing" constant="28" id="dds-ru-GzA"/>
+                        <constraint firstAttribute="bottom" secondItem="Kqd-h0-whe" secondAttribute="bottom" constant="16" id="iGH-7J-Owg"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="Q7b-j8-hdR"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="3MS-fc-fpW" firstAttribute="centerX" secondItem="2Ss-HJ-A54" secondAttribute="centerX" id="SQ7-92-qPT"/>
+                <constraint firstItem="3MS-fc-fpW" firstAttribute="top" secondItem="Q7b-j8-hdR" secondAttribute="top" constant="20" id="VPi-B5-Twd"/>
+                <constraint firstItem="Q7b-j8-hdR" firstAttribute="bottom" secondItem="63y-ri-B8D" secondAttribute="bottom" constant="47.5" id="b19-0r-78u"/>
+                <constraint firstItem="63y-ri-B8D" firstAttribute="centerX" secondItem="2Ss-HJ-A54" secondAttribute="centerX" id="myR-PK-GYh"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="130.43478260869566" y="356.91964285714283"/>
+        </view>
+        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="vrz-c9-iYc">
+            <rect key="frame" x="0.0" y="0.0" width="469" height="266"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gGu-v6-ufY">
+                    <rect key="frame" x="148" y="107" width="173" height="52.5"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Some message" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgU-vv-kEX">
+                            <rect key="frame" x="28" y="16" width="117" height="20.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                    <constraints>
+                        <constraint firstItem="xgU-vv-kEX" firstAttribute="leading" secondItem="gGu-v6-ufY" secondAttribute="leading" constant="28" id="Bsj-Na-g4a"/>
+                        <constraint firstAttribute="trailing" secondItem="xgU-vv-kEX" secondAttribute="trailing" constant="28" id="Dhz-u4-T02"/>
+                        <constraint firstAttribute="bottom" secondItem="xgU-vv-kEX" secondAttribute="bottom" constant="16" id="Eui-wa-Pc0"/>
+                        <constraint firstItem="xgU-vv-kEX" firstAttribute="top" secondItem="gGu-v6-ufY" secondAttribute="top" constant="16" id="nZf-Wx-k1O"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="ghB-eU-KvL"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="gGu-v6-ufY" firstAttribute="centerX" secondItem="vrz-c9-iYc" secondAttribute="centerX" id="OSd-hJ-eRx"/>
+                <constraint firstItem="gGu-v6-ufY" firstAttribute="centerY" secondItem="vrz-c9-iYc" secondAttribute="centerY" id="Rdd-bu-Jyr"/>
+                <constraint firstItem="gGu-v6-ufY" firstAttribute="centerX" secondItem="vrz-c9-iYc" secondAttribute="centerX" id="hNu-fU-uQd"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="109" y="633"/>
+        </view>
     </objects>
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Simplenote/SnackbarViewController.swift
+++ b/Simplenote/SnackbarViewController.swift
@@ -1,0 +1,22 @@
+//
+//  SnackbarViewController.swift
+//  Simplenote
+//
+//  Created by Kevin LaCoste on 2020-11-09.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class SnackbarViewController: UIViewController {
+	
+	deinit {
+		print("VC deinit.")
+	}
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		view.layer.cornerRadius = 12
+		view.backgroundColor = .yellow
+	}
+}

--- a/Simplenote/SnackbarViewController.swift
+++ b/Simplenote/SnackbarViewController.swift
@@ -1,11 +1,3 @@
-//
-//  SnackbarViewController.swift
-//  Simplenote
-//
-//  Created by Kevin LaCoste on 2020-11-09.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
-
 import UIKit
 
 protocol SnackbarViewControllerDelegate: AnyObject {

--- a/Simplenote/SnackbarViewController.swift
+++ b/Simplenote/SnackbarViewController.swift
@@ -8,10 +8,16 @@
 
 import UIKit
 
+protocol SnackbarViewControllerDelegate: AnyObject {
+    func snackbarActionWasTapped(sender: SnackbarViewController)
+}
+
 class SnackbarViewController: UIViewController {
     
     @IBOutlet weak var messageLabel: UILabel!
     @IBOutlet weak var actionButton: UIButton!
+    
+    weak var delegate: SnackbarViewControllerDelegate?
     
     deinit {
         print("VC deinit.")
@@ -24,6 +30,7 @@ class SnackbarViewController: UIViewController {
     }
     
     @IBAction func actionButtonTapped(_ sender: UIButton) {
-        print("Button tapped!")
+        actionButton.isEnabled = false
+        delegate?.snackbarActionWasTapped(sender: self)
     }
 }

--- a/Simplenote/SnackbarViewController.swift
+++ b/Simplenote/SnackbarViewController.swift
@@ -19,6 +19,17 @@ class SnackbarViewController: UIViewController {
         super.viewDidLoad()
         view.layer.cornerRadius = 12
         view.backgroundColor = .lightGray
+        
+        actionButton.isHidden = true
+    }
+    
+    func configureActionButton(title: String) {
+        actionButton.isHidden = false
+        actionButton.setTitle(title, for: .normal)
+    }
+    
+    func configureMessageLabel(message: String) {
+        messageLabel.text = message
     }
     
     @IBAction func actionButtonTapped(_ sender: UIButton) {

--- a/Simplenote/SnackbarViewController.swift
+++ b/Simplenote/SnackbarViewController.swift
@@ -10,6 +10,9 @@ import UIKit
 
 class SnackbarViewController: UIViewController {
 	
+	@IBOutlet weak var messageLabel: UILabel!
+	@IBOutlet weak var actionButton: UIButton!
+	
 	deinit {
 		print("VC deinit.")
 	}
@@ -17,6 +20,10 @@ class SnackbarViewController: UIViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		view.layer.cornerRadius = 12
-		view.backgroundColor = .yellow
+		view.backgroundColor = .lightGray
+	}
+	
+	@IBAction func actionButtonTapped(_ sender: UIButton) {
+		print("Button tapped!")
 	}
 }

--- a/Simplenote/SnackbarViewController.swift
+++ b/Simplenote/SnackbarViewController.swift
@@ -9,21 +9,21 @@
 import UIKit
 
 class SnackbarViewController: UIViewController {
-	
-	@IBOutlet weak var messageLabel: UILabel!
-	@IBOutlet weak var actionButton: UIButton!
-	
-	deinit {
-		print("VC deinit.")
-	}
-	
-	override func viewDidLoad() {
-		super.viewDidLoad()
-		view.layer.cornerRadius = 12
-		view.backgroundColor = .lightGray
-	}
-	
-	@IBAction func actionButtonTapped(_ sender: UIButton) {
-		print("Button tapped!")
-	}
+    
+    @IBOutlet weak var messageLabel: UILabel!
+    @IBOutlet weak var actionButton: UIButton!
+    
+    deinit {
+        print("VC deinit.")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.layer.cornerRadius = 12
+        view.backgroundColor = .lightGray
+    }
+    
+    @IBAction func actionButtonTapped(_ sender: UIButton) {
+        print("Button tapped!")
+    }
 }

--- a/Simplenote/SnackbarViewController.swift
+++ b/Simplenote/SnackbarViewController.swift
@@ -6,9 +6,14 @@ protocol SnackbarViewControllerDelegate: AnyObject {
 
 class SnackbarViewController: UIViewController {
     
-    @IBOutlet weak var messageLabel: UILabel!
-    @IBOutlet weak var actionButton: UIButton!
+    @IBOutlet weak var simpleSnackView: UIView!
+    @IBOutlet weak var activeSnackView: UIView!
     
+    @IBOutlet weak var simpleMessageLabel: UILabel!
+    @IBOutlet weak var activeMessageLabel: UILabel!
+
+    @IBOutlet weak var actionButton: UIButton!
+
     weak var delegate: SnackbarViewControllerDelegate?
     
     deinit {
@@ -17,23 +22,36 @@ class SnackbarViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.layer.cornerRadius = 12
-        view.backgroundColor = .lightGray
         
-        actionButton.isHidden = true
+        // Simple snack config.
+        simpleSnackView.layer.cornerRadius = simpleSnackView.frame.height / 2
+        simpleSnackView.backgroundColor = SPUserInterface.isDark ? .darkGray : .lightGray
+        simpleMessageLabel.textColor = SPUserInterface.isDark ? .white : .black
+        
+        // Active snack config.
+        activeSnackView.layer.cornerRadius = activeSnackView.frame.height / 2
+        activeSnackView.backgroundColor = SPUserInterface.isDark ? .darkGray : .lightGray
+        activeMessageLabel.textColor = SPUserInterface.isDark ? .white : .black
     }
     
-    func configureActionButton(title: String) {
+    func configureSimpleSnackbar(message: String) {
+        simpleMessageLabel.text = message
+    }
+    
+    func configureActiveSnackbar(message: String, buttonTitle title: String) {
+        activeMessageLabel.text = message
         actionButton.isHidden = false
         actionButton.setTitle(title, for: .normal)
     }
     
-    func configureMessageLabel(message: String) {
-        messageLabel.text = message
-    }
-    
     @IBAction func actionButtonTapped(_ sender: UIButton) {
+        print("Tapped!")
         actionButton.isEnabled = false
         delegate?.snackbarActionWasTapped(sender: self)
+    }
+    
+    func activeView() -> UIView {
+        
+        return (delegate == nil) ? simpleSnackView : activeSnackView
     }
 }


### PR DESCRIPTION
### Details
Part of #938, **In-App Notifications: Snackbar**. This is the initial plumbing demonstrating one possible way to present Snackbars. Covers the view lifecycle, display, and clean up. Basic support for dynamic text.

Still needs:

- [x] 1. Proper theming for light & dark mode.
- [x] 2. Re-sizing the view based on message length. The original Issue shows the containing view only taking up the width necessary to show the message + the action button's title. Need some clarity on clipping vs wrapping longer messages.
- [x] 3. Additional initializer to wire up the action button. Currently the button just logs when clicked. Additional initializer would include a closure and execute that when clicked.
- [x] 4. Prevents additional notices if one is currently displayed.
- [x] 5. Needs to set duration based on presence of action button. Currently just puts up the notice for 2 seconds regardless of type.
- [ ] 6. Final colours for Dark & Light mode.
- [ ] 7. Haptic feedback.
- [ ] 8. Rotation support (appears to work but not throughly tested yet).
- [ ] 9. Remove debug logs showing presentation flow.

Not implemented but might be nice to have:

- [ ] Queuing mechanism if we wanted to chain notices.

### Test
1. Build and run.
2. With a note visible, click the Note Info button to see a simple message. Click the Note Options button to see a message with an action button.
3. See the Snackbar animate in then fade out.

### Release
**Do not merge!** This is a draft of work in progress.

### Comments

The basic architecture is built around the `Snackbar` and `SnackbarPresenter` classes with `SnackbarViewController` for XIB-based loading of the view. Only the `Snackbar` class is needed to present a notification.

```
let snackbar = Snackbar(message: "Some message")
snackbar.show()
```

For a Snackbar with action button:
```
let snackbar = Snackbar(message: "Snackbar with action!", actionTitle: "Boom!") {
    print("Callback code executed!")
}

```

**Light Mode example:**

<img src="https://user-images.githubusercontent.com/40267301/99146734-b7d41e00-26b5-11eb-96d8-41dbfa9c4027.gif" width="300" />

**Dark Mode with larger text:**

<img src="https://user-images.githubusercontent.com/40267301/99146778-fcf85000-26b5-11eb-9f07-8ac80d6ce91e.gif" width="300" />