### PR TITLE
Update screenshots automation with new details and iOS version – Local only

### DIFF
--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -54,25 +54,6 @@ class SimplenoteScreenshots: XCTestCase {
 
         actionButton.tap()
 
-        // The collaborators screen will ask to access our contacts. Before loading the screen,
-        // let's setup an handler to dismiss the alert, so it doesn't come in the screenshots.
-        // Fastlane's snapshot _should_ do this for us, but it seems to happen unreliably.
-        //
-        // Not sure when this happened, but at least since Xcode 12.3, it doesn't seem necessary
-        // to dismiss the system dialog anymore in this test suite.
-        //
-        // Leaving the code to do it here for future reference.
-        //
-        // This logic is super rough, but for the context of this test script where we know we'll
-        // only get one alert, it'll do us. Obviously, when the time comes to refine the script by
-        // adopting the `BaseScreen` pattern from the WooCommerce iOS repo, this should logic should
-        // be improved as well.
-        //
-//         addUIInterruptionMonitor(withDescription: "Any system dialog") { alert in
-//            alert.buttons.firstMatch.tap()
-//            return true
-//        }
-
         let collaborateButton = app.staticTexts["Collaborate"].firstMatch
         XCTAssertTrue(collaborateButton.waitForExistence(timeout: 3))
 
@@ -82,14 +63,15 @@ class SimplenoteScreenshots: XCTestCase {
         let doneButton = app.buttons["Done"]
         XCTAssertTrue(doneButton.waitForExistence(timeout: 3))
 
-        // Now that we know the collaborators picker screen is presented, we also know that a system
-        // dialog to grant access to the contacts might have been shown. If it has, interacting with
-        // the app will trigger the UI interruption monitor. If it hasn't, this interaction won't
-        // result in any UI change (with how the UI is laid out at the time of writing this).
+        // The collaborators screen will ask to access our contacts the first time it's presented.
         //
-        // This code is unnecessary, but it's here for future reference. See not in the
-        // `addUIInterruptionMonitor` call above.
-//        app.tap()
+        // Let's wait to see if a system dialog appeared and dismiss it if so.
+        let systemAlert = XCUIApplication(bundleIdentifier: "com.apple.springboard").alerts.firstMatch
+        if systemAlert.waitForExistence(timeout: 2) {
+            // It doesn't matter whether we allow or deny access in the Simulator for the kind of
+            // screenshots we want to make.
+            systemAlert.buttons.firstMatch.tap()
+        }
 
         // The index 3 is _intentional_ as that's the desired position of the screenshot in the App
         // Store

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -58,14 +58,20 @@ class SimplenoteScreenshots: XCTestCase {
         // let's setup an handler to dismiss the alert, so it doesn't come in the screenshots.
         // Fastlane's snapshot _should_ do this for us, but it seems to happen unreliably.
         //
+        // Not sure when this happened, but at least since Xcode 12.3, it doesn't seem necessary
+        // to dismiss the system dialog anymore in this test suite.
+        //
+        // Leaving the code to do it here for future reference.
+        //
         // This logic is super rough, but for the context of this test script where we know we'll
         // only get one alert, it'll do us. Obviously, when the time comes to refine the script by
         // adopting the `BaseScreen` pattern from the WooCommerce iOS repo, this should logic should
         // be improved as well.
-        addUIInterruptionMonitor(withDescription: "Any system dialog") { alert in
-            alert.buttons.firstMatch.tap()
-            return true
-        }
+        //
+//         addUIInterruptionMonitor(withDescription: "Any system dialog") { alert in
+//            alert.buttons.firstMatch.tap()
+//            return true
+//        }
 
         let collaborateButton = app.staticTexts["Collaborate"].firstMatch
         XCTAssertTrue(collaborateButton.waitForExistence(timeout: 3))
@@ -80,7 +86,10 @@ class SimplenoteScreenshots: XCTestCase {
         // dialog to grant access to the contacts might have been shown. If it has, interacting with
         // the app will trigger the UI interruption monitor. If it hasn't, this interaction won't
         // result in any UI change (with how the UI is laid out at the time of writing this).
-        app.tap()
+        //
+        // This code is unnecessary, but it's here for future reference. See not in the
+        // `addUIInterruptionMonitor` call above.
+//        app.tap()
 
         // The index 3 is _intentional_ as that's the desired position of the screenshot in the App
         // Store

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -67,7 +67,7 @@ class SimplenoteScreenshots: XCTestCase {
             return true
         }
 
-        let collaborateButton = app.buttons["Collaborate"]
+        let collaborateButton = app.staticTexts["Collaborate"].firstMatch
         XCTAssertTrue(collaborateButton.waitForExistence(timeout: 3))
 
         collaborateButton.tap()
@@ -90,7 +90,7 @@ class SimplenoteScreenshots: XCTestCase {
         // menu.
         doneButton.tap()
 
-        let backButton = app.buttons.matching(NSPredicate(format: "label = %@", "Notes")).firstMatch
+        let backButton = app.buttons.matching(NSPredicate(format: "label = %@", "All Notes")).firstMatch
         XCTAssertTrue(backButton.waitForExistence(timeout: 3))
         backButton.tap()
 
@@ -161,10 +161,7 @@ class SimplenoteScreenshots: XCTestCase {
     }
 
     func logout(using app: XCUIApplication) {
-        let menu = app.otherElements.matching(identifier: "menu").firstMatch
-        XCTAssertTrue(menu.waitForExistence(timeout: 10))
-
-        menu.tap()
+        getMenuButtonElement(from: app).tap()
 
         let settings = app.textFields["Settings"]
         XCTAssertTrue(settings.waitForExistence(timeout: 3))
@@ -176,9 +173,13 @@ class SimplenoteScreenshots: XCTestCase {
     }
 
     func openMenu(using app: XCUIApplication) {
-        let menu = app.otherElements.matching(identifier: "menu").firstMatch
+        getMenuButtonElement(from: app).tap()
+    }
+
+    func getMenuButtonElement(from app: XCUIApplication) -> XCUIElement {
+        let menu = app.buttons.matching(identifier: "menu").firstMatch
         XCTAssertTrue(menu.waitForExistence(timeout: 10))
-        menu.tap()
+        return menu
     }
 
     func loadPasscodeScreen(using app: XCUIApplication) {

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -74,14 +74,20 @@ class SimplenoteScreenshots: XCTestCase {
 
         XCTAssertTrue(noteTextView.waitForExistence(timeout: 1))
 
-        // The next step is to type in the note to bring up the inter-note linking view.
-        // The natural thing to do here would be tapping the note:
+        // We need to add text at the end of the note. There is no dedicated API to do so. Our best
+        // bet is to try to scroll the text view to the bottom and tap there. There are no APIs for
+        // that either, so our next best bet is to 1) swipe up real fast to simulate a scroll to the
+        // bottom; 2) tap in the bottom right corner of the text view.
         //
-        // noteTextView.tap()
+        // Fun (?) fact worth tracking here for future reference. On the iPad Simulator^, tapping on
+        // the `noteTextView` `XCUIElement` doesn't work. Luckily, tapping on the `XCUICoordinate`
+        // works. Another option could have been to call `tap()` on the `XCUIApplication` itself,
+        // but that might result in tapping in the middle of the text on a small screen.
         //
-        // Doing so works on iOS, but fails on iPad Pro 12.9" 2nd and 3rd generation, on Xcode 12.3.
-        // Luckily, tapping the app itself does the job, too.
-        app.tap()
+        // ^: iPad Pro 12.9" 2nd and 3rd generation Simulator on Xcode 12.3.
+        noteTextView.swipeUp(velocity: .fast)
+        let lowerRightCorner = noteTextView.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.9))
+        lowerRightCorner.tap()
 
         let interlinkingTriggerString = "\n[L"
         noteTextView.typeText(interlinkingTriggerString)

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -129,29 +129,27 @@ class SimplenoteScreenshots: XCTestCase {
         openMenu(using: app)
         loadPasscodeScreen(using: app)
         // Set the passcode
-        // Writing the value here in clear because anyways one can see it being typed.
-        type("1234", onFirstKeyboardOf: app)
+        // Writing the value here in clear because one can see it being typed anyways.
+        typeOnPassCodeScreen(1234, using: app)
         // Confirm it
-        type("1234", onFirstKeyboardOf: app)
+        typeOnPassCodeScreen(1234, using: app)
 
         // Kill the app and relaunch it so we can take a screenshot of the lock screen
         app.terminate()
         app.launch()
 
-        // Assuming that if a keyboard is on screen, then the passcode screen has loaded
-        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10))
-
-        // The screenshot for the passcode should have only 3 characters inserted
-        type("123", onFirstKeyboardOf: app)
+        // The screenshot for the passcode should have only 3 characters inserted.
+        // (Typing in the passcode screen also ensures it's visible first)
+        typeOnPassCodeScreen(123, using: app)
 
         takeScreenshot("6-passcode")
 
-        type("4", onFirstKeyboardOf: app)
+        typeOnPassCodeScreen(4, using: app)
 
         // Now, disable the passcode so we're not blocked by it on next launch.
         openMenu(using: app)
         loadPasscodeScreen(using: app)
-        type(ScreenshotsCredentials.testUserPasscode, onFirstKeyboardOf: app)
+        typeOnPassCodeScreen(1234, using: app)
     }
 
     func logout(using app: XCUIApplication) {
@@ -191,8 +189,24 @@ class SimplenoteScreenshots: XCTestCase {
         XCTAssertTrue(passcodeCell.waitForExistence(timeout: 3))
         passcodeCell.tap()
 
-        // Let's just assume that if a keyboard is on screen, then the passcode screen has loaded
-        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 3))
+        // The passcode screen has custom button views mimicking the default iOS passcode one.
+        // Let's check a few numbers are on screen as a mean to verify it loaded
+        XCTAssertTrue(app.staticTexts["1"].waitForExistence(timeout: 3))
+        // No need to wait once the first wait succeeded. Really, these other assertions are almost
+        // superfluous.
+        XCTAssertTrue(app.staticTexts["9"].exists)
+        XCTAssertTrue(app.staticTexts["0"].exists)
+    }
+
+    func typeOnPassCodeScreen(_ input: Int, using app: XCUIApplication) {
+        // This converts an Int into an [Int] of its digits
+        let digits = "\(input.magnitude)".compactMap(\.wholeNumberValue)
+
+        digits.forEach { digit in
+            let input = app.staticTexts["\(digit)"].firstMatch
+            XCTAssertTrue(input.waitForExistence(timeout: 3))
+            input.tap()
+        }
     }
 
     func type(_ text: String, onFirstKeyboardOf app: XCUIApplication) {

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -81,9 +81,7 @@ class SimplenoteScreenshots: XCTestCase {
         // menu.
         doneButton.tap()
 
-        let backButton = app.buttons.matching(NSPredicate(format: "label = %@", "All Notes")).firstMatch
-        XCTAssertTrue(backButton.waitForExistence(timeout: 3))
-        backButton.tap()
+        goBackFromEditor(using: app)
 
         // Before taking a screenshot of the notes, make sure the review prompt header is not on
         // screen.
@@ -161,6 +159,12 @@ class SimplenoteScreenshots: XCTestCase {
         let logOut = app.staticTexts["Log Out"]
         XCTAssertTrue(logOut.waitForExistence(timeout: 3))
         logOut.tap()
+    }
+
+    func goBackFromEditor(using app: XCUIApplication) {
+        let backButton = app.buttons.matching(NSPredicate(format: "label = %@", "All Notes")).firstMatch
+        XCTAssertTrue(backButton.waitForExistence(timeout: 3))
+        backButton.tap()
     }
 
     func openMenu(using app: XCUIApplication) {

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -91,6 +91,10 @@ class SimplenoteScreenshots: XCTestCase {
         let interlinkingTriggerString = "\n[L"
         noteTextView.typeText(interlinkingTriggerString)
 
+        // Before taking the screenshot, let's make sure the inter note liking window appeared by
+        // checking the text of one of its notes is on screen
+        XCTAssertTrue(app.staticTexts["Blueberry Recipes"].firstMatch.waitForExistence(timeout: 1))
+
         takeScreenshot("3-interlinking")
 
         // Reset for the next test

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -30,9 +30,8 @@ class SimplenoteScreenshots: XCTestCase {
 
         let password = app.secureTextFields["Password"]
         XCTAssertTrue(password.waitForExistence(timeout: 10))
-        // -.-'
         password.tap()
-        password.pasteText(text: ScreenshotsCredentials.testUserPassword)
+        password.typeText(ScreenshotsCredentials.testUserPassword)
 
         // Need to check for the login button again, otherwise we'll attempt to press the one from
         // the previous screen.
@@ -193,19 +192,4 @@ class SimplenoteScreenshots: XCTestCase {
 
     let noteForDetailScreenshot = "Lemon Cake & Blueberry"
     let noteForInterlinkingScreenshot = "Colors"
-}
-
-extension XCUIElement {
-
-    func pasteText(text: String) -> Void {
-        let previousPasteboardContents = UIPasteboard.general.string
-        UIPasteboard.general.string = text
-
-        self.press(forDuration: 1.2)
-        XCUIApplication().menuItems.firstMatch.tap()
-
-        if let string = previousPasteboardContents {
-            UIPasteboard.general.string = string
-        }
-    }
 }

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -40,7 +40,7 @@ class SimplenoteScreenshots: XCTestCase {
         XCTAssertTrue(newLogin.waitForExistence(timeout: 10))
         newLogin.tap()
 
-        let firstNote = app.cells["Lemon Cake & Blueberry"]
+        let firstNote = app.cells[noteForDetailScreenshot]
         // Super long timeout in case the test user has many notes and the connection is a bit slow
 
         XCTAssertTrue(firstNote.waitForExistence(timeout: 20))
@@ -196,6 +196,8 @@ class SimplenoteScreenshots: XCTestCase {
 
         snapshot("\(title)-\(mode)")
     }
+
+    let noteForDetailScreenshot = "Lemon Cake & Blueberry"
 }
 
 extension XCUIElement {

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -47,39 +47,7 @@ class SimplenoteScreenshots: XCTestCase {
 
         firstNote.tap()
 
-        let actionButton = app.buttons.matching(identifier: "note-menu").firstMatch
-        XCTAssertTrue(actionButton.waitForExistence(timeout: 10))
-
         takeScreenshot("1-note")
-
-        actionButton.tap()
-
-        let collaborateButton = app.staticTexts["Collaborate"].firstMatch
-        XCTAssertTrue(collaborateButton.waitForExistence(timeout: 3))
-
-        collaborateButton.tap()
-
-        // Let's wait for the screen to be presented
-        let doneButton = app.buttons["Done"]
-        XCTAssertTrue(doneButton.waitForExistence(timeout: 3))
-
-        // The collaborators screen will ask to access our contacts the first time it's presented.
-        //
-        // Let's wait to see if a system dialog appeared and dismiss it if so.
-        let systemAlert = XCUIApplication(bundleIdentifier: "com.apple.springboard").alerts.firstMatch
-        if systemAlert.waitForExistence(timeout: 2) {
-            // It doesn't matter whether we allow or deny access in the Simulator for the kind of
-            // screenshots we want to make.
-            systemAlert.buttons.firstMatch.tap()
-        }
-
-        // The index 3 is _intentional_ as that's the desired position of the screenshot in the App
-        // Store
-        takeScreenshot("3-collaborators")
-
-        // Tapping done in the collaborate view dismisses the collaborate screen _and_ the action
-        // menu.
-        doneButton.tap()
 
         goBackFromEditor(using: app)
 
@@ -98,6 +66,28 @@ class SimplenoteScreenshots: XCTestCase {
         }
 
         takeScreenshot("2-all-notes")
+
+        let interlinkingNote = app.cells[noteForInterlinkingScreenshot]
+        XCTAssertTrue(interlinkingNote.waitForExistence(timeout: 5))
+        interlinkingNote.tap()
+
+        let noteTextView = app.textViews.firstMatch
+
+        XCTAssertTrue(noteTextView.waitForExistence(timeout: 1))
+
+        noteTextView.tap()
+
+        let interlinkingTriggerString = "\n[L"
+        noteTextView.typeText(interlinkingTriggerString)
+
+        takeScreenshot("3-interlinking")
+
+        // Reset for the next test
+        (0 ..< interlinkingTriggerString.count).forEach { _ in
+            noteTextView.typeText(XCUIKeyboardKey.delete.rawValue)
+        }
+
+        goBackFromEditor(using: app)
 
         openMenu(using: app)
 
@@ -202,6 +192,7 @@ class SimplenoteScreenshots: XCTestCase {
     }
 
     let noteForDetailScreenshot = "Lemon Cake & Blueberry"
+    let noteForInterlinkingScreenshot = "Colors"
 }
 
 extension XCUIElement {

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -74,7 +74,14 @@ class SimplenoteScreenshots: XCTestCase {
 
         XCTAssertTrue(noteTextView.waitForExistence(timeout: 1))
 
-        noteTextView.tap()
+        // The next step is to type in the note to bring up the inter-note linking view.
+        // The natural thing to do here would be tapping the note:
+        //
+        // noteTextView.tap()
+        //
+        // Doing so works on iOS, but fails on iPad Pro 12.9" 2nd and 3rd generation, on Xcode 12.3.
+        // Luckily, tapping the app itself does the job, too.
+        app.tap()
 
         let interlinkingTriggerString = "\n[L"
         noteTextView.typeText(interlinkingTriggerString)

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -12,6 +12,8 @@ class SimplenoteScreenshots: XCTestCase {
         setupSnapshot(app)
         app.launch()
 
+        dismissVerifyEmailIfNeeded(using: app)
+
         let login = app.buttons["Log In"]
 
         if login.waitForExistence(timeout: 3) == false {
@@ -37,6 +39,8 @@ class SimplenoteScreenshots: XCTestCase {
         let newLogin = app.buttons["Log In"]
         XCTAssertTrue(newLogin.waitForExistence(timeout: 10))
         newLogin.tap()
+
+        dismissVerifyEmailIfNeeded(using: app)
 
         let firstNote = app.cells[noteForDetailScreenshot]
         // Super long timeout in case the test user has many notes and the connection is a bit slow
@@ -146,10 +150,17 @@ class SimplenoteScreenshots: XCTestCase {
 
         typeOnPassCodeScreen(4, using: app)
 
+        dismissVerifyEmailIfNeeded(using: app)
+
         // Now, disable the passcode so we're not blocked by it on next launch.
         openMenu(using: app)
         loadPasscodeScreen(using: app)
         typeOnPassCodeScreen(1234, using: app)
+    }
+
+    func dismissVerifyEmailIfNeeded(using app: XCUIApplication) {
+        guard app.staticTexts["Verify Your Email"].waitForExistence(timeout: 10) else { return }
+        app.buttons["icon cross"].tap()
     }
 
     func logout(using app: XCUIApplication) {

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -214,9 +214,11 @@ class SimplenoteScreenshots: XCTestCase {
         let digits = "\(input.magnitude)".compactMap(\.wholeNumberValue)
 
         digits.forEach { digit in
-            let input = app.staticTexts["\(digit)"].firstMatch
+            let input = app.staticTexts["\(digit)"]
             XCTAssertTrue(input.waitForExistence(timeout: 3))
-            input.tap()
+            // Both the custom UIButton and its UILabel match the "\(digit)" query. We need to pick
+            // one for the tap to work.
+            input.firstMatch.tap()
         }
     }
 

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -155,7 +155,7 @@ class SimplenoteScreenshots: XCTestCase {
     func logout(using app: XCUIApplication) {
         getMenuButtonElement(from: app).tap()
 
-        let settings = app.textFields["Settings"]
+        let settings = app.staticTexts["Settings"]
         XCTAssertTrue(settings.waitForExistence(timeout: 3))
         settings.tap()
 

--- a/SimplenoteScreenshots/SnapshotHelper.swift
+++ b/SimplenoteScreenshots/SnapshotHelper.swift
@@ -38,22 +38,13 @@ func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
 }
 
 enum SnapshotError: Error, CustomDebugStringConvertible {
-    case cannotDetectUser
-    case cannotFindHomeDirectory
     case cannotFindSimulatorHomeDirectory
-    case cannotAccessSimulatorHomeDirectory(String)
     case cannotRunOnPhysicalDevice
 
     var debugDescription: String {
         switch self {
-        case .cannotDetectUser:
-            return "Couldn't find Snapshot configuration files - can't detect current user "
-        case .cannotFindHomeDirectory:
-            return "Couldn't find Snapshot configuration files - can't detect `Users` dir"
         case .cannotFindSimulatorHomeDirectory:
             return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
-        case .cannotAccessSimulatorHomeDirectory(let simulatorHostHome):
-            return "Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?"
         case .cannotRunOnPhysicalDevice:
             return "Can't use Snapshot on a physical device."
         }
@@ -75,7 +66,7 @@ open class Snapshot: NSObject {
         Snapshot.waitForAnimations = waitForAnimations
 
         do {
-            let cacheDir = try pathPrefix()
+            let cacheDir = try getCacheDirectory()
             Snapshot.cacheDirectory = cacheDir
             setLanguage(app)
             setLocale(app)
@@ -174,6 +165,8 @@ open class Snapshot: NSObject {
             }
 
             let screenshot = XCUIScreen.main.screenshot()
+            let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+
             guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
 
             do {
@@ -183,12 +176,25 @@ open class Snapshot: NSObject {
                 simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
-                try screenshot.pngRepresentation.write(to: path)
+                try image.pngData()?.write(to: path, options: .atomic)
             } catch let error {
                 NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
                 NSLog(error.localizedDescription)
             }
         #endif
+    }
+
+    class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+        if #available(iOS 10.0, *) {
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = image.scale
+            let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+            return renderer.image { context in
+                image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+            }
+        } else {
+            return image
+        }
     }
 
     class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
@@ -206,40 +212,28 @@ open class Snapshot: NSObject {
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
-    class func pathPrefix() throws -> URL? {
-        let homeDir: URL
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
         // on OSX config is stored in /Users/<username>/Library
         // and on iOS/tvOS/WatchOS it's in simulator's home dir
         #if os(OSX)
-            guard let user = ProcessInfo().environment["USER"] else {
-                throw SnapshotError.cannotDetectUser
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
             }
-
-            guard let usersDir = FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
-                throw SnapshotError.cannotFindHomeDirectory
-            }
-
-            homeDir = usersDir.appendingPathComponent(user)
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
         #else
-            #if arch(i386) || arch(x86_64)
-                guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
-                    throw SnapshotError.cannotFindSimulatorHomeDirectory
-                }
-                guard let homeDirUrl = URL(string: simulatorHostHome) else {
-                    throw SnapshotError.cannotAccessSimulatorHomeDirectory(simulatorHostHome)
-                }
-                homeDir = URL(fileURLWithPath: homeDirUrl.path)
-            #else
-                throw SnapshotError.cannotRunOnPhysicalDevice
-            #endif
+            throw SnapshotError.cannotRunOnPhysicalDevice
         #endif
-        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }
 }
 
 private extension XCUIElementAttributes {
     var isNetworkLoadingIndicator: Bool {
-        if hasAllowedIdentifier { return false }
+        if hasAllowListedIdentifier { return false }
 
         let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
         let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
@@ -247,10 +241,10 @@ private extension XCUIElementAttributes {
         return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
     }
 
-    var hasAllowedIdentifier: Bool {
-        let allowedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
 
-        return allowedIdentifiers.contains(identifier)
+        return allowListedIdentifiers.contains(identifier)
     }
 
     func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
@@ -300,4 +294,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.21]
+// SnapshotHelperVersion [1.24]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -493,6 +493,13 @@ end
       # But fail completely after those 3 retries
       stop_after_first_error: true,
 
+      # Run one Simulator at a time. One of the screenshots requires adding
+      # text to a note but because we're using the same account across all the
+      # Simulators, editing the note on one will result in the changes
+      # appearing on the other making for unexpected and inconsistent
+      # screnshots
+      concurrent_simulators: false,
+
       # Allow the caller to invoke dark mode
       dark_mode: options[:mode].to_s.downcase == "dark"
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -681,5 +681,5 @@ def screenshot_devices()
 end
 
 def simulator_version
-  '13.4'
+  '14.3'
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -680,13 +680,13 @@ end
 
 def screenshot_devices()
   [
-    "iPhone Xs Max",
-    "iPhone 8 Plus",
+    "iPhone X",
+    "iPhone 8",
     "iPad Pro (12.9-inch) (2nd generation)",
     "iPad Pro (12.9-inch) (3rd generation)",
   ]
 end
 
 def simulator_version
-  '14.3'
+  '14.4'
 end

--- a/fastlane/appstoreres/assets/ipad_2nd_gen.png
+++ b/fastlane/appstoreres/assets/ipad_2nd_gen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd4c8949130361f6ccc78d1cfd0a8d8f9c5f9c73f657a913a303b4ee0b3579f5
-size 109520
+oid sha256:7166b4805b87ce74a030d54428ccb84314bb23ee880430f7cb73b7275c76e12d
+size 107536

--- a/fastlane/appstoreres/assets/ipad_3rd_gen.png
+++ b/fastlane/appstoreres/assets/ipad_3rd_gen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed463de387bd7efbfb6cf5c831debb0fa21764f4dba3e55d7e93d5745fab0361
-size 111706
+oid sha256:2a56f8bb3b861240d27890cd5ef90904f220ab3ee7b8e24772d8f0d75532f0ec
+size 110535

--- a/fastlane/appstoreres/assets/iphone_8_plus.png
+++ b/fastlane/appstoreres/assets/iphone_8_plus.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2726de9a28dde80c42ae1545564049e1c5c9c55db88d592d0229991d34830ba
-size 210749
+oid sha256:a0baf4e93eb39a4d012f6b378cb10e851e1d00f193d328f84b0dd3d56135f53e
+size 56386

--- a/fastlane/appstoreres/assets/iphone_Xs_max.png
+++ b/fastlane/appstoreres/assets/iphone_Xs_max.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10be6fd46285a1f95de8a807fd9c170c8d35e990099a33580438366a7a67a538
-size 275866
+oid sha256:e82b29df5730a8d5ebc0ac4b3d2250410a59583dbd4f72a8bc70e0055785200b
+size 76328

--- a/fastlane/appstoreres/assets/styles/style.css
+++ b/fastlane/appstoreres/assets/styles/style.css
@@ -1,5 +1,5 @@
 *{
-  color: #101517; /* This is gray90 from https://color-studio.blog */
+  color: #ffffff;
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: normal ;

--- a/fastlane/metadata/en-US/app_store_screenshot_1.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_1.txt
@@ -1,2 +1,2 @@
-A simple
-note taking experience
+A simple note taking
+experience

--- a/fastlane/metadata/en-US/app_store_screenshot_1.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_1.txt
@@ -1,0 +1,2 @@
+A simple
+note taking experience

--- a/fastlane/metadata/en-US/app_store_screenshot_2.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_2.txt
@@ -1,0 +1,1 @@
+Sync everything across all your devices

--- a/fastlane/metadata/en-US/app_store_screenshot_3.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_3.txt
@@ -1,1 +1,1 @@
-Collaborate and work together
+Reference and link to other notes

--- a/fastlane/metadata/en-US/app_store_screenshot_3.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_3.txt
@@ -1,0 +1,1 @@
+Collaborate and work together

--- a/fastlane/metadata/en-US/app_store_screenshot_4.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_4.txt
@@ -1,0 +1,2 @@
+Stay organized
+with tags

--- a/fastlane/metadata/en-US/app_store_screenshot_5.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_5.txt
@@ -1,0 +1,1 @@
+Find what you're looking for instantly

--- a/fastlane/metadata/en-US/app_store_screenshot_6.txt
+++ b/fastlane/metadata/en-US/app_store_screenshot_6.txt
@@ -1,0 +1,1 @@
+Protect your notes with a passcode lock

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -116,7 +116,7 @@
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-03.png",
 			"background": "#FFFFFF",
-			"screenshot": "iPhone Xs Max-3-collaborators-light.png",
+			"screenshot": "iPhone Xs Max-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{
@@ -159,7 +159,7 @@
 			"device": "iPad Pro (12.9-inch) (2nd generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-03.png",
 			"background": "#FFFFFF",
-			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-collaborators-light.png",
+			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{
@@ -202,7 +202,7 @@
 			"device": "iPad Pro (12.9-inch) (3rd generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-03.png",
 			"background": "#FFFFFF",
-			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-collaborators-light.png",
+			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -58,42 +58,42 @@
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-01.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone 8 Plus-1-note-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-02.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone 8 Plus-2-all-notes-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-03.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone 8 Plus-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-04.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone 8 Plus-4-menu-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-05.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone 8 Plus-5-search-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-06.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone 8 Plus-6-passcode-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_6.txt"
 		},
@@ -101,42 +101,42 @@
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-01.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone Xs Max-1-note-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-02.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone Xs Max-2-all-notes-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-03.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone Xs Max-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-04.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone Xs Max-4-menu-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-05.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone Xs Max-5-search-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-06.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPhone Xs Max-6-passcode-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_6.txt"
 		},
@@ -144,42 +144,42 @@
 		{
 			"device": "iPad Pro (12.9-inch) (2nd generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-01.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-1-note-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (2nd generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-02.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-2-all-notes-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (2nd generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-03.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (2nd generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-04.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-4-menu-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (2nd generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-05.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-5-search-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (2nd generation)",
 			"filename": "iPad Pro (12.9-inch) (2nd generation)-06.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (2nd generation)-6-passcode-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_6.txt"
 		},
@@ -187,42 +187,42 @@
 		{
 			"device": "iPad Pro (12.9-inch) (3rd generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-01.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-1-note-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (3rd generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-02.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-2-all-notes-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (3rd generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-03.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (3rd generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-04.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-4-menu-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (3rd generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-05.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-5-search-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 		{
 			"device": "iPad Pro (12.9-inch) (3rd generation)",
 			"filename": "iPad Pro (12.9-inch) (3rd generation)-06.png",
-			"background": "#FFFFFF",
+			"background": "#3361CC",
 			"screenshot": "iPad Pro (12.9-inch) (3rd generation)-6-passcode-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_6.txt"
 		}

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -73,7 +73,7 @@
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-03.png",
 			"background": "#FFFFFF",
-			"screenshot": "iPhone 8 Plus-3-collaborators-light.png",
+			"screenshot": "iPhone 8 Plus-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{

--- a/fastlane/screenshots.json
+++ b/fastlane/screenshots.json
@@ -59,42 +59,42 @@
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-01.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone 8 Plus-1-note-light.png",
+			"screenshot": "iPhone 8-1-note-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-02.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone 8 Plus-2-all-notes-dark.png",
+			"screenshot": "iPhone 8-2-all-notes-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-03.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone 8 Plus-3-interlinking-light.png",
+			"screenshot": "iPhone 8-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-04.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone 8 Plus-4-menu-dark.png",
+			"screenshot": "iPhone 8-4-menu-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-05.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone 8 Plus-5-search-light.png",
+			"screenshot": "iPhone 8-5-search-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 		{
 			"device": "iPhone 8 Plus",
 			"filename": "iPhone 8 Plus-06.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone 8 Plus-6-passcode-dark.png",
+			"screenshot": "iPhone 8-6-passcode-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_6.txt"
 		},
 
@@ -102,42 +102,42 @@
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-01.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone Xs Max-1-note-light.png",
+			"screenshot": "iPhone X-1-note-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_1.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-02.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone Xs Max-2-all-notes-dark.png",
+			"screenshot": "iPhone X-2-all-notes-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_2.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-03.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone Xs Max-3-interlinking-light.png",
+			"screenshot": "iPhone X-3-interlinking-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_3.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-04.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone Xs Max-4-menu-dark.png",
+			"screenshot": "iPhone X-4-menu-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_4.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-05.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone Xs Max-5-search-light.png",
+			"screenshot": "iPhone X-5-search-light.png",
 			"text": "metadata/{locale}/app_store_screenshot_5.txt"
 		},
 		{
 			"device": "iPhone Xs Max",
 			"filename": "iPhone Xs Max-06.png",
 			"background": "#3361CC",
-			"screenshot": "iPhone Xs Max-6-passcode-dark.png",
+			"screenshot": "iPhone X-6-passcode-dark.png",
 			"text": "metadata/{locale}/app_store_screenshot_6.txt"
 		},
 


### PR DESCRIPTION
### Fix

Updates the screenshots automation to work with ~~Xcode 12.3 and the iOS 14.3 Simulators~~ Xcode 12.4 and the iOS 14.4 Simulators.

It also replaces the screenshot for the collaborate screen with one for the inter-note linking features. Internal ref p2XJRt-2wR.

~~This is off `release/4.30` because I want the new screenshots to go in with that release.~~

### Test

I'm having issues on CI, because of the [known `xcodebuild` bug with SPM and SSH repositories](https://discuss.bitrise.io/t/xcode-11-resolving-packages-fails-with-ssh-fingerprint/10388/2). To keep the work on this PR from taking too long, I decided to drop the CI update part. I think this is acceptable, albeit undesirable because we rarely updates the screenshot.

To test locally, you can either:

- Running the "SimplenoteScreenshots" scheme; it should pass
- Running `bundle exec fastalne take_screenshots`; this will take a while and the result should be:

![screencapture-file-Users-gio-Developer-a8c-snios-fastlane-screenshots-screenshots-html-2021-01-15-20_54_45](https://user-images.githubusercontent.com/1218433/104710233-f77dbb80-5773-11eb-9b59-71b3bbac9fdb.png)

In particular, notice the new screenshot with the inter note linking:

![image](https://user-images.githubusercontent.com/1218433/103731498-630bae80-5039-11eb-8a05-7a4dc2e9c4ac.png)

and the one with the new passcode screen:

![image](https://user-images.githubusercontent.com/1218433/104710366-1aa86b00-5774-11eb-884d-8aeb1706e387.png)

If you run the screenshots composition with 

```
bf create_promo_screenshots source:$(pwd)/fastlane/screenshots/
```

You should see up-to-date copy and background, as per internal discussion, ref p2XJRt-2wR.

### Review
Only one platform developer required to review these changes, but anyone can perform the review.

### Release

These changes do not require release notes.