### PR TITLE
Bugfix: Configure popover when presenting tag delete sheet on iPad

### DIFF
--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -498,6 +498,10 @@ extension TagListViewController: TagListViewCellDelegate {
         }
 
         alertController.addCancelActionWithTitle(Localization.TagDeletionConfirmation.cancellationButton)
+        
+        alertController.popoverPresentationController?.sourceRect = cell.bounds
+        alertController.popoverPresentationController?.sourceView = cell
+        alertController.popoverPresentationController?.permittedArrowDirections = .any
 
         present(alertController, animated: true, completion: nil)
     }


### PR DESCRIPTION
### Fix
This PR fixes a crash which happens while trying to delete a tag from a sidebar on iPad. The app crashes because of missing popover configuration for action sheet. 

### Test
1. On iPad: open sidebar, make sure to have some tags
2. Enter editing mode
3. Tap on Trash icon next to one of the tags

- [x] Check that popover appears next to the row of the tag that you're trying to delete
- [ ] App doesn't crash

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
