### PR TITLE
Make Note non-optional in SPNoteEditorViewController

### DIFF
--- a/Simplenote/Classes/EditorFactory.swift
+++ b/Simplenote/Classes/EditorFactory.swift
@@ -22,12 +22,20 @@ class EditorFactory: NSObject {
 
     /// Returns a new Editor Instance
     ///
-    func build() -> SPNoteEditorViewController {
+    func build(with note: Note?) -> SPNoteEditorViewController {
         assert(restorationClass != nil)
 
-        let controller = SPNoteEditorViewController()
+        let controller = SPNoteEditorViewController(note: note ?? newNote())
         controller.restorationClass = restorationClass
         controller.restorationIdentifier = SPNoteEditorViewController.defaultRestorationIdentifier
         return controller
+    }
+
+    private func newNote() -> Note {
+        let note = SPObjectManager.shared().newDefaultNote()
+        if let tagName = SPAppDelegate.shared().filteredTagName {
+            note.addTag(tagName)
+        }
+        return note
     }
 }

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -482,21 +482,16 @@ extension SPNoteEditorViewController {
 
         SPTracker.trackEditorNoteCreated()
 
-        let snapshotRect = CGRect(x: 0,
-                                  y: noteEditorTextView.adjustedContentInset.top,
-                                  width: noteEditorTextView.frame.width,
-                                  height: noteEditorTextView.frame.height - noteEditorTextView.adjustedContentInset.top)
+        presentNewNoteReplacingCurrentEditor()
+    }
 
-        guard let snapshotView = view.resizableSnapshotView(from: snapshotRect, afterScreenUpdates: false, withCapInsets: .zero),
-              let navigationController = navigationController else {
+    private func presentNewNoteReplacingCurrentEditor() {
+        guard let navigationController = navigationController,
+              let snapshotView = createAndAddEditorSnapshotView() else {
             return
         }
 
-        snapshotView.frame.origin.y = noteEditorTextView.adjustedContentInset.top
-
-        navigationController.view.addSubview(snapshotView)
-
-        let viewControllers: [UIViewController] = navigationController.viewControllers.map{
+        let viewControllers: [UIViewController] = navigationController.viewControllers.map {
             if $0 == self {
                 return EditorFactory.shared.build(with: nil)
             }
@@ -510,6 +505,23 @@ extension SPNoteEditorViewController {
         } completion: { (_) in
             snapshotView.removeFromSuperview()
         }
+    }
+
+    private func createAndAddEditorSnapshotView() -> UIView? {
+        let snapshotRect = CGRect(x: 0,
+                                  y: noteEditorTextView.adjustedContentInset.top,
+                                  width: noteEditorTextView.frame.width,
+                                  height: noteEditorTextView.frame.height - noteEditorTextView.adjustedContentInset.top)
+
+        guard let snapshotView = view.resizableSnapshotView(from: snapshotRect, afterScreenUpdates: false, withCapInsets: .zero),
+              let navigationController = navigationController else {
+            return nil
+        }
+
+        snapshotView.frame.origin.y = snapshotRect.origin.y
+        navigationController.view.addSubview(snapshotView)
+
+        return snapshotView
     }
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -45,7 +45,7 @@ extension SPNoteEditorViewController {
         informationButton = UIBarButtonItem(image: .image(name: .info), style: .plain, target: self, action: #selector(noteInformationWasPressed(_:)))
         informationButton.accessibilityLabel = NSLocalizedString("Information", comment: "Note Information Button (metrics + references)")
 
-        createNoteButton = UIBarButtonItem(image: .image(name: .newNote), style: .plain, target: self, action: #selector(newButtonAction(_:)))
+        createNoteButton = UIBarButtonItem(image: .image(name: .newNote), style: .plain, target: self, action: #selector(handleTapOnCreateNewNoteButton))
         createNoteButton.accessibilityLabel = NSLocalizedString("New note", comment: "Label to create a new note")
 
         keyboardButton = UIBarButtonItem(image: .image(name: .hideKeyboard), style: .plain, target: self, action: #selector(keyboardButtonAction(_:)))
@@ -113,10 +113,30 @@ extension SPNoteEditorViewController {
     ///
     @objc
     func configureTextViewKeyboard() {
-        noteEditorTextView?.keyboardDismissMode = .interactive
+        noteEditorTextView.keyboardDismissMode = .interactive
     }
 }
 
+
+// MARK: - Notifications
+//
+extension SPNoteEditorViewController {
+    @objc
+    func startListeningToNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(dismissEditor(_:)),
+                                               name: NSNotification.Name(rawValue: SPTransitionControllerPopGestureTriggeredNotificationName),
+                                               object: nil)
+
+        // voiceover status is tracked because the tag view is anchored
+        // to the bottom of the screen when voiceover is enabled to allow
+        // easier access
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(refreshVoiceoverSupport),
+                                               name: UIAccessibility.voiceOverStatusDidChangeNotification,
+                                               object: nil)
+    }
+}
 
 // MARK: - Keyboard Handling
 //
@@ -221,16 +241,18 @@ extension SPNoteEditorViewController {
 //
 extension SPNoteEditorViewController {
 
-    var simperium: Simperium {
+    /// NSCoder Keys
+    ///
+    enum CodingKeys: String {
+        case currentNoteKey
+    }
+
+    private var simperium: Simperium {
         SPAppDelegate.shared().simperium
     }
 
     open override func encodeRestorableState(with coder: NSCoder) {
         super.encodeRestorableState(with: coder)
-
-        guard let note = currentNote else {
-            return
-        }
 
         // Always make sure the object is persisted before proceeding
         if note.objectID.isTemporaryID {
@@ -238,17 +260,6 @@ extension SPNoteEditorViewController {
         }
 
         coder.encode(note.simperiumKey, forKey: CodingKeys.currentNoteKey.rawValue)
-    }
-
-    open override func decodeRestorableState(with coder: NSCoder) {
-        guard let simperiumKey = coder.decodeObject(forKey: CodingKeys.currentNoteKey.rawValue) as? String,
-            let note = simperium.bucket(forName: Note.classNameWithoutNamespaces)?.object(forKey: simperiumKey) as? Note
-            else {
-                navigationController?.popViewController(animated: false)
-                return
-        }
-
-        display(note)
     }
 }
 
@@ -273,7 +284,7 @@ extension SPNoteEditorViewController {
 
         dimLinksInEditor()
 
-        let viewController = SPNoteHistoryViewController(note: currentNote, delegate: self)
+        let viewController = SPNoteHistoryViewController(note: note, delegate: self)
         viewController.configureToPresentAsCard(presentationDelegate: self)
         historyViewController = viewController
 
@@ -377,12 +388,10 @@ extension SPNoteEditorViewController {
 
         restoreDefaultLinksDimmingInEditor()
         informationViewController.dismiss(animated: false) { [weak self] in
-            guard let self = self,
-                  let note = self.currentNote,
-                  let informationButton = self.informationButton else {
+            guard let self = self else {
                 return
             }
-            self.presentInformationController(for: note, from: informationButton)
+            self.presentInformationController(for: self.note, from: self.informationButton)
         }
     }
 }
@@ -446,15 +455,6 @@ private extension SPNoteEditorViewController {
 //
 extension SPNoteEditorViewController {
 
-    @objc
-    func newNote() -> Note {
-        let note = SPObjectManager.shared().newDefaultNote()
-        if let tagName = SPAppDelegate.shared().filteredTagName {
-            note.addTag(tagName)
-        }
-        return note
-    }
-
     func delete(note: Note) {
         SPTracker.trackEditorNoteDeleted()
         SPObjectManager.shared().trashNote(note)
@@ -463,17 +463,53 @@ extension SPNoteEditorViewController {
 
     @objc
     func ensureEmptyNoteIsDeleted() {
-        guard let note = currentNote else {
-            return
-        }
-
         guard note.isBlank, noteEditorTextView.text.isEmpty else {
             save()
             return
         }
 
         SPObjectManager.shared().trashNote(note)
-        currentNote = nil
+    }
+
+    @objc
+    private func handleTapOnCreateNewNoteButton() {
+        saveIfNeeded()
+
+        if note.isBlank {
+            noteEditorTextView.becomeFirstResponder()
+            return
+        }
+
+        SPTracker.trackEditorNoteCreated()
+
+        let snapshotRect = CGRect(x: 0,
+                                  y: noteEditorTextView.adjustedContentInset.top,
+                                  width: noteEditorTextView.frame.width,
+                                  height: noteEditorTextView.frame.height - noteEditorTextView.adjustedContentInset.top)
+
+        guard let snapshotView = view.resizableSnapshotView(from: snapshotRect, afterScreenUpdates: false, withCapInsets: .zero),
+              let navigationController = navigationController else {
+            return
+        }
+
+        snapshotView.frame.origin.y = noteEditorTextView.adjustedContentInset.top
+
+        navigationController.view.addSubview(snapshotView)
+
+        let viewControllers: [UIViewController] = navigationController.viewControllers.map{
+            if $0 == self {
+                return EditorFactory.shared.build(with: nil)
+            }
+            return $0
+        }
+
+        navigationController.setViewControllers(viewControllers, animated: false)
+
+        UIView.animate(withDuration: 0.2) {
+            snapshotView.transform = .init(translationX: 0, y: snapshotView.frame.height)
+        } completion: { (_) in
+            snapshotView.removeFromSuperview()
+        }
     }
 }
 
@@ -513,7 +549,7 @@ private extension SPNoteEditorViewController {
     }
 
     func restoreOriginalNoteContent() {
-        updateEditor(with: currentNote.content)
+        updateEditor(with: note.content)
     }
 
     func dimLinksInEditor() {
@@ -576,21 +612,11 @@ extension SPNoteEditorViewController {
 
     @IBAction
     func noteOptionsWasPressed(_ sender: UIBarButtonItem) {
-        guard let note = currentNote else {
-            assertionFailure()
-            return
-        }
-
         presentOptionsController(for: note, from: sender)
     }
 
     @objc
     private func noteInformationWasPressed(_ sender: UIBarButtonItem) {
-        guard let note = currentNote else {
-            assertionFailure()
-            return
-        }
-
         presentInformationController(for: note, from: sender)
     }
 }
@@ -647,7 +673,7 @@ extension SPNoteEditorViewController: InterlinkProcessorPresentationContextProvi
 extension SPNoteEditorViewController: InterlinkProcessorDelegate {
 
     func excludedEntityIdentifierForInterlinkProcessor(_ processor: InterlinkProcessor) -> NSManagedObjectID? {
-        currentNote?.objectID
+        note.objectID
     }
 
     func interlinkProcessor(_ processor: InterlinkProcessor, insert text: String, in range: Range<String.Index>) {
@@ -786,10 +812,6 @@ extension SPNoteEditorViewController {
 extension SPNoteEditorViewController {
     @objc
     func updateHomeScreenQuickActions() {
-        guard let note = currentNote else {
-            return
-        }
-
         ShortcutsHandler.shared.updateHomeScreenQuickActions(with: note)
     }
 }
@@ -807,11 +829,4 @@ private enum Metrics {
 
     static let searchMapWidth: CGFloat = 15.0
 
-}
-
-
-// MARK: - NSCoder Keys
-//
-private enum CodingKeys: String {
-    case currentNoteKey
 }

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -9,22 +9,24 @@
 @class SPTagView;
 @class SearchMapView;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SPNoteEditorViewController : UIViewController  <SPBucketDelegate>
 
 // Navigation Bar
-@property (nonatomic, strong, readonly) SPBlurEffectView * _Nonnull navigationBarBackground;
+@property (nonatomic, strong, readonly) SPBlurEffectView * navigationBarBackground;
 
 // Navigation Buttons
-@property (nonatomic, strong) UIBarButtonItem * _Nonnull actionButton;
-@property (nonatomic, strong) UIBarButtonItem * _Nonnull checklistButton;
-@property (nonatomic, strong) UIBarButtonItem * _Nonnull keyboardButton;
-@property (nonatomic, strong) UIBarButtonItem * _Nonnull createNoteButton;
-@property (nonatomic, strong) UIBarButtonItem * _Nonnull informationButton;
+@property (nonatomic, strong) UIBarButtonItem * actionButton;
+@property (nonatomic, strong) UIBarButtonItem * checklistButton;
+@property (nonatomic, strong) UIBarButtonItem * keyboardButton;
+@property (nonatomic, strong) UIBarButtonItem * createNoteButton;
+@property (nonatomic, strong) UIBarButtonItem * informationButton;
 
-@property (nonatomic, strong, readonly) Note * _Nonnull note;
-@property (nonatomic, strong) SPEditorTextView * _Nonnull noteEditorTextView;
+@property (nonatomic, strong, readonly) Note * note;
+@property (nonatomic, strong) SPEditorTextView * noteEditorTextView;
 
-@property (nonatomic, strong) SPTagView * _Nonnull tagView;
+@property (nonatomic, strong) SPTagView * tagView;
 
 
 // History
@@ -34,10 +36,10 @@
 @property (nonatomic, weak) UIViewController * _Nullable informationViewController;
 
 // Interlinks
-@property (nonatomic, strong) InterlinkProcessor * _Nonnull interlinkProcessor;
+@property (nonatomic, strong) InterlinkProcessor * interlinkProcessor;
 
 // Voiceover
-@property (nonatomic, strong) UIView * _Nonnull bottomView;
+@property (nonatomic, strong) UIView * bottomView;
 
 // Keyboard!
 @property (nonatomic, strong) NSArray * _Nullable keyboardNotificationTokens;
@@ -50,7 +52,7 @@
 @property (nonatomic, getter=isPreviewing) BOOL previewing;
 @property (nonatomic, assign) BOOL modified;
 
-- (instancetype _Nonnull)initWithNote:(Note * _Nonnull)note;
+- (instancetype _Nonnull)initWithNote:(Note *)note;
 
 - (void)dismissEditor:(id _Nullable )sender;
 - (void)insertChecklistAction:(id _Nullable )sender;
@@ -73,3 +75,5 @@
 - (void)updateWithSearchQuery:(id _Nullable )query;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -12,51 +12,50 @@
 @interface SPNoteEditorViewController : UIViewController  <SPBucketDelegate>
 
 // Navigation Bar
-@property (nonatomic, strong, readonly) SPBlurEffectView *navigationBarBackground;
+@property (nonatomic, strong, readonly) SPBlurEffectView * _Nonnull navigationBarBackground;
 
 // Navigation Buttons
-@property (nonatomic, strong) UIBarButtonItem *actionButton;
-@property (nonatomic, strong) UIBarButtonItem *checklistButton;
-@property (nonatomic, strong) UIBarButtonItem *keyboardButton;
-@property (nonatomic, strong) UIBarButtonItem *createNoteButton;
-@property (nonatomic, strong) UIBarButtonItem *informationButton;
+@property (nonatomic, strong) UIBarButtonItem * _Nonnull actionButton;
+@property (nonatomic, strong) UIBarButtonItem * _Nonnull checklistButton;
+@property (nonatomic, strong) UIBarButtonItem * _Nonnull keyboardButton;
+@property (nonatomic, strong) UIBarButtonItem * _Nonnull createNoteButton;
+@property (nonatomic, strong) UIBarButtonItem * _Nonnull informationButton;
 
-@property (nonatomic, strong) Note *currentNote;
-@property (nonatomic, strong) SPEditorTextView *noteEditorTextView;
+@property (nonatomic, strong, readonly) Note * _Nonnull note;
+@property (nonatomic, strong) SPEditorTextView * _Nonnull noteEditorTextView;
 
-@property (nonatomic, strong) SPTagView *tagView;
+@property (nonatomic, strong) SPTagView * _Nonnull tagView;
 
 
 // History
-@property (nonatomic, weak) UIViewController *historyViewController;
+@property (nonatomic, weak) UIViewController * _Nullable historyViewController;
 
 // Information
-@property (nonatomic, weak) UIViewController *informationViewController;
+@property (nonatomic, weak) UIViewController * _Nullable informationViewController;
 
 // Interlinks
-@property (nonatomic, strong) InterlinkProcessor *interlinkProcessor;
+@property (nonatomic, strong) InterlinkProcessor * _Nonnull interlinkProcessor;
 
 // Voiceover
-@property (nonatomic, strong) UIView *bottomView;
+@property (nonatomic, strong) UIView * _Nonnull bottomView;
 
 // Keyboard!
-@property (nonatomic, strong) NSArray *keyboardNotificationTokens;
+@property (nonatomic, strong) NSArray * _Nullable keyboardNotificationTokens;
 @property (nonatomic) BOOL isKeyboardVisible;
 
-@property (nonatomic, strong) SearchMapView *searchMapView;
+@property (nonatomic, strong) SearchMapView * _Nullable searchMapView;
 
 // State
 @property (nonatomic, getter=isEditingNote) BOOL editingNote;
 @property (nonatomic, getter=isPreviewing) BOOL previewing;
 @property (nonatomic, assign) BOOL modified;
 
-- (void)dismissEditor:(id)sender;
-- (void)insertChecklistAction:(id)sender;
-- (void)keyboardButtonAction:(id)sender;
-- (void)newButtonAction:(id)sender;
+- (instancetype _Nonnull)initWithNote:(Note * _Nonnull)note;
 
-- (void)displayNote:(Note *)note;
-- (void)clearNote;
+- (void)dismissEditor:(id _Nullable )sender;
+- (void)insertChecklistAction:(id _Nullable )sender;
+- (void)keyboardButtonAction:(id _Nullable )sender;
+
 - (void)endEditing;
 - (void)bounceMarkdownPreview;
 
@@ -68,8 +67,9 @@
 - (void)didDeleteCurrentNote;
 
 - (void)save;
+- (void)saveIfNeeded;
 
 // TODO: We can't use `SearchQuery` as a type here because it doesn't work from swift code (because of SPM) :-(
-- (void)updateWithSearchQuery:(id)query;
+- (void)updateWithSearchQuery:(id _Nullable )query;
 
 @end

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, getter=isPreviewing) BOOL previewing;
 @property (nonatomic, assign) BOOL modified;
 
-- (instancetype _Nonnull)initWithNote:(Note *)note;
+- (instancetype)initWithNote:(Note *)note;
 
 - (void)dismissEditor:(id _Nullable )sender;
 - (void)insertChecklistAction:(id _Nullable )sender;

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -14,19 +14,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SPNoteEditorViewController : UIViewController  <SPBucketDelegate>
 
 // Navigation Bar
-@property (nonatomic, strong, readonly) SPBlurEffectView * navigationBarBackground;
+@property (nonatomic, strong, readonly) SPBlurEffectView *navigationBarBackground;
 
 // Navigation Buttons
-@property (nonatomic, strong) UIBarButtonItem * actionButton;
-@property (nonatomic, strong) UIBarButtonItem * checklistButton;
-@property (nonatomic, strong) UIBarButtonItem * keyboardButton;
-@property (nonatomic, strong) UIBarButtonItem * createNoteButton;
-@property (nonatomic, strong) UIBarButtonItem * informationButton;
+@property (nonatomic, strong) UIBarButtonItem *actionButton;
+@property (nonatomic, strong) UIBarButtonItem *checklistButton;
+@property (nonatomic, strong) UIBarButtonItem *keyboardButton;
+@property (nonatomic, strong) UIBarButtonItem *createNoteButton;
+@property (nonatomic, strong) UIBarButtonItem *informationButton;
 
-@property (nonatomic, strong, readonly) Note * note;
-@property (nonatomic, strong) SPEditorTextView * noteEditorTextView;
+@property (nonatomic, strong, readonly) Note *note;
+@property (nonatomic, strong) SPEditorTextView *noteEditorTextView;
 
-@property (nonatomic, strong) SPTagView * tagView;
+@property (nonatomic, strong) SPTagView *tagView;
 
 
 // History
@@ -36,10 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) UIViewController * _Nullable informationViewController;
 
 // Interlinks
-@property (nonatomic, strong) InterlinkProcessor * interlinkProcessor;
+@property (nonatomic, strong) InterlinkProcessor *interlinkProcessor;
 
 // Voiceover
-@property (nonatomic, strong) UIView * bottomView;
+@property (nonatomic, strong) UIView *bottomView;
 
 // Keyboard!
 @property (nonatomic, strong) NSArray * _Nullable keyboardNotificationTokens;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -75,36 +75,10 @@ CGFloat const SPSelectedAreaPadding = 20;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (instancetype)init {
-    
+- (instancetype _Nonnull)initWithNote:(Note * _Nonnull)note {
     self = [super init];
     if (self) {
-        // Editor
-        [self configureTextView];
-        [self configureBottomView];
-
-        // TagView
-        _tagView = _noteEditorTextView.tagView;
-        _noteEditorTextView.tagView.tagDelegate = self;
-
-        // Notifications
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(dismissEditor:)
-                                                     name:SPTransitionControllerPopGestureTriggeredNotificationName
-                                                   object:nil];
-        
-        
-        // voiceover status is tracked because the tag view is anchored
-        // to the bottom of the screen when voiceover is enabled to allow
-        // easier access
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(didReceiveVoiceOverNotification:)
-                                                     name:UIAccessibilityVoiceOverStatusDidChangeNotification
-                                                   object:nil];
-
-        // Apply the current style right away!
-        [self startListeningToThemeNotifications];
-        [self refreshStyle];
+        _note = note;
     }
     
     return self;
@@ -125,6 +99,12 @@ CGFloat const SPSelectedAreaPadding = 20;
 
     self.navigationItem.title = nil;
 
+    // Editor
+    [self configureTextView];
+    [self configureBottomView];
+
+    [self configureTagView];
+
     [self configureNavigationBarItems];
     [self configureNavigationBarBackground];
     [self configureRootView];
@@ -133,6 +113,13 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self configureInterlinksProcessor];
     [self refreshVoiceoverSupport];
     [self configureTextViewKeyboard];
+
+    [self startListeningToNotifications];
+    [self startListeningToThemeNotifications];
+
+    [self refreshStyle];
+
+    [self displayNote];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -150,18 +137,14 @@ CGFloat const SPSelectedAreaPadding = 20;
 {
     [super viewDidAppear:animated];
 
-    /// Note:
-    /// This must happen in viewDidAppear (and not before) because of State Restoration.
-    /// Decode happens right after `viewWillAppear`, and this way we get to avoid spurious empty notes.
-    ///
-    if (!_currentNote) {
-        [self newButtonAction:nil];
-    } else {
-        [_noteEditorTextView processChecklists];
-        self.userActivity = [NSUserActivity openNoteActivityFor:_currentNote];
-    }
-
+    self.userActivity = [NSUserActivity openNoteActivityFor:self.note];
     [self ensureEditorIsFirstResponder];
+}
+
+- (void)configureTagView
+{
+    _tagView = _noteEditorTextView.tagView;
+    _noteEditorTextView.tagView.tagDelegate = self;
 }
 
 - (void)configureNavigationBarBackground
@@ -179,7 +162,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)ensureEditorIsFirstResponder
 {
-    if ((_currentNote.content.length == 0) && !self.isShowingHistory && !self.isPreviewing) {
+    if ((self.note.content.length == 0) && !self.isShowingHistory && !self.isPreviewing) {
         [_noteEditorTextView becomeFirstResponder];
     }
 }
@@ -192,11 +175,8 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)themeDidChange
 {
-    if (self.currentNote != nil) {
-        [self save];
-        [self.noteEditorTextView endEditing:YES];
-    }
-
+    [self save];
+    [self.noteEditorTextView endEditing:YES];
     [self refreshStyle];
 }
 
@@ -327,24 +307,19 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self setToolbarItems:@[self.doneSearchButton, flexibleSpace, detailButton, flexibleSpaceTwo, self.prevSearchButton, self.nextSearchButton] animated:NO];
 }
 
-- (void)didReceiveVoiceOverNotification:(NSNotification *)notification
-{
-    [self refreshVoiceoverSupport];
-}
-
 - (void)ensureNoteIsVisibleInList
 {
     // TODO: This should definitely be handled by the Note List itself. Please!
+    // This code is only called in limited amount of cases. It is not called when you press back button in the nav bar.
+    // Do we need this code? :thinking:
     SPNoteListViewController *listController = [[SPAppDelegate sharedDelegate] noteListViewController];
-    if (_currentNote) {
-        
-        NSIndexPath *notePath = [listController.notesListController indexPathForObject:_currentNote];
-        
-        if (![[listController.tableView indexPathsForVisibleRows] containsObject:notePath])
-            [listController.tableView scrollToRowAtIndexPath:notePath
-                                            atScrollPosition:UITableViewScrollPositionTop
-                                                    animated:NO];
-    }
+
+    NSIndexPath *notePath = [listController.notesListController indexPathForObject:self.note];
+
+    if (notePath && ![[listController.tableView indexPathsForVisibleRows] containsObject:notePath])
+        [listController.tableView scrollToRowAtIndexPath:notePath
+                                        atScrollPosition:UITableViewScrollPositionTop
+                                                animated:NO];
 }
 
 - (void)dismissEditor:(id)sender
@@ -360,31 +335,23 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self.navigationController popToRootViewControllerAnimated:YES];
 }
 
-- (void)displayNote:(Note *)note
+- (void)displayNote
 {
-    if (!note) {
-        _noteEditorTextView.text = nil;
-        return;
-    }
-    
-    _currentNote = note;
     [self.noteEditorTextView scrollToTop];
 
     // Synchronously set the TextView's contents. Otherwise we risk race conditions with `highlightSearchResults`
-    self.noteEditorTextView.attributedText = [note.content attributedString];
+    self.noteEditorTextView.attributedText = [self.note.content attributedString];
 
     // Push off Checklist Processing to smoothen out push animation
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.noteEditorTextView processChecklists];
     });
 
-    [self dismissHistoryControllerAnimated:NO];
-
     // mark note as read
-    note.unread = NO;
+    self.note.unread = NO;
     
     // update tags field
-    NSArray *tags = note.tagsArray;
+    NSArray *tags = self.note.tagsArray;
     if (tags.count > 0) {
         [_tagView setupWithTagNames:tags];
     } else {
@@ -395,16 +362,6 @@ CGFloat const SPSelectedAreaPadding = 20;
     self.previewing = NO;
 
     [self updateHomeScreenQuickActions];
-}
-
-- (void)clearNote
-{
-    _currentNote = nil;
-    _noteEditorTextView.text = @"";
-    
-    [self endSearching:nil];
-    
-    [_tagView clearAllTags];
 }
 
 - (void)endEditing
@@ -529,7 +486,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (BOOL)interactivePushPopAnimationControllerShouldBeginPush:(SPInteractivePushPopAnimationController *)controller touchPoint:(CGPoint)touchPoint
 {
-    if (!self.currentNote.markdown) {
+    if (!self.note.markdown) {
         return NO;
     }
 
@@ -802,7 +759,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)saveIfNeeded
 {
-    if (self.currentNote == nil || self.modified == NO) {
+    if (self.modified == NO) {
         return;
     }
 
@@ -811,24 +768,24 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)save
 {
-    if (_currentNote == nil || self.isShowingHistory || [self isDictatingText]) {
+    if (self.isShowingHistory || [self isDictatingText]) {
 		return;
     }
 
-	if (self.modified || _currentNote.deleted == YES)
+	if (self.modified || self.note.deleted == YES)
 	{
         // Update note
-        _currentNote.content = [_noteEditorTextView plainText];
-        _currentNote.modificationDate = [NSDate date];
+        self.note.content = [_noteEditorTextView plainText];
+        self.note.modificationDate = [NSDate date];
 
         // Force an update of the note's content preview in case only tags changed
-        [_currentNote createPreview];
+        [self.note createPreview];
         
         
         // Simperum: save
         [[SPAppDelegate sharedDelegate] save];
         [SPTracker trackEditorNoteEdited];
-        [[CSSearchableIndex defaultSearchableIndex] indexSearchableNote:_currentNote];
+        [[CSSearchableIndex defaultSearchableIndex] indexSearchableNote:self.note];
         
         self.modified = NO;
 
@@ -841,25 +798,25 @@ CGFloat const SPSelectedAreaPadding = 20;
     self.cursorLocationBeforeRemoteUpdate = [_noteEditorTextView selectedRange].location;
     self.noteContentBeforeRemoteUpdate = [_noteEditorTextView plainText];
 	
-    if (_currentNote != nil && ![_noteEditorTextView.text isEqualToString:@""]) {
-        _currentNote.content = [_noteEditorTextView plainText];
+    if (![_noteEditorTextView.text isEqualToString:@""]) {
+        self.note.content = [_noteEditorTextView plainText];
         [[SPAppDelegate sharedDelegate].simperium saveWithoutSyncing];
     }
 }
 
 - (void)didReceiveNewContent {
     
-    NSUInteger newLocation = [self newCursorLocation:_currentNote.content
+    NSUInteger newLocation = [self newCursorLocation:self.note.content
                                              oldText:self.noteContentBeforeRemoteUpdate
                                      currentLocation:self.cursorLocationBeforeRemoteUpdate];
 	
-	_noteEditorTextView.attributedText = [_currentNote.content attributedString];
+	_noteEditorTextView.attributedText = [self.note.content attributedString];
     [_noteEditorTextView processChecklists];
 	
 	NSRange newRange = NSMakeRange(newLocation, 0);
 	[_noteEditorTextView setSelectedRange:newRange];
 	
-	NSArray *tags = _currentNote.tagsArray;
+	NSArray *tags = self.note.tagsArray;
 	if (tags.count > 0) {
 		[_tagView setupWithTagNames:tags];
     }
@@ -872,7 +829,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleAlert];
     [alertController addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction *action) {
-        [self clearNote];
+        [self endSearching:nil];
         [self dismissEditor:nil];
     }];
 
@@ -885,59 +842,6 @@ CGFloat const SPSelectedAreaPadding = 20;
     
     [self endEditing];
     [_tagView endEditing:YES];
-}
-
-- (void)newButtonAction:(id)sender
-{
-    [self saveIfNeeded];
-
-    if (self.currentNote.isBlank) {
-        [_noteEditorTextView becomeFirstResponder];
-        return;
-    }
-    
-    if ([sender isEqual:self.createNoteButton]) {
-        [SPTracker trackEditorNoteCreated];
-    }
-
-    Note *newNote = [self newNote];
-
-    // animate current note off the screen and begin editing new note
-    BOOL animateContentView = _noteEditorTextView.text.length;
-    
-    if (animateContentView) {
-        
-        CGRect snapshotRect = CGRectMake(0,
-                                         _noteEditorTextView.contentInset.top,
-                                         self.view.frame.size.width,
-                                         _noteEditorTextView.frame.size.height - _noteEditorTextView.contentInset.top);
-        UIView *snapshot = [self.noteEditorTextView resizableSnapshotViewFromRect:snapshotRect
-                                                 afterScreenUpdates:NO
-                                                      withCapInsets:UIEdgeInsetsZero ];
-
-        snapshot.frame = snapshotRect;
-        [self.view addSubview:snapshot];
-        [self displayNote:newNote];
-
-        [UIView animateWithDuration:0.2
-                         animations:^{
-                             
-                             CGRect newFrame = snapshot.frame;
-                             newFrame.origin.y += newFrame.size.height;
-                             
-                             snapshot.frame = newFrame;
-
-                         } completion:^(BOOL finished) {
-                             
-                             [snapshot removeFromSuperview];
-                             [self.noteEditorTextView becomeFirstResponder];
-
-                         }];
-
-    } else {
-
-        [self displayNote:newNote];
-    }
 }
 
 - (void)insertChecklistAction:(id)sender {
@@ -981,7 +885,7 @@ CGFloat const SPSelectedAreaPadding = 20;
                                         repeats:NO];
     }
     
-    [_currentNote addTag:tagName];
+    [self.note addTag:tagName];
 
     self.modified = YES;
     [self save];
@@ -991,12 +895,12 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (BOOL)tagView:(SPTagView *)tagView shouldCreateTagName:(NSString *)tagName {
     
-    return ![_currentNote hasTag:tagName];
+    return ![self.note hasTag:tagName];
 }
 
 - (void)tagView:(SPTagView *)tagView didRemoveTagName:(NSString *)tagName {
     
-    [_currentNote stripTag:tagName];
+    [self.note stripTag:tagName];
     self.modified = YES;
     
     NSString *deletedTagBuffer = _deletedTagBuffer;

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -787,8 +787,7 @@ private extension SPNoteListViewController {
     }
 
     func previewingViewController(for note: Note) -> SPNoteEditorViewController {
-        let editorViewController = EditorFactory.shared.build()
-        editorViewController.display(note)
+        let editorViewController = EditorFactory.shared.build(with: note)
         editorViewController.isPreviewing = true
         editorViewController.update(withSearchQuery: searchQuery)
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -32,7 +32,6 @@
 @property (nonatomic, strong) UIBarButtonItem                               *emptyTrashButton;
 
 - (void)update;
-- (void)openNoteWithSimperiumKey:(NSString *)simperiumKey animated:(BOOL)animated;
 - (void)openNote:(Note *)note animated:(BOOL)animated;
 - (void)openNote:(Note *)note ignoringSearchQuery:(BOOL)ignoringSearchQuery animated:(BOOL)animated;
 - (void)setWaitingForIndex:(BOOL)waiting;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -418,16 +418,6 @@
 
 #pragma mark - Public API
 
-- (void)openNoteWithSimperiumKey:(NSString *)simperiumKey animated:(BOOL)animated
-{
-    Note *note = [self.notesListController noteForSimperiumKey:simperiumKey];
-    if (!note) {
-        return;
-    }
-
-    [self openNote:note animated:animated];
-}
-
 - (void)openNote:(Note *)note animated:(BOOL)animated
 {
     [self openNote:note ignoringSearchQuery:NO animated:animated];
@@ -442,8 +432,7 @@
     [self.searchBar resignFirstResponder];
 
     // Always a new Editor!
-    SPNoteEditorViewController *editor = [[EditorFactory shared] build];
-    [editor displayNote:note];
+    SPNoteEditorViewController *editor = [[EditorFactory shared] buildWith:note];
 
     if (!ignoringSearchQuery && self.isSearchActive) {
         [editor updateWithSearchQuery:self.searchQuery];

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -95,8 +95,7 @@ extension SPAppDelegate {
             return false
         }
 
-        let editorViewController = EditorFactory.shared.build()
-        editorViewController.display(note)
+        let editorViewController = EditorFactory.shared.build(with: note)
         replaceNoteEditor(editorViewController)
 
         return true
@@ -182,7 +181,7 @@ extension SPAppDelegate: UIViewControllerRestoration {
         sidebarViewController.restorationClass = SPAppDelegate.self
     }
 
-    func viewController(restorationIdentifier: String) -> UIViewController? {
+    func viewController(restorationIdentifier: String, coder: NSCoder) -> UIViewController? {
         switch restorationIdentifier {
         case tagListViewController.restorationIdentifier:
             return tagListViewController
@@ -191,8 +190,12 @@ extension SPAppDelegate: UIViewControllerRestoration {
             return noteListViewController
 
         case SPNoteEditorViewController.defaultRestorationIdentifier:
-            // Yea! always a new instance (we're not keeping a reference to the active editor anymore)
-            return EditorFactory.shared.build()
+            guard let simperiumKey = coder.decodeObject(forKey: SPNoteEditorViewController.CodingKeys.currentNoteKey.rawValue) as? String,
+                  let note = simperium.bucket(forName: Note.classNameWithoutNamespaces)?.object(forKey: simperiumKey) as? Note
+            else {
+                return nil
+            }
+            return EditorFactory.shared.build(with: note)
 
         case navigationController.restorationIdentifier:
             return navigationController
@@ -214,7 +217,7 @@ extension SPAppDelegate: UIViewControllerRestoration {
             return nil
         }
 
-        return appDelegate.viewController(restorationIdentifier: restorationIdentifier)
+        return appDelegate.viewController(restorationIdentifier: restorationIdentifier, coder: coder)
     }
 }
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -158,7 +158,6 @@
     [[ShortcutsHandler shared] updateHomeScreenQuickActionsIfNeeded];
 
     // Initialize UI
-    [self loadLastSelectedNote];
     [self loadSelectedTheme];
     
     // Check to see if first time user
@@ -223,12 +222,7 @@
     if (_selectedTag) {
         [[NSUserDefaults standardUserDefaults] setObject:_selectedTag forKey:kSelectedTagKey];
     }
-    
-    NSString *currentNoteKey = self.noteEditorViewController.currentNote.simperiumKey;
-    if (currentNoteKey) {
-        [[NSUserDefaults standardUserDefaults] setObject:currentNoteKey forKey:kSelectedNoteKey];
-    }
-    
+
     // Save any pending changes
     [self.noteEditorViewController save];
 }
@@ -294,17 +288,6 @@
 
 
 #pragma mark - Launch Helpers
-
-- (void)loadLastSelectedNote
-{
-    NSString *selectedNoteKey = [[NSUserDefaults standardUserDefaults] objectForKey:kSelectedNoteKey];
-    if (selectedNoteKey) {
-        [self.noteListViewController openNoteWithSimperiumKey:selectedNoteKey animated:NO];
-    }
-
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kSelectedNoteKey];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kSelectedTagKey];
-}
 
 - (void)loadSelectedTheme
 {
@@ -417,7 +400,6 @@
             [self.noteListViewController update];
 			
 			NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-			[defaults removeObjectForKey:kSelectedNoteKey];
 			[defaults removeObjectForKey:kSelectedTagKey];
 			[defaults synchronize];
 			
@@ -467,7 +449,7 @@
         switch (change) {
             case SPBucketChangeTypeUpdate:
             {
-                if ([key isEqualToString:self.noteEditorViewController.currentNote.simperiumKey]) {
+                if ([key isEqualToString:self.noteEditorViewController.note.simperiumKey]) {
                     [self.noteEditorViewController didReceiveNewContent];
                 }
                 Note *note = [bucket objectForKey:key];
@@ -482,7 +464,7 @@
                 break;
 			case SPBucketChangeTypeDelete:
             {
-                if ([key isEqualToString:self.noteEditorViewController.currentNote.simperiumKey]) {
+                if ([key isEqualToString:self.noteEditorViewController.note.simperiumKey]) {
                     [self.noteEditorViewController didDeleteCurrentNote];
                 }
                 [[CSSearchableIndex defaultSearchableIndex] deleteSearchableItemsWithIdentifiers:@[key] completionHandler:nil];
@@ -516,7 +498,7 @@
 {
     if ([bucket isEqual:[_simperium notesBucket]]) {
         for (NSString *key in keys) {
-            if ([key isEqualToString:self.noteEditorViewController.currentNote.simperiumKey]) {
+            if ([key isEqualToString:self.noteEditorViewController.note.simperiumKey]) {
                 [self.noteEditorViewController willReceiveNewContent];
             }
         }

--- a/Simplenote/SPConstants.h
+++ b/Simplenote/SPConstants.h
@@ -25,7 +25,6 @@ extern NSString *const kShareExtensionGroupName;
 extern NSString *const kSimplenoteWPServiceName;
 
 extern NSString *const kSelectedTagKey;
-extern NSString *const kSelectedNoteKey;
 extern NSString *const kSimplenoteTrashKey;
 extern NSString *const kSimplenoteUntaggedKey;
 extern NSString *const kSimplenoteUseBiometryKey;

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -32,7 +32,6 @@ NSString *const kShareExtensionGroupName            = @"group.com.codality.Notat
 #endif
 
 NSString *const kSelectedTagKey                     = @"SPSelectedTag";
-NSString *const kSelectedNoteKey                    = @"SPSelectedNote";
 NSString *const kSimplenoteTrashKey                 = @"__##__trash__##__";
 NSString *const kSimplenoteUntaggedKey              = @"__##__untagged__##__";
 NSString *const kSimplenoteWPServiceName            = @"simplenote-wpcom";


### PR DESCRIPTION
### Details
In this PR we're making `note` non optional in `SPNoteEditorViewController`. Every time we present another note we create a new `SPNoteEditorViewController`. 

### Test
- [x] Check state restoration
- [x] Check creating new note from the editor
- [x] Please do a quick smoke test of the note list / editor

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
