### PR TITLE
Persist scroll positions to a local file

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		A68ABCA624ABFA5800715EBD /* UIView+Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */; };
 		A68ABCA824ABFB5300715EBD /* SPShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68ABCA724ABFB5300715EBD /* SPShadowView.swift */; };
 		A6900346253D87060087D0D2 /* VersionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6900345253D87060087D0D2 /* VersionsController.swift */; };
+		A694ABAB25D1549D00CC3A2D /* FileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A694ABAA25D1549D00CC3A2D /* FileStorage.swift */; };
+		A694ABB325D1687200CC3A2D /* NoteScrollPositionCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A694ABB225D1687200CC3A2D /* NoteScrollPositionCacheTests.swift */; };
 		A69F850F253EC2B2005140F2 /* SPCardConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F850E253EC2B2005140F2 /* SPCardConfigurable.swift */; };
 		A69F851D253EC877005140F2 /* UISlider+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */; };
 		A69F861C25408085005140F2 /* NoteInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69F861A25408085005140F2 /* NoteInformationViewController.swift */; };
@@ -581,6 +583,8 @@
 		A68ABCA524ABFA5800715EBD /* UIView+Constraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Constraints.swift"; sourceTree = "<group>"; };
 		A68ABCA724ABFB5300715EBD /* SPShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPShadowView.swift; sourceTree = "<group>"; };
 		A6900345253D87060087D0D2 /* VersionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionsController.swift; sourceTree = "<group>"; };
+		A694ABAA25D1549D00CC3A2D /* FileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileStorage.swift; path = Classes/FileStorage.swift; sourceTree = "<group>"; };
+		A694ABB225D1687200CC3A2D /* NoteScrollPositionCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteScrollPositionCacheTests.swift; sourceTree = "<group>"; };
 		A69F850E253EC2B2005140F2 /* SPCardConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCardConfigurable.swift; sourceTree = "<group>"; };
 		A69F851C253EC877005140F2 /* UISlider+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISlider+Simplenote.swift"; sourceTree = "<group>"; };
 		A69F861A25408085005140F2 /* NoteInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteInformationViewController.swift; sourceTree = "<group>"; };
@@ -1465,6 +1469,7 @@
 				B58218A41FCC45330094ECA1 /* KeychainMigratorTests.swift */,
 				A645FA6F254C5E69008A1519 /* NoteContentHelperTests.swift */,
 				A6344AD8255952C70072FA07 /* NoteContentPreviewTests.swift */,
+				A694ABB225D1687200CC3A2D /* NoteScrollPositionCacheTests.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1692,6 +1697,7 @@
 				A6F4879825A79D130050CFA8 /* ApplicationStateProvider.swift */,
 				A6F487EC25A85F970050CFA8 /* TagTextFieldInputValidator.swift */,
 				A6C0DFA625C0992D00B9BE39 /* NoteScrollPositionCache.swift */,
+				A694ABAA25D1549D00CC3A2D /* FileStorage.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -2487,6 +2493,7 @@
 				B537730F252E14C600BC78C5 /* OptionsViewController.swift in Sources */,
 				B56A696722F9D55F00B90398 /* UIView+Animations.swift in Sources */,
 				A60DF30825A44F0F00FDADF3 /* PinLockRemoveController.swift in Sources */,
+				A694ABAB25D1549D00CC3A2D /* FileStorage.swift in Sources */,
 				B513FB2422EF6A4B00B178AC /* SPUserInterface.swift in Sources */,
 				B5DF734022A54EE800602CE7 /* SPDefaultTableViewCell.swift in Sources */,
 				B5796549250684EC00DFD6F7 /* EditorFactory.swift in Sources */,
@@ -2714,6 +2721,7 @@
 			files = (
 				A6CC0B1F25B840A400F12A85 /* MockAccountVerificationRemote.swift in Sources */,
 				A6CC0B1025B83FE400F12A85 /* AccountVerificationControllerTests.swift in Sources */,
+				A694ABB325D1687200CC3A2D /* NoteScrollPositionCacheTests.swift in Sources */,
 				A6E6CE7525A5B4A3005A92DB /* MockPinLockManager.swift in Sources */,
 				A6CC0B4425B8505700F12A85 /* MockURLSessionDataTask.swift in Sources */,
 				A6CC0B3625B8502800F12A85 /* MockURLSession.swift in Sources */,

--- a/Simplenote/Classes/EditorFactory.swift
+++ b/Simplenote/Classes/EditorFactory.swift
@@ -16,7 +16,10 @@ class EditorFactory: NSObject {
 
     /// Scroll position cache
     ///
-    private let scrollPositionCache = NoteScrollPositionCache()
+    let scrollPositionCache: NoteScrollPositionCache = {
+        let fileURL = FileManager.documentsURL.appendingPathComponent(Constants.filename)
+        return NoteScrollPositionCache(storage: FileStorage(fileURL: fileURL))
+    }()
 
     /// You shall not pass!
     ///
@@ -43,4 +46,11 @@ class EditorFactory: NSObject {
         }
         return note
     }
+}
+
+
+// MARK: - Constants
+//
+private struct Constants {
+    static let filename = ".scroll-cache"
 }

--- a/Simplenote/Classes/FileStorage.swift
+++ b/Simplenote/Classes/FileStorage.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+// MARK: - FileStorage
+//
+class FileStorage<T: Codable> {
+    private let fileURL: URL
+
+    private lazy var decoder = JSONDecoder()
+    private lazy var encoder = JSONEncoder()
+
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// Load an object
+    ///
+    func load() throws -> T? {
+        let data = try Data(contentsOf: fileURL)
+        return try decoder.decode(T.self, from: data)
+    }
+
+    /// Save an object
+    ///
+    func save(object: T) throws {
+        let data = try encoder.encode(object)
+        try data.write(to: fileURL)
+    }
+}

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -135,6 +135,16 @@ extension SPNoteEditorViewController {
                                                selector: #selector(refreshVoiceoverSupport),
                                                name: UIAccessibility.voiceOverStatusDidChangeNotification,
                                                object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleAppDidEnterBackground),
+                                               name: UIApplication.didEnterBackgroundNotification,
+                                               object: nil)
+    }
+
+    @objc
+    private func handleAppDidEnterBackground() {
+        saveScrollPosition()
     }
 }
 

--- a/Simplenote/Classes/SPObjectManager.h
+++ b/Simplenote/Classes/SPObjectManager.h
@@ -16,8 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (SPObjectManager *)sharedManager;
 
-- (NSArray *)notes;
-- (NSArray *)tags;
+- (NSArray<Note *> *)notes;
+- (NSArray<Tag *> *)tags;
 
 
 #pragma mark - Tags

--- a/Simplenote/NoteScrollPositionCache.swift
+++ b/Simplenote/NoteScrollPositionCache.swift
@@ -1,9 +1,24 @@
 import Foundation
 
-// MARK: - NoteScrollPositionCache: cache scroll offset and cursor position
+// MARK: - NoteScrollPositionCache: cache scroll offset
 //
 final class NoteScrollPositionCache {
-    private var cache: [String: CGFloat] = [:]
+    typealias ScrollCache = [String: CGFloat]
+
+    private var cache: ScrollCache {
+        didSet {
+            try? storage.save(object: cache)
+        }
+    }
+
+    private let storage: FileStorage<ScrollCache>
+
+    init(storage: FileStorage<ScrollCache>) {
+        self.storage = storage
+
+        let storedCache = try? storage.load()
+        cache = storedCache ?? [:]
+    }
 
     /// Returns cached scroll position
     ///
@@ -15,5 +30,11 @@ final class NoteScrollPositionCache {
     ///
     func store(position: CGFloat, for key: String) {
         cache[key] = position
+    }
+
+    /// Cleanup
+    ///
+    func cleanup(keeping keys: [String]) {
+        cache = cache.filter({ keys.contains($0.key) })
     }
 }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -363,12 +363,8 @@ extension SPAppDelegate {
     @objc
     func cleanupScrollPositionCache() {
         let allNotes = SPObjectManager.shared().notes()
-        let allIdentifiers: [String] = allNotes.compactMap {
-            guard let note = $0 as? Note, !note.deleted else {
-                return nil
-            }
-
-            return note.simperiumKey
+        let allIdentifiers: [String] = allNotes.compactMap { note in 
+            note.deleted ? nil : note.simperiumKey
         }
         EditorFactory.shared.scrollPositionCache.cleanup(keeping: allIdentifiers)
     }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -355,3 +355,21 @@ private extension SPAppDelegate {
         verificationViewController = nil
     }
 }
+
+
+// MARK: - Scroll position cache
+//
+extension SPAppDelegate {
+    @objc
+    func cleanupScrollPositionCache() {
+        let allNotes = SPObjectManager.shared().notes()
+        let allIdentifiers: [String] = allNotes.compactMap {
+            guard let note = $0 as? Note, !note.deleted else {
+                return nil
+            }
+
+            return note.simperiumKey
+        }
+        EditorFactory.shared.scrollPositionCache.cleanup(keeping: allIdentifiers)
+    }
+}

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -190,6 +190,7 @@
     }
 
     [self showPasscodeLockIfNecessary];
+    [self cleanupScrollPositionCache];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application

--- a/SimplenoteTests/NoteScrollPositionCacheTests.swift
+++ b/SimplenoteTests/NoteScrollPositionCacheTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import Simplenote
+
+// MARK: - NoteScrollPositionCacheTests
+//
+class NoteScrollPositionCacheTests: XCTestCase {
+    private lazy var storage = MockFileStorage<NoteScrollPositionCache.ScrollCache>(fileURL: URL(fileURLWithPath: ""))
+    private lazy var cache = NoteScrollPositionCache(storage: storage)
+
+    func testPositionsAreInitiallyLoadedFromStorage() {
+        // Given
+        let key = UUID().uuidString
+        let value = CGFloat.random(in: -99999..<99999)
+        storage.data = [key: value]
+
+        // Then
+        XCTAssertEqual(cache.position(for: key), value)
+    }
+
+    func testPositionsAreSavedToStorage() {
+        // Given
+        let key = UUID().uuidString
+        let value = CGFloat.random(in: -99999..<99999)
+
+        // When
+        cache.store(position: value, for: key)
+
+        // Then
+        XCTAssertEqual(cache.position(for: key), value)
+        XCTAssertEqual(storage.data, [key: value])
+    }
+
+    func testOnlyProvidedKeysAreKeptDuringCleanup() {
+        // Given
+        let key1 = UUID().uuidString
+        let value1 = CGFloat.random(in: -99999..<99999)
+
+        let key2 = UUID().uuidString
+        let value2 = CGFloat.random(in: -99999..<99999)
+
+        cache.store(position: value1, for: key1)
+        cache.store(position: value2, for: key2)
+
+        // When
+        cache.cleanup(keeping: [key1])
+
+        // Then
+        XCTAssertEqual(cache.position(for: key1), value1)
+        XCTAssertNil(cache.position(for: key2))
+    }
+}
+
+private class MockFileStorage<T: Codable>: FileStorage<T> {
+    var data: T? = nil
+
+    override func load() throws -> T? {
+        return data
+    }
+
+    override func save(object: T) throws {
+        data = object
+    }
+}


### PR DESCRIPTION
### Details
In this PR we're persisting scroll position of notes to a local file in documents folder. To keep the file size small we clean it up by removing deleted notes when the app goes to background.

Ref: #1092

### Test
1. Open any note and scroll, remember where you scrolled.
2. Repeat first step a few times
3. Kill the app and open it again

- [x] Check that notes that you scrolled before open exactly at the same position

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
