### PR TITLE
Updates Simperium

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -29,7 +29,9 @@ abstract_target 'Automattic' do
 		#
 		pod 'Automattic-Tracks-iOS', '~> 0.6'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
-		pod 'Simperium', '1.2'
+#		pod 'Simperium', '1.2'
+		pod 'Simperium', :git => 'https://github.com/Simperium/simperium-iOS.git', :commit => '1919142'
+
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 
 		# Testing Target

--- a/Podfile
+++ b/Podfile
@@ -29,8 +29,7 @@ abstract_target 'Automattic' do
 		#
 		pod 'Automattic-Tracks-iOS', '~> 0.6'
 #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
-#		pod 'Simperium', '1.2'
-		pod 'Simperium', :git => 'https://github.com/Simperium/simperium-iOS.git', :commit => '1919142'
+		pod 'Simperium', '1.3'
 
 		pod 'WordPress-Ratings-iOS', '0.0.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AppCenter/Distribute (~> 2.5.1)
   - Automattic-Tracks-iOS (~> 0.6)
   - Gridicons (~> 0.18)
-  - Simperium (= 1.2)
+  - Simperium (from `https://github.com/Simperium/simperium-iOS.git`, commit `1919142`)
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -56,11 +56,20 @@ SPEC REPOS:
     - Gridicons
     - Reachability
     - Sentry
-    - Simperium
     - Sodium-Fork
     - UIDeviceIdentifier
     - WordPress-Ratings-iOS
     - ZIPFoundation
+
+EXTERNAL SOURCES:
+  Simperium:
+    :commit: '1919142'
+    :git: https://github.com/Simperium/simperium-iOS.git
+
+CHECKOUT OPTIONS:
+  Simperium:
+    :commit: '1919142'
+    :git: https://github.com/Simperium/simperium-iOS.git
 
 SPEC CHECKSUMS:
   AppCenter: 765ff38c4d360fc5ec61b61a8be24d74cd6d4d83
@@ -75,6 +84,6 @@ SPEC CHECKSUMS:
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: c819c0b7afdba316e2ca8629042147e8fda31362
+PODFILE CHECKSUM: 0a521cdbf69074d45df0cab81cde0f58b0df38dd
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,17 +23,17 @@ PODS:
   - Sentry (4.5.0):
     - Sentry/Core (= 4.5.0)
   - Sentry/Core (4.5.0)
-  - Simperium (1.2.0):
-    - Simperium/DiffMatchPach (= 1.2.0)
-    - Simperium/JRSwizzle (= 1.2.0)
-    - Simperium/SocketTrust (= 1.2.0)
-    - Simperium/SPReachability (= 1.2.0)
-    - Simperium/SSKeychain (= 1.2.0)
-  - Simperium/DiffMatchPach (1.2.0)
-  - Simperium/JRSwizzle (1.2.0)
-  - Simperium/SocketTrust (1.2.0)
-  - Simperium/SPReachability (1.2.0)
-  - Simperium/SSKeychain (1.2.0)
+  - Simperium (1.3.0):
+    - Simperium/DiffMatchPach (= 1.3.0)
+    - Simperium/JRSwizzle (= 1.3.0)
+    - Simperium/SocketTrust (= 1.3.0)
+    - Simperium/SPReachability (= 1.3.0)
+    - Simperium/SSKeychain (= 1.3.0)
+  - Simperium/DiffMatchPach (1.3.0)
+  - Simperium/JRSwizzle (1.3.0)
+  - Simperium/SocketTrust (1.3.0)
+  - Simperium/SPReachability (1.3.0)
+  - Simperium/SSKeychain (1.3.0)
   - Sodium-Fork (0.8.2)
   - UIDeviceIdentifier (1.6.0)
   - WordPress-Ratings-iOS (0.0.2)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - AppCenter/Distribute (~> 2.5.1)
   - Automattic-Tracks-iOS (~> 0.6)
   - Gridicons (~> 0.18)
-  - Simperium (from `https://github.com/Simperium/simperium-iOS.git`, commit `1919142`)
+  - Simperium (= 1.3)
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -56,20 +56,11 @@ SPEC REPOS:
     - Gridicons
     - Reachability
     - Sentry
+    - Simperium
     - Sodium-Fork
     - UIDeviceIdentifier
     - WordPress-Ratings-iOS
     - ZIPFoundation
-
-EXTERNAL SOURCES:
-  Simperium:
-    :commit: '1919142'
-    :git: https://github.com/Simperium/simperium-iOS.git
-
-CHECKOUT OPTIONS:
-  Simperium:
-    :commit: '1919142'
-    :git: https://github.com/Simperium/simperium-iOS.git
 
 SPEC CHECKSUMS:
   AppCenter: 765ff38c4d360fc5ec61b61a8be24d74cd6d4d83
@@ -78,12 +69,12 @@ SPEC CHECKSUMS:
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
-  Simperium: c4caa6a11164acfcf6117c60aa3f486cdb947d29
+  Simperium: ec7353bae6440417460afeaf55af3126e7fa83e3
   Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 0a521cdbf69074d45df0cab81cde0f58b0df38dd
+PODFILE CHECKSUM: 0042ff93c433b57aebc4a618f8ccfa0fa8560a6c
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
### Fix
In this PR we're mapping a Simperium version which nukes the JSONStorage on logout.

cc @eshurakov 

### Test
1. Log into an account that contains the `email-verification` entity
2. Logout

- [ ] Verify the `email-verification` entity is gone

### Release
These changes do not require release notes.
