### PR TITLE
Prevent bypassing login screen

### DIFF
--- a/Simplenote/Classes/ShortcutsHandler.swift
+++ b/Simplenote/Classes/ShortcutsHandler.swift
@@ -11,6 +11,12 @@ class ShortcutsHandler: NSObject {
     @objc
     static var shared = ShortcutsHandler()
 
+    /// Is User authenticated?
+    ///
+    private var isAuthenticated: Bool {
+        return SPAppDelegate.shared().simperium.user?.authenticated() == true
+    }
+
     /// Supported Activities
     ///
     private let activities = [
@@ -26,7 +32,6 @@ class ShortcutsHandler: NSObject {
     ///     2. Not keeping the Activities around... also causes `becomeCurrent` to fail. That's why `activities` is
     ///        an ivar!
     ///
-    @objc
     func registerSimplenoteActivities() {
         for (index, activity) in activities.enumerated() {
             let delay = DispatchTime.now() + DispatchTimeInterval.seconds(index)
@@ -51,6 +56,10 @@ class ShortcutsHandler: NSObject {
     func handleUserActivity(_ userActivity: NSUserActivity) -> Bool {
         guard let type = ActivityType(rawValue: userActivity.activityType) else {
             return false
+        }
+
+        guard isAuthenticated else {
+            return type == .launch
         }
 
         switch type {
@@ -103,7 +112,7 @@ extension ShortcutsHandler {
     ///
     @objc
     func handleApplicationShortcut(_ shortcut: UIApplicationShortcutItem) {
-        guard let type = ApplicationShortcutItemType(rawValue: shortcut.type) else {
+        guard isAuthenticated, let type = ApplicationShortcutItemType(rawValue: shortcut.type) else {
             return
         }
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -619,17 +619,7 @@
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
     if (!self.simperium.user.authenticated) {
-        if ([WPAuthHandler isWPAuthenticationUrl: url]) {
-            SPUser *newUser = [WPAuthHandler authorizeSimplenoteUserFromUrl:url forAppId:[SPCredentials simperiumAppID]];
-            if (newUser != nil) {
-                self.simperium.user = newUser;
-                [self.navigationController dismissViewControllerAnimated:YES completion:nil];
-                [self.simperium authenticationDidSucceedForUsername:newUser.email token:newUser.authToken];
-
-                [SPTracker trackWPCCLoginSucceeded];
-            }
-        }
-
+        [self performDotcomAuthenticationWithURL:url];
         return YES;
     }
 
@@ -671,6 +661,24 @@
     }
     
     return YES;
+}
+
+- (void)performDotcomAuthenticationWithURL:(NSURL *)url
+{
+    if (![WPAuthHandler isWPAuthenticationUrl:url]) {
+        return;
+    }
+
+    SPUser *user = [WPAuthHandler authorizeSimplenoteUserFromUrl:url forAppId:[SPCredentials simperiumAppID]];
+    if (user == nil) {
+        return;
+    }
+
+    self.simperium.user = user;
+    [self.navigationController dismissViewControllerAnimated:YES completion:nil];
+    [self.simperium authenticationDidSucceedForUsername:user.email token:user.authToken];
+
+    [SPTracker trackWPCCLoginSucceeded];
 }
 
 #pragma mark ================================================================================


### PR DESCRIPTION
### Fix
This PR adds a check if user is authenticated before processing incoming URLs, shortcuts and activities.

Closes #1035 

### Test
1. Logout or fresh install
2. Put the app in the background

- [x] Check that typing `simplenote://new` in Safari doesn't dismiss login screen
- [x] Check that log in with Wordpress works

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
