### PR TITLE
Unit tests for account verification

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -153,6 +153,9 @@
 		A6CC0B0725B8287F00F12A85 /* AccountVerificationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */; };
 		A6CC0B1025B83FE400F12A85 /* AccountVerificationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B0F25B83FE400F12A85 /* AccountVerificationControllerTests.swift */; };
 		A6CC0B1F25B840A400F12A85 /* MockAccountVerificationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B1E25B840A400F12A85 /* MockAccountVerificationRemote.swift */; };
+		A6CC0B2D25B84FF200F12A85 /* AccountVerificationRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B2C25B84FF200F12A85 /* AccountVerificationRemoteTests.swift */; };
+		A6CC0B3625B8502800F12A85 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B3525B8502800F12A85 /* MockURLSession.swift */; };
+		A6CC0B4425B8505700F12A85 /* MockURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B4325B8505700F12A85 /* MockURLSessionDataTask.swift */; };
 		A6CDF900256B9CB900CF2F27 /* ViewSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CDF8FF256B9CB900CF2F27 /* ViewSpinner.swift */; };
 		A6D5AE6525483F8A00326C76 /* NSTextStorage+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D5AE6425483F8A00326C76 /* NSTextStorage+Simplenote.swift */; };
 		A6DE79CE2552E6CC00BC69C6 /* TagListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6DE79CD2552E6CB00BC69C6 /* TagListViewController.swift */; };
@@ -590,6 +593,9 @@
 		A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationRemote.swift; sourceTree = "<group>"; };
 		A6CC0B0F25B83FE400F12A85 /* AccountVerificationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationControllerTests.swift; sourceTree = "<group>"; };
 		A6CC0B1E25B840A400F12A85 /* MockAccountVerificationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAccountVerificationRemote.swift; sourceTree = "<group>"; };
+		A6CC0B2C25B84FF200F12A85 /* AccountVerificationRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationRemoteTests.swift; sourceTree = "<group>"; };
+		A6CC0B3525B8502800F12A85 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		A6CC0B4325B8505700F12A85 /* MockURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionDataTask.swift; sourceTree = "<group>"; };
 		A6CDF8FF256B9CB900CF2F27 /* ViewSpinner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ViewSpinner.swift; path = Classes/ViewSpinner.swift; sourceTree = "<group>"; };
 		A6D5AE6425483F8A00326C76 /* NSTextStorage+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextStorage+Simplenote.swift"; sourceTree = "<group>"; };
 		A6DE79CD2552E6CB00BC69C6 /* TagListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListViewController.swift; sourceTree = "<group>"; };
@@ -1198,6 +1204,7 @@
 			children = (
 				A6CC0B1D25B8408900F12A85 /* Helpers */,
 				A6CC0B0F25B83FE400F12A85 /* AccountVerificationControllerTests.swift */,
+				A6CC0B2C25B84FF200F12A85 /* AccountVerificationRemoteTests.swift */,
 			);
 			path = Verification;
 			sourceTree = "<group>";
@@ -1208,6 +1215,15 @@
 				A6CC0B1E25B840A400F12A85 /* MockAccountVerificationRemote.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		A6CC0B3425B8501B00F12A85 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				A6CC0B3525B8502800F12A85 /* MockURLSession.swift */,
+				A6CC0B4325B8505700F12A85 /* MockURLSessionDataTask.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		A6E1E79C24BDDF30008A44BC /* Card */ = {
@@ -1591,6 +1607,7 @@
 		B5B85BA6235173D900AD5221 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				A6CC0B3425B8501B00F12A85 /* Network */,
 				B5421F3B23CE7A14004DDC19 /* Constants.swift */,
 				B5421F3D23CE7A1C004DDC19 /* MockupStorage.swift */,
 				B5421F3E23CE7A1C004DDC19 /* MockupStorage+Sample.swift */,
@@ -2661,6 +2678,8 @@
 				A6CC0B1F25B840A400F12A85 /* MockAccountVerificationRemote.swift in Sources */,
 				A6CC0B1025B83FE400F12A85 /* AccountVerificationControllerTests.swift in Sources */,
 				A6E6CE7525A5B4A3005A92DB /* MockPinLockManager.swift in Sources */,
+				A6CC0B4425B8505700F12A85 /* MockURLSessionDataTask.swift in Sources */,
+				A6CC0B3625B8502800F12A85 /* MockURLSession.swift in Sources */,
 				B52F35D322F356F500724793 /* UserDefaults+Tests.swift in Sources */,
 				B58218A51FCC45330094ECA1 /* KeychainMigratorTests.swift in Sources */,
 				B511AEE9255A0A5E005B2159 /* InterlinkResultsControllerTests.swift in Sources */,
@@ -2672,6 +2691,7 @@
 				A6E6CE5C25A5A7F7005A92DB /* PinLockBaseControllerTests.swift in Sources */,
 				B55AC57A22D27B9100D8CEB2 /* OptionsTests.swift in Sources */,
 				B543C7DF23CF6AB400003A80 /* NotesListControllerTests.swift in Sources */,
+				A6CC0B2D25B84FF200F12A85 /* AccountVerificationRemoteTests.swift in Sources */,
 				B5421F4023CE7A1C004DDC19 /* MockupStorage+Sample.swift in Sources */,
 				A6F4883225A891A70050CFA8 /* TagTextFieldInputValidatorTests.swift in Sources */,
 				A6E6CE9125A5B970005A92DB /* PinLockRemoveControllerTests.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -150,6 +150,9 @@
 		A6C0589924AD47CB006BC572 /* SPSnappingSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */; };
 		A6C0589B24AD5205006BC572 /* SPNoteHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589A24AD5205006BC572 /* SPNoteHistoryController.swift */; };
 		A6C3D8B7256687970042F584 /* SPObjectManager+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3D8B6256687970042F584 /* SPObjectManager+Simplenote.swift */; };
+		A6CC0B0725B8287F00F12A85 /* AccountVerificationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */; };
+		A6CC0B1025B83FE400F12A85 /* AccountVerificationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B0F25B83FE400F12A85 /* AccountVerificationControllerTests.swift */; };
+		A6CC0B1F25B840A400F12A85 /* MockAccountVerificationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B1E25B840A400F12A85 /* MockAccountVerificationRemote.swift */; };
 		A6CDF900256B9CB900CF2F27 /* ViewSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CDF8FF256B9CB900CF2F27 /* ViewSpinner.swift */; };
 		A6D5AE6525483F8A00326C76 /* NSTextStorage+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D5AE6425483F8A00326C76 /* NSTextStorage+Simplenote.swift */; };
 		A6DE79CE2552E6CC00BC69C6 /* TagListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6DE79CD2552E6CB00BC69C6 /* TagListViewController.swift */; };
@@ -584,6 +587,9 @@
 		A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPSnappingSlider.swift; sourceTree = "<group>"; };
 		A6C0589A24AD5205006BC572 /* SPNoteHistoryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPNoteHistoryController.swift; sourceTree = "<group>"; };
 		A6C3D8B6256687970042F584 /* SPObjectManager+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SPObjectManager+Simplenote.swift"; path = "Classes/SPObjectManager+Simplenote.swift"; sourceTree = "<group>"; };
+		A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationRemote.swift; sourceTree = "<group>"; };
+		A6CC0B0F25B83FE400F12A85 /* AccountVerificationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationControllerTests.swift; sourceTree = "<group>"; };
+		A6CC0B1E25B840A400F12A85 /* MockAccountVerificationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAccountVerificationRemote.swift; sourceTree = "<group>"; };
 		A6CDF8FF256B9CB900CF2F27 /* ViewSpinner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ViewSpinner.swift; path = Classes/ViewSpinner.swift; sourceTree = "<group>"; };
 		A6D5AE6425483F8A00326C76 /* NSTextStorage+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextStorage+Simplenote.swift"; sourceTree = "<group>"; };
 		A6DE79CD2552E6CB00BC69C6 /* TagListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListViewController.swift; sourceTree = "<group>"; };
@@ -1171,6 +1177,7 @@
 				A6A648A225AC3AC00074A094 /* AccountVerificationViewController.swift */,
 				A6A648A325AC3AC00074A094 /* AccountVerificationViewController.xib */,
 				A6A648BA25AC85D40074A094 /* AccountVerificationController.swift */,
+				A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */,
 			);
 			path = Verification;
 			sourceTree = "<group>";
@@ -1184,6 +1191,23 @@
 				A6E1E78824B5196C008A44BC /* SPNoteHistoryControllerDelegate.swift */,
 			);
 			name = "Note History";
+			sourceTree = "<group>";
+		};
+		A6CC0B0E25B83FC800F12A85 /* Verification */ = {
+			isa = PBXGroup;
+			children = (
+				A6CC0B1D25B8408900F12A85 /* Helpers */,
+				A6CC0B0F25B83FE400F12A85 /* AccountVerificationControllerTests.swift */,
+			);
+			path = Verification;
+			sourceTree = "<group>";
+		};
+		A6CC0B1D25B8408900F12A85 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				A6CC0B1E25B840A400F12A85 /* MockAccountVerificationRemote.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		A6E1E79C24BDDF30008A44BC /* Card */ = {
@@ -1514,6 +1538,7 @@
 		B58218981FCC45170094ECA1 /* SimplenoteTests */ = {
 			isa = PBXGroup;
 			children = (
+				A6CC0B0E25B83FC800F12A85 /* Verification */,
 				A6F4883025A891900050CFA8 /* Tags */,
 				A6E6CE5425A5A6CC005A92DB /* PinLock */,
 				B5B85BA6235173D900AD5221 /* Helpers */,
@@ -2614,6 +2639,7 @@
 				A6BF0E352567B29B008DE8E0 /* RoundedCrossButton.swift in Sources */,
 				375D24B121E01131007AB25A /* html5_blocks.c in Sources */,
 				B504D4DE23D2014200AEED27 /* IndexPath+Simplenote.swift in Sources */,
+				A6CC0B0725B8287F00F12A85 /* AccountVerificationRemote.swift in Sources */,
 				B536988D25646C9400817E30 /* CGRect+Simplenote.swift in Sources */,
 				B5E96B611BDE5ACA00D707F5 /* SPMarkdownParser.m in Sources */,
 				B5BA5B082551FB3C002AAD43 /* UIDevice+Simplenote.swift in Sources */,
@@ -2632,6 +2658,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A6CC0B1F25B840A400F12A85 /* MockAccountVerificationRemote.swift in Sources */,
+				A6CC0B1025B83FE400F12A85 /* AccountVerificationControllerTests.swift in Sources */,
 				A6E6CE7525A5B4A3005A92DB /* MockPinLockManager.swift in Sources */,
 				B52F35D322F356F500724793 /* UserDefaults+Tests.swift in Sources */,
 				B58218A51FCC45330094ECA1 /* KeychainMigratorTests.swift in Sources */,

--- a/Simplenote/Verification/AccountVerificationRemote.swift
+++ b/Simplenote/Verification/AccountVerificationRemote.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+// MARK: - AccountVerificationRemote
+//
+class AccountVerificationRemote {
+    private let urlSession: URLSession
+
+    init(urlSession: URLSession = URLSession.shared) {
+        self.urlSession = urlSession
+    }
+
+    /// Send verification request for specified email address
+    ///
+    func verify(email: String, completion: @escaping (_ success: Bool) -> Void) {
+        guard let request = verificationURLRequest(with: email) else {
+            completion(false)
+            return
+        }
+
+        let dataTask = urlSession.dataTask(with: request) { (data, response, error) in
+            DispatchQueue.main.async {
+                // Check for 2xx status code
+                guard let response = response as? HTTPURLResponse, response.statusCode / 100 == 2 else {
+                    completion(false)
+                    return
+                }
+
+                completion(true)
+            }
+        }
+
+        dataTask.resume()
+    }
+
+    private func verificationURLRequest(with email: String) -> URLRequest? {
+        guard let base64EncodedEmail = email.data(using: .utf8)?.base64EncodedString(),
+              let verificationURL = URL(string: SimplenoteConstants.verificationURL) else {
+            return nil
+        }
+
+        var request = URLRequest(url: verificationURL.appendingPathComponent(base64EncodedEmail),
+                                 cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+                                 timeoutInterval: Constants.timeoutInterval)
+        request.httpMethod = Constants.httpMethod
+
+        return request
+    }
+}
+
+// MARK: - Constants
+//
+private struct Constants {
+    static let httpMethod = "GET"
+    static let timeoutInterval: TimeInterval = 30
+}

--- a/SimplenoteTests/Network/MockURLSession.swift
+++ b/SimplenoteTests/Network/MockURLSession.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+// MARK: - MockURLSession
+//
+class MockURLSession: URLSession {
+    var data: (Data?, URLResponse?, Error?)?
+
+    override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        return MockURLSessionDataTask {
+            completionHandler(self.data?.0, self.data?.1, self.data?.2)
+        }
+    }
+}

--- a/SimplenoteTests/Network/MockURLSessionDataTask.swift
+++ b/SimplenoteTests/Network/MockURLSessionDataTask.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// MARK: - MockURLSessionDataTask
+//
+class MockURLSessionDataTask: URLSessionDataTask {
+    private let completion: () -> Void
+
+    init(completion: @escaping () -> Void) {
+        self.completion = completion
+    }
+
+    override func resume() {
+        completion()
+    }
+}

--- a/SimplenoteTests/Verification/AccountVerificationControllerTests.swift
+++ b/SimplenoteTests/Verification/AccountVerificationControllerTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Simplenote
+
+// MARK: - AccountVerificationControllerTests
+//
+class AccountVerificationControllerTests: XCTestCase {
+
+    private let email = UUID().uuidString
+    private lazy var remote = MockAccountVerificationRemote()
+    private lazy var controller = AccountVerificationController(email: email, remote: remote)
+
+    private lazy var invalidVerification: [String: Any] = [:]
+    private lazy var unverifiedVerification: [String: Any] = ["token": "321:0:123",
+                                                              "status": "verified"]
+    private lazy var inProgressVerification: [String: Any] = ["status": "sent"]
+    private lazy var verifiedVerification: [String: Any] = ["token": "\(email):0:123",
+                                                            "status": "verified"]
+
+    func testVerifyCallsRemoteWithProvidedEmail() {
+        // When
+        let expectedResult = Bool.random()
+        var verificationResult: Bool?
+        controller.verify { (result) in
+            verificationResult = result
+        }
+
+        remote.processVerification(for: email, with: expectedResult)
+
+        // Then
+        XCTAssertEqual(verificationResult, expectedResult)
+    }
+
+    func testInitialStateIsUnknown() {
+        XCTAssertEqual(controller.state, .unknown)
+    }
+
+    func testStateIsUnverifiedWhenUpdatingWithInvalidData() {
+        controller.update(with: nil)
+        XCTAssertEqual(controller.state, .unverified)
+
+        controller.update(with: "verified")
+        XCTAssertEqual(controller.state, .unverified)
+
+        controller.update(with: invalidVerification)
+        XCTAssertEqual(controller.state, .unverified)
+    }
+
+    func testStateIsUnverifiedIfTokenEmailDoesntMatchAccountEmail() {
+        controller.update(with: unverifiedVerification)
+        XCTAssertEqual(controller.state, .unverified)
+    }
+
+    func testStateIsInProgressIfStatusIsSent() {
+        controller.update(with: inProgressVerification)
+        XCTAssertEqual(controller.state, .verificationInProgress)
+    }
+
+    func testStateIsVerifiedIfTokenEmailMatchesAccountEmail() {
+        controller.update(with: verifiedVerification)
+        XCTAssertEqual(controller.state, .verified)
+    }
+}

--- a/SimplenoteTests/Verification/AccountVerificationRemoteTests.swift
+++ b/SimplenoteTests/Verification/AccountVerificationRemoteTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Simplenote
+
+// MARK: - AccountVerificationRemoteTests
+//
+class AccountVerificationRemoteTests: XCTestCase {
+    private lazy var urlSession = MockURLSession()
+    private lazy var remote = AccountVerificationRemote(urlSession: urlSession)
+
+    func testSuccessWhenStatusCodeIs2xx() {
+        for _ in 0..<5 {
+            test(withStatusCode: Int.random(in: 200..<300), expectedResult: true)
+        }
+    }
+
+    func testFailureWhenStatusCodeIs4xxOr5xx() {
+        for _ in 0..<5 {
+            test(withStatusCode: Int.random(in: 400..<600), expectedResult: false)
+        }
+    }
+
+    func testFailureWhenNoResponse() {
+        test(withStatusCode: nil, expectedResult: false)
+    }
+
+    private func test(withStatusCode statusCode: Int?, expectedResult: Bool) {
+        urlSession.data = (nil,
+                           response(with: statusCode),
+                           nil)
+
+        let expectation = self.expectation(description: "Verify is called")
+
+        remote.verify(email: UUID().uuidString) { (result) in
+            XCTAssertEqual(result, expectedResult)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    private func response(with statusCode: Int?) -> HTTPURLResponse? {
+        guard let statusCode = statusCode else {
+            return nil
+        }
+        return HTTPURLResponse(url: URL(fileURLWithPath: "/"),
+                               statusCode: statusCode,
+                               httpVersion: nil,
+                               headerFields: nil)
+    }
+}

--- a/SimplenoteTests/Verification/Helpers/MockAccountVerificationRemote.swift
+++ b/SimplenoteTests/Verification/Helpers/MockAccountVerificationRemote.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Simplenote
+
+class MockAccountVerificationRemote: AccountVerificationRemote {
+    private var pendingVerifications: [(email: String, completion: (Bool) -> Void)] = []
+
+    override func verify(email: String, completion: @escaping (Bool) -> Void) {
+        pendingVerifications.append((email, completion))
+    }
+
+    func processVerification(for email: String, with result: Bool) {
+        guard let index = pendingVerifications.firstIndex(where: { $0.email == email }) else {
+            XCTFail("Cannot find pending verification for email \(email)")
+            return
+        }
+
+        let pendingVerification = pendingVerifications.remove(at: index)
+        pendingVerification.completion(result)
+    }
+}


### PR DESCRIPTION
### Details
In this PR we're adding unit tests for `AccountVerificationController`. HTTP call from `AccountVerificationController` is extracted to a separate class `AccountVerificationRemote`.

Ref. #1086

### Test
- [ ] Unit tests are green

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
