### PR TITLE
Fixes an issue where changing keyboard input causes inset sizing issue

### DIFF
--- a/SimplenoteShare/ViewControllers/ShareViewController.swift
+++ b/SimplenoteShare/ViewControllers/ShareViewController.swift
@@ -59,6 +59,7 @@ class ShareViewController: UIViewController {
     ///
     private var keyboardObserverTokens: [Any] = []
 
+    private var keyboardInputChanging: Bool = false
 
     // MARK: Initialization
 
@@ -68,6 +69,7 @@ class ShareViewController: UIViewController {
         self.context = context
         super.init(nibName: type(of: self).nibName, bundle: nil)
         keyboardObserverTokens = addKeyboardObservers()
+        setInputModeObserver()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -102,7 +104,9 @@ class ShareViewController: UIViewController {
 extension ShareViewController: KeyboardObservable {
     func keyboardWillChangeFrame(beginFrame: CGRect?, endFrame: CGRect?, animationDuration: TimeInterval?, animationCurve: UInt?) {
         guard let beginFrame = beginFrame,
-              let endFrame = endFrame else {
+              let endFrame = endFrame,
+              keyboardInputChanging == false else {
+            print("Keyboad input changed")
             return
         }
         //BeginFrame y will be larger IF the keyboard was hidden
@@ -121,7 +125,10 @@ extension ShareViewController: KeyboardObservable {
     
     func keyboardDidChangeFrame(beginFrame: CGRect?, endFrame: CGRect?, animationDuration: TimeInterval?, animationCurve: UInt?) {
         guard let beginFrame = beginFrame,
-              let endFrame = endFrame else {
+              let endFrame = endFrame,
+              keyboardInputChanging == false else {
+            print("Keyboad input changed")
+            keyboardInputChanging = true
             return
         }
         
@@ -142,6 +149,17 @@ extension ShareViewController: KeyboardObservable {
                 self.textView.scrollIndicatorInsets = insets
             }
         }
+    }
+    
+    private func setInputModeObserver() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(inputModeDidChange),
+                                               name: UITextInputMode.currentInputModeDidChangeNotification,
+                                               object: nil)
+    }
+
+    @objc func inputModeDidChange(_ notification: Notification) {
+        keyboardInputChanging = true
     }
 }
 


### PR DESCRIPTION
### Fix
During testing for #1139 I noticed a bit of an edge case issue where a keyboard frame change notification can get triggered, and under circumstances it seems that the height returned from the notification is not correct.  This is an attempt to fix that. 

I feel like the situation is a bit of an edge case, and my sense is that this solution may introduce potential inconsistencies in how the insets in #1139 get set, so wanted to get some feedback on the option.

Setting up the edge case:
So to make this issue happen, on a physical device, choose a language that allows for the predictive text bar at the top of the keyboard. Set that as the current keyboard for your device
Go to settings > General > Keyboard and make sure predictive text is enabled
Now add a keyboard that does NOT have the predictive text keyboard (the only one that I know of is Hebrew)

First it may be easier to understand the edge case if you try the problem without this fix.
If you load #1139 follow these steps:
1. From the SimplenoteShare target, run the code and select the app to share from
2. Tap on share, select Simplenote
3. Paste into the textView that appears enough text that it runs off screen
4. Scroll down to see that the insets work correctly
5. change keyboards till you land on the non predictive text keyboard
6. Check the insets again and the insets will be incorrect, the text will run behind the keyboard

Now you are ready to test:

### Test
1. update the code to using this branch
2. From the SimplenoteShare target, run the code and select the app to share from
3. Tap on share, select Simplenote
4. Paste into the textView that appears enough text that it runs off screen
5. Scroll down to see that the insets work correctly
6. change keyboards till you land on the non predictive text keyboard
7. Check the insets again and the text should still appear correctly.

### Review
***(Required)*** Add instructions for reviewers.  For example:
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
