### PR TITLE
Adds ability to swipe to dismiss SPTextView

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -113,7 +113,7 @@ extension SPNoteEditorViewController {
     ///
     @objc
     func configureTextViewKeyboard() {
-        noteEditorTextView?.keyboardDismissMode = UIScrollView.KeyboardDismissMode.interactive
+        noteEditorTextView?.keyboardDismissMode = .interactive
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -108,6 +108,13 @@ extension SPNoteEditorViewController {
         interlinkProcessor.delegate = self
         interlinkProcessor.contextProvider = self
     }
+    
+    /// Sets up the Keyboard
+    ///
+    @objc
+    func configureTextViewKeyboard() {
+        noteEditorTextView?.keyboardDismissMode = UIScrollView.KeyboardDismissMode.interactive
+    }
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -132,6 +132,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self configureLayout];
     [self configureInterlinksProcessor];
     [self refreshVoiceoverSupport];
+    [self configureTextViewKeyboard];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Simplenote/Classes/SPTextView.m
+++ b/Simplenote/Classes/SPTextView.m
@@ -48,6 +48,8 @@ CGFloat const TextViewHighlightCornerRadius = 3;
         caret position.
      */
         self.textContainer.heightTracksTextView = NO;
+
+        self.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
     }
     return self;
 }

--- a/Simplenote/Classes/SPTextView.m
+++ b/Simplenote/Classes/SPTextView.m
@@ -48,8 +48,6 @@ CGFloat const TextViewHighlightCornerRadius = 3;
         caret position.
      */
         self.textContainer.heightTracksTextView = NO;
-
-        self.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
     }
     return self;
 }


### PR DESCRIPTION
### Fix
This PR fixes issue #33 enabling iOS' built in swipe to dismiss keyboard action.

With this fix, when working on a note or a tag, the keyboard can now be dismissed with a swipe down motion.

example:
<img width="300px" src="https://cdn-std.droplr.net/files/acc_593859/XR5PxX" />

### Test

1. open up a note and tap into the text to make the keyboard appear
2. tap slightly above the keyboard and swipe down to dismiss the keyboard
3. tap into the ta area to make the keyboard appear
4. tap above the tag area and swipe down to dismiss the keyboard

### Review
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
