### PR TITLE
Keyboard support: MK1

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		A6E1E7A224BDE456008A44BC /* SPCardPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1E7A124BDE456008A44BC /* SPCardPresentationAnimator.swift */; };
 		A6E1E7A424BDE472008A44BC /* SPCardPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1E7A324BDE472008A44BC /* SPCardPresentationController.swift */; };
 		A6E1E7A824BE656D008A44BC /* SPCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1E7A724BE656D008A44BC /* SPCardView.swift */; };
+		A6E4872625BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E4872525BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift */; };
 		A6E6CE0025A4B0A9005A92DB /* PinLockVerifyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E6CDFF25A4B0A9005A92DB /* PinLockVerifyController.swift */; };
 		A6E6CE5C25A5A7F7005A92DB /* PinLockBaseControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E6CE5B25A5A7F7005A92DB /* PinLockBaseControllerTests.swift */; };
 		A6E6CE6425A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E6CE6325A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift */; };
@@ -611,6 +612,7 @@
 		A6E1E7A124BDE456008A44BC /* SPCardPresentationAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardPresentationAnimator.swift; sourceTree = "<group>"; };
 		A6E1E7A324BDE472008A44BC /* SPCardPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardPresentationController.swift; sourceTree = "<group>"; };
 		A6E1E7A724BE656D008A44BC /* SPCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardView.swift; sourceTree = "<group>"; };
+		A6E4872525BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIKeyCommand+Simplenote.swift"; path = "Classes/UIKeyCommand+Simplenote.swift"; sourceTree = "<group>"; };
 		A6E6CDFF25A4B0A9005A92DB /* PinLockVerifyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLockVerifyController.swift; sourceTree = "<group>"; };
 		A6E6CE5B25A5A7F7005A92DB /* PinLockBaseControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLockBaseControllerTests.swift; sourceTree = "<group>"; };
 		A6E6CE6325A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PinLockControllerConfiguration+Tests.swift"; sourceTree = "<group>"; };
@@ -1512,6 +1514,7 @@
 				B5DF734322A56E2800602CE7 /* UserDefaults+Simplenote.swift */,
 				A6F487A625A79D350050CFA8 /* UIApplication+Simplenote.swift */,
 				A6F4881225A884CE0050CFA8 /* UITextInput+Simplenote.swift */,
+				A6E4872525BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2617,6 +2620,7 @@
 				46A3C99D17DFA81A002865AE /* SPAddCollaboratorsViewController.m in Sources */,
 				B52646AA22D3E04C00EBF299 /* UIViewController+Simplenote.swift in Sources */,
 				B55E428C22A1A4550018C0CE /* SPSortOrderViewController.swift in Sources */,
+				A6E4872625BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift in Sources */,
 				A6F487FD25A880000050CFA8 /* SPTagView+Extensions.swift in Sources */,
 				B5C2EDFE255B19D300C09B32 /* NSAttributedString+Simplenote.swift in Sources */,
 				E2B0863618070045001ED52D /* SPTagPill.m in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -170,6 +170,8 @@
 		A6E1E7A424BDE472008A44BC /* SPCardPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1E7A324BDE472008A44BC /* SPCardPresentationController.swift */; };
 		A6E1E7A824BE656D008A44BC /* SPCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E1E7A724BE656D008A44BC /* SPCardView.swift */; };
 		A6E4872625BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E4872525BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift */; };
+		A6E4875025BEEC9F00D0CE3B /* SPSidebarViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E4874F25BEEC9F00D0CE3B /* SPSidebarViewController+Extensions.swift */; };
+		A6E4875825BEF3C700D0CE3B /* UIResponder+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E4875725BEF3C700D0CE3B /* UIResponder+Simplenote.swift */; };
 		A6E6CE0025A4B0A9005A92DB /* PinLockVerifyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E6CDFF25A4B0A9005A92DB /* PinLockVerifyController.swift */; };
 		A6E6CE5C25A5A7F7005A92DB /* PinLockBaseControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E6CE5B25A5A7F7005A92DB /* PinLockBaseControllerTests.swift */; };
 		A6E6CE6425A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E6CE6325A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift */; };
@@ -613,6 +615,8 @@
 		A6E1E7A324BDE472008A44BC /* SPCardPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardPresentationController.swift; sourceTree = "<group>"; };
 		A6E1E7A724BE656D008A44BC /* SPCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardView.swift; sourceTree = "<group>"; };
 		A6E4872525BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIKeyCommand+Simplenote.swift"; path = "Classes/UIKeyCommand+Simplenote.swift"; sourceTree = "<group>"; };
+		A6E4874F25BEEC9F00D0CE3B /* SPSidebarViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SPSidebarViewController+Extensions.swift"; path = "Classes/SPSidebarViewController+Extensions.swift"; sourceTree = "<group>"; };
+		A6E4875725BEF3C700D0CE3B /* UIResponder+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIResponder+Simplenote.swift"; path = "Classes/UIResponder+Simplenote.swift"; sourceTree = "<group>"; };
 		A6E6CDFF25A4B0A9005A92DB /* PinLockVerifyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLockVerifyController.swift; sourceTree = "<group>"; };
 		A6E6CE5B25A5A7F7005A92DB /* PinLockBaseControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLockBaseControllerTests.swift; sourceTree = "<group>"; };
 		A6E6CE6325A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PinLockControllerConfiguration+Tests.swift"; sourceTree = "<group>"; };
@@ -1515,6 +1519,7 @@
 				A6F487A625A79D350050CFA8 /* UIApplication+Simplenote.swift */,
 				A6F4881225A884CE0050CFA8 /* UITextInput+Simplenote.swift */,
 				A6E4872525BEB6E500D0CE3B /* UIKeyCommand+Simplenote.swift */,
+				A6E4875725BEF3C700D0CE3B /* UIResponder+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1967,6 +1972,7 @@
 				E20DED0317AE07340086AB5F /* SPPopoverContainerViewController.m */,
 				E2922AC0180CA06B003AF914 /* SPSidebarContainerViewController.h */,
 				E2922AC1180CA06B003AF914 /* SPSidebarContainerViewController.m */,
+				A6E4874F25BEEC9F00D0CE3B /* SPSidebarViewController+Extensions.swift */,
 				E215C797180B130B00AD36B5 /* SPTableViewController.h */,
 				E215C798180B130B00AD36B5 /* SPTableViewController.m */,
 				A6DE79CD2552E6CB00BC69C6 /* TagListViewController.swift */,
@@ -2564,6 +2570,7 @@
 				B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */,
 				B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */,
 				B57DE27825013C6600B4D435 /* Simperium+Simplenote.swift in Sources */,
+				A6E4875025BEEC9F00D0CE3B /* SPSidebarViewController+Extensions.swift in Sources */,
 				A6F4881B25A8881B0050CFA8 /* TagListTextField.swift in Sources */,
 				B50CA5262513EC5400A4742D /* NSAttributedString+AuthError.swift in Sources */,
 				46A3C98817DFA81A002865AE /* Simplenote.xcdatamodeld in Sources */,
@@ -2612,6 +2619,7 @@
 				B56A695B22F9CD4E00B90398 /* UINavigationBar+Simplenote.swift in Sources */,
 				46A3C99B17DFA81A002865AE /* Tag.m in Sources */,
 				B56A696122F9D53400B90398 /* SPAuthError.swift in Sources */,
+				A6E4875825BEF3C700D0CE3B /* UIResponder+Simplenote.swift in Sources */,
 				46A3C99C17DFA81A002865AE /* NSString+Bullets.m in Sources */,
 				B58BF1FB23D78ADF00515B50 /* UIContextualAction+Simplenote.swift in Sources */,
 				E215C79A180B130B00AD36B5 /* SPTableViewController.m in Sources */,

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -916,22 +916,8 @@ extension SPNoteListViewController {
 
     open override var keyCommands: [UIKeyCommand]? {
         [
-            UIKeyCommand(input: "n", modifierFlags: [.command], action: #selector(keyboardNewNote), title: Localization.Shortcuts.newNote),
-            UIKeyCommand(input: "f", modifierFlags: [.command, .shift], action: #selector(keyboardStartSearching), title: Localization.Shortcuts.search),
             UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(keyboardStopSearching)),
-            UIKeyCommand(input: "\r", modifierFlags: [.command], action: #selector(keyboardShowSidebar)),
-            UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(keyboardShowSidebar)),
         ] + tableCommands
-    }
-
-    @objc
-    private func keyboardShowSidebar() {
-        sidebarButtonAction(nil)
-    }
-
-    @objc
-    private func keyboardStartSearching() {
-        startSearching()
     }
 
     @objc
@@ -939,9 +925,7 @@ extension SPNoteListViewController {
         endSearching()
     }
 
-    @objc private func keyboardNewNote() {
-        createNewNote()
-    }
+
 }
 
 // MARK: - Keyboard (List)

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -747,7 +747,6 @@ private extension SPNoteListViewController {
 // MARK: - Services
 //
 private extension SPNoteListViewController {
-
     func delete(note: Note) {
         SPTracker.trackListNoteDeleted()
         SPObjectManager.shared().trashNote(note)
@@ -793,6 +792,21 @@ private extension SPNoteListViewController {
         editorViewController.update(withSearchQuery: searchQuery)
 
         return editorViewController
+    }
+}
+
+
+// MARK: - Services (Internal)
+//
+extension SPNoteListViewController {
+    @objc
+    func createNewNote() {
+        SPTracker.trackListNoteCreated()
+
+        // the editor view will create a note. Passing no note ensures that an emty note isn't added
+        // to the FRC before the animation occurs
+        tableView.setEditing(false, animated: false)
+        open(nil, animated: true)
     }
 }
 
@@ -902,10 +916,11 @@ extension SPNoteListViewController {
 
     open override var keyCommands: [UIKeyCommand]? {
         [
+            UIKeyCommand(input: "n", modifierFlags: [.command], action: #selector(keyboardNewNote), title: Localization.Shortcuts.newNote),
             UIKeyCommand(input: "f", modifierFlags: [.command, .shift], action: #selector(keyboardStartSearching), title: Localization.Shortcuts.search),
             UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(keyboardStopSearching)),
             UIKeyCommand(input: "\r", modifierFlags: [.command], action: #selector(keyboardShowSidebar)),
-            UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(keyboardShowSidebar))
+            UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(keyboardShowSidebar)),
         ] + tableCommands
     }
 
@@ -922,6 +937,10 @@ extension SPNoteListViewController {
     @objc
     private func keyboardStopSearching() {
         endSearching()
+    }
+
+    @objc private func keyboardNewNote() {
+        createNewNote()
     }
 }
 
@@ -1006,5 +1025,6 @@ private enum Localization {
 
     enum Shortcuts {
         static let search = NSLocalizedString("Search", comment: "Keyboard shortcut: Search")
+        static let newNote = NSLocalizedString("New Note", comment: "Keyboard shortcut: New Note")
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -893,6 +893,66 @@ extension SPNoteListViewController {
 }
 
 
+// MARK: - Keyboard
+//
+extension SPNoteListViewController {
+    open override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    open override var keyCommands: [UIKeyCommand]? {
+        [
+            UIKeyCommand(input: "f", modifierFlags: [.command, .shift], action: #selector(keyboardStartSearching), title: Localization.Shortcuts.search),
+            UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(keyboardStopSearching)),
+            UIKeyCommand(input: "\r", modifierFlags: [.command], action: #selector(keyboardShowSidebar)),
+            UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(keyboardShowSidebar))
+        ] + tableCommands
+    }
+
+    @objc
+    private func keyboardShowSidebar() {
+        sidebarButtonAction(nil)
+    }
+
+    @objc
+    private func keyboardStartSearching() {
+        startSearching()
+    }
+
+    @objc
+    private func keyboardStopSearching() {
+        endSearching()
+    }
+}
+
+// MARK: - Keyboard (List)
+//
+private extension SPNoteListViewController {
+    var tableCommands: [UIKeyCommand] {
+        [
+            UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(keyboardUp)),
+            UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(keyboardDown)),
+            UIKeyCommand(input: "\r", modifierFlags: [], action: #selector(keyboardSelect))
+        ]
+    }
+
+    @objc
+    func keyboardUp() {
+        tableView?.selectPrevRow()
+    }
+
+    @objc
+    func keyboardDown() {
+        tableView?.selectNextRow()
+    }
+
+    @objc
+    func keyboardSelect() {
+        tableView?.executeSelection()
+    }
+}
+
+
 // MARK: - Private Types
 //
 private enum ActionTitle {
@@ -942,5 +1002,9 @@ private enum Localization {
         static func searchAction(with searchTerm: String) -> String {
             return String(format: NSLocalizedString("Create a new note titled “%@”", comment: "Tappable message shown when no notes match a search string. Parameter: %@ - search term"), searchTerm)
         }
+    }
+
+    enum Shortcuts {
+        static let search = NSLocalizedString("Search", comment: "Keyboard shortcut: Search")
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -924,8 +924,6 @@ extension SPNoteListViewController {
     private func keyboardStopSearching() {
         endSearching()
     }
-
-
 }
 
 // MARK: - Keyboard (List)
@@ -1005,10 +1003,5 @@ private enum Localization {
         static func searchAction(with searchTerm: String) -> String {
             return String(format: NSLocalizedString("Create a new note titled “%@”", comment: "Tappable message shown when no notes match a search string. Parameter: %@ - search term"), searchTerm)
         }
-    }
-
-    enum Shortcuts {
-        static let search = NSLocalizedString("Search", comment: "Keyboard shortcut: Search")
-        static let newNote = NSLocalizedString("New Note", comment: "Keyboard shortcut: New Note")
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -39,6 +39,4 @@
 - (void)startSearching;
 - (void)endSearching;
 
-- (void)sidebarButtonAction:(id)sender;
-
 @end

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -39,4 +39,6 @@
 - (void)startSearching;
 - (void)endSearching;
 
+- (void)sidebarButtonAction:(id)sender;
+
 @end

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -543,6 +543,8 @@
     self.searchBar.userInteractionEnabled = YES;
 
     self.navigationController.navigationBar.userInteractionEnabled = YES;
+
+    [self becomeFirstResponder];
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -538,6 +538,9 @@
 
     self.navigationController.navigationBar.userInteractionEnabled = YES;
 
+    // We want this VC to be first responder to support keyboard shortcuts.
+    // We don't want to steal first responder from the search bar in case it's already active.
+    // It Can happen if we open the app directly into search mode from the home screen quick action
     if (!self.isSearchActive) {
         [self becomeFirstResponder];
     }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -538,7 +538,9 @@
 
     self.navigationController.navigationBar.userInteractionEnabled = YES;
 
-    [self becomeFirstResponder];
+    if (!self.isSearchActive) {
+        [self becomeFirstResponder];
+    }
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -302,13 +302,7 @@
 #pragma mark - BarButtonActions
 
 - (void)addButtonAction:(id)sender {
-    
-    [SPTracker trackListNoteCreated];
-    
-    // the editor view will create a note. Passing no note ensures that an emty note isn't added
-    // to the FRC before the animation occurs
-    [self.tableView setEditing:NO];   
-    [self openNote:nil animated:YES];
+    [self createNewNote];
 }
 
 - (void)sidebarButtonAction:(id)sender {

--- a/Simplenote/Classes/SPSidebarViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSidebarViewController+Extensions.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+// MARK: - Keyboard shortcuts
+//
+extension SPSidebarContainerViewController {
+    open override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    open override var keyCommands: [UIKeyCommand]? {
+        guard presentedViewController == nil else {
+            return nil
+        }
+
+        var commands = [
+            UIKeyCommand(input: "\r", modifierFlags: [.command], action: #selector(keyboardGoBack)),
+            UIKeyCommand(input: "n", modifierFlags: [.command], action: #selector(keyboardCreateNewNote), title: Localization.Shortcuts.newNote),
+            UIKeyCommand(input: "f", modifierFlags: [.command, .shift], action: #selector(keyboardStartSearching), title: Localization.Shortcuts.search),
+        ]
+
+        let currentFirstResponder = UIResponder.currentFirstResponder
+        if !(currentFirstResponder is UITextView) &&
+            !(currentFirstResponder is UITextField) {
+
+            commands.append(UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(keyboardGoBack)))
+        }
+
+        return commands
+    }
+
+    @objc
+    private func keyboardGoBack() {
+        if isSidebarVisible {
+            hideSidebar(withAnimation: true)
+            return
+        }
+
+        if let mainViewController = mainViewController as? UINavigationController, mainViewController.viewControllers.count > 1 {
+            mainViewController.popViewController(animated: true)
+            return
+        }
+
+        showSidebar()
+    }
+
+    @objc
+    private func keyboardStartSearching() {
+        SPAppDelegate.shared().presentSearch(animated: true)
+    }
+
+    @objc
+    private func keyboardCreateNewNote() {
+        SPAppDelegate.shared().presentNewNoteEditor(animated: true)
+    }
+}
+
+private enum Localization {
+    enum Shortcuts {
+        static let search = NSLocalizedString("Search", comment: "Keyboard shortcut: Search")
+        static let newNote = NSLocalizedString("New Note", comment: "Keyboard shortcut: New Note")
+    }
+}

--- a/Simplenote/Classes/UIKeyCommand+Simplenote.swift
+++ b/Simplenote/Classes/UIKeyCommand+Simplenote.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// MARK: - UIKeyCommand
+//
+extension UIKeyCommand {
+    convenience init(input: String,
+                     modifierFlags: UIKeyModifierFlags,
+                     action: Selector,
+                     title: String? = nil) {
+        self.init(input: input, modifierFlags: modifierFlags, action: action)
+        
+        if let title = title {
+            if #available(iOS 13.0, *) {
+                self.title = title
+            } else {
+                discoverabilityTitle = title
+            }
+        }
+    }
+}

--- a/Simplenote/Classes/UIResponder+Simplenote.swift
+++ b/Simplenote/Classes/UIResponder+Simplenote.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+// MARK: - UIResponder
+//
+extension UIResponder {
+    private static weak var _currentFirstResponder: UIResponder?
+
+    static var currentFirstResponder: UIResponder? {
+        _currentFirstResponder = nil
+        UIApplication.shared.sendAction(#selector(UIResponder.findFirstResponder(_:)), to: nil, from: nil, for: nil)
+
+        return _currentFirstResponder
+    }
+
+    @objc
+    private func findFirstResponder(_ sender: Any) {
+        UIResponder._currentFirstResponder = self
+    }
+}

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -46,3 +46,120 @@ extension UITableView {
         return dequeueReusableHeaderFooterView(withIdentifier: T.reuseIdentifier) as? T
     }
 }
+
+// MARK: - Navigation
+//
+extension UITableView {
+
+    /// Returns first index path from the first non-empty section
+    ///
+    var firstIndexPath: IndexPath? {
+        let indexPath = IndexPath(row: 0, section: 0)
+        if numberOfRows(inSection: 0) == 0 {
+            return nextIndexPath(after: indexPath)
+        }
+
+        return indexPath
+    }
+
+    /// Returns index path after currently selected index path
+    ///
+    var nextIndexPath: IndexPath? {
+        guard let indexPath = indexPathForSelectedRow else {
+            return nil
+        }
+
+        return nextIndexPath(after: indexPath)
+    }
+
+    /// Returns index path before currently selected index path
+    ///
+    var prevIndexPath: IndexPath? {
+        guard let indexPath = indexPathForSelectedRow else {
+            return nil
+        }
+
+        var row = indexPath.row
+        var section = indexPath.section
+
+        while true {
+            if row == 0 {
+                if section == 0 {
+                    return nil
+                }
+
+                section -= 1
+                row = numberOfRows(inSection: section)
+            } else {
+                return IndexPath(row: row - 1, section: section)
+            }
+        }
+    }
+
+    /// Selects row after currently selected row or first row if no row is currently selected
+    ///
+    func selectNextRow() {
+        guard let indexPath = (indexPathForSelectedRow != nil ? nextIndexPath : firstIndexPath) else {
+            return
+        }
+        deselectSelectedRow()
+        selectRow(at: indexPath, animated: false, scrollPosition: .none)
+        scrollRectToVisible(rectForRow(at: indexPath), animated: false)
+    }
+
+    /// Selects row before currently selected row or first row if no row is currently selected
+    ///
+    func selectPrevRow() {
+        guard let indexPath = prevIndexPath ?? firstIndexPath else {
+            return
+        }
+        deselectSelectedRow()
+        selectRow(at: indexPath, animated: false, scrollPosition: .none)
+        scrollRectToVisible(rectForRow(at: indexPath), animated: false)
+    }
+
+    /// Calls `didSelectRow` for a currently selected row
+    ///
+    func executeSelection() {
+        guard let indexPath = indexPathForSelectedRow else {
+            return
+        }
+
+        delegate?.tableView?(self, didSelectRowAt: indexPath)
+    }
+
+    /// Deselects selected row if any
+    ///
+    func deselectSelectedRow() {
+        guard let indexPath = indexPathForSelectedRow else {
+            return
+        }
+
+        deselectRow(at: indexPath, animated: false)
+    }
+}
+
+// MARK: - Navigation (Private)
+//
+private extension UITableView {
+    func nextIndexPath(after prevIndexPath: IndexPath) -> IndexPath? {
+        var row = prevIndexPath.row
+        var section = prevIndexPath.section
+
+        while true {
+            row += 1
+
+            if row >= numberOfRows(inSection: section) {
+                section += 1
+
+                if section >= numberOfSections {
+                    return nil
+                }
+
+                row = -1
+            } else {
+                return IndexPath(row: row, section: section)
+            }
+        }
+    }
+}

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -56,7 +56,7 @@ extension UITableView {
     var firstIndexPath: IndexPath? {
         let indexPath = IndexPath(row: 0, section: 0)
         if numberOfRows(inSection: 0) == 0 {
-            return nextIndexPath(after: indexPath)
+            return self.indexPath(after: indexPath)
         }
 
         return indexPath
@@ -69,7 +69,7 @@ extension UITableView {
             return nil
         }
 
-        return nextIndexPath(after: indexPath)
+        return self.indexPath(after: indexPath)
     }
 
     /// Returns index path before currently selected index path
@@ -79,21 +79,7 @@ extension UITableView {
             return nil
         }
 
-        var row = indexPath.row
-        var section = indexPath.section
-
-        while true {
-            if row == 0 {
-                if section == 0 {
-                    return nil
-                }
-
-                section -= 1
-                row = numberOfRows(inSection: section)
-            } else {
-                return IndexPath(row: row - 1, section: section)
-            }
-        }
+        return self.indexPath(before: indexPath)
     }
 
     /// Selects row after currently selected row or first row if no row is currently selected
@@ -142,7 +128,8 @@ extension UITableView {
 // MARK: - Navigation (Private)
 //
 private extension UITableView {
-    func nextIndexPath(after prevIndexPath: IndexPath) -> IndexPath? {
+
+    func indexPath(after prevIndexPath: IndexPath) -> IndexPath? {
         var row = prevIndexPath.row
         var section = prevIndexPath.section
 
@@ -159,6 +146,24 @@ private extension UITableView {
                 row = -1
             } else {
                 return IndexPath(row: row, section: section)
+            }
+        }
+    }
+
+    func indexPath(before nextIndexPath: IndexPath) -> IndexPath? {
+        var row = nextIndexPath.row
+        var section = nextIndexPath.section
+
+        while true {
+            if row == 0 {
+                if section == 0 {
+                    return nil
+                }
+
+                section -= 1
+                row = numberOfRows(inSection: section)
+            } else {
+                return IndexPath(row: row - 1, section: section)
             }
         }
     }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -104,23 +104,29 @@ extension SPAppDelegate {
 
     /// Opens search
     ///
-    func presentSearch() {
-        popToNoteList()
+    func presentSearch(animated: Bool = false) {
+        popToNoteList(animated: animated)
 
-        UIView.performWithoutAnimation {
+        let block = {
             // Switch from trash to all notes as trash doesn't have search
-            if selectedTag == kSimplenoteTrashKey {
-                selectedTag = nil
+            if self.selectedTag == kSimplenoteTrashKey {
+                self.selectedTag = nil
             }
 
-            noteListViewController.startSearching()
+            self.noteListViewController.startSearching()
+        }
+
+        if animated {
+            block()
+        } else {
+            UIView.performWithoutAnimation(block)
         }
     }
 
     /// Opens editor with a new note
     ///
-    func presentNewNoteEditor() {
-        presentNote(nil)
+    func presentNewNoteEditor(animated: Bool = false) {
+        presentNote(nil, animated: animated)
     }
 
     /// Opens a note with specified simperium key
@@ -136,10 +142,10 @@ extension SPAppDelegate {
     /// Opens a note
     ///
     @objc
-    func presentNote(_ note: Note?) {
-        popToNoteList()
+    func presentNote(_ note: Note?, animated: Bool = false) {
+        popToNoteList(animated: animated)
 
-        noteListViewController.open(note, animated: false)
+        noteListViewController.open(note, animated: animated)
     }
 
     /// Dismisses all modals
@@ -149,12 +155,12 @@ extension SPAppDelegate {
         navigationController.dismiss(animated: animated, completion: completion)
     }
 
-    private func popToNoteList() {
-        dismissAllModals(animated: false, completion: nil)
-        sidebarViewController.hideSidebar(withAnimation: false)
+    private func popToNoteList(animated: Bool = false) {
+        dismissAllModals(animated: animated, completion: nil)
+        sidebarViewController.hideSidebar(withAnimation: animated)
 
         if navigationController.viewControllers.contains(noteListViewController) {
-            navigationController.popToViewController(noteListViewController, animated: false)
+            navigationController.popToViewController(noteListViewController, animated: animated)
         }
     }
 }

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -632,7 +632,7 @@
         }
         [_simperium save];
         
-        [self presentNote:newNote];
+        [self presentNote:newNote animated:NO];
     }
     
     return YES;

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -44,8 +44,9 @@ final class TagListViewController: UIViewController {
         super.viewWillAppear(animated)
         startListeningToKeyboardNotifications()
 
-        tableView.reloadData()
+        reloadTableView()
         startListeningForChanges()
+        becomeFirstResponder()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -54,6 +55,8 @@ final class TagListViewController: UIViewController {
 
         stopListeningToKeyboardNotifications()
         stopListeningForChanges()
+
+        resignFirstResponder()
     }
 }
 
@@ -147,7 +150,7 @@ private extension TagListViewController {
         rightBorderView.backgroundColor = .simplenoteDividerColor
         tagsHeaderView.refreshStyle()
         tableView.applySimplenotePlainStyle()
-        tableView.reloadData()
+        reloadTableView()
     }
 }
 
@@ -267,7 +270,6 @@ extension TagListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        cell.isSelected = shouldSelectCell(at: indexPath)
         cell.adjustSeparatorWidth(width: .full)
     }
 
@@ -289,18 +291,7 @@ extension TagListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let section = Section(rawValue: indexPath.section) else {
-            return
-        }
-
-        switch section {
-        case .system:
-            didSelectSystemRow(at: indexPath)
-        case .tags:
-            didSelectTag(at: indexPath)
-        case .bottom:
-            didSelectBottomRow(at: indexPath)
-        }
+        didSelectRow(at: indexPath, isTraversing: false)
     }
 
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
@@ -330,6 +321,11 @@ extension TagListViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         return .none
+    }
+
+    func reloadTableView() {
+        tableView.reloadData()
+        updateCurrentSelection()
     }
 }
 
@@ -376,32 +372,36 @@ private extension TagListViewController {
         cell.hasClearBackground = true
         cell.imageTintColor = .simplenoteTintColor
     }
+}
 
-    func shouldSelectCell(at indexPath: IndexPath) -> Bool {
-        guard let section = Section(rawValue: indexPath.section) else {
-            return false
-        }
+// MARK: - Selection
+//
+private extension TagListViewController {
+    func updateCurrentSelection() {
+        tableView.selectRow(at: currentSelection, animated: false, scrollPosition: .none)
+    }
 
-        let selectedTag = SPAppDelegate.shared().selectedTag
-
-        switch section {
-        case .system:
-            guard let row = SystemRow(rawValue: indexPath.row) else {
-                return false
+    var currentSelection: IndexPath? {
+        let filter = NotesListFilter(selectedTag: SPAppDelegate.shared().selectedTag)
+        switch filter {
+        case .everything:
+            return IndexPath(row: SystemRow.allNotes.rawValue,
+                             section: Section.system.rawValue)
+        case .deleted:
+            return IndexPath(row: SystemRow.trash.rawValue,
+                             section: Section.system.rawValue)
+        case .untagged:
+            return IndexPath(row: 0,
+                             section: Section.bottom.rawValue)
+        case .tag(let tagName):
+            guard let index = resultsController.fetchedObjects.firstIndex(where: {
+                $0.name == tagName
+            }) else {
+                return nil
             }
-            switch row {
-            case .allNotes:
-                return selectedTag == nil
-            case .trash:
-                return selectedTag == kSimplenoteTrashKey
-            case .settings:
-                return false
-            }
 
-        case .tags:
-            return selectedTag == tag(at: indexPath)?.name
-        case .bottom:
-            return selectedTag == kSimplenoteUntaggedKey
+            return IndexPath(row: index,
+                             section: Section.tags.rawValue)
         }
     }
 }
@@ -409,56 +409,67 @@ private extension TagListViewController {
 // MARK: - Row Press Handlers
 //
 private extension TagListViewController {
-    func didSelectSystemRow(at indexPath: IndexPath) {
+
+    func didSelectRow(at indexPath: IndexPath, isTraversing: Bool) {
+        guard let section = Section(rawValue: indexPath.section) else {
+            return
+        }
+
+        switch section {
+        case .system:
+            didSelectSystemRow(at: indexPath, isTraversing: isTraversing)
+        case .tags:
+            didSelectTag(at: indexPath, isTraversing: isTraversing)
+        case .bottom:
+            didSelectBottomRow(at: indexPath, isTraversing: isTraversing)
+        }
+    }
+
+    func didSelectSystemRow(at indexPath: IndexPath, isTraversing: Bool) {
         guard let row = SystemRow(rawValue: indexPath.row) else {
             return
         }
 
-        setEditing(false)
+        if !isTraversing {
+            setEditing(false)
+        }
 
         switch row {
         case .allNotes:
-            allNotesWasPressed()
+            openNoteListForTagName(nil, isTraversing: isTraversing)
         case .trash:
-            trashWasPressed()
+            SPTracker.trackTrashViewed()
+            openNoteListForTagName(kSimplenoteTrashKey, isTraversing: isTraversing)
         case .settings:
-            tableView.deselectRow(at: indexPath, animated: true)
-            settingsWasPressed()
+            if isTraversing {
+                return
+            }
+            updateCurrentSelection()
+            SPAppDelegate.shared().presentSettingsViewController()
         }
     }
 
-    func didSelectTag(at indexPath: IndexPath) {
+    func didSelectTag(at indexPath: IndexPath, isTraversing: Bool) {
         guard let tag = tag(at: indexPath) else {
             return
         }
 
-        if isEditing {
+        if isEditing && !isTraversing {
             SPTracker.trackTagRowRenamed()
             renameTag(tag)
         } else {
             SPTracker.trackListTagViewed()
-            openNoteListForTagName(tag.name)
+            openNoteListForTagName(tag.name, isTraversing: isTraversing)
         }
     }
 
-    func didSelectBottomRow(at indexPath: IndexPath) {
-        setEditing(false)
+    func didSelectBottomRow(at indexPath: IndexPath, isTraversing: Bool) {
+        if !isTraversing {
+            setEditing(false)
+        }
 
         SPTracker.trackListUntaggedViewed()
-        openNoteListForTagName(kSimplenoteUntaggedKey)
-    }
-
-    func allNotesWasPressed() {
-        openNoteListForTagName(nil)
-    }
-
-    func trashWasPressed() {
-        SPTracker.trackTrashViewed()
-        openNoteListForTagName(kSimplenoteTrashKey)
-    }
-
-    func settingsWasPressed() {
-        SPAppDelegate.shared().presentSettingsViewController()
+        openNoteListForTagName(kSimplenoteUntaggedKey, isTraversing: isTraversing)
     }
 }
 
@@ -515,6 +526,7 @@ private extension TagListViewController {
         super.setEditing(editing, animated: true)
         tableView.setEditing(editing, animated: true)
         refreshEditTagsButton(isEditing: editing)
+        updateCurrentSelection()
     }
 
     func refreshEditTagsButton(isEditing: Bool) {
@@ -522,10 +534,12 @@ private extension TagListViewController {
         tagsHeaderView.actionButton.setTitle(title, for: .normal)
     }
 
-    func openNoteListForTagName(_ tagName: String?) {
+    func openNoteListForTagName(_ tagName: String?, isTraversing: Bool) {
         let appDelegate = SPAppDelegate.shared()
         appDelegate.selectedTag = tagName
-        appDelegate.sidebarViewController.hideSidebar(withAnimation: true)
+        if !isTraversing {
+            appDelegate.sidebarViewController.hideSidebar(withAnimation: true)
+        }
     }
 }
 
@@ -600,9 +614,8 @@ extension TagListViewController: UITextFieldDelegate {
 
         self.renameTag = nil
 
-        let tagCell = cell(for: renameTag)
         if isEditing {
-            tagCell?.setSelected(false, animated: true)
+            updateCurrentSelection()
         }
 
         textField.isEnabled = false
@@ -652,7 +665,7 @@ private extension TagListViewController {
 
     func performFetch() {
         try? resultsController.performFetch()
-        tableView.reloadData()
+        reloadTableView()
     }
 
     func refreshSortDescriptorsAndPerformFetch() {
@@ -674,7 +687,7 @@ private extension TagListViewController {
             // Results controller supports only tags section. We show/hide tags section based on the number of tags®
             guard self.tableView.numberOfSections == self.numberOfSections(in: self.tableView) else {
                 self.setEditing(false)
-                self.tableView.reloadData()
+                self.reloadTableView()
                 return
             }
 
@@ -695,6 +708,7 @@ private extension TagListViewController {
                                           objectsChangeset: objectsChangeset,
                                           animations: animations)
         }, completion: nil)
+        updateCurrentSelection()
     }
 }
 
@@ -731,6 +745,73 @@ private extension TagListViewController {
             self.tableView.contentInset = contentInsets
             self.tableView.scrollIndicatorInsets = .zero
         })
+    }
+}
+
+// MARK: - Keyboard Support
+//
+extension TagListViewController {
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+
+    override var keyCommands: [UIKeyCommand]? {
+        var commands = tableCommands
+        commands.append(UIKeyCommand(input: "\r", modifierFlags: [.command], action: #selector(keyboardShowSidebar)))
+        if isFirstResponder {
+            commands.append(UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [], action: #selector(keyboardShowSidebar)))
+            commands.append(contentsOf: tableCommands)
+        }
+
+        return commands
+    }
+
+    @objc
+    private func keyboardShowSidebar() {
+        let appDelegate = SPAppDelegate.shared()
+        appDelegate.sidebarViewController.hideSidebar(withAnimation: true)
+    }
+}
+
+// MARK: - Keyboard support (List)
+//
+private extension TagListViewController {
+    var tableCommands: [UIKeyCommand] {
+        [
+            UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(keyboardUp)),
+            UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(keyboardDown)),
+            UIKeyCommand(input: "\r", modifierFlags: [], action: #selector(keyboardSelect))
+        ]
+    }
+
+    @objc
+    func keyboardUp() {
+        tableView?.selectPrevRow()
+        updateSelectionWhileTraversing()
+    }
+
+    @objc
+    func keyboardDown() {
+        tableView?.selectNextRow()
+        updateSelectionWhileTraversing()
+    }
+
+    @objc
+    func keyboardSelect() {
+        tableView?.executeSelection()
+    }
+
+    func updateSelectionWhileTraversing() {
+        guard let indexPath = tableView.indexPathForSelectedRow else {
+            return
+        }
+
+        // Skip for settings
+        if indexPath.section == Section.system.rawValue && indexPath.row == SystemRow.settings.rawValue {
+            return
+        }
+
+        didSelectRow(at: indexPath, isTraversing: true)
     }
 }
 

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -756,18 +756,20 @@ extension TagListViewController {
     }
 
     override var keyCommands: [UIKeyCommand]? {
-        var commands = tableCommands
-        commands.append(UIKeyCommand(input: "\r", modifierFlags: [.command], action: #selector(keyboardShowSidebar)))
-        if isFirstResponder {
-            commands.append(UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [], action: #selector(keyboardShowSidebar)))
-            commands.append(contentsOf: tableCommands)
+        guard isFirstResponder else {
+            return nil
         }
+
+        var commands = [
+            UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [], action: #selector(keyboardHideSidebar))
+        ]
+        commands.append(contentsOf: tableCommands)
 
         return commands
     }
 
     @objc
-    private func keyboardShowSidebar() {
+    private func keyboardHideSidebar() {
         let appDelegate = SPAppDelegate.shared()
         appDelegate.sidebarViewController.hideSidebar(withAnimation: true)
     }


### PR DESCRIPTION
### Details
In this PR we're adding keyboard navigation in Note List and Sidebar.
What was added:
* Navigation in the list using up / down arrow
* Navigation between list and sidebar using left / right arrow
* Navigation back through the view controllers stack using cmd + return. Helpful when editor is focused and we can't use left arrow for that
* Search using `cmd + shift + f` (when search bar is focused ESC ends the search)
* Create new note using `cmd + n`

Coming next:
* Shortcuts in the editor
* Improve creating new note from the editor (now it goes back to list)
* Preserving selection in the note list
* Save scroll position
* RTL
* Tracks

Ref: #1092

### Test (iPhone / iPad with external keyboard)

1. Open the app

- [x] It is possible to navigate between sidebar and list using arrows
- [x] It is possible to navigate inside the list using arrows
- [x] `cmd + shift + f` opens search
- [x] `cmd + n` creates new note
- [ ] Hold `cmd` to see available shortcuts

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
