### PR TITLE
Add dismiss handle to Information Sheet

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 		B5EB1EFF1C205A800080A1B3 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */; };
 		B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F3000123F4502C007A7C59 /* SPSortBar.xib */; };
 		B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */; };
+		BA5C1C0725BF9D6C006E3820 /* SPDragBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */; };
 		D435D38FCA5863E8447D5C2C /* Pods_Automattic_SimplenoteShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */; };
 		DE7E545B214E34C8008D9928 /* NSString+Count.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E545A214E34C8008D9928 /* NSString+Count.swift */; };
 		E215C793180B115C00AD36B5 /* SPNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E215C791180B115C00AD36B5 /* SPNavigationController.m */; };
@@ -821,6 +822,7 @@
 		B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = ../Icons.xcassets; sourceTree = "<group>"; };
 		B5F3000123F4502C007A7C59 /* SPSortBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSortBar.xib; path = Classes/SPSortBar.xib; sourceTree = "<group>"; };
 		B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortBar.swift; path = Classes/SPSortBar.swift; sourceTree = "<group>"; };
+		BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPDragBar.swift; sourceTree = "<group>"; };
 		C07B32800E3C783BDF105B3A /* Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		DE7E545A214E34C8008D9928 /* NSString+Count.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSString+Count.swift"; path = "Classes/NSString+Count.swift"; sourceTree = "<group>"; };
 		DF3BADF5A954AA00BCF9B169 /* Pods-Automattic-Simplenote.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1725,6 +1727,7 @@
 				A6ABB688256D95EB00E2A076 /* PinLockProgressView.swift */,
 				A6BF0E342567B29B008DE8E0 /* RoundedCrossButton.swift */,
 				A6CDF8FF256B9CB900CF2F27 /* ViewSpinner.swift */,
+				BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -2528,6 +2531,7 @@
 				46A3C99C17DFA81A002865AE /* NSString+Bullets.m in Sources */,
 				B58BF1FB23D78ADF00515B50 /* UIContextualAction+Simplenote.swift in Sources */,
 				E215C79A180B130B00AD36B5 /* SPTableViewController.m in Sources */,
+				BA5C1C0725BF9D6C006E3820 /* SPDragBar.swift in Sources */,
 				B5AEC38423FAC5D600D24221 /* DateFormatter+Simplenote.swift in Sources */,
 				B5DF734622A5713600602CE7 /* SortMode.swift in Sources */,
 				46A3C99D17DFA81A002865AE /* SPAddCollaboratorsViewController.m in Sources */,

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -5,7 +5,7 @@ import SimplenoteFoundation
 //
 final class NoteInformationViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
-    @IBOutlet weak var dragBar: SPDragBar!
+    @IBOutlet private weak var dragBar: SPDragBar!
 
     private var transitioningManager: UIViewControllerTransitioningDelegate?
 
@@ -122,7 +122,7 @@ private extension NoteInformationViewController {
         preferredContentSize = tableView.contentSize
     }
     
-    func configureDragBar() {
+    private func configureDragBar() {
         dragBar.isHidden = navigationController != nil
     }
 }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -6,7 +6,6 @@ import SimplenoteFoundation
 final class NoteInformationViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet private weak var screenTitleLabel: UILabel!
-    @IBOutlet private weak var dismissButton: UIButton!
     @IBOutlet private weak var headerStackView: UIStackView!
     @IBOutlet weak var dragBar: SPDragBar!
     private lazy var blurEffectView = SPBlurEffectView()
@@ -155,7 +154,7 @@ private extension NoteInformationViewController {
     }
 
     func configureAccessibility() {
-        dismissButton.accessibilityLabel = Localization.dismissAccessibilityLabel
+        //TO DO: Should we do something for accessibility for dismissing the info sheet now that the dismiss button is gone?
     }
     
     func configureScreenTitleLabel() {
@@ -163,7 +162,6 @@ private extension NoteInformationViewController {
         
         if UIDevice.current.userInterfaceIdiom == .phone {
             screenTitleLabel.isHidden = true
-            dismissButton.isHidden = true
         }
     }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -5,7 +5,6 @@ import SimplenoteFoundation
 //
 final class NoteInformationViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
-    @IBOutlet private weak var headerStackView: UIStackView!
     @IBOutlet weak var dragBar: SPDragBar!
 
     private var transitioningManager: UIViewControllerTransitioningDelegate?
@@ -58,13 +57,12 @@ final class NoteInformationViewController: UIViewController {
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
-        configureHeaderLayoutMargins()
         refreshPreferredSize()
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        updateAdditionalSafeAreaInsets()
+        additionalSafeAreaInsets = Consts.tableViewSafeAreaInsets
     }
 }
 
@@ -116,32 +114,12 @@ private extension NoteInformationViewController {
         }
     }
 
-    func configureHeaderLayoutMargins() {
-        headerStackView.isLayoutMarginsRelativeArrangement = true
-
-        var layoutMargins = Consts.headerExtraLayoutMargins
-        layoutMargins.left += tableView.layoutMargins.left
-        layoutMargins.right += tableView.layoutMargins.right
-
-        // Sync layout margins with table view so labels are aligned
-        headerStackView.layoutMargins = layoutMargins
-    }
-
     func configureAccessibility() {
         //TO DO: Should we do something for accessibility for dismissing the info sheet now that the dismiss button is gone?
     }
 
     func refreshPreferredSize() {
         preferredContentSize = tableView.contentSize
-    }
-
-    func updateAdditionalSafeAreaInsets() {
-        guard !headerStackView.isHidden else {
-            additionalSafeAreaInsets = .zero
-            return
-        }
-
-        additionalSafeAreaInsets = UIEdgeInsets(top: headerStackView.frame.maxY, left: 0, bottom: 0, right: 0)
     }
     
     func configureDragBar() {
@@ -301,5 +279,5 @@ private struct Localization {
 }
 
 private struct Consts {
-    static let headerExtraLayoutMargins = UIEdgeInsets(top: 13.0, left: 0.0, bottom: 13.0, right: 0.0)
+    static let tableViewSafeAreaInsets = UIEdgeInsets(top: 26, left: 0, bottom: 0, right: 0)
 }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -182,13 +182,6 @@ private extension NoteInformationViewController {
     
     func configureDragBar() {
         if navigationController == nil {
-            dragBar.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                dragBar.heightAnchor.constraint(equalToConstant: 5),
-                dragBar.widthAnchor.constraint(equalToConstant: 36),
-                dragBar.topAnchor.constraint(equalTo: view.topAnchor, constant: 5),
-                dragBar.centerXAnchor.constraint(equalTo: view.centerXAnchor)
-            ])
         } else {
             dragBar.isHidden = true
         }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -119,10 +119,6 @@ private extension NoteInformationViewController {
         }
     }
 
-    func configureAccessibility() {
-        //TO DO: Should we do something for accessibility for dismissing the info sheet now that the dismiss button is gone?
-    }
-
     func refreshPreferredSize() {
         preferredContentSize = tableView.contentSize
     }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -45,7 +45,6 @@ final class NoteInformationViewController: UIViewController {
         super.viewDidLoad()
 
         configureViews()
-        configureAccessibility()
         configureNavigation()
         configureDragBar()
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -5,7 +5,6 @@ import SimplenoteFoundation
 //
 final class NoteInformationViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
-    @IBOutlet private weak var screenTitleLabel: UILabel!
     @IBOutlet private weak var headerStackView: UIStackView!
     @IBOutlet weak var dragBar: SPDragBar!
     private lazy var blurEffectView = SPBlurEffectView()
@@ -101,11 +100,8 @@ private extension NoteInformationViewController {
 
     func configureViews() {
         configureTableView()
-        configureScreenTitleLabel()
-
         configureHeaderView()
-
-        refreshStyle()
+        styleTableView()
     }
 
     func configureTableView() {
@@ -156,14 +152,6 @@ private extension NoteInformationViewController {
     func configureAccessibility() {
         //TO DO: Should we do something for accessibility for dismissing the info sheet now that the dismiss button is gone?
     }
-    
-    func configureScreenTitleLabel() {
-        screenTitleLabel.text = Localization.document
-        
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            screenTitleLabel.isHidden = true
-        }
-    }
 
     func refreshPreferredSize() {
         preferredContentSize = tableView.contentSize
@@ -186,15 +174,6 @@ private extension NoteInformationViewController {
 // MARK: - Styling
 //
 private extension NoteInformationViewController {
-    func refreshStyle() {
-        styleScreenTitleLabel()
-        styleTableView()
-    }
-
-    func styleScreenTitleLabel() {
-        screenTitleLabel.textColor = .simplenoteNoteHeadlineColor
-    }
-
     func styleTableView() {
         tableView.separatorColor = .simplenoteDividerColor
     }
@@ -308,7 +287,7 @@ private extension NoteInformationViewController {
 
     @objc
     private func themeDidChange() {
-        refreshStyle()
+        styleTableView()
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -185,14 +185,14 @@ private extension NoteInformationViewController {
     func configureDragBar() {
         let dragBar = SPDragBar(frame: CGRect(x: 0, y: 0, width: 36, height: 5))
         
-        view.addSubview(dragBar)
+        headerStackView.addSubview(dragBar)
         
         dragBar.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            dragBar.topAnchor.constraint(equalTo: view.topAnchor, constant: 5),
-            dragBar.bottomAnchor.constraint(equalTo: view.topAnchor, constant: 10),
+            dragBar.heightAnchor.constraint(equalToConstant: 5),
             dragBar.widthAnchor.constraint(equalToConstant: 36),
-            dragBar.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            dragBar.topAnchor.constraint(equalTo: headerStackView.topAnchor, constant: 5),
+            dragBar.centerXAnchor.constraint(equalTo: headerStackView.centerXAnchor)
         ])
     }
 }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -181,9 +181,7 @@ private extension NoteInformationViewController {
     }
     
     func configureDragBar() {
-        if navigationController != nil {
-            dragBar.isHidden = true
-        }
+        dragBar.isHidden = navigationController != nil
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -64,6 +64,11 @@ final class NoteInformationViewController: UIViewController {
         super.viewDidLayoutSubviews()
         additionalSafeAreaInsets = Consts.tableViewSafeAreaInsets
     }
+    
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true, completion: nil)
+        return true
+    }
 }
 
 // MARK: - Controller

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -8,6 +8,7 @@ final class NoteInformationViewController: UIViewController {
     @IBOutlet private weak var screenTitleLabel: UILabel!
     @IBOutlet private weak var dismissButton: UIButton!
     @IBOutlet private weak var headerStackView: UIStackView!
+    @IBOutlet weak var dragBar: SPDragBar!
     private lazy var blurEffectView = SPBlurEffectView()
 
     private var transitioningManager: UIViewControllerTransitioningDelegate?
@@ -183,16 +184,12 @@ private extension NoteInformationViewController {
     }
     
     func configureDragBar() {
-        let dragBar = SPDragBar(frame: CGRect(x: 0, y: 0, width: 36, height: 5))
-        
-        headerStackView.addSubview(dragBar)
-        
         dragBar.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             dragBar.heightAnchor.constraint(equalToConstant: 5),
             dragBar.widthAnchor.constraint(equalToConstant: 36),
-            dragBar.topAnchor.constraint(equalTo: headerStackView.topAnchor, constant: 5),
-            dragBar.centerXAnchor.constraint(equalTo: headerStackView.centerXAnchor)
+            dragBar.topAnchor.constraint(equalTo: view.topAnchor, constant: 5),
+            dragBar.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }
 }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -7,7 +7,6 @@ final class NoteInformationViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet private weak var headerStackView: UIStackView!
     @IBOutlet weak var dragBar: SPDragBar!
-    private lazy var blurEffectView = SPBlurEffectView()
 
     private var transitioningManager: UIViewControllerTransitioningDelegate?
 
@@ -100,7 +99,6 @@ private extension NoteInformationViewController {
 
     func configureViews() {
         configureTableView()
-        configureHeaderView()
         styleTableView()
     }
 
@@ -118,15 +116,6 @@ private extension NoteInformationViewController {
         }
     }
 
-    func configureHeaderView() {
-        guard navigationController == nil else {
-            headerStackView.isHidden = true
-            return
-        }
-
-        configureBlurEffectView()
-    }
-
     func configureHeaderLayoutMargins() {
         headerStackView.isLayoutMarginsRelativeArrangement = true
 
@@ -136,17 +125,6 @@ private extension NoteInformationViewController {
 
         // Sync layout margins with table view so labels are aligned
         headerStackView.layoutMargins = layoutMargins
-    }
-
-    func configureBlurEffectView() {
-        view.insertSubview(blurEffectView, belowSubview: headerStackView)
-        blurEffectView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            blurEffectView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            blurEffectView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            blurEffectView.topAnchor.constraint(equalTo: view.topAnchor),
-            blurEffectView.bottomAnchor.constraint(equalTo: headerStackView.bottomAnchor)
-        ])
     }
 
     func configureAccessibility() {

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -181,8 +181,7 @@ private extension NoteInformationViewController {
     }
     
     func configureDragBar() {
-        if navigationController == nil {
-        } else {
+        if navigationController != nil {
             dragBar.isHidden = true
         }
     }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -51,10 +51,7 @@ final class NoteInformationViewController: UIViewController {
         configureViews()
         configureAccessibility()
         configureNavigation()
-        
-        if !UIDevice.isPad {
-            configureDragBar()
-        }
+        configureDragBar()
 
         refreshPreferredSize()
 
@@ -184,13 +181,17 @@ private extension NoteInformationViewController {
     }
     
     func configureDragBar() {
-        dragBar.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            dragBar.heightAnchor.constraint(equalToConstant: 5),
-            dragBar.widthAnchor.constraint(equalToConstant: 36),
-            dragBar.topAnchor.constraint(equalTo: view.topAnchor, constant: 5),
-            dragBar.centerXAnchor.constraint(equalTo: view.centerXAnchor)
-        ])
+        if navigationController == nil {
+            dragBar.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                dragBar.heightAnchor.constraint(equalToConstant: 5),
+                dragBar.widthAnchor.constraint(equalToConstant: 36),
+                dragBar.topAnchor.constraint(equalTo: view.topAnchor, constant: 5),
+                dragBar.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            ])
+        } else {
+            dragBar.isHidden = true
+        }
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -129,6 +129,17 @@ private extension NoteInformationViewController {
     
     private func configureDragBar() {
         dragBar.isHidden = navigationController != nil
+        dragBar.accessibilityLabel = Localization.dismissAccessibilityLabel
+
+        if UIAccessibility.isVoiceOverRunning == true {
+            let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(informationSheetToBeDismissed))
+            dragBar.addGestureRecognizer(gestureRecognizer)
+        }
+    }
+    
+    @objc
+    func informationSheetToBeDismissed() {
+        dismiss(animated: true, completion: nil)
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -50,6 +50,7 @@ final class NoteInformationViewController: UIViewController {
         configureViews()
         configureAccessibility()
         configureNavigation()
+        configureDragBar()
 
         refreshPreferredSize()
 
@@ -176,6 +177,24 @@ private extension NoteInformationViewController {
         }
 
         additionalSafeAreaInsets = UIEdgeInsets(top: headerStackView.frame.maxY, left: 0, bottom: 0, right: 0)
+    }
+    
+    func configureDragBar() {
+        let dragBar = UIView(frame: CGRect(x: 0, y: 0, width: 36, height: 5))
+        dragBar.backgroundColor = UIColor.black
+        dragBar.alpha = 0.2
+        dragBar.layer.cornerRadius = 2.5
+        dragBar.layer.masksToBounds = true
+        
+        view.addSubview(dragBar)
+        
+        dragBar.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            dragBar.topAnchor.constraint(equalTo: view.topAnchor, constant: 5),
+            dragBar.bottomAnchor.constraint(equalTo: view.topAnchor, constant: 10),
+            dragBar.widthAnchor.constraint(equalToConstant: 36),
+            dragBar.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
     }
 }
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -50,7 +50,10 @@ final class NoteInformationViewController: UIViewController {
         configureViews()
         configureAccessibility()
         configureNavigation()
-        configureDragBar()
+        
+        if !UIDevice.isPad {
+            configureDragBar()
+        }
 
         refreshPreferredSize()
 

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -183,11 +183,7 @@ private extension NoteInformationViewController {
     }
     
     func configureDragBar() {
-        let dragBar = UIView(frame: CGRect(x: 0, y: 0, width: 36, height: 5))
-        dragBar.backgroundColor = UIColor.black
-        dragBar.alpha = 0.2
-        dragBar.layer.cornerRadius = 2.5
-        dragBar.layer.masksToBounds = true
+        let dragBar = SPDragBar(frame: CGRect(x: 0, y: 0, width: 36, height: 5))
         
         view.addSubview(dragBar)
         

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -13,7 +13,6 @@
             <connections>
                 <outlet property="dragBar" destination="lD2-IA-haD" id="als-5f-v3X"/>
                 <outlet property="headerStackView" destination="qBv-kl-fOD" id="eEl-cs-unx"/>
-                <outlet property="screenTitleLabel" destination="9ul-2d-OoP" id="pZb-Nb-szF"/>
                 <outlet property="tableView" destination="HfE-pa-isg" id="5Gu-fK-38o"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -23,16 +22,8 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
+                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
                 </stackView>
                 <tableView contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -12,7 +12,6 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteInformationViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
                 <outlet property="dragBar" destination="lD2-IA-haD" id="als-5f-v3X"/>
-                <outlet property="headerStackView" destination="qBv-kl-fOD" id="eEl-cs-unx"/>
                 <outlet property="tableView" destination="HfE-pa-isg" id="5Gu-fK-38o"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -22,9 +21,6 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
-                </stackView>
                 <tableView contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -48,11 +44,8 @@
                 <constraint firstAttribute="trailing" secondItem="HfE-pa-isg" secondAttribute="trailing" id="17g-xl-0dG"/>
                 <constraint firstAttribute="bottom" secondItem="HfE-pa-isg" secondAttribute="bottom" id="Fr2-jA-fFN"/>
                 <constraint firstItem="HfE-pa-isg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="JtQ-ZA-WOi"/>
-                <constraint firstItem="qBv-kl-fOD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Kky-qU-XXe"/>
                 <constraint firstItem="lD2-IA-haD" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="WtO-HV-AKc"/>
-                <constraint firstItem="qBv-kl-fOD" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="XR7-XE-p8V"/>
                 <constraint firstItem="HfE-pa-isg" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="hrp-6V-pUL"/>
-                <constraint firstAttribute="trailing" secondItem="qBv-kl-fOD" secondAttribute="trailing" id="nD9-Ze-Dqy"/>
                 <constraint firstItem="lD2-IA-haD" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="5" id="pYF-Ho-feS"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -59,10 +59,13 @@
                         <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
                     </connections>
                 </tableView>
-                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lD2-IA-haD" customClass="SPDragBar" customModule="Simplenote" customModuleProvider="target">
-                    <rect key="frame" x="187" y="5" width="36" height="5"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lD2-IA-haD" customClass="SPDragBar" customModule="Simplenote" customModuleProvider="target">
+                    <rect key="frame" x="189" y="5" width="36" height="5"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="36" id="HdR-fd-31k"/>
+                        <constraint firstAttribute="height" constant="5" id="Ver-Mc-ruf"/>
+                    </constraints>
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
@@ -72,9 +75,11 @@
                 <constraint firstAttribute="bottom" secondItem="HfE-pa-isg" secondAttribute="bottom" id="Fr2-jA-fFN"/>
                 <constraint firstItem="HfE-pa-isg" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="JtQ-ZA-WOi"/>
                 <constraint firstItem="qBv-kl-fOD" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Kky-qU-XXe"/>
+                <constraint firstItem="lD2-IA-haD" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="WtO-HV-AKc"/>
                 <constraint firstItem="qBv-kl-fOD" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="XR7-XE-p8V"/>
                 <constraint firstItem="HfE-pa-isg" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="hrp-6V-pUL"/>
                 <constraint firstAttribute="trailing" secondItem="qBv-kl-fOD" secondAttribute="trailing" id="nD9-Ze-Dqy"/>
+                <constraint firstItem="lD2-IA-haD" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="5" id="pYF-Ho-feS"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -11,7 +11,6 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteInformationViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
-                <outlet property="dismissButton" destination="7HZ-2J-9ef" id="rrw-yc-zdP"/>
                 <outlet property="dragBar" destination="lD2-IA-haD" id="als-5f-v3X"/>
                 <outlet property="headerStackView" destination="qBv-kl-fOD" id="eEl-cs-unx"/>
                 <outlet property="screenTitleLabel" destination="9ul-2d-OoP" id="pZb-Nb-szF"/>
@@ -25,30 +24,14 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="30"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ul-2d-OoP">
-                            <rect key="frame" x="0.0" y="5" width="376" height="20.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7HZ-2J-9ef" customClass="RoundedCrossButton" customModule="Simplenote" customModuleProvider="target">
-                            <rect key="frame" x="384" y="0.0" width="30" height="30"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="30" id="zYd-Xa-72n"/>
-                                <constraint firstAttribute="width" constant="30" id="zd7-TM-xEa"/>
-                            </constraints>
-                            <state key="normal" image="icon_cross"/>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                    <real key="value" value="15"/>
-                                </userDefinedRuntimeAttribute>
-                            </userDefinedRuntimeAttributes>
-                            <connections>
-                                <action selector="handleTapOnDismissButton" destination="-1" eventType="touchUpInside" id="qgF-a7-uKd"/>
-                            </connections>
-                        </button>
                     </subviews>
                 </stackView>
                 <tableView contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
@@ -87,7 +70,6 @@
         </view>
     </objects>
     <resources>
-        <image name="icon_cross" width="16" height="16"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Simplenote/Information/NoteInformationViewController.xib
+++ b/Simplenote/Information/NoteInformationViewController.xib
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteInformationViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
                 <outlet property="dismissButton" destination="7HZ-2J-9ef" id="rrw-yc-zdP"/>
+                <outlet property="dragBar" destination="lD2-IA-haD" id="als-5f-v3X"/>
                 <outlet property="headerStackView" destination="qBv-kl-fOD" id="eEl-cs-unx"/>
                 <outlet property="screenTitleLabel" destination="9ul-2d-OoP" id="pZb-Nb-szF"/>
                 <outlet property="tableView" destination="HfE-pa-isg" id="5Gu-fK-38o"/>
@@ -22,14 +24,6 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <connections>
-                        <outlet property="dataSource" destination="-1" id="dIp-Oc-ZbT"/>
-                        <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
-                    </connections>
-                </tableView>
                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qBv-kl-fOD">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="30"/>
                     <subviews>
@@ -57,6 +51,19 @@
                         </button>
                     </subviews>
                 </stackView>
+                <tableView contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="400" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="HfE-pa-isg" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="663"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="dIp-Oc-ZbT"/>
+                        <outlet property="delegate" destination="-1" id="fhS-m2-l5Y"/>
+                    </connections>
+                </tableView>
+                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lD2-IA-haD" customClass="SPDragBar" customModule="Simplenote" customModuleProvider="target">
+                    <rect key="frame" x="187" y="5" width="36" height="5"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -76,5 +83,8 @@
     </objects>
     <resources>
         <image name="icon_cross" width="16" height="16"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Simplenote/SPDragBar.swift
+++ b/Simplenote/SPDragBar.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+class SPDragBar: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configure()
+    }
+    
+    func configure() {
+        self.backgroundColor = UIColor.black
+        self.alpha = 0.2
+        self.layer.cornerRadius = 2.5
+        self.layer.masksToBounds = true
+    }
+}

--- a/Simplenote/SPDragBar.swift
+++ b/Simplenote/SPDragBar.swift
@@ -18,5 +18,7 @@ class SPDragBar: UIView {
         alpha = 0.2
         layer.cornerRadius = 2.5
         layer.masksToBounds = true
+        
+        isAccessibilityElement = true
     }
 }

--- a/Simplenote/SPDragBar.swift
+++ b/Simplenote/SPDragBar.swift
@@ -12,7 +12,11 @@ class SPDragBar: UIView {
     }
     
     func configure() {
-        self.backgroundColor = UIColor.black
+        if SPUserInterface.isDark {
+            self.backgroundColor = UIColor.white
+        } else {
+            self.backgroundColor = UIColor.black
+        }
         self.alpha = 0.2
         self.layer.cornerRadius = 2.5
         self.layer.masksToBounds = true

--- a/Simplenote/SPDragBar.swift
+++ b/Simplenote/SPDragBar.swift
@@ -12,7 +12,9 @@ class SPDragBar: UIView {
     }
     
     private func configure() {
-        backgroundColor = SPUserInterface.isDark ? .white : .black
+        let color = UIColor(lightColor: ColorStudio.black, darkColor: ColorStudio.white)
+        
+        backgroundColor = color
         alpha = 0.2
         layer.cornerRadius = 2.5
         layer.masksToBounds = true

--- a/Simplenote/SPDragBar.swift
+++ b/Simplenote/SPDragBar.swift
@@ -11,14 +11,10 @@ class SPDragBar: UIView {
         configure()
     }
     
-    func configure() {
-        if SPUserInterface.isDark {
-            self.backgroundColor = UIColor.white
-        } else {
-            self.backgroundColor = UIColor.black
-        }
-        self.alpha = 0.2
-        self.layer.cornerRadius = 2.5
-        self.layer.masksToBounds = true
+    private func configure() {
+        backgroundColor = SPUserInterface.isDark ? .white : .black
+        alpha = 0.2
+        layer.cornerRadius = 2.5
+        layer.masksToBounds = true
     }
 }


### PR DESCRIPTION
### Fix
This PR continues with the design changes in issue #1061. Specifically this PR adds in a visual element to alert the user that they can dismiss the information sheet by dragging down on the top of the information sheet element.

The drag bar element will not appear on iPad and should look a bit like this:

<img src="https://cdn-std.droplr.net/files/acc_593859/WpyBbZ" />

### Test

1. Open up Simplenote on an iPhone and go to a Note > Information sheet, confirm that the drag bar appears
2. Open up Simplenote again on an iPad and go to a note > Information sheet, confirm there is no drag bar

### Review
One developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
