### PR TITLE
Updates Verification Parser

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -29,7 +29,8 @@ abstract_target 'Automattic' do
 		#
 		pod 'Automattic-Tracks-iOS', '~> 0.6'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
-		pod 'Simperium', '1.2'
+#		pod 'Simperium', '1.2'
+		pod 'Simperium', :git => 'https://github.com/Simperium/simperium-ios.git', :commit => 'ec28264'
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 
 		# Testing Target

--- a/Podfile
+++ b/Podfile
@@ -29,8 +29,8 @@ abstract_target 'Automattic' do
 		#
 		pod 'Automattic-Tracks-iOS', '~> 0.6'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
-#		pod 'Simperium', '1.2'
-		pod 'Simperium', :git => 'https://github.com/Simperium/simperium-ios.git', :commit => 'ec28264'
+		pod 'Simperium', '1.4'
+# 		pod 'Simperium', :git => 'https://github.com/Simperium/simperium-ios.git', :commit => 'ec28264'
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 
 		# Testing Target

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,17 +23,17 @@ PODS:
   - Sentry (4.5.0):
     - Sentry/Core (= 4.5.0)
   - Sentry/Core (4.5.0)
-  - Simperium (1.2.0):
-    - Simperium/DiffMatchPach (= 1.2.0)
-    - Simperium/JRSwizzle (= 1.2.0)
-    - Simperium/SocketTrust (= 1.2.0)
-    - Simperium/SPReachability (= 1.2.0)
-    - Simperium/SSKeychain (= 1.2.0)
-  - Simperium/DiffMatchPach (1.2.0)
-  - Simperium/JRSwizzle (1.2.0)
-  - Simperium/SocketTrust (1.2.0)
-  - Simperium/SPReachability (1.2.0)
-  - Simperium/SSKeychain (1.2.0)
+  - Simperium (1.3.0):
+    - Simperium/DiffMatchPach (= 1.3.0)
+    - Simperium/JRSwizzle (= 1.3.0)
+    - Simperium/SocketTrust (= 1.3.0)
+    - Simperium/SPReachability (= 1.3.0)
+    - Simperium/SSKeychain (= 1.3.0)
+  - Simperium/DiffMatchPach (1.3.0)
+  - Simperium/JRSwizzle (1.3.0)
+  - Simperium/SocketTrust (1.3.0)
+  - Simperium/SPReachability (1.3.0)
+  - Simperium/SSKeychain (1.3.0)
   - Sodium-Fork (0.8.2)
   - UIDeviceIdentifier (1.6.0)
   - WordPress-Ratings-iOS (0.0.2)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AppCenter/Distribute (~> 2.5.1)
   - Automattic-Tracks-iOS (~> 0.6)
   - Gridicons (~> 0.18)
-  - Simperium (= 1.2)
+  - Simperium (from `https://github.com/Simperium/simperium-ios.git`, commit `ec28264`)
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -56,11 +56,20 @@ SPEC REPOS:
     - Gridicons
     - Reachability
     - Sentry
-    - Simperium
     - Sodium-Fork
     - UIDeviceIdentifier
     - WordPress-Ratings-iOS
     - ZIPFoundation
+
+EXTERNAL SOURCES:
+  Simperium:
+    :commit: ec28264
+    :git: https://github.com/Simperium/simperium-ios.git
+
+CHECKOUT OPTIONS:
+  Simperium:
+    :commit: ec28264
+    :git: https://github.com/Simperium/simperium-ios.git
 
 SPEC CHECKSUMS:
   AppCenter: 765ff38c4d360fc5ec61b61a8be24d74cd6d4d83
@@ -69,12 +78,12 @@ SPEC CHECKSUMS:
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
-  Simperium: c4caa6a11164acfcf6117c60aa3f486cdb947d29
+  Simperium: ec7353bae6440417460afeaf55af3126e7fa83e3
   Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: c819c0b7afdba316e2ca8629042147e8fda31362
+PODFILE CHECKSUM: 79da326270924dbd27af8eea11438d4fef658781
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,17 +23,17 @@ PODS:
   - Sentry (4.5.0):
     - Sentry/Core (= 4.5.0)
   - Sentry/Core (4.5.0)
-  - Simperium (1.3.0):
-    - Simperium/DiffMatchPach (= 1.3.0)
-    - Simperium/JRSwizzle (= 1.3.0)
-    - Simperium/SocketTrust (= 1.3.0)
-    - Simperium/SPReachability (= 1.3.0)
-    - Simperium/SSKeychain (= 1.3.0)
-  - Simperium/DiffMatchPach (1.3.0)
-  - Simperium/JRSwizzle (1.3.0)
-  - Simperium/SocketTrust (1.3.0)
-  - Simperium/SPReachability (1.3.0)
-  - Simperium/SSKeychain (1.3.0)
+  - Simperium (1.4.0):
+    - Simperium/DiffMatchPach (= 1.4.0)
+    - Simperium/JRSwizzle (= 1.4.0)
+    - Simperium/SocketTrust (= 1.4.0)
+    - Simperium/SPReachability (= 1.4.0)
+    - Simperium/SSKeychain (= 1.4.0)
+  - Simperium/DiffMatchPach (1.4.0)
+  - Simperium/JRSwizzle (1.4.0)
+  - Simperium/SocketTrust (1.4.0)
+  - Simperium/SPReachability (1.4.0)
+  - Simperium/SSKeychain (1.4.0)
   - Sodium-Fork (0.8.2)
   - UIDeviceIdentifier (1.6.0)
   - WordPress-Ratings-iOS (0.0.2)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AppCenter/Distribute (~> 2.5.1)
   - Automattic-Tracks-iOS (~> 0.6)
   - Gridicons (~> 0.18)
-  - Simperium (from `https://github.com/Simperium/simperium-ios.git`, commit `ec28264`)
+  - Simperium (= 1.4)
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -56,20 +56,11 @@ SPEC REPOS:
     - Gridicons
     - Reachability
     - Sentry
+    - Simperium
     - Sodium-Fork
     - UIDeviceIdentifier
     - WordPress-Ratings-iOS
     - ZIPFoundation
-
-EXTERNAL SOURCES:
-  Simperium:
-    :commit: ec28264
-    :git: https://github.com/Simperium/simperium-ios.git
-
-CHECKOUT OPTIONS:
-  Simperium:
-    :commit: ec28264
-    :git: https://github.com/Simperium/simperium-ios.git
 
 SPEC CHECKSUMS:
   AppCenter: 765ff38c4d360fc5ec61b61a8be24d74cd6d4d83
@@ -78,12 +69,12 @@ SPEC CHECKSUMS:
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
-  Simperium: ec7353bae6440417460afeaf55af3126e7fa83e3
+  Simperium: e198df96d0eec12ff1ab408ab2e775b4623c5525
   Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 79da326270924dbd27af8eea11438d4fef658781
+PODFILE CHECKSUM: 1c0b34c545c1da8087f8f769802995f9b44aa31b
 
 COCOAPODS: 1.10.0

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -290,6 +290,7 @@
 		B56E763422BD394C00C5AA47 /* UIImage+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56E763322BD394C00C5AA47 /* UIImage+Simplenote.swift */; };
 		B56E763622BD565700C5AA47 /* UIView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56E763522BD565700C5AA47 /* UIView+Simplenote.swift */; };
 		B570D2D92360F16F006E1C85 /* UIBlurEffect+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570D2D82360F16F006E1C85 /* UIBlurEffect+Simplenote.swift */; };
+		B57401A025B7D9960058960E /* EmailVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B574019F25B7D9960058960E /* EmailVerificationTests.swift */; };
 		B5757368232BED0700443C2E /* UIBezierPath+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5757367232BED0700443C2E /* UIBezierPath+Simplenote.swift */; };
 		B575736A232C567000443C2E /* UIImage+Dynamic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5757369232C567000443C2E /* UIImage+Dynamic.swift */; };
 		B575736C232D454300443C2E /* UIColor+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B575736B232D454300443C2E /* UIColor+Helpers.swift */; };
@@ -731,6 +732,7 @@
 		B56E763322BD394C00C5AA47 /* UIImage+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIImage+Simplenote.swift"; path = "Classes/UIImage+Simplenote.swift"; sourceTree = "<group>"; };
 		B56E763522BD565700C5AA47 /* UIView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIView+Simplenote.swift"; path = "Classes/UIView+Simplenote.swift"; sourceTree = "<group>"; };
 		B570D2D82360F16F006E1C85 /* UIBlurEffect+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIBlurEffect+Simplenote.swift"; path = "Classes/UIBlurEffect+Simplenote.swift"; sourceTree = "<group>"; };
+		B574019F25B7D9960058960E /* EmailVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationTests.swift; sourceTree = "<group>"; };
 		B5757367232BED0700443C2E /* UIBezierPath+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIBezierPath+Simplenote.swift"; path = "Classes/UIBezierPath+Simplenote.swift"; sourceTree = "<group>"; };
 		B5757369232C567000443C2E /* UIImage+Dynamic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIImage+Dynamic.swift"; path = "Classes/UIImage+Dynamic.swift"; sourceTree = "<group>"; };
 		B575736B232D454300443C2E /* UIColor+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIColor+Helpers.swift"; path = "Classes/UIColor+Helpers.swift"; sourceTree = "<group>"; };
@@ -1508,6 +1510,14 @@
 			path = Extractors;
 			sourceTree = "<group>";
 		};
+		B57401A825B7D9B30058960E /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				B574019F25B7D9960058960E /* EmailVerificationTests.swift */,
+			);
+			name = Model;
+			sourceTree = "<group>";
+		};
 		B58218981FCC45170094ECA1 /* SimplenoteTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1516,6 +1526,7 @@
 				B5B85BA6235173D900AD5221 /* Helpers */,
 				B52F35D422F3573300724793 /* Extensions */,
 				B511AEE7255A0A3E005B2159 /* Interlinks */,
+				B57401A825B7D9B30058960E /* Model */,
 				B5B9AB4122EA6FE1001CB0AD /* Themes */,
 				B55AC57822D27B7F00D8CEB2 /* Settings */,
 				B55AC57B22D27BA300D8CEB2 /* Tools */,
@@ -2643,6 +2654,7 @@
 				B5421F4023CE7A1C004DDC19 /* MockupStorage+Sample.swift in Sources */,
 				A6F4883225A891A70050CFA8 /* TagTextFieldInputValidatorTests.swift in Sources */,
 				A6E6CE9125A5B970005A92DB /* PinLockRemoveControllerTests.swift in Sources */,
+				B57401A025B7D9960058960E /* EmailVerificationTests.swift in Sources */,
 				A6E6CEC925A6053A005A92DB /* MockApplication.swift in Sources */,
 				A645FA70254C5E69008A1519 /* NoteContentHelperTests.swift in Sources */,
 				A6E6CE6425A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift in Sources */,

--- a/Simplenote/EmailVerification.swift
+++ b/Simplenote/EmailVerification.swift
@@ -5,19 +5,13 @@ import Foundation
 //
 struct EmailVerification {
     let token: EmailVerificationToken?
-    let pending: EmailVerificationPending?
+    let sentTo: String?
 }
 
 // MARK: - EmailVerificationToken
 //
 struct EmailVerificationToken: Decodable {
     let username: String
-}
-
-// MARK: - EmailVerificationPending
-//
-struct EmailVerificationPending {
-    let email: String
 }
 
 // MARK: - Init from payload
@@ -36,24 +30,7 @@ extension EmailVerification {
             return try? JSONDecoder().decode(EmailVerificationToken.self, from: data)
         }()
 
-
-        pending = {
-            guard let payload = payload[EmailVerificationKeys.pending.rawValue] as? [AnyHashable: Any] else {
-                return nil
-            }
-
-            return EmailVerificationPending(payload: payload)
-        }()
-    }
-}
-
-extension EmailVerificationPending {
-    init?(payload: [AnyHashable: Any]) {
-        guard let email = payload[EmailVerificationPendingKeys.email.rawValue] as? String else {
-            return nil
-        }
-
-        self.email = email
+        sentTo = payload[EmailVerificationKeys.sentTo.rawValue] as? String
     }
 }
 
@@ -61,9 +38,5 @@ extension EmailVerificationPending {
 //
 private enum EmailVerificationKeys: String {
     case token
-    case pending
-}
-
-private enum EmailVerificationPendingKeys: String {
-    case email = "sent_to"
+    case sentTo = "sent_to"
 }

--- a/Simplenote/EmailVerification.swift
+++ b/Simplenote/EmailVerification.swift
@@ -8,8 +8,8 @@ struct EmailVerification {
     let status: EmailVerificationStatus
 }
 
-enum EmailVerificationStatus: String {
-    case sent
+enum EmailVerificationStatus: Equatable {
+    case sent(email: String?)
     case verified
 }
 
@@ -21,20 +21,57 @@ extension EmailVerification {
     /// Initializes an EmailVerification entity from a dictionary
     ///
     init?(payload: [AnyHashable: Any]) {
-        guard let rawStatus = payload[CodingKeys.status.rawValue] as? String,
-              let parsedStatus = EmailVerificationStatus(rawValue: rawStatus)
+        guard let rawStatus = payload[EmailVerificationKeys.status.rawValue] as? String,
+            let parsedStatus = EmailVerificationStatus(rawValue: rawStatus)
         else {
             return nil
         }
 
-        self.token = payload[CodingKeys.token.rawValue] as? String
+        self.token = payload[EmailVerificationKeys.token.rawValue] as? String
         self.status = parsedStatus
+    }
+
+    var tokenEmail: String? {
+        guard let email = token?.split(separator: ":", maxSplits: 1).first else {
+            return nil
+        }
+        return String(email)
     }
 }
 
+
+// MARK: - EmailVerificationStatus Parsing
+//
+extension EmailVerificationStatus {
+
+    init?(rawValue: String) {
+        let tokens = rawValue.lowercased().split(separator: ":", maxSplits: 2).map {
+            String($0)
+        }
+
+        switch tokens.first {
+        case EmailStatusKeys.verified.rawValue:
+            self = .verified
+
+        case EmailStatusKeys.sent.rawValue:
+            let value = tokens.last != tokens.first ? tokens.last : nil
+            self = .sent(email: value)
+
+        default:
+            return nil
+        }
+    }
+}
+
+
 // MARK: - CodingKeys
 //
-private enum CodingKeys: String {
+private enum EmailVerificationKeys: String {
     case token
     case status
+}
+
+private enum EmailStatusKeys: String {
+    case verified
+    case sent
 }

--- a/Simplenote/Verification/AccountVerificationController.swift
+++ b/Simplenote/Verification/AccountVerificationController.swift
@@ -63,7 +63,7 @@ class AccountVerificationController: NSObject {
 
         if emailVerification.token?.username == email {
             state = .verified
-        } else if emailVerification.pending != nil {
+        } else if emailVerification.sentTo != nil {
             state = .verificationInProgress
         } else {
             state = .unverified

--- a/Simplenote/Verification/AccountVerificationController.swift
+++ b/Simplenote/Verification/AccountVerificationController.swift
@@ -54,15 +54,16 @@ class AccountVerificationController: NSObject {
             return
         }
 
-        guard let rawData = rawData as? [AnyHashable: Any],
-              let emailVerification = EmailVerification(payload: rawData) else {
+        guard let rawData = rawData as? [AnyHashable: Any] else {
             state = .unverified
             return
         }
 
-        if emailVerification.tokenEmail == email {
+        let emailVerification = EmailVerification(payload: rawData)
+
+        if emailVerification.token?.username == email {
             state = .verified
-        } else if emailVerification.status == .sent {
+        } else if emailVerification.pending != nil {
             state = .verificationInProgress
         } else {
             state = .unverified

--- a/SimplenoteTests/EmailVerificationTests.swift
+++ b/SimplenoteTests/EmailVerificationTests.swift
@@ -16,30 +16,26 @@ class EmailVerificationTests: XCTestCase {
 
     func testEmailVerificationCorrectlyParsesPending() {
         let payload = [
-            "pending": [
-                "sent_to": "1234"
-            ]
+            "sent_to": "1234"
         ]
         let parsed = EmailVerification(payload: payload)
-        XCTAssertEqual(parsed.pending?.email, "1234")
+        XCTAssertEqual(parsed.sentTo, "1234")
     }
 
     func testEmailVerificationCorrectlyParsesEmptyPayload() {
         let payload: [AnyHashable: Any] = [:]
         let parsed = EmailVerification(payload: payload)
         XCTAssertNil(parsed.token)
-        XCTAssertNil(parsed.pending)
+        XCTAssertNil(parsed.sentTo)
     }
 
     func testEmailVerificationIgnoresBrokenPayload() {
         let payload : [AnyHashable: Any] = [
             "token": #"{"user": "1234"}"#,
-            "pending": [
-                "sent": "1234"
-            ]
+            "sent_to": 1234
         ]
         let parsed = EmailVerification(payload: payload)
         XCTAssertNil(parsed.token)
-        XCTAssertNil(parsed.pending)
+        XCTAssertNil(parsed.sentTo)
     }
 }

--- a/SimplenoteTests/EmailVerificationTests.swift
+++ b/SimplenoteTests/EmailVerificationTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Simplenote
+
+
+// MARK: - EmailVerificationTests
+//
+class EmailVerificationTests: XCTestCase {
+
+    func testEmailVerificationCorrectlyParsesSentStatusWithEmail() {
+        let rawSent = [ "status": "SENT:1234" ]
+        let parsedSent = EmailVerification(payload: rawSent)
+        XCTAssertEqual(parsedSent?.status, .sent(email: "1234"))
+    }
+
+    func testEmailVerificationCorrectlyParsesSentStatusWithoutEmail() {
+        let rawSent = [ "status": "SENT" ]
+        let parsedSent = EmailVerification(payload: rawSent)
+        XCTAssertEqual(parsedSent?.status, .sent(email: nil))
+    }
+
+    func testEmailVerificationCorrectlyParsesVerifiedStatus() {
+        let rawVerified = [ "status": "verified" ]
+        let parsedVerified = EmailVerification(payload: rawVerified)
+        XCTAssertEqual(parsedVerified?.status, .verified)
+    }
+
+    func testEmailVerificationCorrectlyParsesVerifiedStatusAndDisregardsAnyExtraColonSeparatedValues() {
+        let rawVerified = [ "status": "verified:1234" ]
+        let parsedVerified = EmailVerification(payload: rawVerified)
+        XCTAssertEqual(parsedVerified?.status, .verified)
+    }
+
+    func testEmailVerificationCorrectlyParsesTokenFields() {
+        let rawVerified = [ "status": "verified:1234", "token": "yosemite" ]
+        let parsedVerified = EmailVerification(payload: rawVerified)
+        XCTAssertEqual(parsedVerified?.token, "yosemite")
+    }
+}
+
+
+// MARK: - EmailVerificationStatus Helpers
+//
+private extension EmailVerificationStatus {
+
+    init?(payload: [String: String]) {
+        let data = try! JSONEncoder().encode(payload)
+        let string = String(data: data, encoding: .utf8)!
+
+        self.init(rawValue: string)
+    }
+}

--- a/SimplenoteTests/Verification/AccountVerificationControllerTests.swift
+++ b/SimplenoteTests/Verification/AccountVerificationControllerTests.swift
@@ -11,7 +11,7 @@ class AccountVerificationControllerTests: XCTestCase {
 
     private lazy var invalidVerification: [String: Any] = [:]
     private lazy var unverifiedVerification: [String: Any] = ["token": #"{"username": "123"}"#]
-    private lazy var inProgressVerification: [String: Any] = ["pending": ["sent_to": "123"]]
+    private lazy var inProgressVerification: [String: Any] = ["sent_to": "123"]
     private lazy var verifiedVerification: [String: Any] = ["token": "{\"username\": \"\(email)\"}"]
 }
 

--- a/SimplenoteTests/Verification/AccountVerificationControllerTests.swift
+++ b/SimplenoteTests/Verification/AccountVerificationControllerTests.swift
@@ -10,11 +10,9 @@ class AccountVerificationControllerTests: XCTestCase {
     private lazy var controller = AccountVerificationController(email: email, remote: remote)
 
     private lazy var invalidVerification: [String: Any] = [:]
-    private lazy var unverifiedVerification: [String: Any] = ["token": "321:0:123",
-                                                              "status": "verified"]
-    private lazy var inProgressVerification: [String: Any] = ["status": "sent"]
-    private lazy var verifiedVerification: [String: Any] = ["token": "\(email):0:123",
-                                                            "status": "verified"]
+    private lazy var unverifiedVerification: [String: Any] = ["token": #"{"username": "123"}"#]
+    private lazy var inProgressVerification: [String: Any] = ["pending": ["sent_to": "123"]]
+    private lazy var verifiedVerification: [String: Any] = ["token": "{\"username\": \"\(email)\"}"]
 }
 
 // MARK: - Verify


### PR DESCRIPTION
### Details
Our (new) Email Verification data structure was updated, backend wise. Whenever the status is `sent`, the `email` will be present as well, as follows:

```
{
   "status": "sent:email"
}
```

Ref. #1086
cc @eshurakov (Thank youuu)

### Test
1. Log into an account that contains the `email-verification` entity
2. Logout

- [x] Verify the `email-verification` entity is gone
- [x] Verify the Unit Tests are green

### Release
These changes do not require release notes.
