### PR TITLE
AccountVerificationController: Case insensitive comparison

### DIFF
--- a/Simplenote/Verification/AccountVerificationController.swift
+++ b/Simplenote/Verification/AccountVerificationController.swift
@@ -61,7 +61,7 @@ class AccountVerificationController: NSObject {
 
         let emailVerification = EmailVerification(payload: rawData)
 
-        if emailVerification.token?.username == email {
+        if emailVerification.token?.username.lowercased() == email.lowercased() {
             state = .verified
         } else if emailVerification.sentTo != nil {
             state = .verificationInProgress


### PR DESCRIPTION
### Fix
In this PR we're fixing a bug that caused the Email Verification alert to show up, in verified accounts.

### Test
1. Verify your account
2. Logout from Simplenote
3. Log into your account: shift randomly the case of each letter ( `eMAIl@DomAin.com`)

- [ ] Verify the Email Verification UI doesn't show up after auth

### Release
These changes do not require release notes.
