### PR TITLE
Exclude share to books from UIActivityViewController

### DIFF
--- a/Simplenote/UIActivityViewController+Simplenote.swift
+++ b/Simplenote/UIActivityViewController+Simplenote.swift
@@ -18,5 +18,9 @@ extension UIActivityViewController {
         let source = SimplenoteActivityItemSource(note: note)
 
         self.init(activityItems: [print, source], applicationActivities: nil)
+        
+        excludedActivityTypes = [
+            UIActivity.ActivityType.openInIBooks
+        ]
     }
 }

--- a/Simplenote/UIActivityViewController+Simplenote.swift
+++ b/Simplenote/UIActivityViewController+Simplenote.swift
@@ -19,6 +19,8 @@ extension UIActivityViewController {
 
         self.init(activityItems: [print, source], applicationActivities: nil)
         
+        // Share to ibooks feature that is added by the SimpleTextPrintFormatter requires a locally generated PDF or the share fails silently
+        // After much discussion the decision was to not implement a PDF generator into SN at this time, removing share to books as an option.
         excludedActivityTypes = [
             UIActivity.ActivityType.openInIBooks
         ]


### PR DESCRIPTION
### Fix
This PR responds to issue #517 where sharing from Simplenote using iOS sharing there is an option to share to Apple Books, when selected a message appears saying a PDF is being generated, but it fails silently and no PDF is generated

I spent some time on this, ultimately decided the best way forward is to exclude sharing to books as an option in the share sheet.  This PR removes sharing to books as an option

### Test
To Test:
1. Open a note and go to Options > Share
2. look for books, it should not be one of the options available under apps

### Review
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
