### PR TITLE
Fix crash while generating excerpts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.30
 -----
- 
+-   Fixed a bug that caused a crash while searching #1055
+
 4.29
 -----
 -   Updated Empty State placeholders #951

--- a/Simplenote/Classes/Note+Properties.swift
+++ b/Simplenote/Classes/Note+Properties.swift
@@ -83,7 +83,7 @@ extension Note {
     /// Returns excerpt of the content around the first match of one of the keywords
     ///
     func bodyExcerpt(keywords: [String]?) -> String? {
-        guard let keywords = keywords, !keywords.isEmpty, let content = content else {
+        guard let keywords = keywords, !keywords.isEmpty, let content = content?.precomposedStringWithCanonicalMapping else {
             return bodyPreview
         }
 

--- a/SimplenoteTests/NoteBodyExcerptTests.swift
+++ b/SimplenoteTests/NoteBodyExcerptTests.swift
@@ -69,4 +69,15 @@ class NoteBodyExcerptTests: XCTestCase {
         let actual = note.bodyExcerpt(keywords: ["version"])
         XCTAssertEqual(actual, expected)
     }
+
+    /// Verifies that certain character sequence doesn't crash the app
+    ///
+    func testCertainCharacterSequenceDoesntCrash() {
+        let body = "t\n\u{30bf}\nglo\u{0300}b"
+        note = storage.insertSampleNote(contents: "Title\n\(body)")
+
+        let expected = body.replacingOccurrences(of: "\n", with: " ")
+        let actual = note.bodyExcerpt(keywords: ["t"])
+        XCTAssertEqual(actual, expected)
+    }
 }


### PR DESCRIPTION
Closes #1055 

### Fix
In this PR we're fixing the crash that happens while generating excerpts. The root cause if unknown, but related to the unicode form of the string.

The fix is to convert the string to normalised form using `precomposedStringWithCanonicalMapping`

### Test

1. Checkout a develop branch and run the app.
2. Create a note with the any title and the content from the following file: [crash.txt](https://github.com/Automattic/simplenote-ios/files/5751246/crash.txt)
3. Search for "t", the app should crash
4. Update the branch to `issue/1055-fix-excerpt-crash` and run the app
5. Search for "t", the app should not crash


### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release

`RELEASE-NOTES.txt` was updated in c9672021d557b09b7d766c36ba149e083a0c26b8 with:
> 
>  Fixed a bug that caused a crash while searching #1055
