### PR TITLE
Re-bundle gems with Bundler 2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,4 +299,4 @@ DEPENDENCIES
   xcpretty-travis-formatter!
 
 BUNDLED WITH
-   2.2.0
+   2.2.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   cocoapods (~> 1.10)!
@@ -298,4 +299,4 @@ DEPENDENCIES
   xcpretty-travis-formatter!
 
 BUNDLED WITH
-   2.1.4
+   2.2.0


### PR DESCRIPTION
Bundler 2.2.0 contains a fix for an issue with optional groups and the `.bundle/config` file.

The issue resulted in the file being touched every time we'd run a `BUNDLE_WITH=screenshots bundle install` with a change that, if tracked, would have required all developers to set up all the screenshots automation tooling while that's only needed by platforms developers. See https://github.com/rubygems/rubygems/issues/3708.

### Test

**1)** Checkout this branch.

**2)** Check your version of Bundler with `bundle version`, if it's less than 2.2.0, take a note of what version it is (e.g. 2.1.4) then update bundler `gem update bundler`. If your Bundler already is at the latest version, you can use `gem info bundler` to see all the installed versions. Ideally, you'll have an older one too, e.g.:

```
➜ gem info bundler

*** LOCAL GEMS ***

bundler (2.2.0, 2.1.4, 2.0.2, 1.17.3, 1.17.2)
```

If not, you can always install an older one with `gem install bundler:<version>`, e.g.: `gem install bundler:2.1.4`.

**3)** Run the command resulting in the undesired behavior on the _old_ version of Bundler. E.g:

`BUNDLE_WITH=screenshots bundle _2.1.4_ install`. (_TIL you can pass the version of Bundler to use to `bundle` like that_). You should see that:

- A warning message is shown saying "Warning: the running version of Bundler (2.1.2) is older than the version that created the lockfile (2.2.0). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.0`." _That's just default Bundler behavior, not our custom logic, but it's nice to see it because hopefully it'll help people running `bundle install` being on the expected version of the tool._
- The tracked `.bundle/config` file changed with the following diff

```diff
diff --git a/.bundle/config b/.bundle/config
index 23692288..0bfa20ce 100644
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,3 @@
 ---
 BUNDLE_PATH: "vendor/bundle"
+BUNDLE_WITH: "screenshots"
```

Discard those changes.

**3)** Run the command that resulted in the undesired behavior on Bundler 2.2.0.

`BUNDLE_WITH=screenshots bundle install`

Verify that neither the warning nor the `.bundle/config` change happened.

### Review
Only one platform developer required to review these changes, but anyone can perform the review.

### Release

These changes do not require release notes.