### PR TITLE
Refactor SimplenoteActivityItemSource

### DIFF
--- a/Simplenote/Classes/FileManager+Simplenote.swift
+++ b/Simplenote/Classes/FileManager+Simplenote.swift
@@ -14,19 +14,12 @@ extension FileManager {
 
         return url
     }
-
-    /// Writes a given Note to the Documents folder
+    
+    /// Writes a given String to the documents folder
     ///
-    class func writeToDocuments(note: Note) -> URL? {
-        guard let payload = note.content else {
-            return nil
-        }
-
-        let filename = String(format: "%@.txt", note.simperiumKey)
-        let targetURL = FileManager.documentsURL.appendingPathComponent(filename)
-
+    class func writeStringToDocuments(string: String, to targetURL: URL) -> URL? {
         do {
-            try payload.write(to: targetURL, atomically: true, encoding: .utf8)
+            try string.write(to: targetURL, atomically: true, encoding: .utf8)
         } catch {
             NSLog("Note Exporter Failure: \(error)")
             return nil

--- a/Simplenote/Classes/SimplenoteActivityItemSource.swift
+++ b/Simplenote/Classes/SimplenoteActivityItemSource.swift
@@ -7,24 +7,26 @@ class SimplenoteActivityItemSource: NSObject, UIActivityItemSource {
 
     /// The Note that's about to be exported
     ///
-    private let note: Note
+    private let content: String
+    private let targetURL: URL
 
     /// Designated Initializer
     ///
-    init(note: Note) {
-        self.note = note
+    init(content: String, filename: String) {
+        self.content = content
+        self.targetURL = FileManager.documentsURL.appendingPathComponent(filename)
         super.init()
     }
 
     func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
-        return note.content ?? String()
+        return content
     }
 
     func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
         guard activityType?.isWordPressActivity == true else {
-            return note.content
+            return content
         }
 
-        return FileManager.writeToDocuments(note: note) ?? note.content
+        return FileManager.writeStringToDocuments(string: content, to: targetURL) ?? content
     }
 }

--- a/Simplenote/UIActivityViewController+Simplenote.swift
+++ b/Simplenote/UIActivityViewController+Simplenote.swift
@@ -13,10 +13,11 @@ extension UIActivityViewController {
         guard let content = note.content else {
             return nil
         }
+        let shareFilename = note.exportFilename()
 
         let print = SPSimpleTextPrintFormatter(text: content)
-        let source = SimplenoteActivityItemSource(note: note)
-        let link = PDFLinkActivityItemProvider(content: content, filename: String(format: "%@.pdf", note.exportFilename()))
+        let source = SimplenoteActivityItemSource(content: content, filename: String(format: "%@.txt", shareFilename))
+        let link = PDFLinkActivityItemProvider(content: content, filename: String(format: "%@.pdf", shareFilename))
 
         self.init(activityItems: [print, source, link], applicationActivities: nil)
     }


### PR DESCRIPTION
### Fix
This is a quick PR to refactor the setup for SimplenoteActivityItemSource.  Previously the SimplenoteActivityItemSource  required a note to be passed in at initialization, this was only required so that the FileManager could access the simperiumID when writing the note content to a file.

In this PR I have changed it so that SimplenoteActivityItemSource accepts text and a filename for the destination file, decoupling SimplenoteActivityItemSource from FileaManager and Note

### Test
Should work the same as before, but just to make sure
1. run unit tests
2. open up a note and go to Info > Share and try a few different options other than Books and print
3. Make sure to share to Wordpress, there is custom logic in SimplenoteActivityItemSource for that

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer s required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
