### PR TITLE
Update `notesWithTag` method to use `SimplenoteFoundation`

### DIFF
--- a/Simplenote/Classes/SPObjectManager+Simplenote.swift
+++ b/Simplenote/Classes/SPObjectManager+Simplenote.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SimplenoteFoundation
 
 // MARK: - SPObjectManager
 //
@@ -23,4 +24,18 @@ extension SPObjectManager {
         return note
     }
 
+    @objc
+    func notesWithTag(_ tag: Tag?) -> [Note] {
+        guard let tagName = tag?.name else {
+            return []
+        }
+
+        let request = NSFetchRequest<Note>(entityName: Note.entityName)
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            .predicateForNotes(tag: tagName),
+            .predicateForNotes(deleted: false)
+        ])
+
+        return (try? managedObjectContext.fetch(request)) ?? []
+    }
 }

--- a/Simplenote/Classes/SPObjectManager.h
+++ b/Simplenote/Classes/SPObjectManager.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Tags
 
-- (NSArray *)notesWithTag:(Tag *)tag;
 - (void)editTag:(Tag *)tag title:(NSString *)newTitle;
 - (BOOL)removeTagName:(NSString *)tagName;
 - (BOOL)removeTag:(Tag *)tag;

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -188,24 +188,6 @@
     
 }
 
-
--(NSArray *)notesWithTag:(Tag *)tag
-{
-    if (!tag.name)
-        return nil;
-    
-    NSMutableArray *predicateList = [NSMutableArray arrayWithCapacity:3];
-    [predicateList addObject: [NSPredicate predicateWithFormat: @"deleted == %@", [NSNumber numberWithBool:NO]]];
-    [predicateList addObject: [NSPredicate predicateWithFormat: @"tags CONTAINS[c] %@", tag.name]];
-    NSString *regEx = [NSString stringWithFormat:@".*\"%@\".*", tag.name];
-    [predicateList addObject: [NSPredicate predicateWithFormat: @"tags MATCHES[c] %@", regEx]];
-    
-    NSPredicate *compound = [NSCompoundPredicate andPredicateWithSubpredicates:predicateList];
-    
-	NSManagedObjectContext *context = [[SPAppDelegate sharedDelegate] managedObjectContext];
-    return [context fetchObjectsForEntityName:@"Note" withPredicate:compound];
-}
-
 - (void)moveTagFromIndex:(NSInteger)fromIndex toIndex:(NSInteger)toIndex {
     
     NSArray *tagList = [self tags];


### PR DESCRIPTION
### Fix
Updating `notesWithTag` method to use `SimplenoteFoundation` and be in line with macOS.

cc @jleandroperez mind taking a quick peek? Thank you!

### Test
1. Create tags `aaaa` and `aa`
2. Assign those tags to some notes

- [x] Rename tag `aa` to `aaa` and check that the changes are reflected correctly inside notes 
- [x] Delete tag `aaa` and check that the changes are reflected correctly inside notes (and that tag `aaaa` is not affected)

### Release
> These changes do not require release notes.
