### PR TITLE
Interlinking: Dynamic Height

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -201,6 +201,8 @@
 		B531090823D0B685002B0998 /* SPSimpleTextPrintFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B531090723D0B685002B0998 /* SPSimpleTextPrintFormatter.swift */; };
 		B5358C5A2371DFBC007604E0 /* UITextView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5358C592371DFBC007604E0 /* UITextView+Simplenote.swift */; };
 		B535F2E72399BFB600C1DDCA /* SPRatingsPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535F2E62399BFB600C1DDCA /* SPRatingsPromptView.swift */; };
+		B536988D25646C9400817E30 /* CGRect+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B536988C25646C9400817E30 /* CGRect+Simplenote.swift */; };
+		B536989B25646D3900817E30 /* CGRectSimplenoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B536989A25646D3900817E30 /* CGRectSimplenoteTests.swift */; };
 		B537730F252E14C600BC78C5 /* OptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B537730E252E14C600BC78C5 /* OptionsViewController.swift */; };
 		B537732B252E176C00BC78C5 /* OptionsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B537732A252E176C00BC78C5 /* OptionsViewController.xib */; };
 		B537733B252E29D400BC78C5 /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B537733A252E29D300BC78C5 /* SwitchTableViewCell.swift */; };
@@ -591,6 +593,8 @@
 		B531090723D0B685002B0998 /* SPSimpleTextPrintFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SPSimpleTextPrintFormatter.swift; path = Classes/SPSimpleTextPrintFormatter.swift; sourceTree = "<group>"; };
 		B5358C592371DFBC007604E0 /* UITextView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITextView+Simplenote.swift"; path = "Classes/UITextView+Simplenote.swift"; sourceTree = "<group>"; };
 		B535F2E62399BFB600C1DDCA /* SPRatingsPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPRatingsPromptView.swift; path = Classes/SPRatingsPromptView.swift; sourceTree = "<group>"; };
+		B536988C25646C9400817E30 /* CGRect+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "CGRect+Simplenote.swift"; path = "Classes/CGRect+Simplenote.swift"; sourceTree = "<group>"; };
+		B536989A25646D3900817E30 /* CGRectSimplenoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectSimplenoteTests.swift; sourceTree = "<group>"; };
 		B537730E252E14C600BC78C5 /* OptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OptionsViewController.swift; path = Classes/OptionsViewController.swift; sourceTree = "<group>"; };
 		B537732A252E176C00BC78C5 /* OptionsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = OptionsViewController.xib; path = Classes/OptionsViewController.xib; sourceTree = "<group>"; };
 		B537733A252E29D300BC78C5 /* SwitchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwitchTableViewCell.swift; path = Classes/SwitchTableViewCell.swift; sourceTree = "<group>"; };
@@ -1206,6 +1210,7 @@
 		B52F35D422F3573300724793 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B536989A25646D3900817E30 /* CGRectSimplenoteTests.swift */,
 				374F5EF421BF057E00B57E8B /* NSMutableAttributedStringStylingTests.swift */,
 				B51F6DD62460D7C20074DDD9 /* NSPredicateEmailTests.swift */,
 				B5D367BD23ECF42D0024215D /* NSStringCondensingTests.swift */,
@@ -1296,6 +1301,7 @@
 			children = (
 				B5E951E224FEE25A004B10B8 /* Links */,
 				B5CBEF4122D3B419009DBE67 /* Bundle+Simplenote.swift */,
+				B536988C25646C9400817E30 /* CGRect+Simplenote.swift */,
 				F52A2FD01DE8B1FB002DEB0E /* CSSearchable+Helpers.swift */,
 				B5AEC38323FAC5D600D24221 /* DateFormatter+Simplenote.swift */,
 				B52BB74922CFC0670042C162 /* FileManager+Simplenote.swift */,
@@ -1588,7 +1594,6 @@
 				B5F3000023F446FC007A7C59 /* SortBar */,
 				B546BE9A234E758E00A126DA /* TableViewCells */,
 				E2922AB3180C7322003AF914 /* Tag View */,
-				A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */,
 				B5C2EDEF255AFB6C00C09B32 /* PassthruView.swift */,
 				B5DF733F22A54EE800602CE7 /* SPDefaultTableViewCell.swift */,
 				E25C39DE17A4772900B2591A /* SPEntryListAutoCompleteCell.h */,
@@ -1612,7 +1617,8 @@
 				A68ABCA724ABFB5300715EBD /* SPShadowView.swift */,
 				A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */,
 				A6E1E7A724BE656D008A44BC /* SPCardView.swift */,
-				A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */,				A604DB21255A993E00B802CA /* SearchMapView.swift */,
+				A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */,
+				A604DB21255A993E00B802CA /* SearchMapView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2462,6 +2468,7 @@
 				B521A1961BC8446900E1CF2A /* SPAutomatticTracker.m in Sources */,
 				375D24B121E01131007AB25A /* html5_blocks.c in Sources */,
 				B504D4DE23D2014200AEED27 /* IndexPath+Simplenote.swift in Sources */,
+				B536988D25646C9400817E30 /* CGRect+Simplenote.swift in Sources */,
 				B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */,
 				B5BA5B082551FB3C002AAD43 /* UIDevice+Simplenote.swift in Sources */,
 				A681C7342541772D00F369C2 /* NumberFormatter+Simplenote.swift in Sources */,
@@ -2494,6 +2501,7 @@
 				B5421F3C23CE7A14004DDC19 /* Constants.swift in Sources */,
 				B5421F3F23CE7A1C004DDC19 /* MockupStorage.swift in Sources */,
 				A6344AD9255952C70072FA07 /* NoteContentPreviewTests.swift in Sources */,
+				B536989B25646D3900817E30 /* CGRectSimplenoteTests.swift in Sources */,
 				B576076824CFA2250097D295 /* NSStringSimplenoteTests.swift in Sources */,
 				A64DE701255D4570001D0526 /* NoteBodyExcerptTests.swift in Sources */,
 			);

--- a/Simplenote/Classes/CGRect+Simplenote.swift
+++ b/Simplenote/Classes/CGRect+Simplenote.swift
@@ -10,18 +10,18 @@ extension CGRect {
     /// - Note: We rely on this API to determine the available editing area above and below the cursor
     /// - Important: **For simplicity's sake** we won't return an optional. If the parameters are invalid, we'll just pass along the "non split receiver"
     ///
-    func split(by rect: CGRect) -> (upperSlice: CGRect, lowerSlice: CGRect) {
+    func split(by rect: CGRect) -> (aboveSlice: CGRect, belowSlice: CGRect) {
         guard contains(rect) else {
             return (.zero, self)
         }
 
-        var lowerSlice = self
-        lowerSlice.size.height = rect.minY - minY
+        var belowSlice = self
+        belowSlice.size.height = rect.minY - minY
 
-        var upperSlice = self
-        upperSlice.origin.y = rect.maxY
-        upperSlice.size.height = height - lowerSlice.height - rect.height
+        var aboveSlice = self
+        aboveSlice.origin.y = rect.maxY
+        aboveSlice.size.height = maxY - rect.maxY
 
-        return (upperSlice, lowerSlice)
+        return (aboveSlice, belowSlice)
     }
 }

--- a/Simplenote/Classes/CGRect+Simplenote.swift
+++ b/Simplenote/Classes/CGRect+Simplenote.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+
+// MARK: - CGRect Methods
+//
+extension CGRect {
+
+    /// Returns the resulting Rectangles by splitting the receiver in two, by the specified Rectangle's **minY** and **maxY**
+    ///
+    /// - Note: We rely on this API to determine the available editing area above and below the cursor
+    /// - Important: **For simplicity's sake** we won't return an optional. If the parameters are invalid, we'll just pass along the "non split receiver"
+    ///
+    func split(by rect: CGRect) -> (upperSlice: CGRect, lowerSlice: CGRect) {
+        guard contains(rect) else {
+            return (.zero, self)
+        }
+
+        var lowerSlice = self
+        lowerSlice.size.height = rect.minY - minY
+
+        var upperSlice = self
+        upperSlice.origin.y = rect.maxY
+        upperSlice.size.height = height - lowerSlice.height - rect.height
+
+        return (upperSlice, lowerSlice)
+    }
+}

--- a/Simplenote/Classes/CGRect+Simplenote.swift
+++ b/Simplenote/Classes/CGRect+Simplenote.swift
@@ -6,15 +6,9 @@ import Foundation
 extension CGRect {
 
     /// Returns the resulting Rectangles by splitting the receiver in two, by the specified Rectangle's **minY** and **maxY**
-    ///
     /// - Note: We rely on this API to determine the available editing area above and below the cursor
-    /// - Important: **For simplicity's sake** we won't return an optional. If the parameters are invalid, we'll just pass along the "non split receiver"
     ///
     func split(by rect: CGRect) -> (aboveSlice: CGRect, belowSlice: CGRect) {
-        guard contains(rect) else {
-            return (.zero, self)
-        }
-
         var belowSlice = self
         belowSlice.size.height = rect.minY - minY
 

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -191,13 +191,16 @@ private extension InterlinkViewController {
 
 
     /// Returns the target Size.Height for the current ViewPort metrics
-    /// - Important: We're **SIMPLIFYING** the availableHeight calculations, by assuming the cursor might be in the top / bottom edge.
     ///
     func calculateHeight(around anchor: CGRect, in viewport: CGRect) -> CGFloat {
         let fullHeight = CGFloat(notes.count) * Metrics.defaultCellHeight
-        let availableHeight = viewport.height - anchor.height - Metrics.defaultTableInsets.top - Metrics.defaultTableInsets.bottom
 
-        return min(fullHeight, min(Metrics.maximumTableHeight, availableHeight))
+        let (viewportAboveCursor, viewportBelowCursor) = viewport.split(by: anchor)
+        let maximumAvailableHeight = max(viewportAboveCursor.height, viewportBelowCursor.height)
+        let insetAvailableHeight = maximumAvailableHeight - Metrics.defaultTableInsets.top - Metrics.defaultTableInsets.bottom
+        let cappedAvailableHeight = min(insetAvailableHeight, Metrics.maximumTableHeight)
+
+        return max(min(fullHeight, cappedAvailableHeight), Metrics.minimumTableHeight)
     }
 }
 
@@ -225,4 +228,5 @@ private enum Metrics {
     static let defaultTableWidth = CGFloat(300)
     static let maximumVisibleCells = 3.5
     static let maximumTableHeight = defaultCellHeight * CGFloat(maximumVisibleCells)
+    static let minimumTableHeight = defaultCellHeight
 }

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -152,12 +152,14 @@ private extension InterlinkViewController {
     /// -   Important: We'll always prefer the orientation that results in the **Least Clipped Surface™**
     ///
     func calculateTopLocation(for height: CGFloat, around anchor: CGRect, in viewport: CGRect) -> CGFloat {
-        let minimumLocationForFullHeight = anchor.minY - Metrics.defaultTableInsets.top - Metrics.maximumTableHeight
         let locationAbove = anchor.minY - Metrics.defaultTableInsets.top - height
         let locationBelow = anchor.maxY + Metrics.defaultTableInsets.top
 
-        let deltaAbove = minimumLocationForFullHeight - viewport.minY
-        let deltaBelow = viewport.maxY - locationBelow - height
+        /// Always consider the *Maximum Height* when determining if we should render above or below
+        /// - Why: Perhaps deleting a character yields way more results, and we intend to avoid flickering!
+        ///
+        let deltaAbove = anchor.minY - viewport.minY - Metrics.maximumTableHeight
+        let deltaBelow = viewport.maxY - anchor.maxY - Metrics.maximumTableHeight
         let dispayingAboveClips = deltaAbove < .zero
         let dispayingBelowClips = deltaBelow < .zero
 

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -54,7 +54,7 @@ extension InterlinkViewController {
         let anchorFrame = view.convert(anchor, from: nil)
         let editingRect = view.convert(viewport, from: nil)
 
-        let targetHeight = calculateHeight()
+        let targetHeight = calculateHeight(around: anchorFrame, in: editingRect)
         let targetTop = calculateTopLocation(for: targetHeight, around: anchorFrame, in: editingRect)
         let targetLeading = calculateLeadingLocation(around: anchorFrame, in: editingRect)
 
@@ -190,11 +190,14 @@ private extension InterlinkViewController {
     }
 
 
-    /// Returns the target Size.Height
+    /// Returns the target Size.Height for the current ViewPort metrics
+    /// - Important: We're **SIMPLIFYING** the availableHeight calculations, by assuming the cursor might be in the top / bottom edge.
     ///
-    func calculateHeight() -> CGFloat {
+    func calculateHeight(around anchor: CGRect, in viewport: CGRect) -> CGFloat {
         let fullHeight = CGFloat(notes.count) * Metrics.defaultCellHeight
-        return min(fullHeight, Metrics.maximumTableHeight)
+        let availableHeight = viewport.height - anchor.height - Metrics.defaultTableInsets.top - Metrics.defaultTableInsets.bottom
+
+        return min(fullHeight, min(Metrics.maximumTableHeight, availableHeight))
     }
 }
 
@@ -218,7 +221,7 @@ private extension InterlinkViewController {
 private enum Metrics {
     static let cornerRadius = CGFloat(10)
     static let defaultCellHeight = CGFloat(44)
-    static let defaultTableInsets = UIEdgeInsets(top: 12, left: 20, bottom: 0, right: 20)
+    static let defaultTableInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
     static let defaultTableWidth = CGFloat(300)
     static let maximumVisibleCells = 3.5
     static let maximumTableHeight = defaultCellHeight * CGFloat(maximumVisibleCells)

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -155,18 +155,15 @@ private extension InterlinkViewController {
         let locationAbove = anchor.minY - Metrics.defaultTableInsets.top - height
         let locationBelow = anchor.maxY + Metrics.defaultTableInsets.top
 
-        /// Always consider the *Maximum Height* when determining if we should render above or below
-        /// - Why: Perhaps deleting a character yields way more results, and we intend to avoid flickering!
+        /// We'll always prefer displaying the Autocomplete UI **above** the cursor, whenever such location does not produce clipping.
+        /// Even if there's more room at the bottom (that's why a simple max calculation isn't enough!)
         ///
-        let deltaAbove = anchor.minY - viewport.minY - Metrics.maximumTableHeight
-        let deltaBelow = viewport.maxY - anchor.maxY - Metrics.maximumTableHeight
-        let dispayingAboveClips = deltaAbove < .zero
-        let dispayingBelowClips = deltaBelow < .zero
+        /// - Important: In order to avoid flipping Up / Down, we'll consider the Maximum Heigh tour TableView can acquire
+        ///
+        let paddingAbove = anchor.minY - viewport.minY - Metrics.maximumTableHeight - Metrics.defaultTableInsets.top
+        let paddingBelow = viewport.maxY - anchor.maxY - Metrics.maximumTableHeight - Metrics.defaultTableInsets.top
 
-        if dispayingAboveClips == false && dispayingBelowClips == false ||
-            dispayingAboveClips == false && deltaAbove > deltaBelow ||
-            dispayingAboveClips && dispayingBelowClips && deltaAbove > deltaBelow
-        {
+        if (paddingAbove >= .zero) || (paddingAbove < .zero && paddingBelow < .zero && paddingAbove > paddingBelow) {
             return locationAbove
         }
 

--- a/Simplenote/Classes/InterlinkViewController.swift
+++ b/Simplenote/Classes/InterlinkViewController.swift
@@ -167,6 +167,8 @@ private extension InterlinkViewController {
     /// - Important: In order to avoid flipping Up / Down, we'll consider the Maximum Heigh tour TableView can acquire
     ///
     func calculateViewportSlice(around anchor: CGRect, in viewport: CGRect) -> (Orientation, CGRect) {
+        /// Nosebleed: In iOS the (0, 0) is top left. For that reason we're inverting the Above / Below subframes.
+        ///
         let (viewportBelow, viewportAbove)  = viewport.split(by: anchor)
         let deltaAbove                      = viewportAbove.height - Metrics.maximumTableHeight
         let deltaBelow                      = viewportBelow.height - Metrics.maximumTableHeight

--- a/Simplenote/Classes/InterlinkViewController.xib
+++ b/Simplenote/Classes/InterlinkViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -63,7 +63,7 @@
                     </view>
                     <blurEffect style="regular"/>
                 </visualEffectView>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" bouncesZoom="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Ce-It-s4R">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" showsHorizontalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" bouncesZoom="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Ce-It-s4R">
                     <rect key="frame" x="16" y="12" width="300" height="50"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>

--- a/SimplenoteTests/CGRectSimplenoteTests.swift
+++ b/SimplenoteTests/CGRectSimplenoteTests.swift
@@ -6,18 +6,6 @@ import XCTest
 //
 class CGRectSimplenoteTests: XCTestCase {
 
-    /// Verifies that `splity(by:)` returns zero CGRect.zero in the upper slice and self in the lower slice whenever the anchor is invalid
-    ///
-    func testSplitByRectReturnsTheReceiversRectWheneverTheInputIsInvalid() {
-        let input = CGRect(x: .zero, y: .zero, width: 300, height: 300)
-        let anchor = CGRect(x: -1, y: -1, width: .zero, height: .zero)
-
-        let (above, below) = input.split(by: anchor)
-
-        XCTAssertEqual(above, .zero)
-        XCTAssertEqual(below, input)
-    }
-
     /// Verifies that `splity(by:)` returns a zero height lower slice whenever the anchor has Zero location and Height
     ///
     func testSplitByRectReturnsEmptyLowerSliceWheneverTheInputHasZeroHeight() {

--- a/SimplenoteTests/CGRectSimplenoteTests.swift
+++ b/SimplenoteTests/CGRectSimplenoteTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Simplenote
+
+
+// MARK: - CGRect Tests
+//
+class CGRectSimplenoteTests: XCTestCase {
+
+    /// Verifies that `splity(by:)` returns zero CGRect.zero in the upper slice and self in the lower slice whenever the anchor is invalid
+    ///
+    func testSplitByRectReturnsTheReceiversRectWheneverTheInputIsInvalid() {
+        let input = CGRect(x: .zero, y: .zero, width: 300, height: 300)
+        let anchor = CGRect(x: -1, y: -1, width: .zero, height: .zero)
+
+        let (upper, lower) = input.split(by: anchor)
+
+        XCTAssertEqual(upper, .zero)
+        XCTAssertEqual(lower, input)
+    }
+
+    /// Verifies that `splity(by:)` returns a zero height lower slice whenever the anchor has Zero location and Height
+    ///
+    func testSplitByRectReturnsEmptyLowerSliceWheneverTheInputHasZeroHeight() {
+        let input = CGRect(x: .zero, y: .zero, width: 300, height: 300)
+        let anchor = CGRect(x: .zero, y: .zero, width: 0, height: 0)
+
+        let expectedLower = CGRect(x: .zero, y: .zero, width: 300, height: 0)
+        let (upper, lower) = input.split(by: anchor)
+
+        XCTAssertEqual(upper, input)
+        XCTAssertEqual(lower, expectedLower)
+    }
+
+    /// Verifies that `splity(by:)` returns the expected Slices
+    ///
+    func testSplitByRectReturnsTheExpectedResultingSlices() {
+        let input = CGRect(x: .zero, y: .zero, width: 300, height: 300)
+        let anchor = CGRect(x: .zero, y: 100, width: .zero, height: 100)
+
+        let expectedUpper = CGRect(x: .zero, y: 200, width: 300, height: 100)
+        let expectedLower = CGRect(x: .zero, y: .zero, width: 300, height: 100)
+        let (upper, lower) = input.split(by: anchor)
+
+        XCTAssertEqual(upper, expectedUpper)
+        XCTAssertEqual(lower, expectedLower)
+    }
+}

--- a/SimplenoteTests/CGRectSimplenoteTests.swift
+++ b/SimplenoteTests/CGRectSimplenoteTests.swift
@@ -12,10 +12,10 @@ class CGRectSimplenoteTests: XCTestCase {
         let input = CGRect(x: .zero, y: .zero, width: 300, height: 300)
         let anchor = CGRect(x: -1, y: -1, width: .zero, height: .zero)
 
-        let (upper, lower) = input.split(by: anchor)
+        let (above, below) = input.split(by: anchor)
 
-        XCTAssertEqual(upper, .zero)
-        XCTAssertEqual(lower, input)
+        XCTAssertEqual(above, .zero)
+        XCTAssertEqual(below, input)
     }
 
     /// Verifies that `splity(by:)` returns a zero height lower slice whenever the anchor has Zero location and Height
@@ -24,11 +24,11 @@ class CGRectSimplenoteTests: XCTestCase {
         let input = CGRect(x: .zero, y: .zero, width: 300, height: 300)
         let anchor = CGRect(x: .zero, y: .zero, width: 0, height: 0)
 
-        let expectedLower = CGRect(x: .zero, y: .zero, width: 300, height: 0)
-        let (upper, lower) = input.split(by: anchor)
+        let expectedBelow = CGRect(x: .zero, y: .zero, width: 300, height: 0)
+        let (above, below) = input.split(by: anchor)
 
-        XCTAssertEqual(upper, input)
-        XCTAssertEqual(lower, expectedLower)
+        XCTAssertEqual(above, input)
+        XCTAssertEqual(below, expectedBelow)
     }
 
     /// Verifies that `splity(by:)` returns the expected Slices
@@ -37,11 +37,11 @@ class CGRectSimplenoteTests: XCTestCase {
         let input = CGRect(x: .zero, y: .zero, width: 300, height: 300)
         let anchor = CGRect(x: .zero, y: 100, width: .zero, height: 100)
 
-        let expectedUpper = CGRect(x: .zero, y: 200, width: 300, height: 100)
-        let expectedLower = CGRect(x: .zero, y: .zero, width: 300, height: 100)
-        let (upper, lower) = input.split(by: anchor)
+        let expectedAbove = CGRect(x: .zero, y: 200, width: 300, height: 100)
+        let expectedBelow = CGRect(x: .zero, y: .zero, width: 300, height: 100)
+        let (above, below) = input.split(by: anchor)
 
-        XCTAssertEqual(upper, expectedUpper)
-        XCTAssertEqual(lower, expectedLower)
+        XCTAssertEqual(above, expectedAbove)
+        XCTAssertEqual(below, expectedBelow)
     }
 }


### PR DESCRIPTION
### Details
In this PR we're limiting the Interlinking UI's height to the available area.

**Note:** The algorithm is overly simplified, and assumes the cursor is either at the top or bottom of the viewport. Overflow in any other case is expected!

cc @eshurakov (Thank youuu!!)
Closes #914

### Test
1. Open the editor
2. Turn the app in landscape mode
3. Place the cursor either at the top or bottom of the editor
4. Type `[keyword`

- [x] Verify the Interlink UI doesn't overflow. (As long as the cursor is anchored at the top / bottom!!)

### Release
These changes do not require release notes.
