### PR TITLE
Nü passcode screen: I

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -124,6 +124,9 @@
 		A64DE6F9255D21B9001D0526 /* StringContentSliceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64DE6F8255D21B9001D0526 /* StringContentSliceTests.swift */; };
 		A64DE701255D4570001D0526 /* NoteBodyExcerptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64DE700255D4570001D0526 /* NoteBodyExcerptTests.swift */; };
 		A66224FD2546B460003A949E /* TableHeaderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66224FC2546B460003A949E /* TableHeaderViewCell.swift */; };
+		A66E41D0256D08E6000C6FCB /* PinLockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66E41CE256D08E6000C6FCB /* PinLockViewController.swift */; };
+		A66E41D1256D08E6000C6FCB /* PinLockViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A66E41CF256D08E6000C6FCB /* PinLockViewController.xib */; };
+		A66E41E1256D0F44000C6FCB /* RoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66E41E0256D0F44000C6FCB /* RoundedButton.swift */; };
 		A681C72C254172B600F369C2 /* NoteMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C72B254172B600F369C2 /* NoteMetrics.swift */; };
 		A681C7342541772D00F369C2 /* NumberFormatter+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C7332541772D00F369C2 /* NumberFormatter+Simplenote.swift */; };
 		A681C73C2541AC8D00F369C2 /* HuggableTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */; };
@@ -523,6 +526,9 @@
 		A64DE6F8255D21B9001D0526 /* StringContentSliceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringContentSliceTests.swift; sourceTree = "<group>"; };
 		A64DE700255D4570001D0526 /* NoteBodyExcerptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteBodyExcerptTests.swift; sourceTree = "<group>"; };
 		A66224FC2546B460003A949E /* TableHeaderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableHeaderViewCell.swift; sourceTree = "<group>"; };
+		A66E41CE256D08E6000C6FCB /* PinLockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLockViewController.swift; sourceTree = "<group>"; };
+		A66E41CF256D08E6000C6FCB /* PinLockViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PinLockViewController.xib; sourceTree = "<group>"; };
+		A66E41E0256D0F44000C6FCB /* RoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RoundedButton.swift; path = Classes/RoundedButton.swift; sourceTree = "<group>"; };
 		A681C72B254172B600F369C2 /* NoteMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteMetrics.swift; sourceTree = "<group>"; };
 		A681C7332541772D00F369C2 /* NumberFormatter+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Simplenote.swift"; sourceTree = "<group>"; };
 		A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HuggableTableView.swift; sourceTree = "<group>"; };
@@ -1072,6 +1078,16 @@
 				8C573B0B22CD1A6F005BC6F5 /* Simplenote.release.xcconfig */,
 			);
 			path = config;
+			sourceTree = "<group>";
+		};
+		A66E41CD256D08BE000C6FCB /* PinLock */ = {
+			isa = PBXGroup;
+			children = (
+				A66E41CE256D08E6000C6FCB /* PinLockViewController.swift */,
+				A66E41CF256D08E6000C6FCB /* PinLockViewController.xib */,
+			);
+			name = PinLock;
+			path = Classes/PinLock;
 			sourceTree = "<group>";
 		};
 		A690032F253D85C40087D0D2 /* Controllers */ = {
@@ -1625,6 +1641,7 @@
 				A6E1E7A724BE656D008A44BC /* SPCardView.swift */,
 				A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */,
 				A604DB21255A993E00B802CA /* SearchMapView.swift */,
+				A66E41E0256D0F44000C6FCB /* RoundedButton.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1775,6 +1792,7 @@
 		E29ADD751784902700E55842 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				A66E41CD256D08BE000C6FCB /* PinLock */,
 				B59035FB251294D400034BAF /* Diagnostics */,
 				B511AECA255A0A01005B2159 /* Interlinks */,
 				B56A695122F9CCF400B90398 /* Onboarding */,
@@ -2046,6 +2064,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				46A3C9C217DFA81A002865AE /* InfoPlist.strings in Resources */,
+				A66E41D1256D08E6000C6FCB /* PinLockViewController.xib in Resources */,
 				46A3C9C317DFA81A002865AE /* Images.xcassets in Resources */,
 				B5476BBB23D89B66000E7723 /* SPSectionHeaderView.xib in Resources */,
 				B5767F9122FDF2B900052D81 /* LaunchScreen.storyboard in Resources */,
@@ -2340,6 +2359,7 @@
 				375D24BB21E01131007AB25A /* html.c in Sources */,
 				B5B0DE24239AFD1D00F1009D /* SPFeedbackManager.swift in Sources */,
 				46A3C97B17DFA81A002865AE /* SPInteractiveTextStorage.m in Sources */,
+				A66E41E1256D0F44000C6FCB /* RoundedButton.swift in Sources */,
 				E2B0862F1806FFB3001ED52D /* SPTagCompletionPill.m in Sources */,
 				F920265B2294661C0061B1DE /* BuildConfiguration.swift in Sources */,
 				B59188C0240059950069EF96 /* NSRegularExpression+Simplenote.swift in Sources */,
@@ -2407,6 +2427,7 @@
 				B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */,
 				B513F2B42319A8D50021CFA4 /* SPNoteTableViewCell.swift in Sources */,
 				375D24B321E01131007AB25A /* autolink.c in Sources */,
+				A66E41D0256D08E6000C6FCB /* PinLockViewController.swift in Sources */,
 				46A3C99217DFA81A002865AE /* SPEditorTextView.m in Sources */,
 				B537733B252E29D400BC78C5 /* SwitchTableViewCell.swift in Sources */,
 				46A3C99417DFA81A002865AE /* Note.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		A69F851D253EC877005140F2 /* UISlider+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */; };
 		A69F861C25408085005140F2 /* NoteInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F861A25408085005140F2 /* NoteInformationViewController.swift */; };
 		A69F861D25408085005140F2 /* NoteInformationViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A69F861B25408085005140F2 /* NoteInformationViewController.xib */; };
+		A6ABB689256D95EB00E2A076 /* PinLockProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6ABB688256D95EB00E2A076 /* PinLockProgressView.swift */; };
 		A6BBDA3E25502FE3005C8343 /* NSAttributedStringToMarkdownConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BBDA3D25502FE3005C8343 /* NSAttributedStringToMarkdownConverter.swift */; };
 		A6BBDA46255034E6005C8343 /* SPEditorTextView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BBDA45255034E6005C8343 /* SPEditorTextView+Simplenote.swift */; };
 		A6C0589424AD2B8F006BC572 /* SPNoteHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589224AD2B8F006BC572 /* SPNoteHistoryViewController.swift */; };
@@ -539,6 +540,7 @@
 		A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISlider+Simplenote.swift"; sourceTree = "<group>"; };
 		A69F861A25408085005140F2 /* NoteInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteInformationViewController.swift; sourceTree = "<group>"; };
 		A69F861B25408085005140F2 /* NoteInformationViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteInformationViewController.xib; sourceTree = "<group>"; };
+		A6ABB688256D95EB00E2A076 /* PinLockProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLockProgressView.swift; sourceTree = "<group>"; };
 		A6BBDA3D25502FE3005C8343 /* NSAttributedStringToMarkdownConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringToMarkdownConverter.swift; sourceTree = "<group>"; };
 		A6BBDA45255034E6005C8343 /* SPEditorTextView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPEditorTextView+Simplenote.swift"; sourceTree = "<group>"; };
 		A6C0589224AD2B8F006BC572 /* SPNoteHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPNoteHistoryViewController.swift; path = Classes/SPNoteHistoryViewController.swift; sourceTree = "<group>"; };
@@ -1642,6 +1644,7 @@
 				A681C73B2541AC8D00F369C2 /* HuggableTableView.swift */,
 				A604DB21255A993E00B802CA /* SearchMapView.swift */,
 				A66E41E0256D0F44000C6FCB /* RoundedButton.swift */,
+				A6ABB688256D95EB00E2A076 /* PinLockProgressView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2393,6 +2396,7 @@
 				A6E1E79E24BDE401008A44BC /* SPCardTransitioningManager.swift in Sources */,
 				74388F4622CFFA8B001C5EC0 /* NSObject+Helpers.swift in Sources */,
 				46A3C98617DFA81A002865AE /* SPEntryListViewController.m in Sources */,
+				A6ABB689256D95EB00E2A076 /* PinLockProgressView.swift in Sources */,
 				B56A696322F9D53400B90398 /* SPAuthViewController.swift in Sources */,
 				B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */,
 				B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */,

--- a/Simplenote/Classes/PinLock/PinLockViewController.swift
+++ b/Simplenote/Classes/PinLock/PinLockViewController.swift
@@ -1,18 +1,39 @@
 import UIKit
 
+// MARK: - PinLockViewController
+//
 class PinLockViewController: UIViewController {
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
     @IBOutlet private var keypadButtons: [UIButton] = [] {
         didSet {
             for button in keypadButtons {
                 button.setBackgroundImage(UIColor.simplenoteLockScreenButtonColor.dynamicImageRepresentation(), for: .normal)
                 button.setBackgroundImage(UIColor.simplenoteLockScreenHighlightedButtonColor.dynamicImageRepresentation(), for: .highlighted)
+                button.addTarget(self, action: #selector(handleTapOnKeypadButton(_:)), for: .touchUpInside)
             }
         }
     }
+
     @IBOutlet private var cancelButton: UIButton! {
         didSet {
-            cancelButton.setTitle(Localization.cancelButton, for: .normal)
             cancelButton.setTitleColor(.white, for: .normal)
+            updateCancelButton()
+        }
+    }
+
+    @IBOutlet private var progressView: PinLockProgressView! {
+        didSet {
+            progressView.length = Constants.pinLength
+        }
+    }
+
+    private var inputValues: [Int] = [] {
+        didSet {
+            progressView.progress = inputValues.count
+            updateCancelButton()
         }
     }
 
@@ -27,11 +48,56 @@ class PinLockViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        view.backgroundColor = .simplenoteLockScreenBackgroudColor
+        setup()
     }
 }
 
+// MARK: - Private
+//
+private extension PinLockViewController {
+    func setup() {
+        view.backgroundColor = .simplenoteLockScreenBackgroudColor
+    }
+
+    func updateCancelButton() {
+        cancelButton.setTitle(inputValues.isEmpty ? Localization.cancelButton : Localization.deleteButton,
+                              for: .normal)
+    }
+}
+
+// MARK: - Buttons
+//
+private extension PinLockViewController {
+    @objc
+    func handleTapOnKeypadButton(_ button: UIButton) {
+        guard let index = keypadButtons.firstIndex(of: button),
+              inputValues.count < Constants.pinLength else {
+            return
+        }
+
+        inputValues.append(index)
+
+    }
+
+    @IBAction
+    private func handleTapOnCancelButton() {
+        guard !inputValues.isEmpty else {
+            return
+        }
+
+        inputValues.removeLast()
+    }
+}
+
+// MARK: - Localization
+//
 private enum Localization {
-    static let cancelButton = NSLocalizedString("Cancel", comment: "PinLock screen cancel button")
+    static let deleteButton = NSLocalizedString("Delete", comment: "PinLock screen \"delete\" button")
+    static let cancelButton = NSLocalizedString("Cancel", comment: "PinLock screen \"cancel\" button")
+}
+
+// MARK: - Constants
+//
+private enum Constants {
+    static let pinLength: Int = 4
 }

--- a/Simplenote/Classes/PinLock/PinLockViewController.swift
+++ b/Simplenote/Classes/PinLock/PinLockViewController.swift
@@ -8,6 +8,7 @@ class PinLockViewController: UIViewController {
     }
 
     @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var messageLabel: UILabel!
     @IBOutlet private weak var cancelButton: UIButton!
     @IBOutlet private weak var progressView: PinLockProgressView!
     @IBOutlet private var keypadButtons: [UIButton] = []
@@ -40,6 +41,7 @@ private extension PinLockViewController {
     func setup() {
         view.backgroundColor = .simplenoteLockScreenBackgroudColor
         setupTitleLabel()
+        setupMessageLabel()
         setupCancelButton()
         setupProgressView()
         setupKeypadButtons()
@@ -64,6 +66,10 @@ private extension PinLockViewController {
 
     func setupTitleLabel() {
         titleLabel.text = Localization.enterYourPasscode
+    }
+
+    func setupMessageLabel() {
+        messageLabel.textColor = .simplenoteLockScreenMessageColor
     }
 
     func updateCancelButton() {

--- a/Simplenote/Classes/PinLock/PinLockViewController.swift
+++ b/Simplenote/Classes/PinLock/PinLockViewController.swift
@@ -1,0 +1,37 @@
+import UIKit
+
+class PinLockViewController: UIViewController {
+    @IBOutlet private var keypadButtons: [UIButton] = [] {
+        didSet {
+            for button in keypadButtons {
+                button.setBackgroundImage(UIColor.simplenoteLockScreenButtonColor.dynamicImageRepresentation(), for: .normal)
+                button.setBackgroundImage(UIColor.simplenoteLockScreenHighlightedButtonColor.dynamicImageRepresentation(), for: .highlighted)
+            }
+        }
+    }
+    @IBOutlet private var cancelButton: UIButton! {
+        didSet {
+            cancelButton.setTitle(Localization.cancelButton, for: .normal)
+            cancelButton.setTitleColor(.white, for: .normal)
+        }
+    }
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        modalPresentationStyle = .fullScreen
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .simplenoteLockScreenBackgroudColor
+    }
+}
+
+private enum Localization {
+    static let cancelButton = NSLocalizedString("Cancel", comment: "PinLock screen cancel button")
+}

--- a/Simplenote/Classes/PinLock/PinLockViewController.swift
+++ b/Simplenote/Classes/PinLock/PinLockViewController.swift
@@ -7,28 +7,10 @@ class PinLockViewController: UIViewController {
         return .lightContent
     }
 
-    @IBOutlet private var keypadButtons: [UIButton] = [] {
-        didSet {
-            for button in keypadButtons {
-                button.setBackgroundImage(UIColor.simplenoteLockScreenButtonColor.dynamicImageRepresentation(), for: .normal)
-                button.setBackgroundImage(UIColor.simplenoteLockScreenHighlightedButtonColor.dynamicImageRepresentation(), for: .highlighted)
-                button.addTarget(self, action: #selector(handleTapOnKeypadButton(_:)), for: .touchUpInside)
-            }
-        }
-    }
-
-    @IBOutlet private var cancelButton: UIButton! {
-        didSet {
-            cancelButton.setTitleColor(.white, for: .normal)
-            updateCancelButton()
-        }
-    }
-
-    @IBOutlet private var progressView: PinLockProgressView! {
-        didSet {
-            progressView.length = Constants.pinLength
-        }
-    }
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var cancelButton: UIButton!
+    @IBOutlet private weak var progressView: PinLockProgressView!
+    @IBOutlet private var keypadButtons: [UIButton] = []
 
     private var inputValues: [Int] = [] {
         didSet {
@@ -57,6 +39,31 @@ class PinLockViewController: UIViewController {
 private extension PinLockViewController {
     func setup() {
         view.backgroundColor = .simplenoteLockScreenBackgroudColor
+        setupTitleLabel()
+        setupCancelButton()
+        setupProgressView()
+        setupKeypadButtons()
+    }
+
+    func setupCancelButton() {
+        cancelButton.setTitleColor(.white, for: .normal)
+        updateCancelButton()
+    }
+
+    func setupProgressView() {
+        progressView.length = Constants.pinLength
+    }
+
+    func setupKeypadButtons() {
+        for button in keypadButtons {
+            button.setBackgroundImage(UIColor.simplenoteLockScreenButtonColor.dynamicImageRepresentation(), for: .normal)
+            button.setBackgroundImage(UIColor.simplenoteLockScreenHighlightedButtonColor.dynamicImageRepresentation(), for: .highlighted)
+            button.addTarget(self, action: #selector(handleTapOnKeypadButton(_:)), for: .touchUpInside)
+        }
+    }
+
+    func setupTitleLabel() {
+        titleLabel.text = Localization.enterYourPasscode
     }
 
     func updateCancelButton() {
@@ -92,6 +99,7 @@ private extension PinLockViewController {
 // MARK: - Localization
 //
 private enum Localization {
+    static let enterYourPasscode = NSLocalizedString("Enter your passcode", comment: "Title on the PinLock screen asking to enter a passcode")
     static let deleteButton = NSLocalizedString("Delete", comment: "PinLock screen \"delete\" button")
     static let cancelButton = NSLocalizedString("Cancel", comment: "PinLock screen \"cancel\" button")
 }

--- a/Simplenote/Classes/PinLock/PinLockViewController.xib
+++ b/Simplenote/Classes/PinLock/PinLockViewController.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PinLockViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
                 <outlet property="cancelButton" destination="EY1-yW-LpJ" id="pU7-Wr-CkJ"/>
+                <outlet property="messageLabel" destination="amM-I9-F7S" id="FwI-Ox-zxH"/>
                 <outlet property="progressView" destination="ZqA-yv-5ub" id="mbM-z7-b03"/>
                 <outlet property="titleLabel" destination="WOh-Ux-wmS" id="EEN-uz-p6o"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -32,11 +33,11 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="kUd-Ix-uIM">
-                    <rect key="frame" x="65" y="201.5" width="284" height="503"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="kUd-Ix-uIM">
+                    <rect key="frame" x="65" y="193.5" width="284" height="519"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="27" translatesAutoresizingMaskIntoConstraints="NO" id="1oZ-M4-eDV">
-                            <rect key="frame" x="0.0" y="0.0" width="284" height="101"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="1oZ-M4-eDV">
+                            <rect key="frame" x="0.0" y="0.0" width="284" height="142"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WOh-Ux-wmS">
                                     <rect key="frame" x="118" y="0.0" width="48" height="24"/>
@@ -45,12 +46,18 @@
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="50" distribution="fillEqually" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="ZqA-yv-5ub" customClass="PinLockProgressView" customModule="Simplenote" customModuleProvider="target">
-                                    <rect key="frame" x="142" y="51" width="0.0" height="50"/>
+                                    <rect key="frame" x="142" y="49" width="0.0" height="50"/>
                                 </stackView>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 Failed Passcode Attempts" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="amM-I9-F7S">
+                                    <rect key="frame" x="47" y="124" width="190" height="18"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
                             </subviews>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Z1C-0F-Pl0">
-                            <rect key="frame" x="0.0" y="151" width="284" height="352"/>
+                            <rect key="frame" x="0.0" y="167" width="284" height="352"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-h3-DyR">
                                     <rect key="frame" x="0.0" y="0.0" width="284" height="76"/>

--- a/Simplenote/Classes/PinLock/PinLockViewController.xib
+++ b/Simplenote/Classes/PinLock/PinLockViewController.xib
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="cancelButton" destination="EY1-yW-LpJ" id="pU7-Wr-CkJ"/>
                 <outlet property="progressView" destination="ZqA-yv-5ub" id="mbM-z7-b03"/>
+                <outlet property="titleLabel" destination="WOh-Ux-wmS" id="EEN-uz-p6o"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
                 <outletCollection property="keypadButtons" destination="He8-HI-UVX" collectionClass="NSMutableArray" id="GFC-o1-Neq"/>
                 <outletCollection property="keypadButtons" destination="vYD-BP-2G8" collectionClass="NSMutableArray" id="4Ka-a1-dkp"/>

--- a/Simplenote/Classes/PinLock/PinLockViewController.xib
+++ b/Simplenote/Classes/PinLock/PinLockViewController.xib
@@ -135,26 +135,32 @@
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <state key="normal" title="0"/>
                                         </button>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EY1-yW-LpJ">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QEI-Lo-gGb">
                                             <rect key="frame" x="208" y="0.0" width="76" height="76"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <state key="normal" title="Button"/>
-                                            <connections>
-                                                <action selector="handleTapOnCancelButton" destination="-1" eventType="touchUpInside" id="9Hu-Yv-bSW"/>
-                                            </connections>
-                                        </button>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </view>
                                     </subviews>
                                 </stackView>
                             </subviews>
                         </stackView>
                     </subviews>
                 </stackView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EY1-yW-LpJ">
+                    <rect key="frame" x="298" y="821" width="51" height="33"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                    <state key="normal" title="Button"/>
+                    <connections>
+                        <action selector="handleTapOnCancelButton" destination="-1" eventType="touchUpInside" id="9Hu-Yv-bSW"/>
+                    </connections>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemTealColor"/>
             <constraints>
                 <constraint firstItem="kUd-Ix-uIM" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="EaN-W5-Zci"/>
+                <constraint firstItem="EY1-yW-LpJ" firstAttribute="trailing" secondItem="Z1C-0F-Pl0" secondAttribute="trailing" id="V2R-j1-Ij6"/>
                 <constraint firstItem="kUd-Ix-uIM" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="d85-ya-WaS"/>
+                <constraint firstAttribute="bottomMargin" secondItem="EY1-yW-LpJ" secondAttribute="bottom" constant="8" id="oQl-6D-5Ae"/>
             </constraints>
             <point key="canvasLocation" x="137.68115942028987" y="152.67857142857142"/>
         </view>

--- a/Simplenote/Classes/PinLock/PinLockViewController.xib
+++ b/Simplenote/Classes/PinLock/PinLockViewController.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PinLockViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
                 <outlet property="cancelButton" destination="EY1-yW-LpJ" id="pU7-Wr-CkJ"/>
+                <outlet property="progressView" destination="ZqA-yv-5ub" id="mbM-z7-b03"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
                 <outletCollection property="keypadButtons" destination="He8-HI-UVX" collectionClass="NSMutableArray" id="GFC-o1-Neq"/>
                 <outletCollection property="keypadButtons" destination="vYD-BP-2G8" collectionClass="NSMutableArray" id="4Ka-a1-dkp"/>
@@ -31,21 +32,24 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="kUd-Ix-uIM">
-                    <rect key="frame" x="65" y="240" width="284" height="426"/>
+                    <rect key="frame" x="65" y="201.5" width="284" height="503"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="1oZ-M4-eDV">
-                            <rect key="frame" x="0.0" y="0.0" width="284" height="24"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="27" translatesAutoresizingMaskIntoConstraints="NO" id="1oZ-M4-eDV">
+                            <rect key="frame" x="0.0" y="0.0" width="284" height="101"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WOh-Ux-wmS">
-                                    <rect key="frame" x="0.0" y="0.0" width="284" height="24"/>
+                                    <rect key="frame" x="118" y="0.0" width="48" height="24"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <nil key="highlightedColor"/>
                                 </label>
+                                <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="50" distribution="fillEqually" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="ZqA-yv-5ub" customClass="PinLockProgressView" customModule="Simplenote" customModuleProvider="target">
+                                    <rect key="frame" x="142" y="51" width="0.0" height="50"/>
+                                </stackView>
                             </subviews>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Z1C-0F-Pl0">
-                            <rect key="frame" x="0.0" y="74" width="284" height="352"/>
+                            <rect key="frame" x="0.0" y="151" width="284" height="352"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-h3-DyR">
                                     <rect key="frame" x="0.0" y="0.0" width="284" height="76"/>
@@ -127,6 +131,9 @@
                                             <rect key="frame" x="208" y="0.0" width="76" height="76"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <state key="normal" title="Button"/>
+                                            <connections>
+                                                <action selector="handleTapOnCancelButton" destination="-1" eventType="touchUpInside" id="9Hu-Yv-bSW"/>
+                                            </connections>
                                         </button>
                                     </subviews>
                                 </stackView>

--- a/Simplenote/Classes/PinLock/PinLockViewController.xib
+++ b/Simplenote/Classes/PinLock/PinLockViewController.xib
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PinLockViewController" customModule="Simplenote" customModuleProvider="target">
+            <connections>
+                <outlet property="cancelButton" destination="EY1-yW-LpJ" id="pU7-Wr-CkJ"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outletCollection property="keypadButtons" destination="He8-HI-UVX" collectionClass="NSMutableArray" id="GFC-o1-Neq"/>
+                <outletCollection property="keypadButtons" destination="vYD-BP-2G8" collectionClass="NSMutableArray" id="4Ka-a1-dkp"/>
+                <outletCollection property="keypadButtons" destination="nsZ-02-d4z" collectionClass="NSMutableArray" id="IYL-pf-fBd"/>
+                <outletCollection property="keypadButtons" destination="ROd-Mk-dWc" collectionClass="NSMutableArray" id="aUG-UT-kJ1"/>
+                <outletCollection property="keypadButtons" destination="BjF-OJ-s6n" collectionClass="NSMutableArray" id="pHe-5Y-F0o"/>
+                <outletCollection property="keypadButtons" destination="Kb3-N4-0L1" collectionClass="NSMutableArray" id="Bqk-JW-hEv"/>
+                <outletCollection property="keypadButtons" destination="ycp-6v-0pD" collectionClass="NSMutableArray" id="7rI-Fk-27o"/>
+                <outletCollection property="keypadButtons" destination="yD5-B4-rkf" collectionClass="NSMutableArray" id="skx-KI-kX5"/>
+                <outletCollection property="keypadButtons" destination="th7-BP-TaK" collectionClass="NSMutableArray" id="N3W-mu-MKx"/>
+                <outletCollection property="keypadButtons" destination="OLO-MV-4cd" collectionClass="NSMutableArray" id="X7s-0y-0rs"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="kUd-Ix-uIM">
+                    <rect key="frame" x="65" y="240" width="284" height="426"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="1oZ-M4-eDV">
+                            <rect key="frame" x="0.0" y="0.0" width="284" height="24"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WOh-Ux-wmS">
+                                    <rect key="frame" x="0.0" y="0.0" width="284" height="24"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Z1C-0F-Pl0">
+                            <rect key="frame" x="0.0" y="74" width="284" height="352"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="NE9-h3-DyR">
+                                    <rect key="frame" x="0.0" y="0.0" width="284" height="76"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vYD-BP-2G8" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="76" height="76"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="76" id="59Y-T1-eRv"/>
+                                                <constraint firstAttribute="width" secondItem="vYD-BP-2G8" secondAttribute="height" multiplier="1:1" id="Ze8-bJ-9hg"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="1"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nsZ-02-d4z" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="104" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="2"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ROd-Mk-dWc" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="208" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="3"/>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="5xf-f4-VCV">
+                                    <rect key="frame" x="0.0" y="92" width="284" height="76"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BjF-OJ-s6n" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="4"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kb3-N4-0L1" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="104" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="5"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ycp-6v-0pD" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="208" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="6"/>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="WiL-Pd-nca">
+                                    <rect key="frame" x="0.0" y="184" width="284" height="76"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yD5-B4-rkf" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="7"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="th7-BP-TaK" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="104" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="8"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OLO-MV-4cd" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="208" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="9"/>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="YbO-VL-ArF">
+                                    <rect key="frame" x="0.0" y="276" width="284" height="76"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xkt-tY-cgq">
+                                            <rect key="frame" x="0.0" y="0.0" width="76" height="76"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </view>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="He8-HI-UVX" customClass="RoundedButton" customModule="Simplenote" customModuleProvider="target">
+                                            <rect key="frame" x="104" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <state key="normal" title="0"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EY1-yW-LpJ">
+                                            <rect key="frame" x="208" y="0.0" width="76" height="76"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                            <state key="normal" title="Button"/>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemTealColor"/>
+            <constraints>
+                <constraint firstItem="kUd-Ix-uIM" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="EaN-W5-Zci"/>
+                <constraint firstItem="kUd-Ix-uIM" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="d85-ya-WaS"/>
+            </constraints>
+            <point key="canvasLocation" x="137.68115942028987" y="152.67857142857142"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemTealColor">
+            <color red="0.35294117647058826" green="0.78431372549019607" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Simplenote/Classes/RoundedButton.swift
+++ b/Simplenote/Classes/RoundedButton.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+// MARK: - RoundedButton
+//
+class RoundedButton: UIButton {
+    override var bounds: CGRect {
+        didSet {
+            guard bounds.size != oldValue.size else {
+                return
+            }
+
+            updateCornerRadius()
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+}
+
+// MARK: - Private
+//
+private extension RoundedButton {
+    func configure() {
+        layer.masksToBounds = true
+        updateCornerRadius()
+    }
+
+    func updateCornerRadius() {
+        layer.cornerRadius = min(frame.height, frame.width) / 2
+    }
+}

--- a/Simplenote/Classes/RoundedCrossButton.swift
+++ b/Simplenote/Classes/RoundedCrossButton.swift
@@ -2,23 +2,13 @@ import UIKit
 
 // MARK: RoundedCrossButton
 //
-class RoundedCrossButton: UIButton {
+class RoundedCrossButton: RoundedButton {
 
     /// Style
     ///
     enum Style {
         case standard
         case blue
-    }
-
-    override var bounds: CGRect {
-        didSet {
-            guard bounds.size != oldValue.size else {
-                return
-            }
-
-            updateCornerRadius()
-        }
     }
 
     var style: Style = .standard {
@@ -47,14 +37,7 @@ class RoundedCrossButton: UIButton {
 private extension RoundedCrossButton {
     func configure() {
         startListeningToNotifications()
-
-        layer.masksToBounds = true
-        updateCornerRadius()
         refreshStyle()
-    }
-
-    func updateCornerRadius() {
-        layer.cornerRadius = min(frame.height, frame.width) / 2
     }
 
     func refreshStyle() {

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -365,4 +365,16 @@ extension UIColor {
         UIColor(lightColor: .spBlue50,
                 darkColor: .spBlue50)
     }
+
+    static var simplenoteLockScreenBackgroudColor: UIColor {
+        return UIColor(studioColor: .blue50)
+    }
+
+    static var simplenoteLockScreenButtonColor: UIColor {
+        return UIColor(studioColor: .blue40)
+    }
+
+    static var simplenoteLockScreenHighlightedButtonColor: UIColor {
+        return UIColor(studioColor: .blue20)
+    }
 }

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -372,14 +372,18 @@ extension UIColor {
     }
 
     static var simplenoteLockScreenBackgroudColor: UIColor {
-        return UIColor(studioColor: .blue50)
+        return UIColor(studioColor: .spBlue50)
     }
 
     static var simplenoteLockScreenButtonColor: UIColor {
-        return UIColor(studioColor: .blue40)
+        return UIColor(studioColor: .spBlue40)
     }
 
     static var simplenoteLockScreenHighlightedButtonColor: UIColor {
-        return UIColor(studioColor: .blue20)
+        return UIColor(studioColor: .spBlue20)
+    }
+
+    static var simplenoteLockScreenMessageColor: UIColor {
+        return UIColor(studioColor: .spBlue5)
     }
 }

--- a/Simplenote/PinLockProgressView.swift
+++ b/Simplenote/PinLockProgressView.swift
@@ -71,5 +71,5 @@ private extension PinLockProgressView {
 //
 private enum Constants {
     static let buttonBorderWidth: CGFloat = 1.0
-    static let buttonSideSize: CGFloat = 15.0
+    static let buttonSideSize: CGFloat = 14.0
 }

--- a/Simplenote/PinLockProgressView.swift
+++ b/Simplenote/PinLockProgressView.swift
@@ -1,0 +1,75 @@
+import UIKit
+
+// MARK: - PinLockProgressView
+//
+final class PinLockProgressView: UIStackView {
+
+    /// Length of the progress view
+    ///
+    var length: Int = 0 {
+        didSet {
+            configure()
+        }
+    }
+
+    /// Progress is from 0 to `length`
+    ///
+    var progress: Int = 0 {
+        didSet {
+            guard oldValue != progress else {
+                return
+            }
+
+            progress = min(progress, length)
+            update()
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+}
+
+// MARK: - Private
+//
+private extension PinLockProgressView {
+    func configure() {
+        for view in arrangedSubviews {
+            removeArrangedSubview(view)
+        }
+
+        for _ in 0..<length {
+            let button = RoundedButton()
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.isUserInteractionEnabled = false
+            button.setBackgroundImage(UIColor.clear.dynamicImageRepresentation(), for: .normal)
+            button.setBackgroundImage(UIColor.white.dynamicImageRepresentation(), for: .highlighted)
+            button.layer.borderWidth = Constants.buttonBorderWidth
+            button.layer.borderColor = UIColor.white.cgColor
+            NSLayoutConstraint.activate([
+                button.widthAnchor.constraint(equalToConstant: Constants.buttonSideSize),
+                button.heightAnchor.constraint(equalToConstant: Constants.buttonSideSize)
+            ])
+            addArrangedSubview(button)
+        }
+    }
+
+    func update() {
+        for (i, button) in arrangedSubviews.enumerated() {
+            (button as? UIButton)?.isHighlighted = i < progress
+        }
+    }
+}
+
+// MARK: - Constants
+//
+private enum Constants {
+    static let buttonBorderWidth: CGFloat = 1.0
+    static let buttonSideSize: CGFloat = 15.0
+}


### PR DESCRIPTION
### Fix
Add new passcode screen with a keypad that is always on screen and doesn't rely on built-in keyboard.
New passcode screen is not wired with the current code and it is an initial effort to create the UI. Wiring will be done in a follow up PR. 

cc @jleandroperez Thank you!

Related issue: #761 

Before             |  After
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 08 18 05](https://user-images.githubusercontent.com/54751/100195666-f65caa80-2ef7-11eb-8695-e734828d0127.png) |  ![Simulator Screen Shot - iPhone 11 - 2020-11-25 at 13 03 42](https://user-images.githubusercontent.com/54751/100225684-e1474200-2f1e-11eb-816e-d59ef7dc6611.png)
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-11-25 at 08 11 43](https://user-images.githubusercontent.com/54751/100195734-112f1f00-2ef8-11eb-96b1-f1874d944d72.png) |  ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-11-25 at 13 04 41](https://user-images.githubusercontent.com/54751/100225710-edcb9a80-2f1e-11eb-92eb-34a0b9b6a6f2.png)


### Test
As the screen is not wired with the current passcode code, the best way to test the UI is to present the view controller from the app delegate:

```
DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
    let vc = PinLockViewController()
    self.window.rootViewController?.present(vc, animated: true, completion: nil)
}
```

- [x] Check that all buttons can be pressed
- [x] Pressing on a number key on the keypad fills a `dot`
- [x] Pressing `delete` on a keypad removes the last filled `dot`
- [x] If noting is filled, the bottom right button reads `cancel`

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
