### PR TITLE
Interlinks Autocomplete: RTL Support

### DIFF
--- a/Simplenote/Classes/InterlinkProcessor.swift
+++ b/Simplenote/Classes/InterlinkProcessor.swift
@@ -121,6 +121,8 @@ private extension InterlinkProcessor {
         let interlinkViewController = InterlinkViewController()
         interlinkViewController.attachWithAnimation(to: parentViewController, below: parentOverlayView)
         presentedViewController = interlinkViewController
+
+        SPTracker.trackEditorInterlinkAutocompleteViewed()
     }
 
     func relocateInterlinkController(around range: Range<String.Index>) {

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -14,7 +14,7 @@ class InterlinkViewController: UIViewController {
 
     /// Layout Constraints: Inner TableView
     ///
-    @IBOutlet private var tableLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet private var tableLeftConstraint: NSLayoutConstraint!
     @IBOutlet private var tableTopConstraint: NSLayoutConstraint!
     @IBOutlet private var tableHeightConstraint: NSLayoutConstraint!
 
@@ -56,11 +56,11 @@ extension InterlinkViewController {
 
         let targetHeight = calculateHeight()
         let targetTop = calculateTopLocation(for: targetHeight, around: anchorFrame, in: editingRect)
-        let targetLeading = calculateLeadingLocation(around: anchorFrame, in: editingRect)
+        let targetLeft = calculateLeftLocation(around: anchorFrame, in: editingRect)
 
         tableTopConstraint.constant = targetTop
         tableHeightConstraint.constant = targetHeight
-        tableLeadingConstraint.constant = targetLeading
+        tableLeftConstraint.constant = targetLeft
     }
 
     /// Adjusts the Interlink TableView by the specified offset
@@ -180,7 +180,7 @@ private extension InterlinkViewController {
     /// -   Note: We'll align the Table **Text**, horizontally, with regards of the anchor frame. That's why we consider layout margins!
     /// -   Important: Whenever we overflow horizontally, we'll simply ensure there's enough breathing room on the right hand side
     ///
-    func calculateLeadingLocation(around anchor: CGRect, in viewport: CGRect) -> CGFloat {
+    func calculateLeftLocation(around anchor: CGRect, in viewport: CGRect) -> CGFloat {
         let maximumX = anchor.minX + Metrics.defaultTableWidth + tableView.layoutMargins.right
         if viewport.width > maximumX {
             return anchor.minX - tableView.layoutMargins.left

--- a/Simplenote/Classes/InterlinkViewController.xib
+++ b/Simplenote/Classes/InterlinkViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,7 +13,7 @@
                 <outlet property="backgroundView" destination="ZZD-kk-l5T" id="vLO-Vd-nH7"/>
                 <outlet property="shadowView" destination="J1j-Rs-BRd" id="F6m-io-a8C"/>
                 <outlet property="tableHeightConstraint" destination="pJU-Uf-0Oq" id="8xE-WM-Fgp"/>
-                <outlet property="tableLeadingConstraint" destination="YkW-MZ-sEN" id="ewM-9i-2qp"/>
+                <outlet property="tableLeftConstraint" destination="YkW-MZ-sEN" id="dLy-Pg-tWY"/>
                 <outlet property="tableTopConstraint" destination="1aU-WG-N13" id="UWn-PU-7Am"/>
                 <outlet property="tableView" destination="0Ce-It-s4R" id="rdg-1f-23L"/>
                 <outlet property="view" destination="URg-NP-0Et" id="xef-Np-8pC"/>
@@ -86,7 +86,7 @@
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="top" secondItem="0Ce-It-s4R" secondAttribute="top" id="Jda-bL-BQO"/>
                 <constraint firstItem="ZZD-kk-l5T" firstAttribute="leading" secondItem="0Ce-It-s4R" secondAttribute="leading" id="U49-aZ-qMs"/>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="bottom" secondItem="0Ce-It-s4R" secondAttribute="bottom" id="Xos-pY-37F"/>
-                <constraint firstItem="0Ce-It-s4R" firstAttribute="leading" secondItem="URg-NP-0Et" secondAttribute="leading" priority="999" id="YkW-MZ-sEN"/>
+                <constraint firstItem="0Ce-It-s4R" firstAttribute="left" secondItem="URg-NP-0Et" secondAttribute="left" priority="999" id="YkW-MZ-sEN"/>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="trailing" secondItem="0Ce-It-s4R" secondAttribute="trailing" id="cl7-N9-OKH"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0Ce-It-s4R" secondAttribute="trailing" constant="16" id="hN1-X0-aCU"/>
                 <constraint firstItem="0Ce-It-s4R" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="URg-NP-0Et" secondAttribute="leading" constant="16" id="m4j-uj-bVK"/>

--- a/Simplenote/Classes/SPTracker.h
+++ b/Simplenote/Classes/SPTracker.h
@@ -36,6 +36,7 @@
 + (void)trackEditorCollaboratorsAccessed;
 + (void)trackEditorCopiedInternalLink;
 + (void)trackEditorCopiedPublicLink;
++ (void)trackEditorInterlinkAutocompleteViewed;
 
 #pragma mark - Note List
 + (void)trackListNoteCreated;

--- a/Simplenote/Classes/SPTracker.m
+++ b/Simplenote/Classes/SPTracker.m
@@ -128,6 +128,12 @@
     [self trackAutomatticEventWithName:@"editor_copied_public_link" properties:nil];
 }
 
++ (void)trackEditorInterlinkAutocompleteViewed
+{
+    [self trackAutomatticEventWithName:@"editor_interlink_autocomplete_viewed" properties:nil];
+}
+
+
 #pragma mark - Note List
 
 + (void)trackListNoteCreated


### PR DESCRIPTION
### Fix
In this PR we're adding RTL support for the Interlinks window

**Plus:** We're adding a Tracks invocation, for analytics purposes.

@eshurakov Can I trouble you with this one?
Thank you sir!!

Ref. #914

### Test
1. Launch Simplenote in RTL mode
2. Open the Editor
3. Type `[keyword` with `keyword` being a word contained in another note's title

- [x] Verify Autocomplete looks exactly where it should
- [x] Verify this still looks great in LTR mode
- [x] Verify iPad is also great!

### Release
These changes do not require release notes.
