### PR TITLE
Issue #1037 Empty Trash Button Remains Enabled

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -184,6 +184,7 @@ extension SPNoteListViewController {
 
             self.tableView.performBatchChanges(sectionsChangeset: sectionsChangeset, objectsChangeset: objectsChangeset) { _ in
                 self.displayPlaceholdersIfNeeded()
+                self.refreshEmptyTrashState()
             }
         }
     }
@@ -670,7 +671,6 @@ private extension SPNoteListViewController {
             UIContextualAction(style: .destructive, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { (_, _, completion) in
                 SPTracker.trackListNoteDeleted()
                 SPObjectManager.shared().permenentlyDeleteNote(note)
-                self.setEmptyTrashEnabled()
                 completion(true)
             }
         ]

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -391,7 +391,7 @@ extension SPNoteListViewController {
         let isTrashOnScreen = self.isDeletedFilterActive
         let isNotEmpty = !self.isListEmpty
         
-        self.emptyTrashButton.isEnabled = isTrashOnScreen && isNotEmpty
+        emptyTrashButton.isEnabled = isTrashOnScreen && isNotEmpty
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -660,6 +660,7 @@ private extension SPNoteListViewController {
             UIContextualAction(style: .destructive, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { (_, _, completion) in
                 SPTracker.trackListNoteDeleted()
                 SPObjectManager.shared().permenentlyDeleteNote(note)
+                self.setEmptyTrashEnabled()
                 completion(true)
             }
         ]

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -382,6 +382,16 @@ extension SPNoteListViewController {
         }
         open(note, ignoringSearchQuery: true, animated: true)
     }
+    
+    /// Sets the state of the trash button
+    ///
+    @objc
+    func refreshEmptyTrashState() {
+        let isTrashOnScreen = self.isDeletedFilterActive
+        let isNotEmpty = !self.isListEmpty
+        
+        self.emptyTrashButton.isEnabled = isTrashOnScreen && isNotEmpty
+    }
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -29,8 +29,7 @@
 @property (nonatomic) CGFloat                                               keyboardHeight;
 @property (nonatomic) BOOL                                                  firstLaunch;
 @property (nonatomic) BOOL                                                  mustScrollToFirstRow;
-@property (nonatomic, strong) UIBarButtonItem
-    *emptyTrashButton;
+@property (nonatomic, strong) UIBarButtonItem                               *emptyTrashButton;
 
 - (void)update;
 - (void)openNoteWithSimperiumKey:(NSString *)simperiumKey animated:(BOOL)animated;

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -29,6 +29,8 @@
 @property (nonatomic) CGFloat                                               keyboardHeight;
 @property (nonatomic) BOOL                                                  firstLaunch;
 @property (nonatomic) BOOL                                                  mustScrollToFirstRow;
+@property (nonatomic, strong) UIBarButtonItem
+    *emptyTrashButton;
 
 - (void)update;
 - (void)setEmptyTrashEnabled;

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -31,6 +31,7 @@
 @property (nonatomic) BOOL                                                  mustScrollToFirstRow;
 
 - (void)update;
+- (void)setEmptyTrashEnabled;
 - (void)openNoteWithSimperiumKey:(NSString *)simperiumKey animated:(BOOL)animated;
 - (void)openNote:(Note *)note animated:(BOOL)animated;
 - (void)openNote:(Note *)note ignoringSearchQuery:(BOOL)ignoringSearchQuery animated:(BOOL)animated;

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -33,7 +33,6 @@
     *emptyTrashButton;
 
 - (void)update;
-- (void)setEmptyTrashEnabled;
 - (void)openNoteWithSimperiumKey:(NSString *)simperiumKey animated:(BOOL)animated;
 - (void)openNote:(Note *)note animated:(BOOL)animated;
 - (void)openNote:(Note *)note ignoringSearchQuery:(BOOL)ignoringSearchQuery animated:(BOOL)animated;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -500,14 +500,21 @@
     [self refreshSortBarText];
 
     BOOL isTrashOnScreen = self.isDeletedFilterActive;
-    BOOL isNotEmpty = !self.isListEmpty;
 
-    self.emptyTrashButton.enabled = isTrashOnScreen && isNotEmpty;
+    [self setEmptyTrashEnabled];
     self.tableView.allowsSelection = !isTrashOnScreen;
     
     [self displayPlaceholdersIfNeeded];
     [self updateNavigationBar];
     [self hideRatingViewIfNeeded];
+}
+
+- (void)setEmptyTrashEnabled
+{
+    BOOL isTrashOnScreen = self.isDeletedFilterActive;
+    BOOL isNotEmpty = !self.isListEmpty;
+
+    self.emptyTrashButton.enabled = isTrashOnScreen && isNotEmpty;
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -30,7 +30,6 @@
 @property (nonatomic, strong) SPBlurEffectView                      *navigationBarBackground;
 @property (nonatomic, strong) UIBarButtonItem                       *addButton;
 @property (nonatomic, strong) UIBarButtonItem                       *sidebarButton;
-@property (nonatomic, strong) UIBarButtonItem                       *emptyTrashButton;
 
 @property (nonatomic, strong) SearchDisplayController               *searchController;
 @property (nonatomic, strong) UIActivityIndicatorView               *activityIndicator;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -500,20 +500,12 @@
 
     BOOL isTrashOnScreen = self.isDeletedFilterActive;
 
-    [self setEmptyTrashEnabled];
+    [self refreshEmptyTrashState];
     self.tableView.allowsSelection = !isTrashOnScreen;
     
     [self displayPlaceholdersIfNeeded];
     [self updateNavigationBar];
     [self hideRatingViewIfNeeded];
-}
-
-- (void)setEmptyTrashEnabled
-{
-    BOOL isTrashOnScreen = self.isDeletedFilterActive;
-    BOOL isNotEmpty = !self.isListEmpty;
-
-    self.emptyTrashButton.enabled = isTrashOnScreen && isNotEmpty;
 }
 
 


### PR DESCRIPTION
### Fix
This PR fixes issue #1037 

When viewing the notes trash list, if you remove all of the notes either by restoring them or deleting them one at a time, the empty notes button remains active.  

With this fix if when the list becomes empty by removing items either using the empty button or by removing single items, the empty trash button will become disabled.

Example:

<img width="300px" src ="https://cdn-std.droplr.net/files/acc_593859/lTFJ9Y" />

### Test
1. Create multiple new notes and then trash them
2. Go to the trash menu and restore them all to the notes list.  Make sure that the empty trash button stays enabled until the last note is restore
3. Trash the notes again, return to the notes list and delete each note individually by swiping to the left and selecting the red trash button.  Make sure that the trash button stays enabled till the last note is deleted
4. Create a few new notes and trash them
5. Return to the trash list and use the empty trash button.  Make sure the trash button disables after the list is cleared.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
