### PR TITLE
Information card improvements

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -264,6 +264,8 @@ extension SPNoteEditorViewController {
         ensureSearchIsDismissed()
         save()
 
+        dimLinksInEditor()
+
         let viewController = SPNoteHistoryViewController(note: currentNote, delegate: self)
         viewController.configureToPresentAsCard(presentationDelegate: self)
         historyViewController = viewController
@@ -288,6 +290,7 @@ extension SPNoteEditorViewController {
     }
 
     private func cleanUpAfterHistoryDismissal() {
+        restoreDefaultLinksDimmingInEditor()
         historyViewController = nil
     }
 }
@@ -346,7 +349,11 @@ extension SPNoteEditorViewController {
             self.informationViewController = navigationController
             present(navigationController, animated: true, completion: nil)
         } else {
-            informationViewController.configureToPresentAsCard()
+            dimLinksInEditor()
+
+            informationViewController.configureToPresentAsCard(onDismissCallback: { [weak self] in
+                self?.restoreDefaultLinksDimmingInEditor()
+            })
             self.informationViewController = informationViewController
             present(informationViewController, animated: true, completion: nil)
         }
@@ -361,6 +368,7 @@ extension SPNoteEditorViewController {
             return
         }
 
+        restoreDefaultLinksDimmingInEditor()
         informationViewController.dismiss(animated: false) { [weak self] in
             guard let self = self,
                   let note = self.currentNote,
@@ -490,6 +498,14 @@ private extension SPNoteEditorViewController {
 
     func restoreOriginalNoteContent() {
         updateEditor(with: currentNote.content)
+    }
+
+    func dimLinksInEditor() {
+        noteEditorTextView.tintAdjustmentMode = .dimmed
+    }
+
+    func restoreDefaultLinksDimmingInEditor() {
+        noteEditorTextView.tintAdjustmentMode = .automatic
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -113,7 +113,11 @@ private extension NoteInformationViewController {
         tableView.register(Value1TableViewCell.self, forCellReuseIdentifier: Value1TableViewCell.reuseIdentifier)
         tableView.register(SubtitleTableViewCell.self, forCellReuseIdentifier: SubtitleTableViewCell.reuseIdentifier)
         tableView.register(TableHeaderViewCell.self, forCellReuseIdentifier: TableHeaderViewCell.reuseIdentifier)
-        tableView.tableFooterView = UIView()
+
+        // remove separator for last cell if we're in popover
+        if popoverPresentationController != nil {
+            tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: CGFloat.leastNormalMagnitude))
+        }
     }
 
     func configureHeaderView() {

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -59,6 +59,7 @@ final class NoteInformationViewController: UIViewController {
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         configureHeaderLayoutMargins()
+        refreshPreferredSize()
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -14,6 +14,8 @@ final class NoteInformationViewController: UIViewController {
     private var sections: [NoteInformationController.Section] = []
     private let controller: NoteInformationController
 
+    private var onDismissCallback: (() -> Void)?
+
     /// Designated initializer
     ///
     /// - Parameters:
@@ -166,6 +168,7 @@ private extension NoteInformationViewController {
 private extension NoteInformationViewController {
     @IBAction func handleTapOnDismissButton() {
         dismiss(animated: true, completion: nil)
+        onDismissCallback?()
     }
 }
 
@@ -271,12 +274,21 @@ extension NoteInformationViewController {
 
     /// Configure view controller to be presented as a card
     ///
-    func configureToPresentAsCard() {
+    func configureToPresentAsCard(onDismissCallback: (() -> Void)? = nil) {
+        self.onDismissCallback = onDismissCallback
+
         let transitioningManager = SPCardTransitioningManager()
         self.transitioningManager = transitioningManager
+        transitioningManager.presentationDelegate = self
 
         transitioningDelegate = transitioningManager
         modalPresentationStyle = .custom
+    }
+}
+
+extension NoteInformationViewController: SPCardPresentationControllerDelegate {
+    func cardDidDismiss(_ viewController: UIViewController, reason: SPCardDismissalReason) {
+        onDismissCallback?()
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -330,5 +330,5 @@ private struct Localization {
 }
 
 private struct Consts {
-    static let headerExtraLayoutMargins = UIEdgeInsets(top: 16.0, left: 0.0, bottom: 8.0, right: 0.0)
+    static let headerExtraLayoutMargins = UIEdgeInsets(top: 13.0, left: 0.0, bottom: 13.0, right: 0.0)
 }

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,54 +22,52 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="9hs-LD-rni">
-                    <rect key="frame" x="0.0" y="44" width="414" height="619"/>
+                <tableView contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="dIp-Oc-ZbT"/>
+                        <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
+                    </connections>
+                </tableView>
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="30"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="203"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
-                                    <rect key="frame" x="0.0" y="91.5" width="376" height="20.5"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7HZ-2J-9ef" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
-                                    <rect key="frame" x="384" y="86.5" width="30" height="30"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="30" id="zYd-Xa-72n"/>
-                                        <constraint firstAttribute="width" constant="30" id="zd7-TM-xEa"/>
-                                    </constraints>
-                                    <state key="normal" image="icon_cross"/>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                            <real key="value" value="15"/>
-                                        </userDefinedRuntimeAttribute>
-                                    </userDefinedRuntimeAttributes>
-                                    <connections>
-                                        <action selector="handleTapOnDismissButton" destination="-1" eventType="touchUpInside" id="qgF-a7-uKd"/>
-                                    </connections>
-                                </button>
-                            </subviews>
-                        </stackView>
-                        <tableView clipsSubviews="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="219" width="414" height="400"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
+                            <rect key="frame" x="0.0" y="5" width="376" height="20.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7HZ-2J-9ef" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                            <rect key="frame" x="384" y="0.0" width="30" height="30"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="30" id="zYd-Xa-72n"/>
+                                <constraint firstAttribute="width" constant="30" id="zd7-TM-xEa"/>
+                            </constraints>
+                            <state key="normal" image="icon_cross"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                    <real key="value" value="15"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
                             <connections>
-                                <outlet property="dataSource" destination="-1" id="dIp-Oc-ZbT"/>
-                                <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
+                                <action selector="handleTapOnDismissButton" destination="-1" eventType="touchUpInside" id="qgF-a7-uKd"/>
                             </connections>
-                        </tableView>
+                        </button>
                     </subviews>
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="9hs-LD-rni" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="1Jc-dZ-rp6"/>
-                <constraint firstItem="9hs-LD-rni" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Ixl-Rz-z1H"/>
-                <constraint firstAttribute="trailing" secondItem="9hs-LD-rni" secondAttribute="trailing" id="XkJ-f0-nW0"/>
-                <constraint firstAttribute="bottom" secondItem="9hs-LD-rni" secondAttribute="bottom" id="Ysh-TV-19V"/>
+                <constraint firstAttribute="trailing" secondItem="HfE-pa-isg" secondAttribute="trailing" id="17g-xl-0dG"/>
+                <constraint firstAttribute="bottom" secondItem="HfE-pa-isg" secondAttribute="bottom" id="Fr2-jA-fFN"/>
+                <constraint firstItem="HfE-pa-isg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="JtQ-ZA-WOi"/>
+                <constraint firstItem="qBv-kl-fOD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Kky-qU-XXe"/>
+                <constraint firstItem="qBv-kl-fOD" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="XR7-XE-p8V"/>
+                <constraint firstItem="HfE-pa-isg" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="hrp-6V-pUL"/>
+                <constraint firstAttribute="trailing" secondItem="qBv-kl-fOD" secondAttribute="trailing" id="nD9-Ze-Dqy"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/Simplenote/SPShadowView.swift
+++ b/Simplenote/SPShadowView.swift
@@ -161,7 +161,7 @@ private extension SPShadowView {
     struct Constants {
         static let shadowColor = UIColor.black
         static let shadowOpacity: CGFloat = 0.1
-        static let shadowRadius: CGFloat = 4.0
+        static let shadowRadius: CGFloat = 20.0
         static let shadowOffset = CGSize(width: 0, height: -2)
     }
 }


### PR DESCRIPTION
### Details
This PR adds a few improvements to the information and history cards:
* When info / version card is on screen, links in the editor are dimmed (become gray)
* Shadow is adjusted and now has bigger radius 
* Title bar on the info card now has blurred background (in case there are multiple references and content becomes scrollable)

@jleandroperez May I bug you with this PR. Thanks!

Closes #969

### Test
**Open a note with links**

Info card:
- [x] Open an info card, check that links become gray
- [x] Open an info card, check that links become blue again

History card:
- [x] Open a history card, check that links become gray
- [x] Open a history card, check that links become blue again

### Test (References)
**Open a note that has a lot of references**

- [x] Open an info card, check that header view has blur if content is scrolled under the header.

### Test (iPad)
**Open an info card on iPad**

- [x] Check that if content fits in the popover, it's not scrollable

### Release
These changes do not require release notes.
