### PR TITLE
List: Updates long press action

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -839,7 +839,7 @@ extension SPNoteListViewController {
 //
 private enum ActionTitle {
     static let cancel = NSLocalizedString("Cancel", comment: "Dismissing an interface")
-    static let copyLink = NSLocalizedString("Copy Link", comment: "Copies Link to a Note")
+    static let copyLink = NSLocalizedString("Copy Internal Link", comment: "Copies Link to a Note")
     static let delete = NSLocalizedString("Move to Trash", comment: "Deletes a note")
     static let pin = NSLocalizedString("Pin to Top", comment: "Pins a note")
     static let share = NSLocalizedString("Share...", comment: "Shares a note")


### PR DESCRIPTION
### Fix
In this PR we're updating the text of a long press action.

cc @SylvesterWilmott 
@eshurakov Incoming quick PR! (Thank you!!)

### Test
1. Log into your account
2. Long press over any note

- [ ] Verify there's an action that reads `Copy Internal Link` (and that, effectively, it copies the note's interlink!)

### Release
These changes do not require release notes.
