### PR TITLE
Editor: Fixing keyword navigation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -   Fixed a bug that affected Text Selection #973
 -   Fixed a bug that toggled Edition while dragging the Editor #972
 -   Fixed an issue that caused changes not to be persisted immediately #996
+-   Fixed a bug that affected search highlight navigation #1009
 
 4.27
 -----

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -583,23 +583,19 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self highlightSearchResultAtIndex:self.highlightedSearchResultIndex];
 }
 
-- (void)highlightSearchResultAtIndex:(NSInteger)index {
-    
+- (void)highlightSearchResultAtIndex:(NSInteger)index
+{
     NSInteger searchResultCount = self.searchResultRanges.count;
     if (index >= 0 && index < searchResultCount) {
         
         // enable or disbale search result puttons accordingly
         self.prevSearchButton.enabled = index > 0;
         self.nextSearchButton.enabled = index < searchResultCount - 1;
-        
-        [_noteEditorTextView highlightRange:[(NSValue *)self.searchResultRanges[index] rangeValue]
-                           animated:YES
-                          withBlock:^(CGRect highlightFrame) {
 
-                              // scroll to block
-                              highlightFrame.origin.y += highlightFrame.size.height;
-                              [self.noteEditorTextView scrollRectToVisible:highlightFrame animated:YES];
-                          }];
+        NSRange targetRange = [(NSValue *)self.searchResultRanges[index] rangeValue];
+        [_noteEditorTextView highlightRange:targetRange animated:YES withBlock:^(CGRect highlightFrame) {
+            [self.noteEditorTextView scrollRectToVisible:highlightFrame animated:YES];
+        }];
     }
 }
 


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that affected Search keyword Navigation.

Closes #1008
@eshurakov WDYT?

### Test
1. Open a long document
2. Type the word keyword at the top
3. Scroll all the way to the bottom, and type keyword
4. Back to the notes list
5. Search for keyword and open the same document you've edited in (1)
6. Navigate to the bottom keyword
7. Press the left chevron < to navigate back to the top keyword

- [x] Verify the first word is visible


### Release
`RELEASE-NOTES.txt` was updated in 5214ce2c with:
 
> Fixed a bug that affected search highlight navigation #1009
