### PR TITLE
Use the CocoaPods CDN

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 
 unless ['BUNDLE_BIN_PATH', 'BUNDLE_GEMFILE'].any? { |k| ENV.key?(k) }
 	raise 'Please run CocoaPods via `bundle exec`'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -49,7 +49,7 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.9)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://cdn.cocoapods.org/:
     - AppCenter
     - Automattic-Tracks-iOS
     - CocoaLumberjack
@@ -75,6 +75,6 @@ SPEC CHECKSUMS:
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: ef08a07055cf95acb86a110c344f47f3d2998b10
+PODFILE CHECKSUM: 80e2ba348292edc2d96028af198f40fdf18a6c05
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
Uses the CocoaPods CDN instead of checking out the entire specs repo in order to speed up pod installation

### Fix
Removes the CocoaPods specs repo from the project in order to enable CI improvements across all projects

### Test
Ensure all tests pass

### Review
Take a quick look at the code – it's a fairly straightforward change.

### Release
These changes do not require release notes.
