### PR TITLE
Fix issue where text could be hidden behind keyboard when sharing to SN

### DIFF
--- a/SimplenoteShare/Presentation/ExtensionPresentationController.swift
+++ b/SimplenoteShare/Presentation/ExtensionPresentationController.swift
@@ -71,7 +71,7 @@ final class ExtensionPresentationController: UIPresentationController {
     }
 
     override func containerViewWillLayoutSubviews() {
-        presentedView?.frame = frameOfPresentedViewInContainerView
+//        presentedView?.frame = frameOfPresentedViewInContainerView
         presentedView?.layer.cornerRadius = Appearance.cornerRadius
         presentedView?.clipsToBounds = true
     }

--- a/SimplenoteShare/ViewControllers/ShareViewController.swift
+++ b/SimplenoteShare/ViewControllers/ShareViewController.swift
@@ -75,7 +75,7 @@ class ShareViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
-        registerKeyboardNotifications()
+//        registerKeyboardNotifications()
         textView.textContainerInset = Constants.textViewInsets
         loadContent()
     }
@@ -194,31 +194,31 @@ private extension ShareViewController {
             self.textView.text = note.content
         }
     }
-    
-    func registerKeyboardNotifications() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardDidChangeFrame(notification:)), name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
-    }
-    
-    @objc
-    func keyboardDidChangeFrame(notification: NSNotification) {
-        guard let keyboardFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
-            return
-        }
-        let textViewFrame = textView.convert(textView.frame, to: nil)
-        let textViewTotalHeight = textViewFrame.origin.y + textViewFrame.height
-        let diff = textViewTotalHeight - keyboardFrame.origin.y
-        print("inset offset value: \(diff)")
-            
-        refreshTextViewInsets(with: diff)
-    }
-    
-    func refreshTextViewInsets(with intersectionHeight: CGFloat) {
-        
-        let contentInsets = UIEdgeInsets(top: 0, left: 0, bottom: intersectionHeight, right: 0)
-        textView.contentInset = contentInsets
-        textView.scrollIndicatorInsets = contentInsets
-    }
+//
+//    func registerKeyboardNotifications() {
+//        NotificationCenter.default.addObserver(self,
+//                                               selector: #selector(keyboardDidChangeFrame(notification:)), name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
+//    }
+//
+//    @objc
+//    func keyboardDidChangeFrame(notification: NSNotification) {
+//        guard let keyboardFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
+//            return
+//        }
+//        let textViewFrame = textView.convert(textView.frame, to: nil)
+//        let textViewTotalHeight = textViewFrame.origin.y + textViewFrame.height
+//        let diff = textViewTotalHeight - keyboardFrame.origin.y
+//        print("inset offset value: \(diff)")
+//
+//        refreshTextViewInsets(with: diff)
+//    }
+//
+//    func refreshTextViewInsets(with intersectionHeight: CGFloat) {
+//
+//        let contentInsets = UIEdgeInsets(top: 0, left: 0, bottom: intersectionHeight, right: 0)
+//        textView.contentInset = contentInsets
+//        textView.scrollIndicatorInsets = contentInsets
+//    }
 }
 
 

--- a/SimplenoteShare/ViewControllers/ShareViewController.swift
+++ b/SimplenoteShare/ViewControllers/ShareViewController.swift
@@ -202,6 +202,13 @@ private extension ShareViewController {
     
     @objc
     func keyboardDidShow(notification: NSNotification) {
+        guard let notificationInfo = notification.userInfo,
+              let keyboardFrame = notificationInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return
+        }
+        let keyboardSize = keyboardFrame.cgRectValue
+        let contentInsets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardSize.height, right: 0)
+        textView.contentInset = contentInsets
     }
 }
 

--- a/SimplenoteShare/ViewControllers/ShareViewController.swift
+++ b/SimplenoteShare/ViewControllers/ShareViewController.swift
@@ -197,11 +197,11 @@ private extension ShareViewController {
     
     func registerKeyboardNotifications() {
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardDidShow(notification:)), name: UIResponder.keyboardDidShowNotification, object: nil)
+                                               selector: #selector(keyboardDidChangeFrame(notification:)), name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
     }
     
     @objc
-    func keyboardDidShow(notification: NSNotification) {
+    func keyboardDidChangeFrame(notification: NSNotification) {
         guard let notificationInfo = notification.userInfo,
               let keyboardFrame = notificationInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
             return

--- a/SimplenoteShare/ViewControllers/ShareViewController.swift
+++ b/SimplenoteShare/ViewControllers/ShareViewController.swift
@@ -75,6 +75,7 @@ class ShareViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
+        registerKeyboardNotifications()
         textView.textContainerInset = Constants.textViewInsets
         loadContent()
     }
@@ -192,6 +193,15 @@ private extension ShareViewController {
             self.originalNote = note
             self.textView.text = note.content
         }
+    }
+    
+    func registerKeyboardNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardDidShow(notification:)), name: UIResponder.keyboardDidShowNotification, object: nil)
+    }
+    
+    @objc
+    func keyboardDidShow(notification: NSNotification) {
     }
 }
 

--- a/SimplenoteShare/ViewControllers/ShareViewController.swift
+++ b/SimplenoteShare/ViewControllers/ShareViewController.swift
@@ -202,13 +202,22 @@ private extension ShareViewController {
     
     @objc
     func keyboardDidChangeFrame(notification: NSNotification) {
-        guard let notificationInfo = notification.userInfo,
-              let keyboardFrame = notificationInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+        guard let keyboardFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
             return
         }
-        let keyboardSize = keyboardFrame.cgRectValue
-        let contentInsets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardSize.height, right: 0)
+        let textViewFrame = textView.convert(textView.frame, to: nil)
+        let textViewTotalHeight = textViewFrame.origin.y + textViewFrame.height
+        let diff = textViewTotalHeight - keyboardFrame.origin.y
+        print("inset offset value: \(diff)")
+            
+        refreshTextViewInsets(with: diff)
+    }
+    
+    func refreshTextViewInsets(with intersectionHeight: CGFloat) {
+        
+        let contentInsets = UIEdgeInsets(top: 0, left: 0, bottom: intersectionHeight, right: 0)
         textView.contentInset = contentInsets
+        textView.scrollIndicatorInsets = contentInsets
     }
 }
 


### PR DESCRIPTION
### Fix
This PR fixes issue number #1036 

The issue described in #1036  is that when sharing to Simplenote from another application (like safari) if the text was too long, the text could hide behind the keyboard.  With this change the edge insets for the text view adjust with the keyboard appearing.


<img width="300px" src="https://user-images.githubusercontent.com/22015538/105681259-c6607080-5f55-11eb-8485-45c8563d24a0.gif" />


### Test
To test:
1. After loading Simplenote onto device or simulator, go to another app that has sharing like safari
2. Click on the share button and choose to share to Simplenote
3. paste in more text than can fit on the screen
4. Scroll down and make sure you can reach the bottom of the pasted in text

### Review
> one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
