### PR TITLE
Bugfix: InterlinkProcessor dismissal on Text Selection

### DIFF
--- a/Simplenote/Classes/InterlinkProcessor.swift
+++ b/Simplenote/Classes/InterlinkProcessor.swift
@@ -83,22 +83,6 @@ class InterlinkProcessor: NSObject {
         lastKnownKeywordRange = keywordRange
     }
 
-    /// Dismisses the Interlink UI when ANY of the following evaluates **true**:
-    ///
-    ///     1.  There is Highlighted Text in the editor (or)
-    ///     2.  There is no Interlink `[keyword` at the selected location
-    ///     3.  There is a `[keyword` at the current location, but it's not the same we've seen before (!!
-    ///     4.  The editor is no longer the first responder
-    ///
-    @objc
-    func dismissInterlinkLookupIfNeeded() {
-        guard isInterlinkLookupOnScreen, mustDismissInterlinkLookup else {
-            return
-        }
-
-        dismissInterlinkLookup()
-    }
-
     /// Dismisses the Interlink UI (if it's onscreen!)
     ///
     @objc
@@ -200,18 +184,6 @@ private extension InterlinkProcessor {
     var mustProcessInterlinkLookup: Bool {
         let editor = parentTextView
         return editor.isFirstResponder && !editor.isTextSelected && !editor.isUndoingEditOP
-    }
-
-    var mustDismissInterlinkLookup: Bool {
-        if parentTextView.isTextSelected || !parentTextView.isFirstResponder {
-            return true
-        }
-
-        guard let (_, keywordRange, _) = parentTextView.interlinkKeywordAtSelectedLocation else {
-            return true
-        }
-
-        return keywordRange.lowerBound != lastKnownKeywordRange?.lowerBound
     }
 }
 

--- a/Simplenote/Classes/SPEditorTextView.h
+++ b/Simplenote/Classes/SPEditorTextView.h
@@ -22,6 +22,9 @@
 @property (nonatomic, strong) UIFont *checklistsFont;
 @property (nonatomic, strong) UIColor *checklistsTintColor;
 
+@property (nonatomic, readonly) BOOL isInserting;
+@property (nonatomic, readonly) BOOL isDeletingBackward;
+
 - (void)scrollToBottomWithAnimation:(BOOL)animated;
 - (void)scrollToTop;
 - (void)processChecklists;

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -41,6 +41,8 @@ NSInteger const ChecklistCursorAdjustment = 2;
 @property (nonatomic) UITextLayoutDirection verticalMoveDirection;
 @property (nonatomic) CGRect verticalMoveStartCaretRect;
 @property (nonatomic) CGRect verticalMoveLastCaretRect;
+@property (nonatomic) BOOL isInserting;
+@property (nonatomic) BOOL isDeletingBackward;
 
 @end
 
@@ -223,6 +225,20 @@ NSInteger const ChecklistCursorAdjustment = 2;
     
     self.editable = YES;
     return [super becomeFirstResponder];
+}
+
+- (void)insertText:(NSString *)text
+{
+    self.isInserting = YES;
+    [super insertText:text];
+    self.isInserting = NO;
+}
+
+- (void)deleteBackward
+{
+    self.isDeletingBackward = YES;
+    [super deleteBackward];
+    self.isDeletingBackward = NO;
 }
 
 - (BOOL)resignFirstResponder

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -754,7 +754,11 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)textViewDidChangeSelection:(UITextView *)textView
 {
-    [self.interlinkProcessor dismissInterlinkLookupIfNeeded];
+    if (self.noteEditorTextView.isInserting || self.noteEditorTextView.isDeletingBackward) {
+        return;
+    }
+
+    [self.interlinkProcessor dismissInterlinkLookup];
 }
 
 

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -19,12 +19,6 @@ extension UITextView {
     var isUndoingEditOP: Bool {
         undoManager?.isUndoing == true
     }
-
-    /// Indicates if the user is Editing an Interlink
-    ///
-    var isEditingInterlink: Bool {
-        interlinkKeywordAtSelectedLocation != nil
-    }
 }
 
 


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug in which the Interlink Autocomplete UI would not be dismissed when pressing elsewhere.

cc @eshurakov Thank you for catching this one!!
Ref. #914 

### Test
1. Add a new Note
2. Add the following note:

```
[keyword TEXT TEXT TEXT
TEXT
TEXT
TEXT [keyword
```

**Bear in mind** that `keyword` must be any word contained in any of your note's titles

3. Press over the first keyword and hit backspace to trigger Interlink Autocomplete
4. Press over the **second keyword**

- [ ] Verify the Interlink Autocomplete gets dismissed right away

### Release
These changes do not require release notes.
