### PR TITLE
Interlinks Autocomplete: Mark V

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.28
 -----
+-   Typing `[` will now allow you to pick Interlinking Notes right from the editor #914
 -   Searching for a note is showing relevant excerpts #956
 -   Tags List now extend to the edge of the screen, in landscape mode #989
 -   Fixed a bug that affected Text Selection #973

--- a/Simplenote/Classes/InterlinkProcessor.swift
+++ b/Simplenote/Classes/InterlinkProcessor.swift
@@ -156,10 +156,10 @@ private extension InterlinkProcessor {
 extension InterlinkProcessor {
 
     /// Relocates the Interlink UI (whenever it's visible) to match the new TextView's Content Offset.
-    /// - Important: Whenever the **Maximum Allowed Scroll Offset** is exceeded, we'll just dismiss the UI
+    /// - Important: Whenever the **Maximum Allowed Scroll Offset** is exceeded (and the scroll event is user initiated), we'll just dismiss the UI
     ///
-    @objc(refreshInterlinkControllerWithNewOffset:)
-    func refreshInterlinkController(contentOffset: CGPoint) {
+    @objc(refreshInterlinkControllerWithNewOffset:isDragging:)
+    func refreshInterlinkController(contentOffset: CGPoint, isDragging: Bool) {
         guard let interlinkViewController = presentedViewController else {
             return
         }
@@ -173,7 +173,9 @@ extension InterlinkProcessor {
         }
 
         interlinkViewController.relocateInterface(by: oldY - contentOffset.y)
-        dismissInterlinkLookupIfNeeded(initialY: initialY, currentY: contentOffset.y)
+        if isDragging {
+            dismissInterlinkLookupIfNeeded(initialY: initialY, currentY: contentOffset.y)
+        }
     }
 
     /// Dismisses the Interlink Lookup whenever the **Maximum Allowed Scroll Offset** is exceeded

--- a/Simplenote/Classes/InterlinkProcessor.swift
+++ b/Simplenote/Classes/InterlinkProcessor.swift
@@ -121,7 +121,11 @@ private extension InterlinkProcessor {
     }
 
     func relocateInterlinkController(around range: Range<String.Index>) {
-        presentedViewController?.anchorView(around: range, in: parentTextView)
+        let keywordFrame = parentTextView.locationInWindowForText(in: range)
+        let editingFrame = parentTextView.editingRectInWindow()
+
+        presentedViewController?.relocateInterface(around: keywordFrame, in: editingFrame)
+        lastKnownEditorOffset = parentTextView.contentOffset
     }
 
     func refreshInterlinkController(notes: [Note]) {

--- a/Simplenote/Classes/InterlinkProcessor.swift
+++ b/Simplenote/Classes/InterlinkProcessor.swift
@@ -40,6 +40,8 @@ class InterlinkProcessor: NSObject {
 
     private let viewContext: NSManagedObjectContext
     private var presentedViewController: InterlinkViewController?
+    private var lastKnownEditorOffset: CGPoint?
+    private var initialEditorOffset: CGPoint?
     private lazy var resultsController = InterlinkResultsController(viewContext: viewContext)
 
     weak var contextProvider: InterlinkProcessorPresentationContextProvider?
@@ -73,6 +75,7 @@ class InterlinkProcessor: NSObject {
         ensureInterlinkControllerIsOnScreen()
         refreshInterlinkController(notes: notes)
         relocateInterlinkController(around: keywordRange)
+        trackLastKnownScrollOffsets()
         setupInterlinkEventListeners(replacementRange: markdownRange)
     }
 
@@ -125,7 +128,11 @@ private extension InterlinkProcessor {
         let editingFrame = parentTextView.editingRectInWindow()
 
         presentedViewController?.relocateInterface(around: keywordFrame, in: editingFrame)
+    }
+
+    func trackLastKnownScrollOffsets() {
         lastKnownEditorOffset = parentTextView.contentOffset
+        initialEditorOffset = parentTextView.contentOffset
     }
 
     func refreshInterlinkController(notes: [Note]) {
@@ -140,6 +147,43 @@ private extension InterlinkProcessor {
 
             self.delegate?.interlinkProcessor(self, insert: text, in: replacementRange)
         }
+    }
+}
+
+
+// MARK: - Scrolling
+//
+extension InterlinkProcessor {
+
+    /// Relocates the Interlink UI (whenever it's visible) to match the new TextView's Content Offset.
+    /// - Important: Whenever the **Maximum Allowed Scroll Offset** is exceeded, we'll just dismiss the UI
+    ///
+    @objc(refreshInterlinkControllerWithNewOffset:)
+    func refreshInterlinkController(contentOffset: CGPoint) {
+        guard let interlinkViewController = presentedViewController else {
+            return
+        }
+
+        defer {
+            lastKnownEditorOffset = contentOffset
+        }
+
+        guard let oldY = lastKnownEditorOffset?.y, let initialY = initialEditorOffset?.y else {
+            return
+        }
+
+        interlinkViewController.relocateInterface(by: oldY - contentOffset.y)
+        dismissInterlinkLookupIfNeeded(initialY: initialY, currentY: contentOffset.y)
+    }
+
+    /// Dismisses the Interlink Lookup whenever the **Maximum Allowed Scroll Offset** is exceeded
+    ///
+    private func dismissInterlinkLookupIfNeeded(initialY: CGFloat, currentY: CGFloat) {
+        guard abs(currentY - initialY) > Settings.maximumAllowedScrollOffset else {
+            return
+        }
+
+        dismissInterlinkLookup()
     }
 }
 
@@ -195,4 +239,11 @@ private extension InterlinkProcessor {
 
         return parent
     }
+}
+
+
+// MARK: - Settings
+//
+private enum Settings {
+    static let maximumAllowedScrollOffset = CGFloat(20)
 }

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -63,7 +63,7 @@ extension InterlinkViewController {
         tableLeadingConstraint.constant = targetLeading
     }
 
-    ///
+    /// Adjusts the Interlink TableView by the specified offset
     ///
     func relocateInterface(by deltaY: CGFloat) {
         tableTopConstraint.constant += deltaY

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -149,7 +149,7 @@ private extension InterlinkViewController {
     ///     - anchor: Frame around which we should position the TableView
     ///     - viewport: Editor's visible frame
     ///
-    /// - Important: We'll always prefer the orientation that results in the **Least Clipped Surface™**
+    /// -   Important: We'll always prefer the orientation that results in the **Least Clipped Surface™**
     ///
     func calculateTopLocation(for height: CGFloat, around anchor: CGRect, in viewport: CGRect) -> CGFloat {
         let minimumLocationForFullHeight = anchor.minY - Metrics.defaultTableInsets.top - Metrics.maximumTableHeight
@@ -161,7 +161,8 @@ private extension InterlinkViewController {
         let dispayingAboveClips = deltaAbove < .zero
         let dispayingBelowClips = deltaBelow < .zero
 
-        if !dispayingAboveClips && deltaAbove > deltaBelow ||
+        if dispayingAboveClips == false && dispayingBelowClips == false ||
+            dispayingAboveClips == false && deltaAbove > deltaBelow ||
             dispayingAboveClips && dispayingBelowClips && deltaAbove > deltaBelow
         {
             return locationAbove
@@ -172,13 +173,20 @@ private extension InterlinkViewController {
 
     /// Returns the Target Origin.X
     ///
+    /// -   Parameters:
+    ///     - anchor: Frame around which we should position the TableView
+    ///     - viewport: Editor's visible frame
+    ///
+    /// -   Note: We'll align the Table **Text**, horizontally, with regards of the anchor frame. That's why we consider layout margins!
+    /// -   Important: Whenever we overflow horizontally, we'll simply ensure there's enough breathing room on the right hand side
+    ///
     func calculateLeadingLocation(around anchor: CGRect, in viewport: CGRect) -> CGFloat {
-        if viewport.width > anchor.minX + Metrics.defaultTableWidth {
-            return anchor.minX
+        let maximumX = anchor.minX + Metrics.defaultTableWidth + tableView.layoutMargins.right
+        if viewport.width > maximumX {
+            return anchor.minX - tableView.layoutMargins.left
         }
 
-        let overflowX = viewport.width - anchor.minX - Metrics.defaultTableWidth
-        return anchor.minX + overflowX - Metrics.defaultTableInsets.right
+        return anchor.minX + viewport.width - maximumX
     }
 
 
@@ -210,7 +218,7 @@ private extension InterlinkViewController {
 private enum Metrics {
     static let cornerRadius = CGFloat(10)
     static let defaultCellHeight = CGFloat(44)
-    static let defaultTableInsets = UIEdgeInsets(top: 12, left: 12, bottom: 0, right: 12)
+    static let defaultTableInsets = UIEdgeInsets(top: 12, left: 20, bottom: 0, right: 20)
     static let defaultTableWidth = CGFloat(300)
     static let maximumVisibleCells = 3.5
     static let maximumTableHeight = defaultCellHeight * CGFloat(maximumVisibleCells)

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -18,10 +18,6 @@ class InterlinkViewController: UIViewController {
     @IBOutlet private var tableTopConstraint: NSLayoutConstraint!
     @IBOutlet private var tableHeightConstraint: NSLayoutConstraint!
 
-    /// KVO
-    ///
-    private var kvoOffsetToken: NSKeyValueObservation?
-
     /// Closure to be executed whenever a Note is selected. The Interlink URL will be passed along.
     ///
     var onInsertInterlink: ((String) -> Void)?
@@ -66,6 +62,11 @@ extension InterlinkViewController {
         tableHeightConstraint.constant = targetHeight
         tableLeadingConstraint.constant = targetLeading
     }
+
+    ///
+    ///
+    func relocateInterface(by deltaY: CGFloat) {
+        tableTopConstraint.constant += deltaY
     }
 }
 
@@ -141,18 +142,8 @@ extension InterlinkViewController: UITableViewDelegate {
 //
 private extension InterlinkViewController {
 
-    /// Starts tracking ContentOffset changes in our sibling TextView
+    /// Returns the Target Origin.Y
     ///
-    func startObservingContentOffset(in textView: UITextView) {
-        kvoOffsetToken = textView.observe(\UITextView.contentOffset, options: [.old, .new]) { [weak self] (_, value) in
-            guard let oldY = value.oldValue?.y, let newY = value.newValue?.y, oldY != newY else {
-                return
-            }
-
-            self?.tableTopConstraint.constant += oldY - newY
-        }
-    }
-
     /// -   Parameters:
     ///     - height: The new target height
     ///     - anchor: Frame around which we should position the TableView

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -15,7 +15,6 @@ class InterlinkViewController: UIViewController {
     /// Layout Constraints: Inner TableView
     ///
     @IBOutlet private var tableLeadingConstraint: NSLayoutConstraint!
-    @IBOutlet private var tableTrailingConstraint: NSLayoutConstraint!
     @IBOutlet private var tableTopConstraint: NSLayoutConstraint!
     @IBOutlet private var tableHeightConstraint: NSLayoutConstraint!
 
@@ -52,12 +51,21 @@ class InterlinkViewController: UIViewController {
 //
 extension InterlinkViewController {
 
-    /// Relocates the receiver so that it shows up around a given Keyword in a **Sibling TextView**
-    /// - Important: We'll start listening for Content Offset changes, and the UI will be automatically repositioned
+    /// Relocates the receiver so that it shows up **around** the specified Anchor Frame, in a given ViewPort.
+    /// - Important: Both frames must be expressed in Window Coordinates. Capisce?
     ///
-    func anchorView(around keywordRange: Range<String.Index>, in siblingTextView: UITextView) {
-        refreshConstraints(keywordRange: keywordRange, in: siblingTextView)
-        startObservingContentOffset(in: siblingTextView)
+    func relocateInterface(around anchor: CGRect, in viewport: CGRect) {
+        let anchorFrame = view.convertFromWindowCoordinates(anchor)
+        let editingRect = view.convertFromWindowCoordinates(viewport)
+
+        let targetHeight = calculateHeight()
+        let targetTop = calculateTopLocation(for: targetHeight, around: anchorFrame, in: editingRect)
+        let targetLeading = calculateLeadingLocation(around: anchorFrame, in: editingRect)
+
+        tableTopConstraint.constant = targetTop
+        tableHeightConstraint.constant = targetHeight
+        tableLeadingConstraint.constant = targetLeading
+    }
     }
 }
 
@@ -133,19 +141,6 @@ extension InterlinkViewController: UITableViewDelegate {
 //
 private extension InterlinkViewController {
 
-    /// Updates the layout constraints so that the receiver shows up **around** the specified Keyword in the specified TextView
-    ///
-    func refreshConstraints(keywordRange: Range<String.Index>, in textView: UITextView) {
-        let targetHeight = calculateHeight()
-        let targetLocation = calculateLocation(for: targetHeight, around: keywordRange, in: textView)
-        let targetPadding = textView.textContainer.lineFragmentPadding
-
-        tableTopConstraint.constant = targetLocation
-        tableHeightConstraint.constant = targetHeight
-        tableLeadingConstraint.constant = targetPadding
-        tableTrailingConstraint.constant = targetPadding
-    }
-
     /// Starts tracking ContentOffset changes in our sibling TextView
     ///
     func startObservingContentOffset(in textView: UITextView) {
@@ -158,24 +153,43 @@ private extension InterlinkViewController {
         }
     }
 
-    /// Returns the target Origin.Y
     /// -   Parameters:
     ///     - height: The new target height
-    ///     - range: Anchor's Range
-    ///     - textView: Sibling TextView
+    ///     - anchor: Frame around which we should position the TableView
+    ///     - viewport: Editor's visible frame
     ///
-    /// - Important: We'll always prefer either the "location above the cursor" whenever the **Maxed Out TableView** can be fit (that is: +3.5 results!)
+    /// - Important: We'll always prefer the orientation that results in the **Least Clipped Surface™**
     ///
-    func calculateLocation(for height: CGFloat, around range: Range<String.Index>, in textView: UITextView) -> CGFloat {
-        let anchorFrame = textView.locationInSuperviewForText(in: range)
-        let minimumLocationForFullHeight = anchorFrame.minY - Metrics.resultsPadding - Metrics.maximumTableHeight
+    func calculateTopLocation(for height: CGFloat, around anchor: CGRect, in viewport: CGRect) -> CGFloat {
+        let minimumLocationForFullHeight = anchor.minY - Metrics.defaultTableInsets.top - Metrics.maximumTableHeight
+        let locationAbove = anchor.minY - Metrics.defaultTableInsets.top - height
+        let locationBelow = anchor.maxY + Metrics.defaultTableInsets.top
 
-        if minimumLocationForFullHeight > textView.editingRect().minY {
-            return anchorFrame.minY - Metrics.resultsPadding - height
+        let deltaAbove = minimumLocationForFullHeight - viewport.minY
+        let deltaBelow = viewport.maxY - locationBelow - height
+        let dispayingAboveClips = deltaAbove < .zero
+        let dispayingBelowClips = deltaBelow < .zero
+
+        if !dispayingAboveClips && deltaAbove > deltaBelow ||
+            dispayingAboveClips && dispayingBelowClips && deltaAbove > deltaBelow
+        {
+            return locationAbove
         }
 
-        return anchorFrame.maxY + Metrics.resultsPadding
+        return locationBelow
     }
+
+    /// Returns the Target Origin.X
+    ///
+    func calculateLeadingLocation(around anchor: CGRect, in viewport: CGRect) -> CGFloat {
+        if viewport.width > anchor.minX + Metrics.defaultTableWidth {
+            return anchor.minX
+        }
+
+        let overflowX = viewport.width - anchor.minX - Metrics.defaultTableWidth
+        return anchor.minX + overflowX - Metrics.defaultTableInsets.right
+    }
+
 
     /// Returns the target Size.Height
     ///
@@ -205,7 +219,8 @@ private extension InterlinkViewController {
 private enum Metrics {
     static let cornerRadius = CGFloat(10)
     static let defaultCellHeight = CGFloat(44)
+    static let defaultTableInsets = UIEdgeInsets(top: 12, left: 12, bottom: 0, right: 12)
+    static let defaultTableWidth = CGFloat(300)
     static let maximumVisibleCells = 3.5
     static let maximumTableHeight = defaultCellHeight * CGFloat(maximumVisibleCells)
-    static let resultsPadding = CGFloat(12)
 }

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -51,8 +51,8 @@ extension InterlinkViewController {
     /// - Important: Both frames must be expressed in Window Coordinates. Capisce?
     ///
     func relocateInterface(around anchor: CGRect, in viewport: CGRect) {
-        let anchorFrame = view.convertFromWindowCoordinates(anchor)
-        let editingRect = view.convertFromWindowCoordinates(viewport)
+        let anchorFrame = view.convert(anchor, from: nil)
+        let editingRect = view.convert(viewport, from: nil)
 
         let targetHeight = calculateHeight()
         let targetTop = calculateTopLocation(for: targetHeight, around: anchorFrame, in: editingRect)

--- a/Simplenote/Classes/InterlinkViewController.xib
+++ b/Simplenote/Classes/InterlinkViewController.xib
@@ -25,7 +25,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J1j-Rs-BRd" customClass="SPShadowView" customModule="Simplenote" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="12" width="300" height="50"/>
+                    <rect key="frame" x="16" y="12" width="300" height="50"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -43,7 +43,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZZD-kk-l5T">
-                    <rect key="frame" x="0.0" y="12" width="300" height="50"/>
+                    <rect key="frame" x="16" y="12" width="300" height="50"/>
                     <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="vc0-Cc-xE6">
                         <rect key="frame" x="0.0" y="0.0" width="300" height="50"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -64,10 +64,10 @@
                     <blurEffect style="regular"/>
                 </visualEffectView>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" bouncesZoom="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Ce-It-s4R">
-                    <rect key="frame" x="0.0" y="12" width="300" height="50"/>
+                    <rect key="frame" x="16" y="12" width="300" height="50"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="300" id="T9c-Ge-tZ2"/>
+                        <constraint firstAttribute="width" priority="999" constant="300" id="T9c-Ge-tZ2"/>
                         <constraint firstAttribute="height" constant="50" id="pJU-Uf-0Oq"/>
                     </constraints>
                     <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -86,8 +86,10 @@
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="top" secondItem="0Ce-It-s4R" secondAttribute="top" id="Jda-bL-BQO"/>
                 <constraint firstItem="ZZD-kk-l5T" firstAttribute="leading" secondItem="0Ce-It-s4R" secondAttribute="leading" id="U49-aZ-qMs"/>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="bottom" secondItem="0Ce-It-s4R" secondAttribute="bottom" id="Xos-pY-37F"/>
-                <constraint firstItem="0Ce-It-s4R" firstAttribute="leading" secondItem="URg-NP-0Et" secondAttribute="leading" id="YkW-MZ-sEN"/>
+                <constraint firstItem="0Ce-It-s4R" firstAttribute="leading" secondItem="URg-NP-0Et" secondAttribute="leading" priority="999" id="YkW-MZ-sEN"/>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="trailing" secondItem="0Ce-It-s4R" secondAttribute="trailing" id="cl7-N9-OKH"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0Ce-It-s4R" secondAttribute="trailing" constant="16" id="hN1-X0-aCU"/>
+                <constraint firstItem="0Ce-It-s4R" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="URg-NP-0Et" secondAttribute="leading" constant="16" id="m4j-uj-bVK"/>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="leading" secondItem="0Ce-It-s4R" secondAttribute="leading" id="wq5-ce-lmK"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/Simplenote/Classes/InterlinkViewController.xib
+++ b/Simplenote/Classes/InterlinkViewController.xib
@@ -15,7 +15,6 @@
                 <outlet property="tableHeightConstraint" destination="pJU-Uf-0Oq" id="8xE-WM-Fgp"/>
                 <outlet property="tableLeadingConstraint" destination="YkW-MZ-sEN" id="ewM-9i-2qp"/>
                 <outlet property="tableTopConstraint" destination="1aU-WG-N13" id="UWn-PU-7Am"/>
-                <outlet property="tableTrailingConstraint" destination="rCB-bk-lF3" id="Kao-66-ddb"/>
                 <outlet property="tableView" destination="0Ce-It-s4R" id="rdg-1f-23L"/>
                 <outlet property="view" destination="URg-NP-0Et" id="xef-Np-8pC"/>
             </connections>
@@ -68,7 +67,7 @@
                     <rect key="frame" x="0.0" y="12" width="300" height="50"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="T9c-Ge-tZ2"/>
+                        <constraint firstAttribute="width" constant="300" id="T9c-Ge-tZ2"/>
                         <constraint firstAttribute="height" constant="50" id="pJU-Uf-0Oq"/>
                     </constraints>
                     <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -89,7 +88,6 @@
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="bottom" secondItem="0Ce-It-s4R" secondAttribute="bottom" id="Xos-pY-37F"/>
                 <constraint firstItem="0Ce-It-s4R" firstAttribute="leading" secondItem="URg-NP-0Et" secondAttribute="leading" id="YkW-MZ-sEN"/>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="trailing" secondItem="0Ce-It-s4R" secondAttribute="trailing" id="cl7-N9-OKH"/>
-                <constraint firstAttribute="trailing" secondItem="0Ce-It-s4R" secondAttribute="trailing" priority="999" id="rCB-bk-lF3"/>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="leading" secondItem="0Ce-It-s4R" secondAttribute="leading" id="wq5-ce-lmK"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -714,7 +714,7 @@ extension SPNoteEditorViewController {
         var textContainerHeight = noteEditorTextView.layoutManager.usedRect(for: noteEditorTextView.textContainer).size.height
         textContainerHeight = textContainerHeight + noteEditorTextView.textContainerInset.top + noteEditorTextView.textContainerInset.bottom
 
-        let textContainerMinHeight = noteEditorTextView.editingRect().size.height
+        let textContainerMinHeight = noteEditorTextView.editingRectInWindow().size.height
         return max(textContainerHeight, textContainerMinHeight)
     }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -639,7 +639,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self.navigationBarBackground adjustAlphaMatchingContentOffsetOf:scrollView];
 
     // Relocate Interlink Suggestions (if they're even onscreen!)
-    [self.interlinkProcessor refreshInterlinkControllerWithNewOffset:scrollView.contentOffset];
+    [self.interlinkProcessor refreshInterlinkControllerWithNewOffset:scrollView.contentOffset isDragging:scrollView.isDragging];
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -637,6 +637,9 @@ CGFloat const SPSelectedAreaPadding = 20;
 {
     // Slowly Fade-In the NavigationBar's Blur
     [self.navigationBarBackground adjustAlphaMatchingContentOffsetOf:scrollView];
+
+    // Relocate Interlink Suggestions (if they're even onscreen!)
+    [self.interlinkProcessor refreshInterlinkControllerWithNewOffset:scrollView.contentOffset];
 }
 
 

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -162,7 +162,8 @@ extension UITextView {
         let paddingBottom = safeAreaInsets.bottom + contentInset.bottom
         let editingHeight = frame.height - paddingTop - paddingBottom
 
-        return CGRect(x: frame.minX, y: paddingTop, width: frame.width, height: editingHeight)
+        let output = CGRect(x: .zero, y: .zero, width: frame.width, height: editingHeight)
+        return convert(output, to: nil)
     }
 
     /// Returns the Window Location for the text at the specified range

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -157,19 +157,19 @@ extension UITextView {
     ///
     /// - Note: `contentInset.bottom` is expected to contain the bottom padding required by the keyboard. Capisce?
     ///
-    func editingRect() -> CGRect {
-        let paddingTop = safeAreaInsets.top
+    func editingRectInWindow() -> CGRect {
+        let paddingTop = frame.minY + safeAreaInsets.top
         let paddingBottom = safeAreaInsets.bottom + contentInset.bottom
         let editingHeight = frame.height - paddingTop - paddingBottom
 
-        return CGRect(x: .zero, y: paddingTop, width: frame.width, height: editingHeight)
+        return CGRect(x: frame.minX, y: paddingTop, width: frame.width, height: editingHeight)
     }
 
     /// Returns the Window Location for the text at the specified range
     ///
-    func locationInSuperviewForText(in range: Range<String.Index>) -> CGRect {
+    func locationInWindowForText(in range: Range<String.Index>) -> CGRect {
         let rectInEditor = boundingRect(for: range)
-        return superview?.convert(rectInEditor, from: self) ?? rectInEditor
+        return window?.convert(rectInEditor, from: self) ?? rectInEditor
     }
 
     /// Returns the Selected Text's bounds

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -162,8 +162,8 @@ extension UITextView {
         let paddingBottom = safeAreaInsets.bottom + contentInset.bottom
         let editingHeight = frame.height - paddingTop - paddingBottom
 
-        let output = CGRect(x: .zero, y: .zero, width: frame.width, height: editingHeight)
-        return convert(output, to: nil)
+        let output = CGRect(x: frame.minX, y: paddingTop, width: frame.width, height: editingHeight)
+        return superview?.convert(output, to: nil) ?? output
     }
 
     /// Returns the Window Location for the text at the specified range

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -169,7 +169,7 @@ extension UITextView {
     ///
     func locationInWindowForText(in range: Range<String.Index>) -> CGRect {
         let rectInEditor = boundingRect(for: range)
-        return window?.convert(rectInEditor, from: self) ?? rectInEditor
+        return convert(rectInEditor, to: nil)
     }
 
     /// Returns the Selected Text's bounds

--- a/Simplenote/Classes/UIView+Simplenote.swift
+++ b/Simplenote/Classes/UIView+Simplenote.swift
@@ -36,13 +36,6 @@ extension UIView {
         return output
     }
 
-    /// Converts a Frame, expressed in Window Coordinates, into the receiver's coordinate system
-    ///
-    func convertFromWindowCoordinates(_ frame: CGRect) -> CGRect {
-        window?.convert(frame, to: self) ?? frame
-    }
-
-
     /// Returns the enclosing TextView, if any
     ///
     @objc

--- a/Simplenote/Classes/UIView+Simplenote.swift
+++ b/Simplenote/Classes/UIView+Simplenote.swift
@@ -36,6 +36,13 @@ extension UIView {
         return output
     }
 
+    /// Converts a Frame, expressed in Window Coordinates, into the receiver's coordinate system
+    ///
+    func convertFromWindowCoordinates(_ frame: CGRect) -> CGRect {
+        window?.convert(frame, to: self) ?? frame
+    }
+
+
     /// Returns the enclosing TextView, if any
     ///
     @objc


### PR DESCRIPTION
### Details:
1. We're using **Window coordinates** when exchanging frames between Editor / Interlink
2. **Dropped KVO in InterlinkViewController**: Explicit scroll invocations
3. Autocomplete is **dismissed when the scrolled offset exceeds a threshold** (30pt)
4. We've overhauled the geometry calculations for Autocomplete

#### Geometry:
1. Autocomplete will always be displayed above the cursor, when possible 📏 
2. Whenever displaying above **and** below cause clipping, we'll pick the orientation that clips the least
3. Horizontal position will be placed to match the Keyword onscreen
4. And we'll definitely never allow horizontal clipping 😄 

@eshurakov One step closer!
cc @SylvesterWilmott Violently improved positioning logic (exactly the same as macOS!)

**Note!!**
RTL support coming up in a follow up!

Ref. #914

### Test: Geometry
1. Open the Editor and add a note with 6 lines
2. Place the cursor in the 6th line
3. Type `[keyword` (with `keyword` being a word contained in any of your note's titles)

- [ ] Verify Autocomplete shows up below the cursor's location
- [ ] Verify that if you type another keyword (and narrow the results) the UI will shrink **but won't jump above**
- [ ] Verify that scrolling over the TextView below causes the Autocomplete window to follow along
- [ ] Verify that if you scroll over 30pt the Autocomplete UI gets dismissed
- [ ] Verify that if you repeat this in the 7th line, the Autocomplete UI shows up above
- [ ] Verify this also works super in an iPad device please!

### Test: Horizontal Overflow
1. Open the Editor
2. Type a long line
3. Type `[keyword` (with `keyword` being a word contained in any of your note's titles)

- [ ] Verify that hte Autocomplete UI never gets clipped offscreen!

### Test: Adaptivity
1. Open the Editor and type `[keyword` to trigger Autocomplete

- [ ] Verify that rotating the device causes Autocomplete to disappear / reappear in the right location

### Release
`RELEASE-NOTES.txt` was updated in bf0d2199 with:
 
> Typing `[` will now allow you to pick Interlinking Notes right from the editor
