### PR TITLE
Interlinks Autocomplete: Mark I

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -88,7 +88,6 @@
 		46A3C99B17DFA81A002865AE /* Tag.m in Sources */ = {isa = PBXBuildFile; fileRef = 467D9C641788A54900785EF3 /* Tag.m */; };
 		46A3C99C17DFA81A002865AE /* NSString+Bullets.m in Sources */ = {isa = PBXBuildFile; fileRef = E2C5C73F17CAD2FD003B9795 /* NSString+Bullets.m */; };
 		46A3C99D17DFA81A002865AE /* SPAddCollaboratorsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E25C39CF17A41F3400B2591A /* SPAddCollaboratorsViewController.m */; };
-		46A3C9A117DFA81A002865AE /* SPTagsListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E277B5E8179EDAFB0095CD24 /* SPTagsListViewController.m */; };
 		46A3C9A217DFA81A002865AE /* DTPinDigitView.m in Sources */ = {isa = PBXBuildFile; fileRef = E2911E7D17B49F4600F13AD9 /* DTPinDigitView.m */; };
 		46A3C9A317DFA81A002865AE /* SPTagEntryField.m in Sources */ = {isa = PBXBuildFile; fileRef = E277B60017A063020095CD24 /* SPTagEntryField.m */; };
 		46A3C9A717DFA81A002865AE /* DTPinLockController.m in Sources */ = {isa = PBXBuildFile; fileRef = E2911E8117B49F4600F13AD9 /* DTPinLockController.m */; };
@@ -158,6 +157,8 @@
 		B50F479F1D1D77FC00822748 /* UIAlertController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50F479E1D1D77FC00822748 /* UIAlertController+Helpers.swift */; };
 		B50F47A41D1D78EA00822748 /* SPRatingsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B50F47A31D1D78EA00822748 /* SPRatingsHelper.m */; };
 		B50F47A61D1D791B00822748 /* NSURL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */; };
+		B511AEDA255A0A2A005B2159 /* InterlinkResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B511AED9255A0A2A005B2159 /* InterlinkResultsController.swift */; };
+		B511AEE9255A0A5E005B2159 /* InterlinkResultsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B511AEE8255A0A5E005B2159 /* InterlinkResultsControllerTests.swift */; };
 		B512AF941C20B0C400FE76D8 /* SPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = B59314D61A486B3800B651ED /* SPConstants.m */; };
 		B513F2B42319A8D50021CFA4 /* SPNoteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513F2B32319A8D50021CFA4 /* SPNoteTableViewCell.swift */; };
 		B513F2B62319A8F40021CFA4 /* SPNoteTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B513F2B52319A8F40021CFA4 /* SPNoteTableViewCell.xib */; };
@@ -540,6 +541,8 @@
 		B50F47A21D1D78EA00822748 /* SPRatingsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPRatingsHelper.h; path = Classes/SPRatingsHelper.h; sourceTree = "<group>"; };
 		B50F47A31D1D78EA00822748 /* SPRatingsHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPRatingsHelper.m; path = Classes/SPRatingsHelper.m; sourceTree = "<group>"; };
 		B50F47A51D1D791B00822748 /* NSURL+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSURL+Extensions.swift"; path = "Classes/NSURL+Extensions.swift"; sourceTree = "<group>"; };
+		B511AED9255A0A2A005B2159 /* InterlinkResultsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InterlinkResultsController.swift; path = Classes/InterlinkResultsController.swift; sourceTree = "<group>"; };
+		B511AEE8255A0A5E005B2159 /* InterlinkResultsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterlinkResultsControllerTests.swift; sourceTree = "<group>"; };
 		B512AF8E1C209DD900FE76D8 /* Simplenote-Share-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Simplenote-Share-Bridging-Header.h"; sourceTree = "<group>"; };
 		B513F2B32319A8D50021CFA4 /* SPNoteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPNoteTableViewCell.swift; path = Classes/SPNoteTableViewCell.swift; sourceTree = "<group>"; };
 		B513F2B52319A8F40021CFA4 /* SPNoteTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPNoteTableViewCell.xib; path = Classes/SPNoteTableViewCell.xib; sourceTree = "<group>"; };
@@ -1090,6 +1093,22 @@
 			name = Card;
 			sourceTree = "<group>";
 		};
+		B511AECA255A0A01005B2159 /* Interlinks */ = {
+			isa = PBXGroup;
+			children = (
+				B511AED9255A0A2A005B2159 /* InterlinkResultsController.swift */,
+			);
+			name = Interlinks;
+			sourceTree = "<group>";
+		};
+		B511AEE7255A0A3E005B2159 /* Interlinks */ = {
+			isa = PBXGroup;
+			children = (
+				B511AEE8255A0A5E005B2159 /* InterlinkResultsControllerTests.swift */,
+			);
+			name = Interlinks;
+			sourceTree = "<group>";
+		};
 		B512AF8F1C209DE800FE76D8 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -1348,6 +1367,7 @@
 			children = (
 				B5B85BA6235173D900AD5221 /* Helpers */,
 				B52F35D422F3573300724793 /* Extensions */,
+				B511AEE7255A0A3E005B2159 /* Interlinks */,
 				B5B9AB4122EA6FE1001CB0AD /* Themes */,
 				B55AC57822D27B7F00D8CEB2 /* Settings */,
 				B55AC57B22D27BA300D8CEB2 /* Tools */,
@@ -1719,6 +1739,7 @@
 			isa = PBXGroup;
 			children = (
 				B59035FB251294D400034BAF /* Diagnostics */,
+				B511AECA255A0A01005B2159 /* Interlinks */,
 				B56A695122F9CCF400B90398 /* Onboarding */,
 				B5A6846B23CE84B900398BBC /* Notes List */,
 				A6C0589124AD2B00006BC572 /* Note History */,
@@ -2260,6 +2281,7 @@
 				B575736A232C567000443C2E /* UIImage+Dynamic.swift in Sources */,
 				46A3C97717DFA81A002865AE /* SPTagView.m in Sources */,
 				B5AB169822FA124F00B4EBA5 /* SPSheetController.swift in Sources */,
+				B511AEDA255A0A2A005B2159 /* InterlinkResultsController.swift in Sources */,
 				B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */,
 				B5DF734222A565DA00602CE7 /* Options.swift in Sources */,
 				B5BA5B2A25520F79002AAD43 /* NSMutableParagraphStyle+Simplenote.swift in Sources */,
@@ -2425,6 +2447,7 @@
 			files = (
 				B52F35D322F356F500724793 /* UserDefaults+Tests.swift in Sources */,
 				B58218A51FCC45330094ECA1 /* KeychainMigratorTests.swift in Sources */,
+				B511AEE9255A0A5E005B2159 /* InterlinkResultsControllerTests.swift in Sources */,
 				374F5EF521BF057E00B57E8B /* NSMutableAttributedStringStylingTests.swift in Sources */,
 				B5B9AB4722EE9CC2001CB0AD /* UIImageSimplenoteTests.swift in Sources */,
 				B55AC57A22D27B9100D8CEB2 /* OptionsTests.swift in Sources */,

--- a/Simplenote/Classes/InterlinkResultsController.swift
+++ b/Simplenote/Classes/InterlinkResultsController.swift
@@ -48,7 +48,7 @@ private extension InterlinkResultsController {
     ///
     func filter(notes: [Note], byTitleKeyword keyword: String, excluding excludedID: NSManagedObjectID?) -> [Note]? {
         let comparisonOptions: NSString.CompareOptions = [.diacriticInsensitive, .caseInsensitive]
-        let normalizedKeyword = keyword.folding(options: comparisonOptions, locale: nil)
+        let normalizedKeyword = keyword.folding(options: comparisonOptions, locale: nil).trimmingCharacters(in: .whitespacesAndNewlines)
         var output = [Note]()
 
         for note in notes where note.objectID != excludedID {

--- a/Simplenote/Classes/InterlinkResultsController.swift
+++ b/Simplenote/Classes/InterlinkResultsController.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SimplenoteFoundation
+
+
+// MARK: - InterlinkResultsController
+//
+class InterlinkResultsController {
+
+    /// ResultsController: In charge of CoreData Queries!
+    ///
+    private let resultsController: ResultsController<Note>
+
+    /// Limits the maximum number of results to fetch
+    ///
+    var maximumNumberOfResults = Settings.defaultMaximumResults
+
+
+    /// Designated Initializer
+    ///
+    init(viewContext: NSManagedObjectContext) {
+        resultsController = ResultsController<Note>(viewContext: viewContext, sortedBy: [
+            NSSortDescriptor(keyPath: \Note.content, ascending: true)
+        ])
+
+        resultsController.predicate = NSPredicate.predicateForNotes(deleted: false)
+        try? resultsController.performFetch()
+    }
+
+    /// Returns the collection of Notes filtered by the specified Keyword in their title, excluding a specific ObjectID
+    /// - Important: Returns `nil` when there are no results!
+    ///
+    func searchNotes(byTitleKeyword keyword: String, excluding excludedID: NSManagedObjectID?) -> [Note]? {
+        filter(notes: resultsController.fetchedObjects, byTitleKeyword: keyword, excluding: excludedID)
+    }
+}
+
+
+// MARK: - Private
+//
+private extension InterlinkResultsController {
+
+    /// Filters a collection of notes by their Title contents, excluding a specific Object ID.
+    ///
+    /// - Important: Why do we perform an *in memory* filtering?
+    ///     - CoreData's SQLite store does not support block based predicates
+    ///     - RegExes aren't diacritic + case insensitve friendly
+    ///     - It's easier and anyone can follow along!
+    ///
+    func filter(notes: [Note], byTitleKeyword keyword: String, excluding excludedID: NSManagedObjectID?) -> [Note]? {
+        let normalizedKeyword = keyword.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+        var output = [Note]()
+
+        for note in notes where note.objectID != excludedID {
+            note.ensurePreviewStringsAreAvailable()
+            guard let normalizedTitle = note.titlePreview?.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil),
+                  normalizedTitle.contains(normalizedKeyword)
+            else {
+                continue
+            }
+
+            output.append(note)
+
+            if output.count >= maximumNumberOfResults {
+                break
+            }
+        }
+
+        return output.isEmpty ? nil : output
+    }
+}
+
+
+// MARK: - Settings!
+//
+private enum Settings {
+    static let defaultMaximumResults = 15
+}

--- a/Simplenote/Classes/InterlinkResultsController.swift
+++ b/Simplenote/Classes/InterlinkResultsController.swift
@@ -48,7 +48,7 @@ private extension InterlinkResultsController {
     ///
     func filter(notes: [Note], byTitleKeyword keyword: String, excluding excludedID: NSManagedObjectID?) -> [Note]? {
         let comparisonOptions: NSString.CompareOptions = [.diacriticInsensitive, .caseInsensitive]
-        let normalizedKeyword = keyword.folding(options: comparisonOptions, locale: nil).trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedKeyword = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
         var output = [Note]()
 
         for note in notes where note.objectID != excludedID {

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -26,7 +26,7 @@ extension String {
     /// Returns the Range enclosing all of the receiver's contents
     ///
     var fullRange: Range<String.Index> {
-        self.startIndex ..< self.endIndex
+        startIndex ..< endIndex
     }
 
     /// Truncates the receiver's full words, up to a specified maximum length.

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -23,6 +23,12 @@ extension String {
 //
 extension String {
 
+    /// Returns the Range enclosing all of the receiver's contents
+    ///
+    var fullRange: Range<String.Index> {
+        self.startIndex ..< self.endIndex
+    }
+
     /// Truncates the receiver's full words, up to a specified maximum length.
     /// - Note: Whenever this is not possible (ie. the receiver doesn't have words), regular truncation will be performed
     ///

--- a/SimplenoteTests/InterlinkResultsControllerTests.swift
+++ b/SimplenoteTests/InterlinkResultsControllerTests.swift
@@ -72,7 +72,7 @@ class InterlinkResultsControllerTests: XCTestCase {
         XCTAssertEqual(results.count, matching.count - 1)
     }
 
-    /// Verifies that `searchNotes:byTitleKeyword:` matches multiple title keywords
+    /// Verifies that `searchNotes:byTitleKeyword:` is diacritic insensitive with regards of the Note Content
     ///
     func testSearchNotesByKeywordsIsDicriticAndCaseInsensitive() {
         let matching = [
@@ -82,6 +82,23 @@ class InterlinkResultsControllerTests: XCTestCase {
         storage.save()
 
         guard let results = resultsController.searchNotes(byTitleKeyword: "diacritics", excluding: nil) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(results.count, matching.count)
+    }
+
+    /// Verifies that `searchNotes:byTitleKeyword:` is diacritic insensitive with a special keyword
+    ///
+    func testSearchNotesByKeywordsIsDicriticAndCaseInsensitiveWithKeywordUsingSpecialCharacters() {
+        let matching = [
+            storage.insertSampleNote(contents: "diacritics"),
+        ]
+
+        storage.save()
+
+        guard let results = resultsController.searchNotes(byTitleKeyword: "DíäcrìtIcs", excluding: nil) else {
             XCTFail()
             return
         }

--- a/SimplenoteTests/InterlinkResultsControllerTests.swift
+++ b/SimplenoteTests/InterlinkResultsControllerTests.swift
@@ -35,7 +35,7 @@ class InterlinkResultsControllerTests: XCTestCase {
     func testSearchNotesByKeywordsOnlyReturnsNotesThatContainTheSpecifiedKeywordInTheirTitle() {
         let (matching, _) = insertSampleEntities()
 
-        guard let results = resultsController.searchNotes(byTitleKeywords: Settings.sampleMatchingKeyword, excluding: nil) else {
+        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: nil) else {
             XCTFail()
             return
         }
@@ -49,7 +49,7 @@ class InterlinkResultsControllerTests: XCTestCase {
         let (_, _) = insertSampleEntities()
 
         resultsController.maximumNumberOfResults = 1
-        guard let results = resultsController.searchNotes(byTitleKeywords: Settings.sampleMatchingKeyword, excluding: nil) else {
+        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: nil) else {
             XCTFail()
             return
         }
@@ -63,7 +63,7 @@ class InterlinkResultsControllerTests: XCTestCase {
         let (matching, _) = insertSampleEntities()
 
         let excluded = matching.randomElement()!
-        guard let results = resultsController.searchNotes(byTitleKeywords: Settings.sampleMatchingKeyword, excluding: excluded.objectID) else {
+        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: excluded.objectID) else {
             XCTFail()
             return
         }
@@ -74,25 +74,6 @@ class InterlinkResultsControllerTests: XCTestCase {
 
     /// Verifies that `searchNotes:byTitleKeyword:` matches multiple title keywords
     ///
-    func testSearchNotesByKeywordsMatchesMultipleKeywords() {
-        let matching = [
-            storage.insertSampleNote(contents: "keywordA something something keywordB"),
-            storage.insertSampleNote(contents: "Something keywordA keywordB")
-        ]
-
-        storage.save()
-
-        guard let results = resultsController.searchNotes(byTitleKeywords: "keyworda keywordb", excluding: nil) else {
-            XCTFail()
-            return
-        }
-
-        XCTAssertEqual(results.count, matching.count)
-    }
-
-
-    /// Verifies that `searchNotes:byTitleKeyword:` matches multiple title keywords
-    ///
     func testSearchNotesByKeywordsIsDicriticAndCaseInsensitive() {
         let matching = [
             storage.insertSampleNote(contents: "DíäcrìtIcs"),
@@ -100,7 +81,7 @@ class InterlinkResultsControllerTests: XCTestCase {
 
         storage.save()
 
-        guard let results = resultsController.searchNotes(byTitleKeywords: "diacritics", excluding: nil) else {
+        guard let results = resultsController.searchNotes(byTitleKeyword: "diacritics", excluding: nil) else {
             XCTFail()
             return
         }

--- a/SimplenoteTests/InterlinkResultsControllerTests.swift
+++ b/SimplenoteTests/InterlinkResultsControllerTests.swift
@@ -32,10 +32,10 @@ class InterlinkResultsControllerTests: XCTestCase {
 
     /// Verifies that only Notes with matching keywords in their title are returned by `searchNotes:byTitleKeyword:`
     ///
-    func testSearchNotesByKeywordOnlyReturnsNotesThatContainTheSpecifiedKeywordInTheirTitle() {
+    func testSearchNotesByKeywordsOnlyReturnsNotesThatContainTheSpecifiedKeywordInTheirTitle() {
         let (matching, _) = insertSampleEntities()
 
-        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: nil) else {
+        guard let results = resultsController.searchNotes(byTitleKeywords: Settings.sampleMatchingKeyword, excluding: nil) else {
             XCTFail()
             return
         }
@@ -45,11 +45,11 @@ class InterlinkResultsControllerTests: XCTestCase {
 
     /// Verifies that `searchNotes:byTitleKeyword:` limits the output count to the value defined by `maximumNumberOfResults`
     ///
-    func testSearchNotesByKeywordRespectsTheMaximumNumberOfResultsLimit() {
+    func testSearchNotesByKeywordsRespectsTheMaximumNumberOfResultsLimit() {
         let (_, _) = insertSampleEntities()
 
         resultsController.maximumNumberOfResults = 1
-        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: nil) else {
+        guard let results = resultsController.searchNotes(byTitleKeywords: Settings.sampleMatchingKeyword, excluding: nil) else {
             XCTFail()
             return
         }
@@ -59,17 +59,53 @@ class InterlinkResultsControllerTests: XCTestCase {
 
     /// Verifies that `searchNotes:byTitleKeyword:` excludes the specified entity
     ///
-    func testSearchNotesByKeywordExcludesTheSpecifiedObjectID() {
+    func testSearchNotesByKeywordsExcludesTheSpecifiedObjectID() {
         let (matching, _) = insertSampleEntities()
 
         let excluded = matching.randomElement()!
-        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: excluded.objectID) else {
+        guard let results = resultsController.searchNotes(byTitleKeywords: Settings.sampleMatchingKeyword, excluding: excluded.objectID) else {
             XCTFail()
             return
         }
 
         XCTAssertFalse(results.contains(excluded))
         XCTAssertEqual(results.count, matching.count - 1)
+    }
+
+    /// Verifies that `searchNotes:byTitleKeyword:` matches multiple title keywords
+    ///
+    func testSearchNotesByKeywordsMatchesMultipleKeywords() {
+        let matching = [
+            storage.insertSampleNote(contents: "keywordA something something keywordB"),
+            storage.insertSampleNote(contents: "Something keywordA keywordB")
+        ]
+
+        storage.save()
+
+        guard let results = resultsController.searchNotes(byTitleKeywords: "keyworda keywordb", excluding: nil) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(results.count, matching.count)
+    }
+
+
+    /// Verifies that `searchNotes:byTitleKeyword:` matches multiple title keywords
+    ///
+    func testSearchNotesByKeywordsIsDicriticAndCaseInsensitive() {
+        let matching = [
+            storage.insertSampleNote(contents: "DíäcrìtIcs"),
+        ]
+
+        storage.save()
+
+        guard let results = resultsController.searchNotes(byTitleKeywords: "diacritics", excluding: nil) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(results.count, matching.count)
     }
 }
 

--- a/SimplenoteTests/InterlinkResultsControllerTests.swift
+++ b/SimplenoteTests/InterlinkResultsControllerTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import Simplenote
+
+
+// MARK: - InterlinkResultsController Tests
+//
+class InterlinkResultsControllerTests: XCTestCase {
+
+    /// InMemory Storage!
+    ///
+    private let storage = MockupStorageManager()
+
+    /// InterlinkResultsController
+    ///
+    private var resultsController: InterlinkResultsController!
+
+
+    // MARK: - Overridden Methods
+
+    override func setUp() {
+        super.setUp()
+        resultsController = InterlinkResultsController(viewContext: storage.viewContext)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        storage.reset()
+    }
+
+
+    // MARK: - Tests: Filtering
+
+    /// Verifies that only Notes with matching keywords in their title are returned by `searchNotes:byTitleKeyword:`
+    ///
+    func testSearchNotesByKeywordOnlyReturnsNotesThatContainTheSpecifiedKeywordInTheirTitle() {
+        let (matching, _) = insertSampleEntities()
+
+        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: nil) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(matching, Set(results))
+    }
+
+    /// Verifies that `searchNotes:byTitleKeyword:` limits the output count to the value defined by `maximumNumberOfResults`
+    ///
+    func testSearchNotesByKeywordRespectsTheMaximumNumberOfResultsLimit() {
+        let (_, _) = insertSampleEntities()
+
+        resultsController.maximumNumberOfResults = 1
+        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: nil) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(results.count, resultsController.maximumNumberOfResults)
+    }
+
+    /// Verifies that `searchNotes:byTitleKeyword:` excludes the specified entity
+    ///
+    func testSearchNotesByKeywordExcludesTheSpecifiedObjectID() {
+        let (matching, _) = insertSampleEntities()
+
+        let excluded = matching.randomElement()!
+        guard let results = resultsController.searchNotes(byTitleKeyword: Settings.sampleMatchingKeyword, excluding: excluded.objectID) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertFalse(results.contains(excluded))
+        XCTAssertEqual(results.count, matching.count - 1)
+    }
+}
+
+
+// MARK: - Private
+//
+private extension InterlinkResultsControllerTests {
+
+    /// Inserts a collection of sample entities.
+    ///
+    func insertSampleEntities() -> (matching: Set<Note>, irrelevant: Set<Note>) {
+        let notesWithKeyword = Set(arrayLiteral:
+            storage.insertSampleNote(contents: Settings.sampleMatchingKeyword.uppercased() + "Match \n nope"),
+            storage.insertSampleNote(contents: "Another " + Settings.sampleMatchingKeyword + " \n nope"),
+            storage.insertSampleNote(contents: "Yet Another " + Settings.sampleMatchingKeyword + " \n nope")
+        )
+
+        let notesWithoutKeyword = Set(arrayLiteral:
+            storage.insertSampleNote(contents: "nope"),
+            storage.insertSampleNote(contents: "neither this one \n " + Settings.sampleMatchingKeyword)
+        )
+
+        storage.save()
+
+        return (notesWithKeyword, notesWithoutKeyword)
+    }
+}
+
+
+// MARK: - Constants
+//
+private enum Settings {
+    static let sampleMatchingKeyword: String = "match"
+}


### PR DESCRIPTION
### Fix
In this PR we're implementing **InterlinkResultsController**. This component will be in charge of:

1. Filtering Notes that contain a specified Interlink keyword
2. Excluding a specified Entity ID (useful to exclude the "current" document, and thus, prevent loop links)

We're also adding capabilities to limit the number of results.

Please bear in mind this is part of a larger feature, splitting this into review friendly pieces.

Ref. #914
cc @eshurakov (Thanks in advance!!)

### Test
- [x] Verify the code makes sense
- [x] Verify the new unit tests are green!
- [x] Yay!

### Release
These changes do not require release notes.
