### PR TITLE
Simperium: Swift Initialization

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -2974,7 +2974,6 @@
 				GCC_PREFIX_HEADER = "Simplenote/Simplenote-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"COCOAPODS=1",
-					"USE_VERBOSE_LOGGING=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Simplenote/Simplenote-Info.plist";
@@ -2993,7 +2992,7 @@
 				PRODUCT_NAME = Simplenote;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Simplenote Development";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(SP_IOS_SDK)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG USE_VERBOSE_LOGGING $(SP_IOS_SDK)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplenote/Simplenote-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -3136,7 +3135,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"INTERNAL_DISTRIBUTION=1",
 					"USE_APPCENTER=1",
-					"USE_VERBOSE_LOGGING=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Simplenote/Simplenote-Info.plist";
@@ -3155,7 +3153,7 @@
 				PRODUCT_NAME = Simplenote;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.codality.NotationalFlow.Alpha";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "BUILD_INTERNAL $(SP_IOS_SDK)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "BUILD_INTERNAL USE_VERBOSE_LOGGING $(SP_IOS_SDK)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplenote/Simplenote-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = app;
@@ -3434,7 +3432,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"INTERNAL_DISTRIBUTION=1",
 					"USE_APPCENTER=1",
-					"USE_VERBOSE_LOGGING=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Simplenote/Simplenote-Info.plist";
@@ -3453,7 +3450,7 @@
 				PRODUCT_NAME = Simplenote;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.codality.NotationalFlow.Internal";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "BUILD_INTERNAL $(SP_IOS_SDK)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "BUILD_INTERNAL USE_VERBOSE_LOGGING $(SP_IOS_SDK)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Simplenote/Simplenote-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				WRAPPER_EXTENSION = app;

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -38,20 +38,6 @@ extension SPAppDelegate {
 //
 extension SPAppDelegate {
 
-    @objc
-    func print() {
-        guard let bucket = simperium.bucket(forName: "Settings") else {
-            return
-        }
-
-        let objects = bucket.allObjects() ?? []
-        NSLog("# Objects \(objects.count)")
-
-        for case let object as SPObject in objects {
-            NSLog("#   Object [\(object.simperiumKey.debugDescription)]: \(object.dictionary.debugDescription))")
-        }
-    }
-    
     /// Returns the actual Selected Tag Name **Excluding** navigation tags, such as Trash or Untagged Notes.
     ///
     /// TODO: This should be gone... **the second** the AppDelegate is Swift-y. We should simply keep a `NoteListFilter` instance.

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -11,12 +11,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SPAppDelegate : UIResponder <UIApplicationDelegate>
+@interface SPAppDelegate : UIResponder <UIApplicationDelegate, SPBucketDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 @property (nullable, strong, nonatomic) UIWindow *pinLockWindow;
 
-@property (strong, nonatomic, readonly) Simperium						*simperium;
+@property (strong, nonatomic) Simperium						            *simperium;
 @property (strong, nonatomic, readonly) NSManagedObjectContext			*managedObjectContext;
 @property (strong, nonatomic, readonly) NSManagedObjectModel			*managedObjectModel;
 @property (strong, nonatomic, readonly) NSPersistentStoreCoordinator	*persistentStoreCoordinator;

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -38,9 +38,8 @@
 #pragma mark Private Properties
 #pragma mark ================================================================================
 
-@interface SPAppDelegate () <SPBucketDelegate>
+@interface SPAppDelegate ()
 
-@property (strong, nonatomic) Simperium                     *simperium;
 @property (strong, nonatomic) NSManagedObjectContext        *managedObjectContext;
 @property (strong, nonatomic) NSManagedObjectModel          *managedObjectModel;
 @property (strong, nonatomic) NSPersistentStoreCoordinator  *persistentStoreCoordinator;
@@ -64,34 +63,6 @@
 #pragma mark ================================================================================
 #pragma mark Frameworks Setup
 #pragma mark ================================================================================
-
-- (void)setupSimperium
-{
-	self.simperium = [[Simperium alloc] initWithModel:self.managedObjectModel context:self.managedObjectContext coordinator:self.persistentStoreCoordinator];
-		  
-#if USE_VERBOSE_LOGGING
-    [_simperium setVerboseLoggingEnabled:YES];
-    NSLog(@"verbose logging enabled");
-#else
-    [_simperium setVerboseLoggingEnabled:NO];
-#endif
-    
-    _simperium.authenticationViewControllerClass    = [SPOnboardingViewController class];
-    _simperium.authenticator.providerString         = @"simplenote.com";
-	
-
-    [_simperium setAuthenticationShouldBeEmbeddedInNavigationController:YES];
-    [_simperium setAllBucketDelegates:self];
-    [_simperium setDelegate:self];
-    
-    NSArray *buckets = @[NSStringFromClass([Note class]),
-                         NSStringFromClass([Tag class]),
-                         NSStringFromClass([Settings class])];
-    
-    for (NSString *bucketName in buckets) {
-        [_simperium bucketForName:bucketName].notifyWhileIndexing = YES;
-    }
-}
 
 - (void)authenticateSimperium
 {

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -12,6 +12,7 @@
 
 #import "Note.h"
 #import "Tag.h"
+#import "Settings.h"
 #import "PersonTag.h"
 #import "SPAppDelegate.h"
 #import "SPConstants.h"


### PR DESCRIPTION
### Details:
In this PR we're updating the way `SPBucket(s)` are initialized: we're now explicitly invoking `bucketForName:` for **all of our entities** (Settings was missing)

This is a required step towards Dynamic Schemas (that is: In Memory JSONStorage, coming up next!).
**Plus** since we were in the neighborhood, Simperium's Init has been Swifted.

cc @eshurakov 
Ref. #1086 

### Test
- [x] Verify in `debug` mode the console reads `[Simperium] Verbose logging Enabled`
- [x] Verify you can log into your account and access your notes

### Release
These changes do not require release notes.
