### PR TITLE
NoteInformationController: Updates references title

### DIFF
--- a/Simplenote/Information/NoteInformationController.swift
+++ b/Simplenote/Information/NoteInformationController.swift
@@ -174,5 +174,5 @@ private struct Localization {
     static let created = NSLocalizedString("Created", comment: "Note Creation Date")
     static let words = NSLocalizedString("Words", comment: "Number of words in the note")
     static let characters = NSLocalizedString("Characters", comment: "Number of characters in the note")
-    static let references = NSLocalizedString("References", comment: "References section header on Info Card")
+    static let references = NSLocalizedString("Referenced In", comment: "References section header on Info Card")
 }


### PR DESCRIPTION
### Fix
In this PR we're updating the References UI copy.

@eshurakov Thank you!!
cc @SylvesterWilmott 

### Test
1. Open a note that contains inbound references
2. Press over the top right `( i )` icon

- [ ] Verify the references section now reads as `Referenced In`

### Release
These changes do not require release notes.
