### PR TITLE
Making Lint Changes as Suggested by SwiftLint

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,6 +24,7 @@ abstract_target 'Automattic' do
 		pod 'Gridicons', '~> 0.18'
 		pod 'AppCenter', '~> 2.5.1'
 		pod 'AppCenter/Distribute', '~> 2.5.1'
+		pod 'SwiftLint'
 
 		# Automattic
 		#

--- a/Podfile
+++ b/Podfile
@@ -24,7 +24,6 @@ abstract_target 'Automattic' do
 		pod 'Gridicons', '~> 0.18'
 		pod 'AppCenter', '~> 2.5.1'
 		pod 'AppCenter/Distribute', '~> 2.5.1'
-		pod 'SwiftLint'
 
 		# Automattic
 		#

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,7 +35,6 @@ PODS:
   - Simperium/SPReachability (1.4.0)
   - Simperium/SSKeychain (1.4.0)
   - Sodium-Fork (0.8.2)
-  - SwiftLint (0.42.0)
   - UIDeviceIdentifier (1.6.0)
   - WordPress-Ratings-iOS (0.0.2)
   - ZIPFoundation (0.9.11)
@@ -46,7 +45,6 @@ DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.6)
   - Gridicons (~> 0.18)
   - Simperium (= 1.4)
-  - SwiftLint
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -60,7 +58,6 @@ SPEC REPOS:
     - Sentry
     - Simperium
     - Sodium-Fork
-    - SwiftLint
     - UIDeviceIdentifier
     - WordPress-Ratings-iOS
     - ZIPFoundation
@@ -74,11 +71,10 @@ SPEC CHECKSUMS:
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   Simperium: e198df96d0eec12ff1ab408ab2e775b4623c5525
   Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: b8e9ccc572dd159626e9bbe1b6c9f14cd4319d25
+PODFILE CHECKSUM: 1c0b34c545c1da8087f8f769802995f9b44aa31b
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,6 +35,7 @@ PODS:
   - Simperium/SPReachability (1.4.0)
   - Simperium/SSKeychain (1.4.0)
   - Sodium-Fork (0.8.2)
+  - SwiftLint (0.42.0)
   - UIDeviceIdentifier (1.6.0)
   - WordPress-Ratings-iOS (0.0.2)
   - ZIPFoundation (0.9.11)
@@ -45,6 +46,7 @@ DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.6)
   - Gridicons (~> 0.18)
   - Simperium (= 1.4)
+  - SwiftLint
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -58,6 +60,7 @@ SPEC REPOS:
     - Sentry
     - Simperium
     - Sodium-Fork
+    - SwiftLint
     - UIDeviceIdentifier
     - WordPress-Ratings-iOS
     - ZIPFoundation
@@ -71,10 +74,11 @@ SPEC CHECKSUMS:
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   Simperium: e198df96d0eec12ff1ab408ab2e775b4623c5525
   Sodium-Fork: 45fe3a7c675898ca0635af4eadcb34985477e868
+  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 1c0b34c545c1da8087f8f769802995f9b44aa31b
+PODFILE CHECKSUM: b8e9ccc572dd159626e9bbe1b6c9f14cd4319d25
 
 COCOAPODS: 1.10.0

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -148,10 +148,10 @@
 		A6C0589524AD2B8F006BC572 /* SPNoteHistoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A6C0589324AD2B8F006BC572 /* SPNoteHistoryViewController.xib */; };
 		A6C0589924AD47CB006BC572 /* SPSnappingSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */; };
 		A6C0589B24AD5205006BC572 /* SPNoteHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589A24AD5205006BC572 /* SPNoteHistoryController.swift */; };
-		A6C0DFE725C18E3300B9BE39 /* NoteEditorTagListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFE525C18E3300B9BE39 /* NoteEditorTagListViewController.swift */; };
-		A6C0DFE825C18E3300B9BE39 /* NoteEditorTagListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A6C0DFE625C18E3300B9BE39 /* NoteEditorTagListViewController.xib */; };
 		A6C0DFA725C0992D00B9BE39 /* NoteScrollPositionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFA625C0992D00B9BE39 /* NoteScrollPositionCache.swift */; };
 		A6C0DFB525C1581D00B9BE39 /* UIScrollView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFB425C1581D00B9BE39 /* UIScrollView+Simplenote.swift */; };
+		A6C0DFE725C18E3300B9BE39 /* NoteEditorTagListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFE525C18E3300B9BE39 /* NoteEditorTagListViewController.swift */; };
+		A6C0DFE825C18E3300B9BE39 /* NoteEditorTagListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A6C0DFE625C18E3300B9BE39 /* NoteEditorTagListViewController.xib */; };
 		A6C2721825AF0C1E00593731 /* TagListViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2721725AF0C1E00593731 /* TagListViewCell.swift */; };
 		A6C3D8B7256687970042F584 /* SPObjectManager+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3D8B6256687970042F584 /* SPObjectManager+Simplenote.swift */; };
 		A6CC0B0725B8287F00F12A85 /* AccountVerificationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */; };
@@ -599,10 +599,10 @@
 		A6C0589324AD2B8F006BC572 /* SPNoteHistoryViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPNoteHistoryViewController.xib; path = Classes/SPNoteHistoryViewController.xib; sourceTree = "<group>"; };
 		A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPSnappingSlider.swift; sourceTree = "<group>"; };
 		A6C0589A24AD5205006BC572 /* SPNoteHistoryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPNoteHistoryController.swift; sourceTree = "<group>"; };
-		A6C0DFE525C18E3300B9BE39 /* NoteEditorTagListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorTagListViewController.swift; sourceTree = "<group>"; };
-		A6C0DFE625C18E3300B9BE39 /* NoteEditorTagListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteEditorTagListViewController.xib; sourceTree = "<group>"; };
 		A6C0DFA625C0992D00B9BE39 /* NoteScrollPositionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteScrollPositionCache.swift; sourceTree = "<group>"; };
 		A6C0DFB425C1581D00B9BE39 /* UIScrollView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIScrollView+Simplenote.swift"; path = "Classes/UIScrollView+Simplenote.swift"; sourceTree = "<group>"; };
+		A6C0DFE525C18E3300B9BE39 /* NoteEditorTagListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorTagListViewController.swift; sourceTree = "<group>"; };
+		A6C0DFE625C18E3300B9BE39 /* NoteEditorTagListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteEditorTagListViewController.xib; sourceTree = "<group>"; };
 		A6C2721725AF0C1E00593731 /* TagListViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListViewCell.swift; sourceTree = "<group>"; };
 		A6C3D8B6256687970042F584 /* SPObjectManager+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SPObjectManager+Simplenote.swift"; path = "Classes/SPObjectManager+Simplenote.swift"; sourceTree = "<group>"; };
 		A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationRemote.swift; sourceTree = "<group>"; };
@@ -2066,6 +2066,7 @@
 			buildConfigurationList = 46A3C9D417DFA81A002865AE /* Build configuration list for PBXNativeTarget "Simplenote" */;
 			buildPhases = (
 				C62AC7EF4EA894D0C1FAFFC0 /* [CP] Check Pods Manifest.lock */,
+				ADBD068925D3400E0045FC84 /* ShellScript */,
 				46A3C96117DFA81A002865AE /* Sources */,
 				46A3C9B017DFA81A002865AE /* Frameworks */,
 				46A3C9C117DFA81A002865AE /* Resources */,
@@ -2385,6 +2386,24 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		ADBD068925D3400E0045FC84 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which ${PODS_ROOT}/SwiftLint/swiftlint >/dev/null; then\n  ${PODS_ROOT}/SwiftLint/swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		B553F5A11D10474600F7E397 /* Delete Frameworks folder (temporary fix for CocoaPods) */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -148,10 +148,10 @@
 		A6C0589524AD2B8F006BC572 /* SPNoteHistoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A6C0589324AD2B8F006BC572 /* SPNoteHistoryViewController.xib */; };
 		A6C0589924AD47CB006BC572 /* SPSnappingSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */; };
 		A6C0589B24AD5205006BC572 /* SPNoteHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0589A24AD5205006BC572 /* SPNoteHistoryController.swift */; };
-		A6C0DFA725C0992D00B9BE39 /* NoteScrollPositionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFA625C0992D00B9BE39 /* NoteScrollPositionCache.swift */; };
-		A6C0DFB525C1581D00B9BE39 /* UIScrollView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFB425C1581D00B9BE39 /* UIScrollView+Simplenote.swift */; };
 		A6C0DFE725C18E3300B9BE39 /* NoteEditorTagListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFE525C18E3300B9BE39 /* NoteEditorTagListViewController.swift */; };
 		A6C0DFE825C18E3300B9BE39 /* NoteEditorTagListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A6C0DFE625C18E3300B9BE39 /* NoteEditorTagListViewController.xib */; };
+		A6C0DFA725C0992D00B9BE39 /* NoteScrollPositionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFA625C0992D00B9BE39 /* NoteScrollPositionCache.swift */; };
+		A6C0DFB525C1581D00B9BE39 /* UIScrollView+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DFB425C1581D00B9BE39 /* UIScrollView+Simplenote.swift */; };
 		A6C2721825AF0C1E00593731 /* TagListViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C2721725AF0C1E00593731 /* TagListViewCell.swift */; };
 		A6C3D8B7256687970042F584 /* SPObjectManager+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3D8B6256687970042F584 /* SPObjectManager+Simplenote.swift */; };
 		A6CC0B0725B8287F00F12A85 /* AccountVerificationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */; };
@@ -599,10 +599,10 @@
 		A6C0589324AD2B8F006BC572 /* SPNoteHistoryViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPNoteHistoryViewController.xib; path = Classes/SPNoteHistoryViewController.xib; sourceTree = "<group>"; };
 		A6C0589824AD47CB006BC572 /* SPSnappingSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPSnappingSlider.swift; sourceTree = "<group>"; };
 		A6C0589A24AD5205006BC572 /* SPNoteHistoryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPNoteHistoryController.swift; sourceTree = "<group>"; };
-		A6C0DFA625C0992D00B9BE39 /* NoteScrollPositionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteScrollPositionCache.swift; sourceTree = "<group>"; };
-		A6C0DFB425C1581D00B9BE39 /* UIScrollView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIScrollView+Simplenote.swift"; path = "Classes/UIScrollView+Simplenote.swift"; sourceTree = "<group>"; };
 		A6C0DFE525C18E3300B9BE39 /* NoteEditorTagListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorTagListViewController.swift; sourceTree = "<group>"; };
 		A6C0DFE625C18E3300B9BE39 /* NoteEditorTagListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteEditorTagListViewController.xib; sourceTree = "<group>"; };
+		A6C0DFA625C0992D00B9BE39 /* NoteScrollPositionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteScrollPositionCache.swift; sourceTree = "<group>"; };
+		A6C0DFB425C1581D00B9BE39 /* UIScrollView+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIScrollView+Simplenote.swift"; path = "Classes/UIScrollView+Simplenote.swift"; sourceTree = "<group>"; };
 		A6C2721725AF0C1E00593731 /* TagListViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagListViewCell.swift; sourceTree = "<group>"; };
 		A6C3D8B6256687970042F584 /* SPObjectManager+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SPObjectManager+Simplenote.swift"; path = "Classes/SPObjectManager+Simplenote.swift"; sourceTree = "<group>"; };
 		A6CC0B0625B8287F00F12A85 /* AccountVerificationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationRemote.swift; sourceTree = "<group>"; };
@@ -2066,7 +2066,6 @@
 			buildConfigurationList = 46A3C9D417DFA81A002865AE /* Build configuration list for PBXNativeTarget "Simplenote" */;
 			buildPhases = (
 				C62AC7EF4EA894D0C1FAFFC0 /* [CP] Check Pods Manifest.lock */,
-				ADBD068925D3400E0045FC84 /* ShellScript */,
 				46A3C96117DFA81A002865AE /* Sources */,
 				46A3C9B017DFA81A002865AE /* Frameworks */,
 				46A3C9C117DFA81A002865AE /* Resources */,
@@ -2386,24 +2385,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		ADBD068925D3400E0045FC84 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which ${PODS_ROOT}/SwiftLint/swiftlint >/dev/null; then\n  ${PODS_ROOT}/SwiftLint/swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		B553F5A11D10474600F7E397 /* Delete Frameworks folder (temporary fix for CocoaPods) */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Simplenote/BuildConfiguration.swift
+++ b/Simplenote/BuildConfiguration.swift
@@ -29,7 +29,7 @@ enum BuildConfiguration: String {
     }
 }
 
-extension BuildConfiguration : CustomStringConvertible {
+extension BuildConfiguration: CustomStringConvertible {
     var description: String {
         return self.rawValue
     }

--- a/Simplenote/Classes/CSSearchable+Helpers.swift
+++ b/Simplenote/Classes/CSSearchable+Helpers.swift
@@ -18,14 +18,14 @@ extension CSSearchableItemAttributeSet {
         title = note.titlePreview
         contentDescription = note.bodyPreview
     }
-    
+
 }
 
 extension CSSearchableItem {
 
     convenience init(note: Note) {
         let attributeSet = CSSearchableItemAttributeSet(note: note)
-        self.init(uniqueIdentifier: note.simperiumKey, domainIdentifier:"notes", attributeSet: attributeSet)
+        self.init(uniqueIdentifier: note.simperiumKey, domainIdentifier: "notes", attributeSet: attributeSet)
     }
 
 }
@@ -40,19 +40,19 @@ extension CSSearchableIndex {
             }
         }
     }
-    
+
     @objc func indexSearchableNotes(_ notes: [Note]) {
         let items = notes.map {
             return CSSearchableItem(note: $0)
         }
-        
+
         indexSearchableItems(items) { error in
             if let error = error {
                 NSLog("Couldn't index notes in spotlight: \(error.localizedDescription)")
             }
         }
     }
-    
+
     @objc func deleteSearchableNote(_ note: Note) {
         deleteSearchableNotes([note])
     }
@@ -61,7 +61,7 @@ extension CSSearchableIndex {
         let ids = notes.map {
             return $0.simperiumKey!
         }
-        
+
         deleteSearchableItems(withIdentifiers: ids) { error in
             if let error = error {
                 NSLog("Couldn't delete notes from spotlight index: \(error.localizedDescription)")

--- a/Simplenote/Classes/NSString+Count.swift
+++ b/Simplenote/Classes/NSString+Count.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 @objc extension NSString {
-    var count:Int {
+    var count: Int {
         let aString = self as String
         return aString.count
     }
-    
-    var charCount:Int {
+
+    var charCount: Int {
         let aString = self as String
         var result = 0
         for char in aString {
@@ -16,14 +16,14 @@ import Foundation
         }
         return result
     }
-    
-    var wordCount:Int {
+
+    var wordCount: Int {
         guard length>0 else {
             return 0
         }
         let ChineseCharacterSet = CharacterSet.CJKUniHan.union(CharacterSet.Hiragana).union(CharacterSet.Katakana)
         var result = 0
-        enumerateSubstrings(in: NSMakeRange(0, length), options: [.byWords,.localized]) { (substring, substringRange, enclosingRange, stop) in
+        enumerateSubstrings(in: NSMakeRange(0, length), options: [.byWords, .localized]) { (substring, substringRange, enclosingRange, stop) in
             if ChineseCharacterSet.contains(substring!.unicodeScalars.first!) {
                 result += substring!.count
             } else if !CharacterSet.whitespacesAndNewlines.contains(substring!.unicodeScalars.first!) { // Sometimes NSString treat "\n" and " " as a word.
@@ -36,49 +36,49 @@ import Foundation
 
 extension CharacterSet {
     // Chinese characters in Unicode 5.0
-    static var CJKUniHanBasic:CharacterSet {
+    static var CJKUniHanBasic: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0x4E00))!...UnicodeScalar(UInt32(0x9FBB))!)
     }
-    static var CJKUniHanExA:CharacterSet {
+    static var CJKUniHanExA: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0x3400))!...UnicodeScalar(UInt32(0x4DB5))!)
     }
-    static var CJKUniHanExB:CharacterSet {
+    static var CJKUniHanExB: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0x20000))!...UnicodeScalar(UInt32(0x2A6D6))!)
     }
-    static var CJKUniHanCompatibility1:CharacterSet {
+    static var CJKUniHanCompatibility1: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0xF900))!...UnicodeScalar(UInt32(0xFA2D))!)
     }
-    static var CJKUniHanCompatibility2:CharacterSet {
+    static var CJKUniHanCompatibility2: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0xFA30))!...UnicodeScalar(UInt32(0xFA6A))!)
     }
-    static var CJKUniHanCompatibility3:CharacterSet {
+    static var CJKUniHanCompatibility3: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0xFA70))!...UnicodeScalar(UInt32(0xFAD9))!)
     }
-    static var CJKUniHanCompatibility4:CharacterSet {
+    static var CJKUniHanCompatibility4: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0x2F800))!...UnicodeScalar(UInt32(0x2FA1D))!)
     }
-    
-    static var CJKUniHan:CharacterSet {
+
+    static var CJKUniHan: CharacterSet {
         return CJKUniHanBasic.union(CJKUniHanExA).union(CJKUniHanExB).union(CJKUniHanCompatibility1).union(CJKUniHanCompatibility2).union(CJKUniHanCompatibility3).union(CJKUniHanCompatibility4)
     }
-    
+
     // Japanese Hiraganas and Katakanas
-    static var Hiragana:CharacterSet {
+    static var Hiragana: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0x3040))!...UnicodeScalar(UInt32(0x309f))!)
     }
-    static var Katakana:CharacterSet {
+    static var Katakana: CharacterSet {
         return CharacterSet(charactersIn: UnicodeScalar(UInt32(0x30A0))!...UnicodeScalar(UInt32(0x30ff))!).union(CharacterSet(charactersIn: UnicodeScalar(UInt32(0x31f0))!...UnicodeScalar(UInt32(0x31ff))!)
         )
     }
-    
+
     // gets all characters from a CharacterSet. Only for testing.
-    var characters:[UnicodeScalar] {
+    var characters: [UnicodeScalar] {
         var chars = [UnicodeScalar]()
-        for plane:UInt8 in 0...16 {
+        for plane: UInt8 in 0...16 {
             if self.hasMember(inPlane: plane) {
                 let p0 = UInt32(plane) << 16
                 let p1 = (UInt32(plane) + 1) << 16
-                for c:UInt32 in p0..<p1 {
+                for c: UInt32 in p0..<p1 {
                     if let us = UnicodeScalar(c) {
                         if self.contains(us) {
                             chars.append(us)
@@ -90,5 +90,3 @@ extension CharacterSet {
         return chars
     }
 }
-
-

--- a/Simplenote/Classes/Note+Properties.swift
+++ b/Simplenote/Classes/Note+Properties.swift
@@ -90,7 +90,7 @@ extension Note {
         guard let bodyRange = NoteContentHelper.structure(of: content).body else {
             return nil
         }
-        
+
         guard let excerpt = content.contentSlice(matching: keywords,
                                                  in: bodyRange,
                                                  leadingLimit: Constants.excerptLeadingLimit,

--- a/Simplenote/Classes/PinLock/PinLockSetupController.swift
+++ b/Simplenote/Classes/PinLock/PinLockSetupController.swift
@@ -47,7 +47,7 @@ final class PinLockSetupController: PinLockBaseController, PinLockController {
                      with: .slideTrailing)
             return
         }
-        
+
         pinLockManager.setPin(pin)
         delegate?.pinLockSetupControllerDidComplete(self)
     }
@@ -73,4 +73,3 @@ private enum Localization {
     static let confirmPasscode = NSLocalizedString("Confirm your passcode", comment: "Title on the PinLock screen asking to confirm a passcode")
     static let passcodesDontMatch = NSLocalizedString("Passcodes did not match. Try again.", comment: "Pin Lock")
 }
-

--- a/Simplenote/Classes/PinLock/PinLockVerifyController.swift
+++ b/Simplenote/Classes/PinLock/PinLockVerifyController.swift
@@ -40,7 +40,7 @@ final class PinLockVerifyController: PinLockBaseController, PinLockController {
     }
 
     func handleCancellation() {
-        
+
     }
 
     func viewDidAppear() {

--- a/Simplenote/Classes/SPAboutViewController.swift
+++ b/Simplenote/Classes/SPAboutViewController.swift
@@ -300,7 +300,7 @@ private extension SPAboutViewController {
         }
 
         let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(NSLocalizedString("OK", comment: ""))
+        alertController.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Closes alert controller for spinner on About view"))
         present(alertController, animated: true, completion: nil)
     }
 

--- a/Simplenote/Classes/SPAboutViewController.swift
+++ b/Simplenote/Classes/SPAboutViewController.swift
@@ -14,7 +14,7 @@ class SPAboutViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         view.backgroundColor = .simplenoteBlue50Color
 
         setupContainerView()
@@ -230,7 +230,7 @@ extension SPAboutViewController: UITableViewDataSource {
 
         cell.textLabel?.text = Constants.titles[indexPath.row]
         cell.detailTextLabel?.text = Constants.descriptions[indexPath.row]
-        
+
         cell.textLabel?.textColor = .white
         cell.detailTextLabel?.textColor = .simplenoteBlue10Color
         cell.detailTextLabel?.font = .preferredFont(forTextStyle: .subheadline)
@@ -239,7 +239,7 @@ extension SPAboutViewController: UITableViewDataSource {
         let bgColorView = UIView()
         bgColorView.backgroundColor = .simplenoteBlue30Color
         cell.selectedBackgroundView = bgColorView
-        
+
         let arrowAccessoryView = UIImageView(image: .image(name: .arrowTopRight))
         arrowAccessoryView.tintColor = .simplenoteBlue10Color
         arrowAccessoryView.frame = CGRect(x: 0, y: 0, width: Constants.cellAccessorySideSize, height: Constants.cellAccessorySideSize)
@@ -253,13 +253,13 @@ extension SPAboutViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate Conformance
 //
 extension SPAboutViewController: UITableViewDelegate {
-    
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         UIApplication.shared.open(Constants.urls[indexPath.row])
         tableView.deselectRow(at: indexPath, animated: false)
     }
-    
-    @objc func onDoneTap(_ sender:UIButton) {
+
+    @objc func onDoneTap(_ sender: UIButton) {
         dismiss(animated: true)
     }
 }

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -61,7 +61,7 @@ extension SPAuthError {
     var message: String {
         switch self {
         case .loginBadCredentials:
-            return NSLocalizedString("Could not login with the provided email address and password.", comment: "Message displayed when login fails");
+            return NSLocalizedString("Could not login with the provided email address and password.", comment: "Message displayed when login fails")
         case .signupBadCredentials:
             return NSLocalizedString("Could not create an account with the provided email address and password.", comment: "Error for bad email or password")
         case .signupUserAlreadyExists:

--- a/Simplenote/Classes/SPBlurEffectView.swift
+++ b/Simplenote/Classes/SPBlurEffectView.swift
@@ -11,7 +11,7 @@ class SPBlurEffectView: UIVisualEffectView {
     ///
     private let tintView: UIView = {
         let output = UIView()
-        output.autoresizingMask = [.flexibleWidth, .flexibleHeight];
+        output.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         return output
     }()
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -90,7 +90,7 @@ extension SPNoteEditorViewController {
         interlinkProcessor.delegate = self
         interlinkProcessor.contextProvider = self
     }
-    
+
     /// Sets up the Keyboard
     ///
     @objc
@@ -800,14 +800,14 @@ extension SPNoteEditorViewController {
         let textStorage = noteEditorTextView.interactiveTextStorage
 
         textStorage.defaultStyle = [
-            .font               : defaultFont,
-            .foregroundColor    : textColor,
-            .paragraphStyle     : NSMutableParagraphStyle(lineSpacing: lineSpacing)
+            .font: defaultFont,
+            .foregroundColor: textColor,
+            .paragraphStyle: NSMutableParagraphStyle(lineSpacing: lineSpacing)
         ]
 
         textStorage.headlineStyle = [
-            .font               : headlineFont,
-            .foregroundColor    : textColor,
+            .font: headlineFont,
+            .foregroundColor: textColor,
         ]
     }
 
@@ -858,7 +858,7 @@ extension SPNoteEditorViewController {
         }
 
         let searchMapView = SearchMapView()
-        
+
         view.addSubview(searchMapView)
         NSLayoutConstraint.activate([
             searchMapView.topAnchor.constraint(equalTo: noteEditorTextView.topAnchor, constant: noteEditorTextView.adjustedContentInset.top),

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -384,14 +384,14 @@ extension SPNoteListViewController {
         }
         open(note, ignoringSearchQuery: true, animated: true)
     }
-    
+
     /// Sets the state of the trash button
     ///
     @objc
     func refreshEmptyTrashState() {
         let isTrashOnScreen = self.isDeletedFilterActive
         let isNotEmpty = !self.isListEmpty
-        
+
         emptyTrashButton.isEnabled = isTrashOnScreen && isNotEmpty
     }
 }
@@ -860,13 +860,13 @@ extension SPNoteListViewController {
 
     @objc(keyboardWillChangeFrame:)
     func keyboardWillChangeFrame(note: Notification) {
-        
+
         guard let _ = view.window else {
             // No window means we aren't in the view hierarchy.
             // Asking UITableView to refresh layout when not in the view hierarcy results in console warnings.
             return
         }
-        
+
         guard let keyboardFrame = (note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
             return
         }

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -424,8 +424,7 @@ private extension NSAttributedString {
                               textColor: UIColor,
                               highlighing keywords: [String]?,
                               highlightColor: UIColor,
-                              paragraphStyle: NSParagraphStyle) -> NSAttributedString
-    {
+                              paragraphStyle: NSParagraphStyle) -> NSAttributedString {
         let output = NSMutableAttributedString(string: string, attributes: [
             .font: font,
             .foregroundColor: textColor,

--- a/Simplenote/Classes/SPRatingsPromptView.swift
+++ b/Simplenote/Classes/SPRatingsPromptView.swift
@@ -198,31 +198,31 @@ private extension State {
     var title: String {
         switch self {
         case .initial:
-            return NSLocalizedString("What do you think about Simplenote?", comment: "")
+            return NSLocalizedString("What do you think about Simplenote?", comment: "Rating view initial title")
         case .liked:
-            return NSLocalizedString("Great! Mind leaving a review to tell us what you like?", comment: "")
+            return NSLocalizedString("Great! Mind leaving a review to tell us what you like?", comment: "Rating view liked title")
         case .disliked:
-            return NSLocalizedString("Could you tell us how we could improve?", comment: "")
+            return NSLocalizedString("Could you tell us how we could improve?", comment: "Rating view disliked title")
         }
     }
 
     var leftTitle: String {
         switch self {
         case .initial:
-            return NSLocalizedString("I like it", comment: "")
+            return NSLocalizedString("I like it", comment: "Rating view - initial - liked button")
         case .liked:
-            return NSLocalizedString("Leave a review", comment: "")
+            return NSLocalizedString("Leave a review", comment: "Rating view - liked - leave review button")
         case .disliked:
-            return NSLocalizedString("Send feedback", comment: "")
+            return NSLocalizedString("Send feedback", comment: "Rating view - disliked - send feedback button")
         }
     }
 
     var rightTitle: String {
         switch self {
         case .initial:
-            return NSLocalizedString("Could be better", comment: "")
+            return NSLocalizedString("Could be better", comment: "Rating view - initial - could be better button")
         case .liked, .disliked:
-            return NSLocalizedString("No thanks", comment: "")
+            return NSLocalizedString("No thanks", comment: "Rating view - liked or disliked - no thanks button")
         }
     }
 }

--- a/Simplenote/Classes/SPSimpleTextPrintFormatter.swift
+++ b/Simplenote/Classes/SPSimpleTextPrintFormatter.swift
@@ -3,7 +3,7 @@ import UIKit
 class SPSimpleTextPrintFormatter: UISimpleTextPrintFormatter {
     override init(text: String) {
         super.init(text: text)
-        
+
         // Check for darkmode
         // If dark mode is enabled change the text color to black before printing
         if SPUserInterface.isDark {

--- a/Simplenote/Classes/SPTextInputView.swift
+++ b/Simplenote/Classes/SPTextInputView.swift
@@ -4,7 +4,7 @@ import Foundation
 // MARK: - SPTextInputViewDelegate
 //
 @objc
-protocol SPTextInputViewDelegate : NSObjectProtocol {
+protocol SPTextInputViewDelegate: NSObjectProtocol {
 
     @objc optional
     func textInputDidBeginEditing(_ textInput: SPTextInputView)

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -93,7 +93,7 @@ extension UIColor {
     static var simplenoteGray80Color: UIColor {
         UIColor(studioColor: .gray80)
     }
-    
+
     @objc
     static var simplenoteGray100Color: UIColor {
         UIColor(studioColor: .gray100)

--- a/Simplenote/Classes/UIKeyCommand+Simplenote.swift
+++ b/Simplenote/Classes/UIKeyCommand+Simplenote.swift
@@ -21,7 +21,7 @@ extension UIKeyCommand {
                      action: Selector,
                      title: String? = nil) {
         self.init(input: input, modifierFlags: modifierFlags, action: action)
-        
+
         if let title = title {
             if #available(iOS 13.0, *) {
                 self.title = title

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -101,7 +101,7 @@ extension UITextView {
     /// Returns the Interlinking Keyword at the current Location (if any)
     ///
     var interlinkKeywordAtSelectedLocation: (Range<String.Index>, Range<String.Index>, String)? {
-        guard let text = text, let range = Range(selectedRange, in: text) else{
+        guard let text = text, let range = Range(selectedRange, in: text) else {
             return nil
         }
 

--- a/Simplenote/Information/NoteInformationController.swift
+++ b/Simplenote/Information/NoteInformationController.swift
@@ -144,7 +144,7 @@ private extension NoteInformationController {
         let referenceRows = references.map { (note) -> Row in
             let date = DateFormatter.dateFormatter.string(from: note.modificationDate)
             let value = "\(Localization.interlinkReferences(references.count)), \(Localization.lastModified(date))"
-            
+
             return .reference(interLink: note.plainInternalLink,
                               title: note.titlePreview,
                               reference: value)
@@ -178,15 +178,15 @@ private struct Localization {
     static let words = NSLocalizedString("Words", comment: "Number of words in the note")
     static let characters = NSLocalizedString("Characters", comment: "Number of characters in the note")
     static let references = NSLocalizedString("Referenced In", comment: "References section header on Info Card")
-    
+
     private static let referenceSigular = NSLocalizedString("%i Reference", comment: "Count of interlink references to a note")
     private static let referencePlural = NSLocalizedString("%i References", comment: "Count of interlink references to a note")
-    
+
     static func interlinkReferences(_ references: Int) -> String {
         let template = references > 1 ? referencePlural : referenceSigular
         return String(format: template, references)
     }
-    
+
     private static let lastModified = NSLocalizedString("Last Modified %1$@", comment: "Date of note last modified. Parameter: %1$@ - formatted date")
     static func lastModified(_ dateString: String) -> String {
         return String(format: lastModified, dateString)

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -63,7 +63,7 @@ final class NoteInformationViewController: UIViewController {
         super.viewDidLayoutSubviews()
         additionalSafeAreaInsets = Consts.tableViewSafeAreaInsets
     }
-    
+
     override func accessibilityPerformEscape() -> Bool {
         dismiss(animated: true, completion: nil)
         return true
@@ -96,7 +96,7 @@ private extension NoteInformationViewController {
                                                             style: .done,
                                                             target: self,
                                                             action: #selector(handleTapOnDismissButton))
-        
+
     }
 
     func configureViews() {
@@ -121,7 +121,7 @@ private extension NoteInformationViewController {
     func refreshPreferredSize() {
         preferredContentSize = tableView.contentSize
     }
-    
+
     private func configureDragBar() {
         dragBar.isHidden = navigationController != nil
         dragBar.accessibilityLabel = Localization.dismissAccessibilityLabel
@@ -131,7 +131,7 @@ private extension NoteInformationViewController {
             dragBar.addGestureRecognizer(gestureRecognizer)
         }
     }
-    
+
     @objc
     func informationSheetToBeDismissed() {
         dismiss(animated: true, completion: nil)
@@ -222,9 +222,9 @@ extension NoteInformationViewController: UITableViewDataSource {
 
     private func updateSeparator(for cell: UITableViewCell, at indexPath: IndexPath) {
         let row = sections[indexPath.section].rows[indexPath.row]
-        
+
         switch row {
-        case .header(_):
+        case .header:
             cell.adjustSeparatorWidth(width: .standard)
         default:
             if indexPath.row == sections[indexPath.section].rows.count - 1 {

--- a/Simplenote/KeychainPasswordItem.swift
+++ b/Simplenote/KeychainPasswordItem.swift
@@ -21,24 +21,24 @@ enum KeychainError: Error {
 struct KeychainPasswordItem {
 
     // MARK: Properties
-    
+
     let service: String
-    
+
     private(set) var account: String
-    
+
     let accessGroup: String?
 
     // MARK: Intialization
-    
+
     init(service: String, account: String, accessGroup: String? = nil) {
         self.service = service
         self.account = account
         self.accessGroup = accessGroup
     }
-    
+
     // MARK: Keychain access
-    
-    func readPassword() throws -> String  {
+
+    func readPassword() throws -> String {
         /*
             Build a query to find the item that matches the service, account and
             access group.
@@ -47,43 +47,43 @@ struct KeychainPasswordItem {
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         query[kSecReturnAttributes as String] = kCFBooleanTrue
         query[kSecReturnData as String] = kCFBooleanTrue
-        
+
         // Try to fetch the existing keychain item that matches the query.
         var queryResult: AnyObject?
         let status = withUnsafeMutablePointer(to: &queryResult) {
             SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
         }
-        
+
         // Check the return status and throw an error if appropriate.
         guard status != errSecItemNotFound else { throw KeychainError.noPassword }
         guard status == noErr else { throw KeychainError.unhandledError(status: status) }
-        
+
         // Parse the password string from the query result.
-        guard let existingItem = queryResult as? [String : AnyObject],
+        guard let existingItem = queryResult as? [String: AnyObject],
             let passwordData = existingItem[kSecValueData as String] as? Data,
             let password = String(data: passwordData, encoding: String.Encoding.utf8)
         else {
             throw KeychainError.unexpectedPasswordData
         }
-        
+
         return password
     }
-    
+
     func savePassword(_ password: String) throws {
         // Encode the password into an Data object.
         let encodedPassword = password.data(using: String.Encoding.utf8)!
-        
+
         do {
             // Check for an existing item in the keychain.
             try _ = readPassword()
 
             // Update the existing item with the new password.
-            var attributesToUpdate = [String : AnyObject]()
+            var attributesToUpdate = [String: AnyObject]()
             attributesToUpdate[kSecValueData as String] = encodedPassword as AnyObject?
 
             let query = KeychainPasswordItem.keychainQuery(withService: service, account: account, accessGroup: accessGroup)
             let status = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
-            
+
             // Throw an error if an unexpected status was returned.
             guard status == noErr else { throw KeychainError.unhandledError(status: status) }
         }
@@ -94,76 +94,76 @@ struct KeychainPasswordItem {
             */
             var newItem = KeychainPasswordItem.keychainQuery(withService: service, account: account, accessGroup: accessGroup)
             newItem[kSecValueData as String] = encodedPassword as AnyObject?
-            
+
             // Add a the new item to the keychain.
             let status = SecItemAdd(newItem as CFDictionary, nil)
-            
+
             // Throw an error if an unexpected status was returned.
             guard status == noErr else { throw KeychainError.unhandledError(status: status) }
         }
     }
-    
+
     mutating func renameAccount(_ newAccountName: String) throws {
         // Try to update an existing item with the new account name.
-        var attributesToUpdate = [String : AnyObject]()
+        var attributesToUpdate = [String: AnyObject]()
         attributesToUpdate[kSecAttrAccount as String] = newAccountName as AnyObject?
-        
+
         let query = KeychainPasswordItem.keychainQuery(withService: service, account: self.account, accessGroup: accessGroup)
         let status = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
-        
+
         // Throw an error if an unexpected status was returned.
         guard status == noErr || status == errSecItemNotFound else { throw KeychainError.unhandledError(status: status) }
-        
+
         self.account = newAccountName
     }
-    
+
     func deleteItem() throws {
         // Delete the existing item from the keychain.
         let query = KeychainPasswordItem.keychainQuery(withService: service, account: account, accessGroup: accessGroup)
         let status = SecItemDelete(query as CFDictionary)
-        
+
         // Throw an error if an unexpected status was returned.
         guard status == noErr || status == errSecItemNotFound else { throw KeychainError.unhandledError(status: status) }
     }
-    
+
     static func passwordItems(forService service: String, accessGroup: String? = nil) throws -> [KeychainPasswordItem] {
         // Build a query for all items that match the service and access group.
         var query = KeychainPasswordItem.keychainQuery(withService: service, accessGroup: accessGroup)
         query[kSecMatchLimit as String] = kSecMatchLimitAll
         query[kSecReturnAttributes as String] = kCFBooleanTrue
         query[kSecReturnData as String] = kCFBooleanFalse
-        
+
         // Fetch matching items from the keychain.
         var queryResult: AnyObject?
         let status = withUnsafeMutablePointer(to: &queryResult) {
             SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
         }
-        
+
         // If no items were found, return an empty array.
         guard status != errSecItemNotFound else { return [] }
 
         // Throw an error if an unexpected status was returned.
         guard status == noErr else { throw KeychainError.unhandledError(status: status) }
-        
+
         // Cast the query result to an array of dictionaries.
-        guard let resultData = queryResult as? [[String : AnyObject]] else { throw KeychainError.unexpectedItemData }
-        
+        guard let resultData = queryResult as? [[String: AnyObject]] else { throw KeychainError.unexpectedItemData }
+
         // Create a `KeychainPasswordItem` for each dictionary in the query result.
         var passwordItems = [KeychainPasswordItem]()
         for result in resultData {
             guard let account  = result[kSecAttrAccount as String] as? String else { throw KeychainError.unexpectedItemData }
-            
+
             let passwordItem = KeychainPasswordItem(service: service, account: account, accessGroup: accessGroup)
             passwordItems.append(passwordItem)
         }
-        
+
         return passwordItems
     }
 
     // MARK: Convenience
-    
-    private static func keychainQuery(withService service: String, account: String? = nil, accessGroup: String? = nil) -> [String : AnyObject] {
-        var query = [String : AnyObject]()
+
+    private static func keychainQuery(withService service: String, account: String? = nil, accessGroup: String? = nil) -> [String: AnyObject] {
+        var query = [String: AnyObject]()
         query[kSecClass as String] = kSecClassGenericPassword
         query[kSecAttrService as String] = service as AnyObject?
 
@@ -174,7 +174,7 @@ struct KeychainPasswordItem {
         if let accessGroup = accessGroup {
             query[kSecAttrAccessGroup as String] = accessGroup as AnyObject?
         }
-        
+
         return query
     }
 }

--- a/Simplenote/NSTextStorage+Simplenote.swift
+++ b/Simplenote/NSTextStorage+Simplenote.swift
@@ -20,7 +20,7 @@ extension NSTextStorage {
 
             addAttribute(.backgroundColor, value: color, range: range)
         }
-        
+
         endEditing()
     }
 }

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -163,7 +163,7 @@ extension Options {
         defaults.removeObject(forKey: .searchSortMode)
         defaults.removeObject(forKey: .useBiometryInsteadOfPin)
     }
-    
+
     /// Returns the number of Preview Lines we should use, per note
     ///
     @objc

--- a/Simplenote/SPDragBar.swift
+++ b/Simplenote/SPDragBar.swift
@@ -5,20 +5,20 @@ class SPDragBar: UIView {
         super.init(frame: frame)
         configure()
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configure()
     }
-    
+
     private func configure() {
         let color = UIColor(lightColor: ColorStudio.black, darkColor: ColorStudio.white)
-        
+
         backgroundColor = color
         alpha = 0.2
         layer.cornerRadius = 2.5
         layer.masksToBounds = true
-        
+
         isAccessibilityElement = true
     }
 }

--- a/Simplenote/SPPinLockManager.swift
+++ b/Simplenote/SPPinLockManager.swift
@@ -26,28 +26,28 @@ class SPPinLockManager: NSObject {
         if maxTimeoutSeconds == 0 {
             return false
         }
-        
+
         var ts = timespec.init()
         clock_gettime(CLOCK_MONOTONIC_RAW, &ts)
         let nowSeconds = max(0, Int(ts.tv_sec)) // The running clock time of the device
-        
+
         // User may have recently rebooted their device, so we'll enforce lock screen
         if lastUsedSeconds > nowSeconds {
             return false
         }
-        
+
         let intervalSinceLastUsed = nowSeconds - lastUsedSeconds
-        return intervalSinceLastUsed < maxTimeoutSeconds;
+        return intervalSinceLastUsed < maxTimeoutSeconds
     }
-    
+
     private var pinLockTimeoutSeconds: Int {
         let timeoutPref = UserDefaults.standard.integer(forKey: kPinTimeoutPreferencesKey)
         let timeoutValues = [0, 15, 30, 60, 120, 180, 240, 300]
-        
+
         if timeoutPref > timeoutValues.count {
             return 0
         }
-        
+
         return timeoutValues[timeoutPref]
     }
 

--- a/Simplenote/SPPrivacyViewController.swift
+++ b/Simplenote/SPPrivacyViewController.swift
@@ -89,7 +89,7 @@ class SPPrivacyViewController: SPTableViewController {
 }
 
 
-// MARK - Event Handlers
+// MARK: - Event Handlers
 //
 extension SPPrivacyViewController {
 

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -509,7 +509,7 @@ extension TagListViewController: TagListViewCellDelegate {
         }
 
         alertController.addCancelActionWithTitle(Localization.TagDeletionConfirmation.cancellationButton)
-        
+
         alertController.popoverPresentationController?.sourceRect = cell.bounds
         alertController.popoverPresentationController?.sourceView = cell
         alertController.popoverPresentationController?.permittedArrowDirections = .any

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -848,13 +848,13 @@ private struct Constants {
 private struct Localization {
     static let edit = NSLocalizedString("Edit", comment: "Edit Tags Action: Visible in the Tags List")
     static let rename = NSLocalizedString("Rename", comment: "Rename a tag")
-    static let done = NSLocalizedString("Done", comment: "")
+    static let done = NSLocalizedString("Done", comment: "Done editing tags")
 
-    static let allNotes = NSLocalizedString("All Notes", comment: "")
-    static let trash = NSLocalizedString("Trash-noun", comment: "")
-    static let settings = NSLocalizedString("Settings", comment: "")
+    static let allNotes = NSLocalizedString("All Notes", comment: "All Notes filter button")
+    static let trash = NSLocalizedString("Trash-noun", comment: "Trash filter button")
+    static let settings = NSLocalizedString("Settings", comment: "Settings button")
 
-    static let tags = NSLocalizedString("Tags", comment: "")
+    static let tags = NSLocalizedString("Tags", comment: "Tags List Header")
     static let untaggedNotes = NSLocalizedString("Untagged Notes", comment: "Allows selecting notes with no tags")
 
     struct TagDeletionConfirmation {

--- a/Simplenote/UIActivityViewController+Simplenote.swift
+++ b/Simplenote/UIActivityViewController+Simplenote.swift
@@ -18,7 +18,7 @@ extension UIActivityViewController {
         let source = SimplenoteActivityItemSource(note: note)
 
         self.init(activityItems: [print, source], applicationActivities: nil)
-        
+
         // Share to ibooks feature that is added by the SimpleTextPrintFormatter requires a locally generated PDF or the share fails silently
         // After much discussion the decision was to not implement a PDF generator into SN at this time, removing share to books as an option.
         excludedActivityTypes = [

--- a/Simplenote/UIView+Constraints.swift
+++ b/Simplenote/UIView+Constraints.swift
@@ -40,7 +40,7 @@ extension UIView {
 
     func pinSubviewToCenter(_ view: UIView) {
         view.translatesAutoresizingMaskIntoConstraints = false
-        
+
         let constraints = [
             view.centerXAnchor.constraint(equalTo: centerXAnchor),
             view.centerYAnchor.constraint(equalTo: centerYAnchor)

--- a/Simplenote/Verification/AccountVerificationViewController.swift
+++ b/Simplenote/Verification/AccountVerificationViewController.swift
@@ -118,7 +118,7 @@ private extension AccountVerificationViewController {
         let alertController = UIAlertController(title: configuration.errorMessageTitle,
                                                 message: Localization.errorMessage,
                                                 preferredStyle: .alert)
-        
+
         alertController.addDefaultActionWithTitle(Localization.okButton)
 
         present(alertController, animated: true, completion: nil)

--- a/SimplenoteShare/Presentation/ExtensionPresentationController.swift
+++ b/SimplenoteShare/Presentation/ExtensionPresentationController.swift
@@ -126,7 +126,7 @@ extension ExtensionPresentationController: KeyboardObservable {
         if let animationCurve = animationCurve {
             animationOptions = UIView.AnimationOptions(rawValue: animationCurve)
         }
-        
+
         UIView.animate(withDuration: duration, delay: 0.0, options: animationOptions, animations: {
             self.presentedView?.frame = translatedFrame
         })

--- a/SimplenoteShare/Simperium/Note.swift
+++ b/SimplenoteShare/Simperium/Note.swift
@@ -42,13 +42,13 @@ class Note {
         }
 
         return [
-            "tags":             [],
-            "deleted":          0,
-            "shareURL":         String(),
-            "publishURL":       String(),
-            "content":          content,
-            "systemTags":       systemTags,
-            "creationDate":     creationDate.timeIntervalSince1970,
+            "tags": [],
+            "deleted": 0,
+            "shareURL": String(),
+            "publishURL": String(),
+            "content": content,
+            "systemTags": systemTags,
+            "creationDate": creationDate.timeIntervalSince1970,
             "modificationDate": modificationDate.timeIntervalSince1970
         ]
     }

--- a/SimplenoteShare/ViewControllers/SharePresentationController.swift
+++ b/SimplenoteShare/ViewControllers/SharePresentationController.swift
@@ -59,7 +59,7 @@ private extension SharePresentationController {
         ]
         navbarAppearance.isTranslucent = false
 
-        let barButtonTitleAttributes: [NSAttributedString.Key : Any] = [
+        let barButtonTitleAttributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: UIColor.simplenoteTintColor
         ]
 

--- a/SimplenoteTests/EmailVerificationTests.swift
+++ b/SimplenoteTests/EmailVerificationTests.swift
@@ -30,7 +30,7 @@ class EmailVerificationTests: XCTestCase {
     }
 
     func testEmailVerificationIgnoresBrokenPayload() {
-        let payload : [AnyHashable: Any] = [
+        let payload: [AnyHashable: Any] = [
             "token": #"{"user": "1234"}"#,
             "sent_to": 1234
         ]

--- a/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
+++ b/SimplenoteTests/NSMutableAttributedStringStylingTests.swift
@@ -12,7 +12,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         let string = "This is a badly formed todo - [ ] Buy avocados - []"
         let regex = NSRegularExpression.regexForChecklists
         let matches = regex.matches(in: string, options: [], range: string.fullRange)
-        
+
         XCTAssertTrue(matches.isEmpty)
     }
 
@@ -52,7 +52,7 @@ class NSMutableAttributedStringStylingTests: XCTestCase {
         let string = "ToDo\n\n- [ ] Buy avocados\n- [ ] Ship it\n- [x ] Malformed!\n- [x] Correct."
         let regex = NSRegularExpression.regexForChecklists
         let matches = regex.matches(in: string, options: [], range: string.fullRange)
-        
+
         XCTAssertEqual(matches.count, 3)
     }
 

--- a/SimplenoteTests/NSStringSimplenoteTests.swift
+++ b/SimplenoteTests/NSStringSimplenoteTests.swift
@@ -16,14 +16,14 @@ class NSStringSimplenoteTests: XCTestCase {
 
         XCTAssertTrue(expectedSet.isSuperset(of: escapedSet))
     }
-    
+
     /// Verifies that `byEncodingAsTagHash` effectively escapes special characters
     ///
     func testByEncodingAsTagHashEncodesAllOfSpecialCharacters() {
         let string = String("TáßvĒёи兔子@#$%^&*+-=_`~/?., ><{}[]\\()\"|':;")
         let hash = string.byEncodingAsTagHash
         let expected = "t%C3%A1%C3%9Fv%C4%93%D1%91%D0%B8%E5%85%94%E5%AD%90%40%23%24%25%5E%26%2A%2B%2D%3D%5F%60%7E%2F%3F%2E%2C%20%3E%3C%7B%7D%5B%5D%5C%28%29%22%7C%27%3A%3B"
-        
+
         XCTAssertEqual(hash, expected)
     }
 
@@ -39,7 +39,7 @@ class NSStringSimplenoteTests: XCTestCase {
             ["\u{0073}\u{0323}\u{0307}", "\u{0073}\u{0307}\u{0323}", "\u{1E69}"], // ṩ
             ["\u{0065}\u{0301}", "\u{00E9}"] // é
         ]
-        
+
         for sample in differentStringsOneHashSamples {
             testNonEqualStringsCreateSameHash(sample)
         }
@@ -49,7 +49,7 @@ class NSStringSimplenoteTests: XCTestCase {
 extension NSStringSimplenoteTests {
     private func testNonEqualStringsCreateSameHash(_ samples: [String]) {
         let sampleToTest = samples[0]
-        
+
         for i in 1..<samples.count {
             XCTAssertNotEqual((sampleToTest as NSString), (samples[i] as NSString))
             XCTAssertEqual(sampleToTest.byEncodingAsTagHash, samples[i].byEncodingAsTagHash)

--- a/SimplenoteTests/OptionsTests.swift
+++ b/SimplenoteTests/OptionsTests.swift
@@ -57,4 +57,3 @@ class OptionsTests: XCTestCase {
         XCTAssert(options.theme == .light)
     }
 }
-


### PR DESCRIPTION
Fixes #1022 

*Edit: * changing to use ~~Swift Package Manager~~ existing rake binary of SwiftLint in PR #1143 rather than using Cocoapods.

### Fix
Making changes suggested by SwiftLint.

### Screenshots
![Screen Shot 2021-02-09 at 4 42 23 PM](https://user-images.githubusercontent.com/13263478/107438466-1f074000-6af6-11eb-8760-6c7441a1a25d.png)

### Test
1. Build Simplenote
2. See that there are errors/warnings showing up in warnings pane on sidebar when there are SwiftLint errors.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

**Note: I separated out the whitespace/etc changes from the NSLocalizedString comment changes in separate commits for easier reviewing.**

### Release
These changes do not require release notes.
