### PR TITLE
Extended unit tests for string hashing

### DIFF
--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -47,7 +47,7 @@ class NSStringSimplenoteTests: XCTestCase {
 }
 
 extension NSStringSimplenoteTests {
-    func testNonEqualStringsCreateSameHash(_ samples: [NSString]) {
+    private func testNonEqualStringsCreateSameHash(_ samples: [NSString]) {
         var count = 0
         
         while count + 1 < samples.count {

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -40,8 +40,9 @@ class NSStringSimplenoteTests: XCTestCase {
             ["\u{0065}\u{0301}", "\u{00E9}"] // é
         ]
         
-        testNonEqualStringsCreateSameHash(differentStringsOneHashSamples[0])
-        testNonEqualStringsCreateSameHash(differentStringsOneHashSamples[1])
+        for sample in differentStringsOneHashSamples {
+            testNonEqualStringsCreateSameHash(sample)
+        }
     }
 }
 

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -34,7 +34,7 @@ class NSStringSimplenoteTests: XCTestCase {
     ///
     /// - Note: When using the `Swift.String` class, the same comparison is actually correct.
     ///
-    func testByEncodingTagAsHashAllowsUsToProperlyCompareStringsThatEvaluateAsNotEqualOtherwise() {
+    func testNonEqualStringsCreateSameHash() {
         let sampleA = NSString(stringLiteral: "\u{0073}\u{0323}\u{0307}")
         let sampleB = NSString(stringLiteral: "\u{0073}\u{0307}\u{0323}")
         let sampleC = NSString(stringLiteral: "\u{1E69}")

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -16,16 +16,6 @@ class NSStringSimplenoteTests: XCTestCase {
 
         XCTAssertTrue(expectedSet.isSuperset(of: escapedSet))
     }
-    
-    /// Verifies that `byEncodingAsTagHash` effectively escapes special characters
-    ///
-    func testByEncodingAsTagHashEncodesAllOfSpecialCharacters() {
-        let string = String("TáßvĒёи兔子@#$%^&*+-=_`~/?., ><{}[]\\()\"|':;")
-        let hash = string.byEncodingAsTagHash
-        let expected = "t%C3%A1%C3%9Fv%C4%93%D1%91%D0%B8%E5%85%94%E5%AD%90%40%23%24%25%5E%26%2A%2B%2D%3D%5F%60%7E%2F%3F%2E%2C%20%3E%3C%7B%7D%5B%5D%5C%28%29%22%7C%27%3A%3B"
-        
-        XCTAssertEqual(hash, expected)
-    }
 
     /// Verifies that `byEncodingAsTagHash` allows us to properly compare Unicode Strings that would otherwise evaluate as not equal.
     /// Although our (three) sample strings yield the exact same character`ṩ`, regular `isEqualString` API returns `false`.
@@ -41,26 +31,23 @@ class NSStringSimplenoteTests: XCTestCase {
         let sampleD = NSString(stringLiteral: "\u{0065}\u{0301}")
         let sampleE = NSString(stringLiteral: "\u{00E9}")
 
-        let hashA = sampleA.byEncodingAsTagHash
-        let hashB = sampleB.byEncodingAsTagHash
-        let hashC = sampleC.byEncodingAsTagHash
-        let hashD = sampleD.byEncodingAsTagHash
-        let hashE = sampleE.byEncodingAsTagHash
+        testNonEqualStringsCreateSameHash([sampleA, sampleB, sampleC])
+        testNonEqualStringsCreateSameHash([sampleD, sampleE])
+    }
+}
 
-        XCTAssertNotEqual(sampleA, sampleB)
-        XCTAssertNotEqual(sampleA, sampleC)
-        XCTAssertNotEqual(sampleA, sampleD)
-        XCTAssertNotEqual(sampleA, sampleE)
-        XCTAssertNotEqual(sampleB, sampleC)
-        XCTAssertNotEqual(sampleB, sampleD)
-        XCTAssertNotEqual(sampleB, sampleE)
-        XCTAssertNotEqual(sampleC, sampleD)
-        XCTAssertNotEqual(sampleC, sampleE)
-        XCTAssertNotEqual(sampleD, sampleE)
-
-        XCTAssertEqual(hashA, hashB)
-        XCTAssertEqual(hashA, hashC)
-        XCTAssertEqual(hashB, hashC)
-        XCTAssertEqual(hashD, hashE)
+extension NSStringSimplenoteTests {
+    func testNonEqualStringsCreateSameHash(_ samples: [NSString]) {
+        var count = 0
+        
+        while count + 1 < samples.count {
+            var testCount = count + 1
+            while testCount < samples.count {
+                XCTAssertNotEqual(samples[count], samples[testCount])
+                XCTAssertEqual(samples[count].byEncodingAsTagHash, samples[testCount].byEncodingAsTagHash)
+                testCount += 1
+            }
+            count += 1
+        }
     }
 }

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -16,6 +16,16 @@ class NSStringSimplenoteTests: XCTestCase {
 
         XCTAssertTrue(expectedSet.isSuperset(of: escapedSet))
     }
+    
+    /// Verifies that `byEncodingAsTagHash` effectively escapes special characters
+    ///
+    func testByEncodingAsTagHashEncodesAllOfSpecialCharacters() {
+        let string = String("TáßvĒёи兔子@#$%^&*+-=_`~/?., ><{}[]\\()\"|':;")
+        let hash = string.byEncodingAsTagHash
+        let expected = "t%C3%A1%C3%9Fv%C4%93%D1%91%D0%B8%E5%85%94%E5%AD%90%40%23%24%25%5E%26%2A%2B%2D%3D%5F%60%7E%2F%3F%2E%2C%20%3E%3C%7B%7D%5B%5D%5C%28%29%22%7C%27%3A%3B"
+        
+        XCTAssertEqual(hash, expected)
+    }
 
     /// Verifies that `byEncodingAsTagHash` allows us to properly compare Unicode Strings that would otherwise evaluate as not equal.
     /// Although our (three) sample strings yield the exact same character`ṩ`, regular `isEqualString` API returns `false`.

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -46,17 +46,14 @@ class NSStringSimplenoteTests: XCTestCase {
 }
 
 extension NSStringSimplenoteTests {
-    private func testNonEqualStringsCreateSameHash(_ samples: [NSString]) {
-        var count = 0
+    private func testNonEqualStringsCreateSameHash(_ samples: [String]) {
+        let sampleToTest = samples[0]
         
-        while count + 1 < samples.count {
-            var testCount = count + 1
-            while testCount < samples.count {
-                XCTAssertNotEqual(samples[count], samples[testCount])
-                XCTAssertEqual(samples[count].byEncodingAsTagHash, samples[testCount].byEncodingAsTagHash)
-                testCount += 1
-            }
-            count += 1
+        for i in 1..<samples.count {
+            XCTAssertNotEqual((sampleToTest as NSString), (samples[i] as NSString))
+            print("sample to test: \(sampleToTest) sample to comare: \(samples[i])")
+            XCTAssertEqual(sampleToTest.byEncodingAsTagHash, samples[i].byEncodingAsTagHash)
+            print("sample to test: \(sampleToTest.byEncodingAsTagHash) sample to comare: \(samples[i].byEncodingAsTagHash)")
         }
     }
 }

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -38,17 +38,29 @@ class NSStringSimplenoteTests: XCTestCase {
         let sampleA = NSString(stringLiteral: "\u{0073}\u{0323}\u{0307}")
         let sampleB = NSString(stringLiteral: "\u{0073}\u{0307}\u{0323}")
         let sampleC = NSString(stringLiteral: "\u{1E69}")
+        let sampleD = NSString(stringLiteral: "\u{0065}\u{0301}")
+        let sampleE = NSString(stringLiteral: "\u{00E9}")
 
         let hashA = sampleA.byEncodingAsTagHash
         let hashB = sampleB.byEncodingAsTagHash
         let hashC = sampleC.byEncodingAsTagHash
+        let hashD = sampleD.byEncodingAsTagHash
+        let hashE = sampleE.byEncodingAsTagHash
 
         XCTAssertNotEqual(sampleA, sampleB)
         XCTAssertNotEqual(sampleA, sampleC)
+        XCTAssertNotEqual(sampleA, sampleD)
+        XCTAssertNotEqual(sampleA, sampleE)
         XCTAssertNotEqual(sampleB, sampleC)
+        XCTAssertNotEqual(sampleB, sampleD)
+        XCTAssertNotEqual(sampleB, sampleE)
+        XCTAssertNotEqual(sampleC, sampleD)
+        XCTAssertNotEqual(sampleC, sampleE)
+        XCTAssertNotEqual(sampleD, sampleE)
 
         XCTAssertEqual(hashA, hashB)
         XCTAssertEqual(hashA, hashC)
         XCTAssertEqual(hashB, hashC)
+        XCTAssertEqual(hashD, hashE)
     }
 }

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -35,14 +35,13 @@ class NSStringSimplenoteTests: XCTestCase {
     /// - Note: When using the `Swift.String` class, the same comparison is actually correct.
     ///
     func testNonEqualStringsCreateSameHash() {
-        let sampleA = NSString(stringLiteral: "\u{0073}\u{0323}\u{0307}")
-        let sampleB = NSString(stringLiteral: "\u{0073}\u{0307}\u{0323}")
-        let sampleC = NSString(stringLiteral: "\u{1E69}")
-        let sampleD = NSString(stringLiteral: "\u{0065}\u{0301}")
-        let sampleE = NSString(stringLiteral: "\u{00E9}")
-
-        testNonEqualStringsCreateSameHash([sampleA, sampleB, sampleC])
-        testNonEqualStringsCreateSameHash([sampleD, sampleE])
+        let differentStringsOneHashSamples = [
+            ["\u{0073}\u{0323}\u{0307}", "\u{0073}\u{0307}\u{0323}", "\u{1E69}"], // ṩ
+            ["\u{0065}\u{0301}", "\u{00E9}"] // é
+        ]
+        
+        testNonEqualStringsCreateSameHash(differentStringsOneHashSamples[0])
+        testNonEqualStringsCreateSameHash(differentStringsOneHashSamples[1])
     }
 }
 

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -52,9 +52,7 @@ extension NSStringSimplenoteTests {
         
         for i in 1..<samples.count {
             XCTAssertNotEqual((sampleToTest as NSString), (samples[i] as NSString))
-            print("sample to test: \(sampleToTest) sample to comare: \(samples[i])")
             XCTAssertEqual(sampleToTest.byEncodingAsTagHash, samples[i].byEncodingAsTagHash)
-            print("sample to test: \(sampleToTest.byEncodingAsTagHash) sample to comare: \(samples[i].byEncodingAsTagHash)")
         }
     }
 }


### PR DESCRIPTION
### Fix
This PR responds to issue #1053 and adds additional unit tests to confirm the hashing done by the string method byEncodingAsTagHash

Some tests for this method already existed, so in this PR I have extended the test "testByEncodingTagAsHashAllowsUsToProperlyCompareStringsThatEvaluateAsNotEqualOtherwise" to include some additional use cases, the cases specifically called for in #1053, and added a test to confirm the encoding of the special character set defined in the issue.

The new test that I created may be repeating the test before it, so may be unnecessary but take a look, I thought specifically checking the special characters would prove useful.  There may also be a more efficient way to get a similar character set than writing out the encoded hash as I did.

### Test
1. in Xcode go to NSStringSimplenoteTests.swift
2. Run the unit tests for the project
3. All tests should pass

### Review

> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.

