### PR TITLE
Issue 19 rtl issues - process guidance

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -709,17 +709,22 @@ extension SPNoteEditorViewController {
         tagView.keyboardAppearance = .simplenoteKeyboardAppearance
     }
 
-    private func refreshTextStorage() {
+    private func refreshTextStorage(with textDirection: NSWritingDirection = .natural) {
         let headlineFont = UIFont.preferredFont(for: .title1, weight: .bold)
         let defaultFont = UIFont.preferredFont(forTextStyle: .body)
         let textColor = UIColor.simplenoteNoteHeadlineColor
-        let lineSpacing = defaultFont.lineHeight * Metrics.lineSpacingMultipler
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = defaultFont.lineHeight * Metrics.lineSpacingMultipler
+        paragraphStyle.baseWritingDirection = textDirection
+        
         let textStorage = noteEditorTextView.interactiveTextStorage
+        
 
         textStorage.defaultStyle = [
             .font               : defaultFont,
             .foregroundColor    : textColor,
-            .paragraphStyle     : NSMutableParagraphStyle(lineSpacing: lineSpacing)
+            .paragraphStyle     : paragraphStyle
         ]
 
         textStorage.headlineStyle = [

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -108,6 +108,17 @@ extension SPNoteEditorViewController {
         interlinkProcessor.delegate = self
         interlinkProcessor.contextProvider = self
     }
+    
+    @objc
+    func configureKeyboardObserver() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(inputModeDidChange), name: UITextInputMode.currentInputModeDidChangeNotification, object: nil)
+    }
+    
+    @objc
+    func inputModeDidChange(_ notification: Notification) {
+
+    }
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -117,9 +117,8 @@ extension SPNoteEditorViewController {
     
     @objc
     func inputModeDidChange(_ notification: Notification) {
-        guard let userInfo = notification.userInfo,
-              let inputMode = userInfo["UITextInputFromInputModeKey"] as? UITextInputMode,
-              let lang = inputMode.primaryLanguage else {
+        guard let input = noteEditorTextView.textInputMode,
+              let lang = input.primaryLanguage else {
             return
         }
         
@@ -127,11 +126,11 @@ extension SPNoteEditorViewController {
         
         switch direction {
         case .leftToRight:
-            print("ltr")
+            refreshTextStorage(with: .leftToRight)
         case .rightToLeft:
-            print("rtl")
+            refreshTextStorage(with: .rightToLeft)
         default:
-            print("default")
+            refreshTextStorage()
         }
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -117,7 +117,22 @@ extension SPNoteEditorViewController {
     
     @objc
     func inputModeDidChange(_ notification: Notification) {
-
+        guard let userInfo = notification.userInfo,
+              let inputMode = userInfo["UITextInputFromInputModeKey"] as? UITextInputMode,
+              let lang = inputMode.primaryLanguage else {
+            return
+        }
+        
+        let direction = NSLocale.characterDirection(forLanguage: lang)
+        
+        switch direction {
+        case .leftToRight:
+            print("ltr")
+        case .rightToLeft:
+            print("rtl")
+        default:
+            print("default")
+        }
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -101,6 +101,8 @@ CGFloat const SPSelectedAreaPadding = 20;
                                                  selector:@selector(didReceiveVoiceOverNotification:)
                                                      name:UIAccessibilityVoiceOverStatusDidChangeNotification
                                                    object:nil];
+        
+
 
         // Apply the current style right away!
         [self startListeningToThemeNotifications];
@@ -132,6 +134,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self configureLayout];
     [self configureInterlinksProcessor];
     [self refreshVoiceoverSupport];
+    [self configureKeyboardObserver];
 }
 
 - (void)viewWillAppear:(BOOL)animated


### PR DESCRIPTION
In this PR, I am looking for a bit of guidance to see if I am on the right path with fixing this issue or if there might be another way to do this.

This branch is intended to improve the RTL support for Simplenote iOS, which will fix #19 Currently Simplenote works fine with RTL languages as long as the app and the keyboard language are in agreement with the text orientation.  For example, if the app/system is set to English (LTR) and the keyboard being used is in Arabic (RTL) the alignment and text direction will not be correct.

The approach that I have started taking in so far to try and fix this is to setup a Notification Center observer for "UITextInputMode.currentInputModeDidChangeNotification" to be notified when ever the input mode changes.  From that notification the keyboard language can be derived and the language direction can be changed accordingly.  

I have a few issues with how this works though, which is why I am unsure about spending more time going in this direction.  
1. Currently the easiest way to make a change to the language direction is to change it for the entire text field, so all text changes alignment, so you could not have multiple languages in the same note if the languages used a different orientation
2. The notification seems to be returning the previous language not the language that has been changed to, which is fine for only two languages but will likely create issues if there are more
3. The system it's self seems to be holding onto it's one orientation values, so when I have been able to change the alignment for RTL languages, as soon as I start typing, it switches back to left alignment.  I haven't sorted that one out yet, but makes me think that I could be on the wrong track.

What do you think of this current approach, do you think I am on the right track here, or do you have additional suggestions of things I could look into?