### PR TITLE
Tags editor, showing autocomplete: MK4

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.33
 -----
 -   Updating new-note and collaborate icons #1103
+-   Updating tags editor #990
  
 4.32
 -----

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		A60A1A1E25655D840041701E /* ApplicationShortcutItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60A1A1D25655D840041701E /* ApplicationShortcutItemType.swift */; };
 		A60DF30825A44F0F00FDADF3 /* PinLockRemoveController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60DF30725A44F0F00FDADF3 /* PinLockRemoveController.swift */; };
 		A60DF31025A4524100FDADF3 /* PinLockBaseController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60DF30F25A4524100FDADF3 /* PinLockBaseController.swift */; };
+		A61471A825D6BC700065D849 /* NoteEditorTagSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61471A625D6BC700065D849 /* NoteEditorTagSuggestionsViewController.swift */; };
+		A61471A925D6BC700065D849 /* NoteEditorTagSuggestionsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A61471A725D6BC700065D849 /* NoteEditorTagSuggestionsViewController.xib */; };
 		A61471B825D70C190065D849 /* PopoverViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A61471B625D70C190065D849 /* PopoverViewController.xib */; };
 		A61471B925D70C190065D849 /* PopoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61471B725D70C190065D849 /* PopoverViewController.swift */; };
 		A6344AD9255952C70072FA07 /* NoteContentPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6344AD8255952C70072FA07 /* NoteContentPreviewTests.swift */; };
@@ -568,6 +570,8 @@
 		A60A1A1D25655D840041701E /* ApplicationShortcutItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ApplicationShortcutItemType.swift; path = Classes/ApplicationShortcutItemType.swift; sourceTree = "<group>"; };
 		A60DF30725A44F0F00FDADF3 /* PinLockRemoveController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLockRemoveController.swift; sourceTree = "<group>"; };
 		A60DF30F25A4524100FDADF3 /* PinLockBaseController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLockBaseController.swift; sourceTree = "<group>"; };
+		A61471A625D6BC700065D849 /* NoteEditorTagSuggestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorTagSuggestionsViewController.swift; sourceTree = "<group>"; };
+		A61471A725D6BC700065D849 /* NoteEditorTagSuggestionsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteEditorTagSuggestionsViewController.xib; sourceTree = "<group>"; };
 		A61471B625D70C190065D849 /* PopoverViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = PopoverViewController.xib; path = Classes/PopoverViewController.xib; sourceTree = "<group>"; };
 		A61471B725D70C190065D849 /* PopoverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PopoverViewController.swift; path = Classes/PopoverViewController.swift; sourceTree = "<group>"; };
 		A6344AD8255952C70072FA07 /* NoteContentPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteContentPreviewTests.swift; sourceTree = "<group>"; };
@@ -1222,6 +1226,8 @@
 			children = (
 				A6C0DFE525C18E3300B9BE39 /* NoteEditorTagListViewController.swift */,
 				A6C0DFE625C18E3300B9BE39 /* NoteEditorTagListViewController.xib */,
+				A61471A625D6BC700065D849 /* NoteEditorTagSuggestionsViewController.swift */,
+				A61471A725D6BC700065D849 /* NoteEditorTagSuggestionsViewController.xib */,
 			);
 			path = Tags;
 			sourceTree = "<group>";
@@ -2265,6 +2271,7 @@
 				B537732B252E176C00BC78C5 /* OptionsViewController.xib in Resources */,
 				B56A696222F9D53400B90398 /* SPAuthViewController.xib in Resources */,
 				B546BEA0234F6DA000A126DA /* SPTagHeaderView.xib in Resources */,
+				A61471A925D6BC700065D849 /* NoteEditorTagSuggestionsViewController.xib in Resources */,
 				A69F861D25408085005140F2 /* NoteInformationViewController.xib in Resources */,
 				B513F2B62319A8F40021CFA4 /* SPNoteTableViewCell.xib in Resources */,
 				B5078A001C1F5595009F097A /* markdown-dark.css in Resources */,
@@ -2524,6 +2531,7 @@
 				B5BE054E1AB75902002417BF /* NSProcessInfo+Util.m in Sources */,
 				375D24B821E01131007AB25A /* hash.c in Sources */,
 				A6D5AE6525483F8A00326C76 /* NSTextStorage+Simplenote.swift in Sources */,
+				A61471A825D6BC700065D849 /* NoteEditorTagSuggestionsViewController.swift in Sources */,
 				A6E02758256E52F3002054DF /* PinLockController.swift in Sources */,
 				B5CBEF4022D3AD92009DBE67 /* MigrationsHandler.swift in Sources */,
 				B5476BBF23D8B686000E7723 /* NotesListSection.swift in Sources */,

--- a/Simplenote/Classes/PassthruView.swift
+++ b/Simplenote/Classes/PassthruView.swift
@@ -5,8 +5,17 @@ import Foundation
 //
 class PassthruView: UIView {
 
+    /// Callback is invoked when interacted with this view and not with subviews
+    ///
+    var onInteraction: (() -> Void)?
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let output = super.hitTest(point, with: event)
-        return output != self ? output : nil
+        if output == self {
+            onInteraction?()
+            return nil
+        }
+
+        return output
     }
 }

--- a/Simplenote/Classes/PopoverViewController.swift
+++ b/Simplenote/Classes/PopoverViewController.swift
@@ -15,8 +15,11 @@ class PopoverViewController: UIViewController {
     ///
     @IBOutlet private(set) var containerLeftConstraint: NSLayoutConstraint!
     @IBOutlet private(set) var containerMaxHeightConstraint: NSLayoutConstraint!
-    @IBOutlet private(set) var containerTopToTopConstraint: NSLayoutConstraint!
-    @IBOutlet private(set) var containerTopToBottomConstraint: NSLayoutConstraint!
+
+    /// Setting the following constraints via XIB resulted in weird behaviour
+    ///
+    private(set) var containerTopToTopConstraint: NSLayoutConstraint!
+    private(set) var containerTopToBottomConstraint: NSLayoutConstraint!
 
     private let viewController: UIViewController
 
@@ -49,6 +52,8 @@ class PopoverViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupContainerConstraints()
+
         setupRootView()
         setupBackgroundView()
         setupContainerView()
@@ -61,6 +66,12 @@ class PopoverViewController: UIViewController {
 // MARK: - Initialization
 //
 private extension PopoverViewController {
+
+    func setupContainerConstraints() {
+        containerTopToTopConstraint = containerView.topAnchor.constraint(equalTo: view.topAnchor)
+        containerTopToBottomConstraint = containerView.bottomAnchor.constraint(equalTo: view.topAnchor)
+        containerTopToTopConstraint.isActive = true
+    }
 
     func setupRootView() {
         view.backgroundColor = .clear

--- a/Simplenote/Classes/PopoverViewController.swift
+++ b/Simplenote/Classes/PopoverViewController.swift
@@ -20,6 +20,22 @@ class PopoverViewController: UIViewController {
 
     private let viewController: UIViewController
 
+    private var passthruView: PassthruView? {
+        return view as? PassthruView
+    }
+
+    /// Callback is invoked when interacted with passthru view
+    ///
+    var onInteractionWithPassthruView: (() -> Void)? {
+        get {
+            passthruView?.onInteraction
+        }
+
+        set {
+            passthruView?.onInteraction = newValue
+        }
+    }
+
     init(viewController: UIViewController) {
         self.viewController = viewController
         super.init(nibName: nil, bundle: nil)

--- a/Simplenote/Classes/PopoverViewController.swift
+++ b/Simplenote/Classes/PopoverViewController.swift
@@ -67,6 +67,12 @@ private extension PopoverViewController {
     }
 
     func setupContainerViewController() {
+        if viewController.parent != nil && viewController.parent != self {
+            viewController.willMove(toParent: nil)
+            viewController.view.removeFromSuperview()
+            viewController.removeFromParent()
+        }
+
         addChild(viewController)
         containerView.addFillingSubview(viewController.view)
         viewController.didMove(toParent: self)

--- a/Simplenote/Classes/PopoverViewController.swift
+++ b/Simplenote/Classes/PopoverViewController.swift
@@ -94,15 +94,7 @@ private extension PopoverViewController {
     }
 
     func setupContainerViewController() {
-        if viewController.parent != nil && viewController.parent != self {
-            viewController.willMove(toParent: nil)
-            viewController.view.removeFromSuperview()
-            viewController.removeFromParent()
-        }
-
-        addChild(viewController)
-        containerView.addFillingSubview(viewController.view)
-        viewController.didMove(toParent: self)
+        viewController.attach(to: self, attachmentView: .into(containerView))
     }
 }
 

--- a/Simplenote/Classes/PopoverViewController.xib
+++ b/Simplenote/Classes/PopoverViewController.xib
@@ -12,8 +12,6 @@
                 <outlet property="backgroundView" destination="ZZD-kk-l5T" id="qtg-b7-9Gr"/>
                 <outlet property="containerLeftConstraint" destination="tlN-Bu-zsm" id="kxU-Vv-S0w"/>
                 <outlet property="containerMaxHeightConstraint" destination="qFL-0w-6D3" id="ieM-EN-hGD"/>
-                <outlet property="containerTopToBottomConstraint" destination="wTC-1b-rhI" id="HBv-wZ-rbL"/>
-                <outlet property="containerTopToTopConstraint" destination="L9L-3d-8l6" id="qxf-HC-0B3"/>
                 <outlet property="containerView" destination="w5c-DK-13l" id="uv8-F9-RLX"/>
                 <outlet property="shadowView" destination="J1j-Rs-BRd" id="WaX-Uj-fdG"/>
                 <outlet property="view" destination="URg-NP-0Et" id="xef-Np-8pC"/>
@@ -25,7 +23,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J1j-Rs-BRd" customClass="SPShadowView" customModule="Simplenote" customModuleProvider="target">
-                    <rect key="frame" x="16" y="12" width="300" height="50"/>
+                    <rect key="frame" x="16" y="50" width="300" height="50"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -43,7 +41,7 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZZD-kk-l5T">
-                    <rect key="frame" x="16" y="12" width="300" height="50"/>
+                    <rect key="frame" x="16" y="50" width="300" height="50"/>
                     <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="vc0-Cc-xE6">
                         <rect key="frame" x="0.0" y="0.0" width="300" height="50"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -64,7 +62,7 @@
                     <blurEffect style="regular"/>
                 </visualEffectView>
                 <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w5c-DK-13l">
-                    <rect key="frame" x="16" y="12" width="300" height="50"/>
+                    <rect key="frame" x="16" y="50" width="300" height="50"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="lessThanOrEqual" constant="50" id="qFL-0w-6D3"/>
@@ -76,7 +74,7 @@
             <constraints>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="trailing" secondItem="w5c-DK-13l" secondAttribute="trailing" id="GQW-Zr-OPQ"/>
                 <constraint firstItem="w5c-DK-13l" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="URg-NP-0Et" secondAttribute="leading" constant="16" id="Jqg-de-oqa"/>
-                <constraint firstItem="w5c-DK-13l" firstAttribute="top" secondItem="URg-NP-0Et" secondAttribute="top" constant="12" id="L9L-3d-8l6"/>
+                <constraint firstItem="w5c-DK-13l" firstAttribute="top" secondItem="URg-NP-0Et" secondAttribute="top" constant="50" placeholder="YES" id="L9L-3d-8l6"/>
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="bottom" secondItem="w5c-DK-13l" secondAttribute="bottom" id="OWv-8b-18z"/>
                 <constraint firstItem="ZZD-kk-l5T" firstAttribute="bottom" secondItem="w5c-DK-13l" secondAttribute="bottom" id="Ven-kl-5Fy"/>
                 <constraint firstItem="ZZD-kk-l5T" firstAttribute="top" secondItem="w5c-DK-13l" secondAttribute="top" id="Vk8-Oc-6T3"/>
@@ -85,15 +83,9 @@
                 <constraint firstItem="J1j-Rs-BRd" firstAttribute="top" secondItem="w5c-DK-13l" secondAttribute="top" id="mrP-al-Lvg"/>
                 <constraint firstItem="ZZD-kk-l5T" firstAttribute="leading" secondItem="w5c-DK-13l" secondAttribute="leading" id="nhs-nR-Anb"/>
                 <constraint firstItem="w5c-DK-13l" firstAttribute="left" secondItem="URg-NP-0Et" secondAttribute="left" priority="999" id="tlN-Bu-zsm"/>
-                <constraint firstItem="w5c-DK-13l" firstAttribute="bottom" secondItem="URg-NP-0Et" secondAttribute="top" constant="12" id="wTC-1b-rhI"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="w5c-DK-13l" secondAttribute="trailing" constant="16" id="wY4-ah-MFc"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="wTC-1b-rhI"/>
-                </mask>
-            </variation>
             <point key="canvasLocation" x="-84.057971014492765" y="-3.0133928571428572"/>
         </view>
     </objects>

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -707,9 +707,12 @@ extension SPNoteEditorViewController: InterlinkProcessorDelegate {
 extension SPNoteEditorViewController {
     @objc
     func configureTagListViewController() {
+        let popoverPresenter = self.popoverPresenter
+        popoverPresenter.dismissOnInteractionWithPassthruView = true
         tagListViewController = NoteEditorTagListViewController(note: note, popoverPresenter: popoverPresenter)
-        addChild(tagListViewController)
 
+        addChild(tagListViewController)
+        
         tagView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tagView)
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -86,14 +86,6 @@ extension SPNoteEditorViewController {
     ///
     @objc
     func configureInterlinksProcessor() {
-        let viewportProvider = { [weak self] () -> CGRect in
-            self?.noteEditorTextView.editingRectInWindow() ?? .zero
-        }
-
-        let popoverPresenter = PopoverPresenter(containerViewController: self,
-                                                viewportProvider: viewportProvider,
-                                                siblingView: navigationBarBackground)
-
         interlinkProcessor = InterlinkProcessor(viewContext: SPAppDelegate.shared().managedObjectContext,
                                                 popoverPresenter: popoverPresenter,
                                                 parentTextView: noteEditorTextView,
@@ -115,6 +107,16 @@ extension SPNoteEditorViewController {
         noteEditorTextView.onContentPositionChange = { [weak self] in
             self?.updateTagListPosition()
         }
+    }
+
+    private var popoverPresenter: PopoverPresenter {
+        let viewportProvider = { [weak self] () -> CGRect in
+            self?.noteEditorTextView.editingRectInWindow() ?? .zero
+        }
+
+        return PopoverPresenter(containerViewController: self,
+                                viewportProvider: viewportProvider,
+                                siblingView: navigationBarBackground)
     }
 }
 
@@ -705,7 +707,7 @@ extension SPNoteEditorViewController: InterlinkProcessorDelegate {
 extension SPNoteEditorViewController {
     @objc
     func configureTagListViewController() {
-        tagListViewController = NoteEditorTagListViewController(note: note)
+        tagListViewController = NoteEditorTagListViewController(note: note, popoverPresenter: popoverPresenter)
         addChild(tagListViewController)
 
         tagView.translatesAutoresizingMaskIntoConstraints = false

--- a/Simplenote/Classes/TagView.swift
+++ b/Simplenote/Classes/TagView.swift
@@ -57,6 +57,23 @@ class TagView: UIView {
         }
     }
 
+    var addTagFieldText: String? {
+        get {
+            addTagField.text
+        }
+
+        set {
+            addTagField.text = newValue
+        }
+    }
+
+    var addTagFieldFrameInWindow: CGRect {
+        var frame = addTagField.convert(addTagField.bounds, to: self)
+        frame.origin.y = 0
+        frame.size.height = frame.size.height
+        return convert(frame, to: nil)
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()

--- a/Simplenote/Classes/UIViewController+Simplenote.swift
+++ b/Simplenote/Classes/UIViewController+Simplenote.swift
@@ -5,6 +5,12 @@ import UIKit
 // MARK: - UIAlertController's Simplenote Methods
 //
 extension UIViewController {
+    /// View to use to attach another view controller
+    ///
+    enum AttachmentView {
+        case below(UIView)
+        case into(UIView)
+    }
 
     /// Presents the receiver from the RootViewController's leaf
     ///
@@ -27,27 +33,58 @@ extension UIViewController {
         leafViewController.present(self, animated: true, completion: nil)
     }
 
+
     /// Attaches a children ViewController (if needed) below the specified sibling view
     ///
-    func attachWithAnimation(to parent: UIViewController, below siblingView: UIView? = nil) {
-        parent.addChild(self)
-        if let siblingView = siblingView {
-            parent.view.insertSubview(view, belowSubview: siblingView)
-        } else {
-            parent.view.addSubview(view)
+    func attach(to parent: UIViewController, attachmentView: AttachmentView? = nil, animated: Bool = false) {
+        guard self.parent != parent else {
+            return
         }
-        parent.view.pinSubviewToAllEdges(view)
-        view.fadeIn()
-        didMove(toParent: parent)
+        detach()
+
+        parent.addChild(self)
+
+        let attachmentView = attachmentView ?? .into(parent.view)
+        switch attachmentView {
+        case .below(let siblingView):
+            siblingView.superview?.insertSubview(view, belowSubview: siblingView)
+            siblingView.superview?.pinSubviewToAllEdges(view)
+        case .into(let containerView):
+            containerView.addFillingSubview(view)
+        }
+
+        let taskBlock = {
+            self.didMove(toParent: parent)
+        }
+
+        if animated {
+            view.fadeIn { _ in
+                taskBlock()
+            }
+        } else {
+            taskBlock()
+        }
     }
 
     /// Detaches the receiver from its parent
     ///
-    func detachWithAnimation() {
-        willMove(toParent: nil)
-        view.fadeOut { _ in
+    func detach(animated: Bool = false) {
+        guard parent != nil else {
+            return
+        }
+
+        let taskBlock = {
             self.view.removeFromSuperview()
             self.removeFromParent()
+        }
+
+        willMove(toParent: nil)
+        if animated {
+            view.fadeOut { _ in
+                taskBlock()
+            }
+        } else {
+            taskBlock()
         }
     }
 }

--- a/Simplenote/HuggableTableView.swift
+++ b/Simplenote/HuggableTableView.swift
@@ -75,7 +75,7 @@ class HuggableTableView: UITableView {
         let rect = rectForRow(at: IndexPath(row: lastRow, section: 0))
 
         let fractionalPart = min(numberOfRows, CGFloat(totalRows)).truncatingRemainder(dividingBy: 1)
-        if fractionalPart > 0.01 {
+        if fractionalPart > .leastNormalMagnitude {
             return rect.minY + rect.height * fractionalPart
         }
 

--- a/Simplenote/PopoverPresenter.swift
+++ b/Simplenote/PopoverPresenter.swift
@@ -47,7 +47,10 @@ final class PopoverPresenter {
                 self?.dismiss()
             }
         }
-        popoverController?.attachWithAnimation(to: containerViewController, below: siblingView)
+
+        popoverController?.attach(to: containerViewController,
+                                  attachmentView: siblingView.map({ .below($0) }),
+                                  animated: true)
 
         relocate(around: anchorInWindow)
     }
@@ -91,7 +94,7 @@ final class PopoverPresenter {
     }
 
     func dismiss() {
-        popoverController?.detachWithAnimation()
+        popoverController?.detach(animated: true)
         popoverController = nil
     }
 }

--- a/Simplenote/PopoverPresenter.swift
+++ b/Simplenote/PopoverPresenter.swift
@@ -19,6 +19,10 @@ final class PopoverPresenter {
         return popoverController != nil
     }
 
+    /// Should popover be dismissed when user interacts with passthru view
+    ///
+    var dismissOnInteractionWithPassthruView: Bool = false
+
     /// Init
     ///
     init(containerViewController: UIViewController,
@@ -38,6 +42,11 @@ final class PopoverPresenter {
         self.desiredHeight = desiredHeight
 
         popoverController = PopoverViewController(viewController: viewController)
+        popoverController?.onInteractionWithPassthruView = { [weak self] in
+            if self?.dismissOnInteractionWithPassthruView == true {
+                self?.dismiss()
+            }
+        }
         popoverController?.attachWithAnimation(to: containerViewController, below: siblingView)
 
         relocate(around: anchorInWindow)

--- a/Simplenote/Tags/NoteEditorTagSuggestionsViewController.swift
+++ b/Simplenote/Tags/NoteEditorTagSuggestionsViewController.swift
@@ -10,6 +10,7 @@ class NoteEditorTagSuggestionsViewController: UIViewController {
             tableView.separatorColor = .simplenoteDividerColor
             tableView.tableFooterView = UIView()
             tableView.alwaysBounceVertical = false
+            tableView.backgroundColor = .clear
 
             tableView.maxNumberOfVisibleRows = Metrics.maxNumberOfVisibleRows
         }
@@ -39,6 +40,11 @@ class NoteEditorTagSuggestionsViewController: UIViewController {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
     }
 
     /// Update with keywords. Tags containing keywords that are not already in the note will be suggested

--- a/Simplenote/Tags/NoteEditorTagSuggestionsViewController.swift
+++ b/Simplenote/Tags/NoteEditorTagSuggestionsViewController.swift
@@ -93,6 +93,11 @@ extension NoteEditorTagSuggestionsViewController: UITableViewDataSource {
         cell.separatorInset = .zero
         return cell
     }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        // "Drops" the last separator!
+        .leastNonzeroMagnitude
+    }
 }
 
 

--- a/Simplenote/Tags/NoteEditorTagSuggestionsViewController.swift
+++ b/Simplenote/Tags/NoteEditorTagSuggestionsViewController.swift
@@ -1,0 +1,103 @@
+import UIKit
+
+
+// MARK: - NoteEditorTagSuggestionsViewController
+//
+class NoteEditorTagSuggestionsViewController: UIViewController {
+    @IBOutlet private weak var tableView: HuggableTableView! {
+        didSet {
+            tableView.register(Value1TableViewCell.self, forCellReuseIdentifier: Value1TableViewCell.reuseIdentifier)
+            tableView.separatorColor = .simplenoteDividerColor
+            tableView.tableFooterView = UIView()
+            tableView.alwaysBounceVertical = false
+
+            tableView.maxNumberOfVisibleRows = Metrics.maxNumberOfVisibleRows
+        }
+    }
+
+    private let note: Note
+    private let objectManager = SPObjectManager.shared()
+
+    private var data: [String] = []
+
+    /// Called when row is selected
+    ///
+    var onSelectionCallback: ((String) -> Void)?
+
+    /// Is empty
+    ///
+    var isEmpty: Bool {
+        return data.isEmpty
+    }
+
+    /// Init
+    ///
+    init(note: Note) {
+        self.note = note
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Update with keywords. Tags containing keywords that are not already in the note will be suggested
+    ///
+    func update(with keywords: String?) {
+        let keywords = (keywords ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !keywords.isEmpty else {
+            reload(with: [])
+            return
+        }
+
+        let tags = objectManager.tags()
+            .filter { tag in
+                !note.hasTag(tag.name) && tag.name.range(of: keywords, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+            }
+            .compactMap { tag in
+                tag.name
+            }
+
+        reload(with: tags)
+    }
+
+    private func reload(with data: [String]) {
+        self.data = data
+        // Can be called before view is loaded
+        tableView?.reloadData()
+    }
+}
+
+
+// MARK: - UITableViewDelegate
+//
+extension NoteEditorTagSuggestionsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: false)
+        onSelectionCallback?(data[indexPath.row])
+    }
+}
+
+
+// MARK: - UITableViewDataSource
+//
+extension NoteEditorTagSuggestionsViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return data.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(ofType: Value1TableViewCell.self, for: indexPath)
+        cell.title = data[indexPath.row]
+        cell.backgroundColor = .clear
+        cell.separatorInset = .zero
+        return cell
+    }
+}
+
+
+// MARK: - Metrics
+//
+private struct Metrics {
+    static let maxNumberOfVisibleRows: CGFloat = 3.5
+}

--- a/Simplenote/Tags/NoteEditorTagSuggestionsViewController.xib
+++ b/Simplenote/Tags/NoteEditorTagSuggestionsViewController.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteEditorTagSuggestionsViewController" customModule="Simplenote" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="Jdb-1I-B1t" id="2IP-dR-ZVH"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="372" height="410"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Jdb-1I-B1t" customClass="HuggableTableView" customModule="Simplenote" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="372" height="410"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="XKP-BS-QQs"/>
+                        <outlet property="delegate" destination="-1" id="dDQ-Y9-DuX"/>
+                    </connections>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="Jdb-1I-B1t" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="9fx-mG-SMr"/>
+                <constraint firstAttribute="trailing" secondItem="Jdb-1I-B1t" secondAttribute="trailing" id="TgQ-el-SF3"/>
+                <constraint firstItem="Jdb-1I-B1t" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="kaO-co-cbx"/>
+                <constraint firstAttribute="bottom" secondItem="Jdb-1I-B1t" secondAttribute="bottom" id="qgh-pp-WZA"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="-69.565217391304358" y="-170.08928571428569"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
### Details
In this PR we're bringing back tags autocomplete using the same popover style used for interlinks.

Closes #990 

### Screenshots

|||
|-|-|
|![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 19 41 57](https://user-images.githubusercontent.com/54751/107984955-6a738f80-6fc9-11eb-933a-1c3c70f105ce.png)|![Simulator Screen Shot - iPhone 12 - 2021-02-15 at 19 42 40](https://user-images.githubusercontent.com/54751/107984965-6e071680-6fc9-11eb-8946-c128d77d6770.png)|

### Test
1. Make sure you have some tags
2. Open a note
3. Start adding a new tag

- [x] Autocomplete popup is shown if there is a tag that contains input string
- [x] Tags that are already in the note are excluded
- [x] Maximum 3.5 rows are visible
- [x] Interaction with the editor hides autocomplete popup

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
`RELEASE-NOTES.txt` was updated in 6cc592d5 with:
> Updating tags editor.
