### PR TITLE
Fix keyboard navigation in search bar

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -941,10 +941,11 @@ extension SPNoteListViewController {
     open override var keyCommands: [UIKeyCommand]? {
         var commands = tableCommands
         if isSearchActive {
-            commands.append(contentsOf: [
-                UIKeyCommand(input: "f", modifierFlags: [.command, .shift], action: #selector(keyboardStopSearching)),
-                UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(keyboardStopSearching))
-            ])
+            commands.append(UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(keyboardStopSearching)))
+
+            if searchBar.isFirstResponder {
+                commands.append(UIKeyCommand(input: "f", modifierFlags: [.command, .shift], action: #selector(keyboardStopSearching)))
+            }
         }
         return commands
     }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -943,6 +943,8 @@ extension SPNoteListViewController {
         if isSearchActive {
             commands.append(UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(keyboardStopSearching)))
 
+            // We add this shortcut only when search bar is first responder because when it's not we don't want to clear the search.
+            // The shortcut that actually focuses on the searchbar is located in `SPSidebarContainerViewController`. This is done to make shortcut work from multiple screens
             if searchBar.isFirstResponder {
                 commands.append(UIKeyCommand(input: "f", modifierFlags: [.command, .shift], action: #selector(keyboardStopSearching)))
             }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -959,12 +959,17 @@ extension SPNoteListViewController {
 //
 private extension SPNoteListViewController {
     var tableCommands: [UIKeyCommand] {
-        [
+        var commands = [
             UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(keyboardUp)),
             UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(keyboardDown)),
-            UIKeyCommand(input: UIKeyCommand.inputReturn, modifierFlags: [], action: #selector(keyboardSelect)),
-            UIKeyCommand(input: UIKeyCommand.inputTrailingArrow, modifierFlags: [], action: #selector(keyboardSelect)),
+            UIKeyCommand(input: UIKeyCommand.inputReturn, modifierFlags: [], action: #selector(keyboardSelect))
         ]
+
+        if isFirstResponder {
+            commands.append(UIKeyCommand(input: UIKeyCommand.inputTrailingArrow, modifierFlags: [], action: #selector(keyboardSelect)))
+        }
+
+        return commands
     }
 
     @objc


### PR DESCRIPTION
### Fix
This PR:
* fixes keyboard navigation in search bar as described in #1151 
* adjusts `cmd + shift + f` so that it dismisses the search only when search bar is the first responder

Closes #1151 
Ref #1111

### Test
1. Activate search bar

- [x] Check that both left and right arrows can be used to navigate entered text
- [x] Open one of the notes and come back to the note list
- [ ] Check that pressing `cmd + shift + f` will bring focus to search bar

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
