### PR TITLE
UIAutomation: Adjusted setUp() and setUpWithError() methods to speed up execution

### DIFF
--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/SimplenoteUITests.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/SimplenoteUITests.xcscheme
@@ -21,6 +21,77 @@
                BlueprintName = "SimplenoteUITests"
                ReferencedContainer = "container:Simplenote.xcodeproj">
             </BuildableReference>
+            <SelectedTests>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsLogin/testLogInWithCorrectCredentials()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsLogin/testLogInWithExistingEmailIncorrectPassword()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsLogin/testLogInWithInvalidEmail()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsLogin/testLogInWithNoEmail()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsLogin/testLogInWithNoEmailNoPassword()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsLogin/testLogInWithNoPassword()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsLogin/testLogInWithTooShortPassword()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsLogin/testLogOut()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testAddedURLIsLinkified()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testBulletedLists()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testCanFlipToEditMode()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testCanPreviewMarkdownBySwiping()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testCreateCheckedItem()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testCreateUncheckedItem()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testLongTappingOnLinkOpensLinkInNewWindow()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testTappingOnLinkInPreviewOpensLinkInNewWindow()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testUndoUndoesTheLastEdit()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsNoteEditor/testUsingInsertChecklistInsertsChecklist()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsTrash/testCanDeleteNoteForeverIndividually()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsTrash/testCanDeleteNotesForeverViaEmpty()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsTrash/testCanRestoreNote()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsTrash/testCanTrashNote()">
+               </Test>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsTrash/testCanViewTrashedNotes()">
+               </Test>
+            </SelectedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/SimplenoteUITests/AllNotes.swift
+++ b/SimplenoteUITests/AllNotes.swift
@@ -79,7 +79,7 @@ class AllNotes {
 class AllNotesAssert {
 
     class func noteExists(noteName: String) {
-        print(">>> Asseting existence of note: " + noteName)
+        print(">>> Asserting note existsence: " + noteName)
         XCTAssertTrue(app.tables.cells[noteName].exists, "\"" + noteName + noteNotFoundInAllNotes)
     }
 

--- a/SimplenoteUITests/AllNotes.swift
+++ b/SimplenoteUITests/AllNotes.swift
@@ -28,7 +28,7 @@ class AllNotes {
         NoteEditor.leaveEditor()
     }
 
-    class func createNotes(noteNamesArray: Array<String>) {
+    class func createNotes(names: Array<String>) {
         for noteName in noteNamesArray {
             createNoteAndLeaveEditor(noteName: noteName)
         }

--- a/SimplenoteUITests/AllNotes.swift
+++ b/SimplenoteUITests/AllNotes.swift
@@ -7,18 +7,18 @@ class AllNotes {
     }
 
     class func isOpen() -> Bool {
-        return app.navigationBars[uidNavBar_AllNotes].exists
+        return app.navigationBars[UID.NavBar.AllNotes].exists
     }
 
     class func open() {
         guard !isOpen() else { return }
 
-        app.navigationBars.element.buttons[uidButton_Menu].tap()
-        app.tables.staticTexts[uidButton_AllNotes].tap()
+        app.navigationBars.element.buttons[UID.Button.Menu].tap()
+        app.tables.staticTexts[UID.Button.AllNotes].tap()
     }
 
     class func addNoteTap() {
-        app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_NewNote].tap()
+        app.navigationBars[UID.NavBar.AllNotes].buttons[UID.Button.NewNote].tap()
     }
 
     class func createNoteAndLeaveEditor(noteName: String) {
@@ -28,8 +28,8 @@ class AllNotes {
         NoteEditor.leaveEditor()
     }
 
-    class func createNotes(names: Array<String>) {
-        for noteName in noteNamesArray {
+    class func createNotes(names: [String]) {
+        for noteName in names {
             createNoteAndLeaveEditor(noteName: noteName)
         }
     }
@@ -61,14 +61,14 @@ class AllNotes {
         for _ in 0..<notesNumber {
             let cell = app.tables.cells.element(boundBy: startingIndex)
             cell.swipeLeft()
-            cell.buttons[uidButton_NoteCell_Trash].tap()
+            cell.buttons[UID.Button.NoteCellTrash].tap()
         }
     }
 
     class func waitForLoad() {
-        let allNotesNavBar = app.navigationBars[uidNavBar_AllNotes]
+        let allNotesNavBar = app.navigationBars[UID.NavBar.AllNotes]
         let predicate = NSPredicate { _, _ in
-            allNotesNavBar.staticTexts[uidText_AllNotes_InProgress].exists == false
+            allNotesNavBar.staticTexts[UID.Text.AllNotesInProgress].exists == false
         }
 
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: .none)
@@ -83,8 +83,8 @@ class AllNotesAssert {
         XCTAssertTrue(app.tables.cells[noteName].exists, "\"" + noteName + noteNotFoundInAllNotes)
     }
 
-    class func notesExist(noteNamesArray: Array<String>) {
-        for noteName in noteNamesArray {
+    class func notesExist(names: [String]) {
+        for noteName in names {
             AllNotesAssert.noteExists(noteName: noteName)
         }
     }
@@ -99,6 +99,6 @@ class AllNotesAssert {
     }
 
     class func screenShown() {
-        XCTAssertTrue(app.navigationBars[uidNavBar_AllNotes].waitForExistence(timeout: maxLoadTimeout), uidNavBar_AllNotes + navBarNotFound)
+        XCTAssertTrue(app.navigationBars[UID.NavBar.AllNotes].waitForExistence(timeout: maxLoadTimeout), UID.NavBar.AllNotes + navBarNotFound)
     }
 }

--- a/SimplenoteUITests/AllNotes.swift
+++ b/SimplenoteUITests/AllNotes.swift
@@ -5,27 +5,33 @@ class AllNotes {
     class func openNote(noteName: String) {
         app.tables.cells[noteName].tap()
     }
-    
+
     class func isOpen() -> Bool {
         return app.navigationBars[uidNavBar_AllNotes].exists
     }
 
-    class func open() {        
+    class func open() {
         guard !isOpen() else { return }
-        
+
         app.navigationBars.element.buttons[uidButton_Menu].tap()
         app.tables.staticTexts[uidButton_AllNotes].tap()
     }
 
     class func addNoteTap() {
-        print(">>> Adding new note...")
         app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_NewNote].tap()
     }
 
-    class func createNoteAndLeaveEditor (noteName: String) {
+    class func createNoteAndLeaveEditor(noteName: String) {
+        print(">>> Creating note: " + noteName)
         AllNotes.addNoteTap()
         NoteEditor.clearAndEnterText(enteredValue: noteName)
         NoteEditor.leaveEditor()
+    }
+
+    class func createNotes(noteNamesArray: Array<String>) {
+        for noteName in noteNamesArray {
+            createNoteAndLeaveEditor(noteName: noteName)
+        }
     }
 
     class func trashNote(noteName: String) {
@@ -37,6 +43,8 @@ class AllNotes {
     }
 
     class func clearAllNotes() {
+        AllNotes.open()
+
         let notesNumber = AllNotes.getNotesNumber()
         let cellsNum = app.tables.element.children(matching: .cell).count
         var startingIndex: Int
@@ -56,13 +64,13 @@ class AllNotes {
             cell.buttons[uidButton_NoteCell_Trash].tap()
         }
     }
-    
+
     class func waitForLoad() {
         let allNotesNavBar = app.navigationBars[uidNavBar_AllNotes]
         let predicate = NSPredicate { _, _ in
             allNotesNavBar.staticTexts[uidText_AllNotes_InProgress].exists == false
         }
-        
+
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: .none)
         XCTWaiter().wait(for: [expectation], timeout: 10)
     }
@@ -71,7 +79,14 @@ class AllNotes {
 class AllNotesAssert {
 
     class func noteExists(noteName: String) {
+        print(">>> Asseting existence of note: " + noteName)
         XCTAssertTrue(app.tables.cells[noteName].exists, "\"" + noteName + noteNotFoundInAllNotes)
+    }
+
+    class func notesExist(noteNamesArray: Array<String>) {
+        for noteName in noteNamesArray {
+            AllNotesAssert.noteExists(noteName: noteName)
+        }
     }
 
     class func noteAbsent(noteName: String) {

--- a/SimplenoteUITests/AssertGeneric.swift
+++ b/SimplenoteUITests/AssertGeneric.swift
@@ -74,10 +74,10 @@ class Assert {
     }
 
     class func signUpLogInScreenShown() {
-        XCTAssertTrue(app.images[uidPicture_AppLogo].waitForExistence(timeout: minLoadTimeout), uidPicture_AppLogo + imageNotFound)
-        XCTAssertTrue(app.staticTexts[text_AppName].waitForExistence(timeout: minLoadTimeout), text_AppName + labelNotFound)
-        XCTAssertTrue(app.staticTexts[text_AppTagline].waitForExistence(timeout: minLoadTimeout), text_AppTagline + labelNotFound)
-        XCTAssertTrue(app.buttons[uidButton_SignUp].waitForExistence(timeout: minLoadTimeout), uidButton_SignUp + buttonNotFound)
-        XCTAssertTrue(app.buttons[uidButton_LogIn].waitForExistence(timeout: minLoadTimeout), uidButton_LogIn + buttonNotFound)
+        XCTAssertTrue(app.images[UID.Picture.AppLogo].waitForExistence(timeout: minLoadTimeout), UID.Picture.AppLogo + imageNotFound)
+        XCTAssertTrue(app.staticTexts[Text.AppName].waitForExistence(timeout: minLoadTimeout), Text.AppName + labelNotFound)
+        XCTAssertTrue(app.staticTexts[Text.AppTagline].waitForExistence(timeout: minLoadTimeout), Text.AppTagline + labelNotFound)
+        XCTAssertTrue(app.buttons[UID.Button.SignUp].waitForExistence(timeout: minLoadTimeout), UID.Button.SignUp + buttonNotFound)
+        XCTAssertTrue(app.buttons[UID.Button.LogIn].waitForExistence(timeout: minLoadTimeout), UID.Button.LogIn + buttonNotFound)
     }
 }

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -7,6 +7,13 @@ class EmailLogin {
         app.buttons[uidButton_LogInWithEmail].tap()
     }
 
+    class func close() {
+        let backButton = app.navigationBars["Log In"].buttons[uidButton_Back]
+        guard backButton.exists else { return }
+
+        backButton.tap()
+    }
+
     class func logIn(email: String, password: String) {
         enterEmail(enteredValue: email)
         enterPassword(enteredValue: password)

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -8,7 +8,7 @@ class EmailLogin {
     }
 
     class func close() {
-        let backButton = app.navigationBars["Log In"].buttons[uidButton_Back]
+        let backButton = app.navigationBars[uidNavBar_LogIn].buttons[uidButton_Back]
         guard backButton.exists else { return }
 
         backButton.tap()

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -3,12 +3,12 @@ import XCTest
 class EmailLogin {
 
     class func open() {
-        app.buttons[uidButton_LogIn].tap()
-        app.buttons[uidButton_LogInWithEmail].tap()
+        app.buttons[UID.Button.LogIn].tap()
+        app.buttons[UID.Button.LogInWithEmail].tap()
     }
 
     class func close() {
-        let backButton = app.navigationBars[uidNavBar_LogIn].buttons[uidButton_Back]
+        let backButton = app.navigationBars[UID.NavBar.LogIn].buttons[UID.Button.Back]
         guard backButton.exists else { return }
 
         backButton.tap()
@@ -17,17 +17,17 @@ class EmailLogin {
     class func logIn(email: String, password: String) {
         enterEmail(enteredValue: email)
         enterPassword(enteredValue: password)
-        app.buttons[uidButton_LogIn].tap()
+        app.buttons[UID.Button.LogIn].tap()
     }
 
     class func enterEmail(enteredValue: String) {
-        let field = app.textFields[uidTextField_Email]
+        let field = app.textFields[UID.TextField.Email]
         field.tap()
         field.typeText(enteredValue)
     }
 
     class func enterPassword(enteredValue: String) {
-        let field = app.secureTextFields[uidTextField_Password]
+        let field = app.secureTextFields[UID.TextField.Password]
         field.tap()
         field.typeText(enteredValue)
     }

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -3,7 +3,7 @@ import XCTest
 private var stepIndex = 0
 
 func attemptLogOut() -> Bool {
-    let allNotesNavBar = app.navigationBars[uidNavBar_AllNotes]
+    let allNotesNavBar = app.navigationBars[UID.NavBar.AllNotes]
     var loggedOut: Bool = false
 
     if allNotesNavBar.exists {
@@ -16,10 +16,10 @@ func attemptLogOut() -> Bool {
 }
 
 func logOut() -> Bool {
-    app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_Menu].tap()
-    app.tables.staticTexts[uidCell_Settings].tap()
-    app.tables.staticTexts[uidButton_Settings_LogOut].tap()
-    return app.buttons[uidButton_LogIn].waitForExistence(timeout: maxLoadTimeout)
+    app.navigationBars[UID.NavBar.AllNotes].buttons[UID.Button.Menu].tap()
+    app.tables.staticTexts[UID.Cell.Settings].tap()
+    app.tables.staticTexts[UID.Button.SettingsLogOut].tap()
+    return app.buttons[UID.Button.LogIn].waitForExistence(timeout: maxLoadTimeout)
 }
 
 func trackTest(_ function: String = #function) {
@@ -64,14 +64,14 @@ class Table {
     class func trashNote(noteName: String) {
         app.tables.cells[noteName].swipeLeft()
         sleep(1)
-        app.tables.cells[noteName].buttons[uidButton_NoteCell_Trash].tap()
+        app.tables.cells[noteName].buttons[UID.Button.NoteCellTrash].tap()
     }
 }
 
 class WebView {
 
     class func tapDone() {
-        let doneButton = app.buttons[uidButton_Done]
+        let doneButton = app.buttons[UID.Button.Done]
         guard doneButton.exists else { return }
         doneButton.tap()
     }
@@ -93,7 +93,7 @@ class Alert {
         let alert = app.alerts.element
         guard alert.exists else { return }
 
-        let confirmPredicate = NSPredicate(format: "label == '" + uidButton_Accept + "' || label == 'AnythingElse'")
+        let confirmPredicate = NSPredicate(format: "label == '" + UID.Button.Accept + "' || label == 'AnythingElse'")
         let confirmationButton = alert.buttons.element(matching: confirmPredicate)
         guard confirmationButton.exists else { return }
 

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -32,6 +32,12 @@ func trackStep() {
     stepIndex += 1
 }
 
+func getToAllNotes() {
+    WebView.tapDone()
+    Preview.leavePreviewViaBackButton()
+    NoteEditor.leaveEditor()
+}
+
 class Table {
 
     class func getNotesNumber() -> Int {
@@ -65,7 +71,9 @@ class Table {
 class WebView {
 
     class func tapDone() {
-        app.buttons[uidButton_Done].tap()
+        let doneButton = app.buttons[uidButton_Done]
+        guard doneButton.exists else { return }
+        doneButton.tap()
     }
 }
 
@@ -76,5 +84,19 @@ class WebViewAssert {
         let staticText = app.staticTexts.element(matching: textPredicate)
 
         XCTAssertTrue(staticText.exists, "\"" + textToFind + textNotFoundInWebView)
+    }
+}
+
+class Alert {
+
+    class func closeAny() {
+        let alert = app.alerts.element
+        guard alert.exists else { return }
+
+        let confirmPredicate = NSPredicate(format: "label == '" + uidButton_Accept + "' || label == 'AnythingElse'")
+        let confirmationButton = alert.buttons.element(matching: confirmPredicate)
+        guard confirmationButton.exists else { return }
+
+        confirmationButton.tap()
     }
 }

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -17,7 +17,7 @@ class NoteEditor {
     class func setFocus() {
         app.textViews.firstMatch.tap()
     }
-    
+
     class func undo() {
         app.textViews.element.tap(withNumberOfTaps: 2, numberOfTouches: 3)
         app.otherElements["UIUndoInteractiveHUD"].children(matching: .other).element(boundBy: 1).children(matching: .other).element(boundBy: 1).tap()
@@ -29,7 +29,10 @@ class NoteEditor {
     }
 
     class func leaveEditor() {
-        app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_NoteEditor_AllNotes].tap()
+        let backButton = app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_NoteEditor_AllNotes]
+        guard backButton.exists else { return }
+
+        backButton.tap()
     }
 
     class func toggleMarkdownState() {
@@ -41,7 +44,7 @@ class NoteEditor {
     class func insertChecklist() {
         app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_NoteEditor_Checklist].tap()
     }
-    
+
     class func markdownEnable() {
         swipeToPreview()
 
@@ -54,9 +57,8 @@ class NoteEditor {
 
     class func markdownDisable() {
         swipeToPreview()
-
         guard app.navigationBars[uidNavBar_NoteEditor_Preview].exists else { return }
-        
+
         Preview.leavePreviewViaBackButton()
         toggleMarkdownState()
     }
@@ -66,28 +68,27 @@ class NoteEditor {
         app.textViews[containerText].links[linkifiedText].press(forDuration: 1.3)
         sleep(4)
     }
-    
+
     class func getAllTextViews() -> XCUIElementQuery {
         // If we are in Note Editor, and there's zero TextViews, we should try setting focus first
         if app.descendants(matching: .textView).count < 1 {
             NoteEditor.setFocus()
         }
-        
+
         return app.descendants(matching: .textView)
     }
-    
+
     class func getCheckboxesForTextCount(text: String) -> Int {
         let matchesCount = NoteEditor.getTextViewsWithExactLabelCount(label: text)
         print(">>> ^ Found " + String(matchesCount) + " Checkboxe(s) for '" + text + "'")
         return matchesCount
     }
-    
+
     class func getTextViewsWithExactValueCount(value: String) -> Int {
         let textViews = getAllTextViews()
         var matchesCounter = 0
 
-        for index in 0...textViews.count - 1
-        {
+        for index in 0...textViews.count - 1 {
             let currentValue = textViews.element(boundBy: index).value as! String
             let currentValueStripped = currentValue.replacingOccurrences(of: "\u{fffc}", with: "")
 
@@ -95,11 +96,11 @@ class NoteEditor {
                 matchesCounter += 1
             }
         }
-        
+
         print(">>> Found " + String(matchesCounter) + " TextView(s) with '" + value + "' value")
         return matchesCounter
     }
-    
+
     class func getTextViewsWithExactLabelCount(label: String) -> Int {
         let _ = getAllTextViews()// To initialize the editor
         let predicate = NSPredicate(format: "label == '" + label + "'")
@@ -108,7 +109,7 @@ class NoteEditor {
         print(">>> Found " + String(matchesCount) + " TextView(s) with '" + label + "' label")
         return matchesCount
     }
-    
+
 }
 
 class NoteEditorAssert {
@@ -133,23 +134,28 @@ class NoteEditorAssert {
         let matchesCount = NoteEditor.getTextViewsWithExactValueCount(value: value)
         XCTAssertEqual(1, matchesCount)
     }
-        
+
+    class func textViewWithExactValueNotShown(value: String) {
+        let matchesCount = NoteEditor.getTextViewsWithExactValueCount(value: value)
+        XCTAssertEqual(0, matchesCount)
+    }
+
     class func textViewWithExactLabelShownOnce(label: String) {
         let matchesCount = NoteEditor.getTextViewsWithExactLabelCount(label: label)
         XCTAssertEqual(1, matchesCount)
     }
-    
+
     class func textViewWithExactLabelsShownOnce(labelsArray: Array<String>) {
         for label in labelsArray {
             NoteEditorAssert.textViewWithExactLabelShownOnce(label: label)
         }
     }
-    
+
     class func checkboxForTextShownOnce(text: String) {
         let matchesCount = NoteEditor.getCheckboxesForTextCount(text: text)
         XCTAssertEqual(1, matchesCount)
     }
-    
+
     class func checkboxForTextNotShown(text: String) {
         let matchesCount = NoteEditor.getCheckboxesForTextCount(text: text)
         XCTAssertEqual(0, matchesCount)

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -29,26 +29,26 @@ class NoteEditor {
     }
 
     class func leaveEditor() {
-        let backButton = app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_NoteEditor_AllNotes]
+        let backButton = app.navigationBars[UID.NavBar.AllNotes].buttons[UID.Button.NoteEditorAllNotes]
         guard backButton.exists else { return }
 
         backButton.tap()
     }
 
     class func toggleMarkdownState() {
-        app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_NoteEditor_Menu].tap()
-        app.tables.staticTexts[uidText_NoteEditor_Options_Markdown].tap()
-        app.navigationBars[uidNavBar_NoteEditor_Options].buttons[uidButton_Done].tap()
+        app.navigationBars[UID.NavBar.AllNotes].buttons[UID.Button.NoteEditorMenu].tap()
+        app.tables.staticTexts[UID.Text.NoteEditorOptionsMarkdown].tap()
+        app.navigationBars[UID.NavBar.NoteEditorOptions].buttons[UID.Button.Done].tap()
     }
 
     class func insertChecklist() {
-        app.navigationBars[uidNavBar_AllNotes].buttons[uidButton_NoteEditor_Checklist].tap()
+        app.navigationBars[UID.NavBar.AllNotes].buttons[UID.Button.NoteEditorChecklist].tap()
     }
 
     class func markdownEnable() {
         swipeToPreview()
 
-        if app.navigationBars[uidNavBar_NoteEditor_Preview].exists {
+        if app.navigationBars[UID.NavBar.NoteEditorPreview].exists {
             Preview.leavePreviewViaBackButton()
         } else {
             toggleMarkdownState()
@@ -57,7 +57,7 @@ class NoteEditor {
 
     class func markdownDisable() {
         swipeToPreview()
-        guard app.navigationBars[uidNavBar_NoteEditor_Preview].exists else { return }
+        guard app.navigationBars[UID.NavBar.NoteEditorPreview].exists else { return }
 
         Preview.leavePreviewViaBackButton()
         toggleMarkdownState()
@@ -121,13 +121,13 @@ class NoteEditorAssert {
     }
 
     class func editorShown() {
-        let allNotesNavBar = app.navigationBars[uidNavBar_AllNotes]
+        let allNotesNavBar = app.navigationBars[UID.NavBar.AllNotes]
 
-        XCTAssertTrue(allNotesNavBar.waitForExistence(timeout: minLoadTimeout), uidNavBar_AllNotes + navBarNotFound)
-        XCTAssertTrue(allNotesNavBar.buttons[uidButton_NoteEditor_AllNotes].waitForExistence(timeout: minLoadTimeout), uidButton_NoteEditor_AllNotes + buttonNotFound)
-        XCTAssertTrue(allNotesNavBar.buttons[uidButton_NoteEditor_Checklist].waitForExistence(timeout: minLoadTimeout), uidButton_NoteEditor_Checklist + buttonNotFound)
-        XCTAssertTrue(allNotesNavBar.buttons[uidButton_NoteEditor_Information].waitForExistence(timeout: minLoadTimeout), uidButton_NoteEditor_Information + buttonNotFound)
-        XCTAssertTrue(allNotesNavBar.buttons[uidButton_NoteEditor_Menu].waitForExistence(timeout: minLoadTimeout), uidButton_NoteEditor_Menu + buttonNotFound)
+        XCTAssertTrue(allNotesNavBar.waitForExistence(timeout: minLoadTimeout), UID.NavBar.AllNotes + navBarNotFound)
+        XCTAssertTrue(allNotesNavBar.buttons[UID.Button.NoteEditorAllNotes].waitForExistence(timeout: minLoadTimeout), UID.Button.NoteEditorAllNotes + buttonNotFound)
+        XCTAssertTrue(allNotesNavBar.buttons[UID.Button.NoteEditorChecklist].waitForExistence(timeout: minLoadTimeout), UID.Button.NoteEditorChecklist + buttonNotFound)
+        XCTAssertTrue(allNotesNavBar.buttons[UID.Button.NoteEditorInformation].waitForExistence(timeout: minLoadTimeout), UID.Button.NoteEditorInformation + buttonNotFound)
+        XCTAssertTrue(allNotesNavBar.buttons[UID.Button.NoteEditorMenu].waitForExistence(timeout: minLoadTimeout), UID.Button.NoteEditorMenu + buttonNotFound)
     }
 
     class func textViewWithExactValueShownOnce(value: String) {
@@ -145,8 +145,8 @@ class NoteEditorAssert {
         XCTAssertEqual(1, matchesCount)
     }
 
-    class func textViewWithExactLabelsShownOnce(labelsArray: Array<String>) {
-        for label in labelsArray {
+    class func textViewWithExactLabelsShownOnce(labels: [String]) {
+        for label in labels {
             NoteEditorAssert.textViewWithExactLabelShownOnce(label: label)
         }
     }

--- a/SimplenoteUITests/Preview.swift
+++ b/SimplenoteUITests/Preview.swift
@@ -9,9 +9,12 @@ class Preview {
     class func getAllStaticTexts() -> XCUIElementQuery {
         return app.webViews.descendants(matching: .staticText)
     }
-    
+
     class func leavePreviewViaBackButton() {
-        app.navigationBars[uidNavBar_NoteEditor_Preview].buttons[uidButton_Back].tap()
+        let backButton = app.navigationBars[uidNavBar_NoteEditor_Preview].buttons[uidButton_Back]
+        guard backButton.exists else { return }
+
+        backButton.tap()
     }
 
     class func tapLink(linkText: String) {
@@ -20,7 +23,7 @@ class Preview {
         link.tap()
         sleep(3)
     }
-    
+
     class func getStaticTextsWithExactValueCount(value: String) -> Int {
         let predicate = NSPredicate(format: "value == '" + value + "'")
         let matchingStaticTexts = app.webViews.descendants(matching: .staticText).matching(predicate)
@@ -28,7 +31,7 @@ class Preview {
         print(">>> Found " + String(matchesCount) + " StaticTexts(s) with '" + value + "' value")
         return matchesCount
     }
-    
+
     class func getStaticTextsWithExactLabelCount(label: String) -> Int {
         let predicate = NSPredicate(format: "label == '" + label + "'")
         let matchingStaticTexts = app.webViews.descendants(matching: .staticText).matching(predicate)
@@ -56,25 +59,25 @@ class PreviewAssert {
     }
 
     class func wholeTextShown(text: String) {
-        XCTAssertEqual(text, Preview.getText(), "Preview text" + notExpectedEnding);
+        XCTAssertEqual(text, Preview.getText(), "Preview text" + notExpectedEnding)
     }
-    
+
     class func staticTextWithExactLabelShownOnce(label: String) {
         let matchesCount = Preview.getStaticTextsWithExactLabelCount(label: label)
         XCTAssertEqual(1, matchesCount)
     }
-    
+
     class func staticTextWithExactValueShownOnce(value: String) {
         let matchesCount = Preview.getStaticTextsWithExactValueCount(value: value)
         XCTAssertEqual(1, matchesCount)
     }
-    
+
     class func staticTextWithExactValuesShownOnce(valuesArray: Array<String>) {
         for value in valuesArray {
             PreviewAssert.staticTextWithExactValueShownOnce(value: value)
         }
     }
-    
+
     class func boxesTotalNumber(expectedSwitchesNumber: Int) {
         XCTAssertEqual(expectedSwitchesNumber, app.switches.count, numberOfBoxesInPreviewNotExpected)
     }
@@ -82,16 +85,16 @@ class PreviewAssert {
     class func boxesStates(expectedCheckedBoxesNumber: Int, expectedEmptyBoxesNumber: Int) {
         let expectedBoxesCount = expectedCheckedBoxesNumber + expectedEmptyBoxesNumber,
             actualBoxesCount = app.switches.count
-        
+
         var actualCheckedBoxesCount = 0,
             actualEmptyBoxesCount = 0
 
         print("Number of boxes found: " + String(actualBoxesCount))
-        
+
         XCTAssertEqual(expectedBoxesCount, actualBoxesCount, numberOfBoxesInPreviewNotExpected)
-        
+
         if actualBoxesCount < 1 { return }
-        
+
         for index in 0...actualBoxesCount - 1 {
             let box = app.descendants(matching: .switch).element(boundBy: index)
             print("Current box debug description: " + box.value.debugDescription)

--- a/SimplenoteUITests/Preview.swift
+++ b/SimplenoteUITests/Preview.swift
@@ -11,7 +11,7 @@ class Preview {
     }
 
     class func leavePreviewViaBackButton() {
-        let backButton = app.navigationBars[uidNavBar_NoteEditor_Preview].buttons[uidButton_Back]
+        let backButton = app.navigationBars[UID.NavBar.NoteEditorPreview].buttons[UID.Button.Back]
         guard backButton.exists else { return }
 
         backButton.tap()
@@ -51,11 +51,11 @@ class PreviewAssert {
     }
 
     class func previewShown() {
-        let previewNavBar = app.navigationBars[uidNavBar_NoteEditor_Preview]
+        let previewNavBar = app.navigationBars[UID.NavBar.NoteEditorPreview]
 
-        XCTAssertTrue(previewNavBar.waitForExistence(timeout: minLoadTimeout), uidNavBar_NoteEditor_Preview + navBarNotFound)
-        XCTAssertTrue(previewNavBar.buttons[uidButton_Back].waitForExistence(timeout: minLoadTimeout), uidButton_Back + buttonNotFound)
-        XCTAssertTrue(previewNavBar.staticTexts[uidText_NoteEditor_Preview].waitForExistence(timeout: minLoadTimeout), uidText_NoteEditor_Preview + labelNotFound)
+        XCTAssertTrue(previewNavBar.waitForExistence(timeout: minLoadTimeout), UID.NavBar.NoteEditorPreview + navBarNotFound)
+        XCTAssertTrue(previewNavBar.buttons[UID.Button.Back].waitForExistence(timeout: minLoadTimeout), UID.Button.Back + buttonNotFound)
+        XCTAssertTrue(previewNavBar.staticTexts[UID.Text.NoteEditorPreview].waitForExistence(timeout: minLoadTimeout), UID.Text.NoteEditorPreview + labelNotFound)
     }
 
     class func wholeTextShown(text: String) {
@@ -72,8 +72,8 @@ class PreviewAssert {
         XCTAssertEqual(1, matchesCount)
     }
 
-    class func staticTextWithExactValuesShownOnce(valuesArray: Array<String>) {
-        for value in valuesArray {
+    class func staticTextWithExactValuesShownOnce(values: [String]) {
+        for value in values {
             PreviewAssert.staticTextWithExactValueShownOnce(value: value)
         }
     }

--- a/SimplenoteUITests/SimplenoteUITests.swift
+++ b/SimplenoteUITests/SimplenoteUITests.swift
@@ -24,46 +24,46 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
         EmailLogin.open()
         EmailLogin.logIn(email: "", password: "")
 
-        Assert.labelExists(labelText: text_LoginEmailInvalid)
-        Assert.labelExists(labelText: text_LoginPasswordShort)
+        Assert.labelExists(labelText: Text.LoginEmailInvalid)
+        Assert.labelExists(labelText: Text.LoginPasswordShort)
     }
 
     func testLogInWithNoEmail() throws {
         EmailLogin.open()
         EmailLogin.logIn(email: "", password: testDataExistingPassword)
 
-        Assert.labelExists(labelText: text_LoginEmailInvalid)
-        Assert.labelAbsent(labelText: text_LoginPasswordShort)
+        Assert.labelExists(labelText: Text.LoginEmailInvalid)
+        Assert.labelAbsent(labelText: Text.LoginPasswordShort)
     }
 
     func testLogInWithInvalidEmail() throws {
         EmailLogin.open()
         EmailLogin.logIn(email: testDataInvalidEmail, password: testDataExistingPassword)
 
-        Assert.labelExists(labelText: text_LoginEmailInvalid)
-        Assert.labelAbsent(labelText: text_LoginPasswordShort)
+        Assert.labelExists(labelText: Text.LoginEmailInvalid)
+        Assert.labelAbsent(labelText: Text.LoginPasswordShort)
     }
 
     func testLogInWithNoPassword() throws {
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: "")
 
-        Assert.labelAbsent(labelText: text_LoginEmailInvalid)
-        Assert.labelExists(labelText: text_LoginPasswordShort)
+        Assert.labelAbsent(labelText: Text.LoginEmailInvalid)
+        Assert.labelExists(labelText: Text.LoginPasswordShort)
     }
 
     func testLogInWithTooShortPassword() throws {
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataInvalidPassword)
 
-        Assert.labelAbsent(labelText: text_LoginEmailInvalid)
-        Assert.labelExists(labelText: text_LoginPasswordShort)
+        Assert.labelAbsent(labelText: Text.LoginEmailInvalid)
+        Assert.labelExists(labelText: Text.LoginPasswordShort)
     }
 
     func testLogInWithExistingEmailIncorrectPassword() throws {
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataNotExistingPassword)
-        Assert.alertExistsAndClose(headingText: text_AlertHeading_Sorry, content: text_AlertContent_LoginFailed, buttonText: uidButton_Accept)
+        Assert.alertExistsAndClose(headingText: Text.AlertHeadingSorry, content: Text.AlertContentLoginFailed, buttonText: UID.Button.Accept)
     }
 
     func testLogInWithCorrectCredentials() throws {
@@ -199,69 +199,69 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         PreviewAssert.boxesStates(expectedCheckedBoxesNumber: 0, expectedEmptyBoxesNumber: 1)
     }
 
-    func testUndoUndoesTheLastEdit() throws {
-        let editorText = "ABCD"
+	func testUndoUndoesTheLastEdit() throws {
+		let editorText = "ABCD"
 
-        // Step 1
-        AllNotes.addNoteTap()
-        NoteEditorAssert.editorShown()
+		// Step 1
+		AllNotes.addNoteTap()
+		NoteEditorAssert.editorShown()
 
-        // Step 2
-        NoteEditor.clearAndEnterText(enteredValue: editorText)
-        NoteEditorAssert.textViewWithExactValueShownOnce(value: editorText)
+		// Step 2
+		NoteEditor.clearAndEnterText(enteredValue: editorText)
+		NoteEditorAssert.textViewWithExactValueShownOnce(value: editorText)
 
-        // Step 3
-        NoteEditor.undo()
-        NoteEditorAssert.textViewWithExactValueNotShown(value: editorText)
-        NoteEditorAssert.textViewWithExactValueShownOnce(value: "ABC")
-    }
+		// Step 3
+		NoteEditor.undo()
+		NoteEditorAssert.textViewWithExactValueNotShown(value: editorText)
+		NoteEditorAssert.textViewWithExactValueShownOnce(value: "ABC")
+	}
 
-    func testAddedURLIsLinkified() throws {
+	func testAddedURLIsLinkified() throws {
 
-        // Step 1
-        AllNotes.addNoteTap()
-        NoteEditorAssert.editorShown()
+		// Step 1
+		AllNotes.addNoteTap()
+		NoteEditorAssert.editorShown()
 
-        // Step 2
-        NoteEditor.markdownEnable()
-        NoteEditor.clearAndEnterText(enteredValue: usualLinkText)
-        NoteEditorAssert.textViewWithExactValueShownOnce(value: usualLinkText)
+		// Step 2
+		NoteEditor.markdownEnable()
+		NoteEditor.clearAndEnterText(enteredValue: usualLinkText)
+		NoteEditorAssert.textViewWithExactValueShownOnce(value: usualLinkText)
 
-        // Step 3
-        NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: usualLinkText)
+		// Step 3
+		NoteEditor.leaveEditor()
+		AllNotesAssert.noteExists(noteName: usualLinkText)
 
-        // Step 4
-        AllNotes.openNote(noteName: usualLinkText)
-        NoteEditorAssert.linkifiedURL(containerText: usualLinkText, linkifiedText: usualLinkText)
-    }
+		// Step 4
+		AllNotes.openNote(noteName: usualLinkText)
+		NoteEditorAssert.linkifiedURL(containerText: usualLinkText, linkifiedText: usualLinkText)
+	}
 
-    func testLongTappingOnLinkOpensLinkInNewWindow() throws {
+	func testLongTappingOnLinkOpensLinkInNewWindow() throws {
 
-        // Step 1
-        AllNotes.addNoteTap()
-        NoteEditorAssert.editorShown()
+		// Step 1
+		AllNotes.addNoteTap()
+		NoteEditorAssert.editorShown()
 
-        // Step 2
-        NoteEditor.markdownEnable()
-        NoteEditor.clearAndEnterText(enteredValue: usualLinkText)
-        NoteEditorAssert.textViewWithExactValueShownOnce(value: usualLinkText)
+		// Step 2
+		NoteEditor.markdownEnable()
+		NoteEditor.clearAndEnterText(enteredValue: usualLinkText)
+		NoteEditorAssert.textViewWithExactValueShownOnce(value: usualLinkText)
 
-        // Step 3
-        NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: usualLinkText)
+		// Step 3
+		NoteEditor.leaveEditor()
+		AllNotesAssert.noteExists(noteName: usualLinkText)
 
-        // Step 4
-        AllNotes.openNote(noteName: usualLinkText)
-        //NoteEditorAssert.editorText(text: usualURL)
-        NoteEditorAssert.linkifiedURL(containerText: usualLinkText, linkifiedText: usualLinkText)
+		// Step 4
+		AllNotes.openNote(noteName: usualLinkText)
+		//NoteEditorAssert.editorText(text: usualURL)
+		NoteEditorAssert.linkifiedURL(containerText: usualLinkText, linkifiedText: usualLinkText)
 
-        // Step 5
-        NoteEditor.pressLink(containerText: usualLinkText, linkifiedText: usualLinkText)
-        for text in webViewTexts {
-            WebViewAssert.textShownOnScreen(textToFind: text)
-        }
-    }
+		// Step 5
+		NoteEditor.pressLink(containerText: usualLinkText, linkifiedText: usualLinkText)
+		for text in webViewTexts {
+			WebViewAssert.textShownOnScreen(textToFind: text)
+		}
+	}
 
     func testTappingOnLinkInPreviewOpensLinkInNewWindow() throws {
 
@@ -314,7 +314,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
     }
 
     func testCreateUncheckedItem() throws {
-        let checklistText = "Unchecked Item"
+		let checklistText = "Unchecked Item"
         let completeText = "- [ ]" + checklistText
 
         // Step 1
@@ -360,16 +360,16 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         trackStep()
         AllNotes.openNote(noteName: noteTitle)
-        NoteEditorAssert.textViewWithExactLabelsShownOnce(labelsArray: ["- Minus1", "- Minus2", "- Minus3"])
-        NoteEditorAssert.textViewWithExactLabelsShownOnce(labelsArray: ["+ Plus1", "+ Plus2", "+ Plus3"])
-        NoteEditorAssert.textViewWithExactLabelsShownOnce(labelsArray: ["* Asterisk1", "* Asterisk2", "* Asterisk3"])
+        NoteEditorAssert.textViewWithExactLabelsShownOnce(labels: ["- Minus1", "- Minus2", "- Minus3"])
+        NoteEditorAssert.textViewWithExactLabelsShownOnce(labels: ["+ Plus1", "+ Plus2", "+ Plus3"])
+        NoteEditorAssert.textViewWithExactLabelsShownOnce(labels: ["* Asterisk1", "* Asterisk2", "* Asterisk3"])
 
         trackStep()
         NoteEditor.markdownEnable()
         NoteEditor.swipeToPreview()
-        PreviewAssert.staticTextWithExactValuesShownOnce(valuesArray: ["• Minus1", "• Minus2", "• Minus3"])
-        PreviewAssert.staticTextWithExactValuesShownOnce(valuesArray: ["• Plus1", "• Plus2", "• Plus3"])
-        PreviewAssert.staticTextWithExactValuesShownOnce(valuesArray: ["• Asterisk1", "• Asterisk2", "• Asterisk3"])
+        PreviewAssert.staticTextWithExactValuesShownOnce(values: ["• Minus1", "• Minus2", "• Minus3"])
+        PreviewAssert.staticTextWithExactValuesShownOnce(values: ["• Plus1", "• Plus2", "• Plus3"])
+        PreviewAssert.staticTextWithExactValuesShownOnce(values: ["• Asterisk1", "• Asterisk2", "• Asterisk3"])
     }
 }
 
@@ -402,8 +402,8 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         // Step 2
         AllNotes.open()
-        AllNotes.createNotes(noteNamesArray: noteNamesArray)
-        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
+        AllNotes.createNotes(names: noteNamesArray)
+        AllNotesAssert.notesExist(names: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
@@ -431,17 +431,17 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         // Step 2
         AllNotes.open()
-        AllNotes.createNotes(noteNamesArray: noteNamesArray)
-        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
+        AllNotes.createNotes(names: noteNamesArray)
+        AllNotesAssert.notesExist(names: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
 
-        // Step 3
-        AllNotes.trashNote(noteName: noteOneName)
-        AllNotes.trashNote(noteName: noteTwoName)
-        AllNotesAssert.noteAbsent(noteName: noteOneName)
-        AllNotesAssert.noteAbsent(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+		// Step 3
+		AllNotes.trashNote(noteName: noteOneName)
+		AllNotes.trashNote(noteName: noteTwoName)
+		AllNotesAssert.noteAbsent(noteName: noteOneName)
+		AllNotesAssert.noteAbsent(noteName: noteTwoName)
+		AllNotesAssert.noteExists(noteName: noteThreeName)
+		AllNotesAssert.notesNumber(expectedNotesNumber: 1)
 
         //Step 4
         Trash.open()
@@ -475,8 +475,8 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         // Step 2
         AllNotes.open()
-        AllNotes.createNotes(noteNamesArray: noteNamesArray)
-        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
+        AllNotes.createNotes(names: noteNamesArray)
+        AllNotesAssert.notesExist(names: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
@@ -517,8 +517,8 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         // Step 2
         AllNotes.open()
-        AllNotes.createNotes(noteNamesArray: noteNamesArray)
-        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
+        AllNotes.createNotes(names: noteNamesArray)
+        AllNotesAssert.notesExist(names: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
@@ -539,7 +539,7 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         //Step 6
         AllNotes.open()
-        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
+        AllNotesAssert.notesExist(names: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
     }
 

--- a/SimplenoteUITests/SimplenoteUITests.swift
+++ b/SimplenoteUITests/SimplenoteUITests.swift
@@ -9,9 +9,14 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
     let testDataInvalidPassword = "ABC"
     let testDataNotExistingPassword = "ABCD"
 
+    override class func setUp() {
+        app.launch()
+    }
+
     override func setUpWithError() throws {
         continueAfterFailure = true
-        app.launch()
+        Alert.closeAny()
+        EmailLogin.close()
         let _ = attemptLogOut()
     }
 
@@ -92,6 +97,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
     override class func setUp() {
         app.launch()
+        getToAllNotes()
         let _ = attemptLogOut()
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
@@ -100,8 +106,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = true
-        app.launch()
-
+        getToAllNotes()
         AllNotes.clearAllNotes()
         Trash.empty()
         AllNotes.open()
@@ -154,7 +159,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
             noteNameInitial = noteTextInitial,
             noteTextWithCheckbox = " " + noteTextInitial,
             noteNameWithCheckbox = "- [ ]" + noteTextWithCheckbox
-        
+
         trackTest()
 
         trackStep()
@@ -193,7 +198,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         PreviewAssert.staticTextWithExactValueShownOnce(value: noteNameInitial)
         PreviewAssert.boxesStates(expectedCheckedBoxesNumber: 0, expectedEmptyBoxesNumber: 1)
     }
-    
+
     func testUndoUndoesTheLastEdit() throws {
         let editorText = "ABCD"
 
@@ -207,7 +212,8 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         // Step 3
         NoteEditor.undo()
-        NoteEditorAssert.textViewWithExactValueShownOnce(value: "")
+        NoteEditorAssert.textViewWithExactValueNotShown(value: editorText)
+        NoteEditorAssert.textViewWithExactValueShownOnce(value: "ABC")
     }
 
     func testAddedURLIsLinkified() throws {
@@ -299,7 +305,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         AllNotes.openNote(noteName: completeText)
         NoteEditorAssert.textViewWithExactValueShownOnce(value: checklistText)
         NoteEditorAssert.checkboxForTextShownOnce(text: checklistText)
-        
+
         // Step 5
         NoteEditor.swipeToPreview()
         //PreviewAssert.substringShown(text: checklistText)
@@ -334,13 +340,13 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         PreviewAssert.staticTextWithExactLabelShownOnce(label: checklistText)
         PreviewAssert.boxesStates(expectedCheckedBoxesNumber: 0, expectedEmptyBoxesNumber: 1)
     }
-    
+
     func testBulletedLists() throws {
         let noteTitle = "Bulleted Lists"
         let noteContent = "\n\nMinuses:\n\n- Minus1\nMinus2\nMinus3" +
             "\n\nPluses:\n\n+ Plus1\nPlus2\nPlus3" +
             "\n\nAsterisks:\n\n* Asterisk1\nAsterisk2\nAsterisk3"
-        
+
         trackTest()
 
         trackStep()
@@ -357,7 +363,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         NoteEditorAssert.textViewWithExactLabelsShownOnce(labelsArray: ["- Minus1", "- Minus2", "- Minus3"])
         NoteEditorAssert.textViewWithExactLabelsShownOnce(labelsArray: ["+ Plus1", "+ Plus2", "+ Plus3"])
         NoteEditorAssert.textViewWithExactLabelsShownOnce(labelsArray: ["* Asterisk1", "* Asterisk2", "* Asterisk3"])
-        
+
         trackStep()
         NoteEditor.markdownEnable()
         NoteEditor.swipeToPreview()
@@ -379,8 +385,6 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = true
-        app.launch()
-        AllNotes.waitForLoad()
         AllNotes.clearAllNotes()
         Trash.empty()
         AllNotes.open()
@@ -390,6 +394,7 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         let noteOneName = "CanView"
         let noteTwoName = "Trashed"
         let noteThreeName = "Notes"
+        let noteNamesArray = [noteOneName, noteTwoName, noteThreeName]
 
         // Step 1
         Trash.open()
@@ -397,12 +402,8 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         // Step 2
         AllNotes.open()
-        AllNotes.createNoteAndLeaveEditor(noteName: noteOneName)
-        AllNotes.createNoteAndLeaveEditor(noteName: noteTwoName)
-        AllNotes.createNoteAndLeaveEditor(noteName: noteThreeName)
-        AllNotesAssert.noteExists(noteName: noteOneName)
-        AllNotesAssert.noteExists(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
+        AllNotes.createNotes(noteNamesArray: noteNamesArray)
+        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
@@ -422,6 +423,7 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         let noteOneName = "CanDelete"
         let noteTwoName = "Note"
         let noteThreeName = "Forever"
+        let noteNamesArray = [noteOneName, noteTwoName, noteThreeName]
 
         // Step 1
         Trash.open()
@@ -429,12 +431,8 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         // Step 2
         AllNotes.open()
-        AllNotes.createNoteAndLeaveEditor(noteName: noteOneName)
-        AllNotes.createNoteAndLeaveEditor(noteName: noteTwoName)
-        AllNotes.createNoteAndLeaveEditor(noteName: noteThreeName)
-        AllNotesAssert.noteExists(noteName: noteOneName)
-        AllNotesAssert.noteExists(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
+        AllNotes.createNotes(noteNamesArray: noteNamesArray)
+        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
@@ -469,6 +467,7 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         let noteOneName = "CanDelete"
         let noteTwoName = "Note"
         let noteThreeName = "Forever"
+        let noteNamesArray = [noteOneName, noteTwoName, noteThreeName]
 
         // Step 1
         Trash.open()
@@ -476,12 +475,8 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         // Step 2
         AllNotes.open()
-        AllNotes.createNoteAndLeaveEditor(noteName: noteOneName)
-        AllNotes.createNoteAndLeaveEditor(noteName: noteTwoName)
-        AllNotes.createNoteAndLeaveEditor(noteName: noteThreeName)
-        AllNotesAssert.noteExists(noteName: noteOneName)
-        AllNotesAssert.noteExists(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
+        AllNotes.createNotes(noteNamesArray: noteNamesArray)
+        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
@@ -514,6 +509,7 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         let noteOneName = "CanRestore"
         let noteTwoName = "Trashed"
         let noteThreeName = "Notes"
+        let noteNamesArray = [noteOneName, noteTwoName, noteThreeName]
 
         // Step 1
         Trash.open()
@@ -521,12 +517,8 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         // Step 2
         AllNotes.open()
-        AllNotes.createNoteAndLeaveEditor(noteName: noteOneName)
-        AllNotes.createNoteAndLeaveEditor(noteName: noteTwoName)
-        AllNotes.createNoteAndLeaveEditor(noteName: noteThreeName)
-        AllNotesAssert.noteExists(noteName: noteOneName)
-        AllNotesAssert.noteExists(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
+        AllNotes.createNotes(noteNamesArray: noteNamesArray)
+        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
@@ -547,9 +539,7 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
 
         //Step 6
         AllNotes.open()
-        AllNotesAssert.noteExists(noteName: noteOneName)
-        AllNotesAssert.noteExists(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
+        AllNotesAssert.notesExist(noteNamesArray: noteNamesArray)
         AllNotesAssert.notesNumber(expectedNotesNumber: 3)
     }
 

--- a/SimplenoteUITests/Trash.swift
+++ b/SimplenoteUITests/Trash.swift
@@ -3,13 +3,13 @@ import XCTest
 class Trash {
 
     class func open() {
-        app.navigationBars.element.buttons[uidButton_Menu].tap()
-        app.tables.staticTexts[uidButton_Trash].tap()
+        app.navigationBars.element.buttons[UID.Button.Menu].tap()
+        app.tables.staticTexts[UID.Button.Trash].tap()
     }
 
     class func restoreNote(noteName: String) {
         app.tables.cells[noteName].swipeLeft()
-        app.tables.cells[noteName].buttons[uidButton_Trash_Restore].tap()
+        app.tables.cells[noteName].buttons[UID.Button.TrashRestore].tap()
     }
 
     class func deleteNote(noteName: String) {
@@ -18,12 +18,11 @@ class Trash {
 
     class func empty() {
         Trash.open()
-        let emptyTrashButton = app.buttons[uidButton_Trash_EmptyTrash]
-                
+        let emptyTrashButton = app.buttons[UID.Button.TrashEmptyTrash]
         guard emptyTrashButton.isEnabled else { return }
-        
-        emptyTrashButton.tap()
-        app.alerts.scrollViews.otherElements.buttons[uidButton_Yes].tap()
+
+		emptyTrashButton.tap()
+        app.alerts.scrollViews.otherElements.buttons[UID.Button.Yes].tap()
     }
 
     class func getNotesNumber() -> Int {

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -2,6 +2,7 @@
 let uidPicture_AppLogo = "simplenote-logo"
 
 let uidNavBar_AllNotes = "All Notes"
+let uidNavBar_LogIn = "Log In"
 let uidNavBar_NoteEditor_Preview = "Preview"
 let uidNavBar_NoteEditor_Options = "Options"
 

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -1,53 +1,61 @@
-// Strings to locate controls by
-let uidPicture_AppLogo = "simplenote-logo"
+enum UID {
+	enum Picture {
+		static let AppLogo = "simplenote-logo"
+	}
 
-let uidNavBar_AllNotes = "All Notes"
-let uidNavBar_LogIn = "Log In"
-let uidNavBar_NoteEditor_Preview = "Preview"
-let uidNavBar_NoteEditor_Options = "Options"
+	enum Cell {
+		static let Settings = "Settings"
+	}
 
-// Buttons
-let uidButton_NewNote = "New note"
-let uidButton_Done = "Done"
-let uidButton_Back = "Back"
-let uidButton_Accept = "Accept"
-let uidButton_Yes = "Yes"
-let uidButton_Menu = "menu"
-let uidButton_SignUp = "Sign Up"
-let uidButton_LogIn = "Log In"
-let uidButton_LogInWithEmail = "Log in with email"
+	enum NavBar {
+		static let AllNotes = "All Notes"
+		static let LogIn = "Log In"
+		static let NoteEditorPreview = "Preview"
+		static let NoteEditorOptions = "Options"
+	}
 
-let uidButton_AllNotes = "All Notes"
-let uidButton_Trash = "Trash"
-let uidButton_Settings_LogOut = "Log Out"
+	enum Button {
+		static let NewNote = "New note"
+		static let Done = "Done"
+		static let Back = "Back"
+		static let Accept = "Accept"
+		static let Yes = "Yes"
+		static let Menu = "menu"
+		static let SignUp = "Sign Up"
+		static let LogIn = "Log In"
+		static let LogInWithEmail = "Log in with email"
+		static let AllNotes = "All Notes"
+		static let Trash = "Trash"
+		static let SettingsLogOut = "Log Out"
+		static let NoteEditorAllNotes = "All Notes"
+		static let NoteEditorChecklist = "Inserts a new Checklist Item"
+		static let NoteEditorInformation = "Information"
+		static let NoteEditorMenu = "note-menu"
+		static let NoteCellTrash = "icon trash"
+		static let TrashRestore = "icon restore"
+		static let TrashEmptyTrash = "Empty"
+	}
 
-let uidButton_NoteEditor_AllNotes = "All Notes"
-let uidButton_NoteEditor_Checklist = "Inserts a new Checklist Item"
-let uidButton_NoteEditor_Information = "Information"
-let uidButton_NoteEditor_Menu = "note-menu"
+	enum Text {
+		static let NoteEditorPreview = "Preview"
+		static let NoteEditorOptionsMarkdown = "Markdown"
+		static let AllNotesInProgress = "In progress"
+	}
 
-let uidButton_NoteCell_Trash = "icon trash"
+	enum TextField {
+		static let Email = "Email"
+		static let Password = "Password"
+	}
+}
 
-let uidButton_Trash_Restore = "icon restore"
-let uidButton_Trash_EmptyTrash = "Empty"
+enum Text {
+	static let AppName = "Simplenote"
+	static let AppTagline = "The simplest way to keep notes."
+	static let AlertHeadingSorry = "Sorry!"
+	static let AlertContentLoginFailed = "Could not login with the provided email address and password."
+	static let LoginEmailInvalid = "Your email address is not valid"
+	static let LoginPasswordShort = "Password must contain at least 4 characters"
+}
 
-let uidCell_Settings = "Settings"
-
-let uidText_NoteEditor_Preview = "Preview"
-let uidText_NoteEditor_Options_Markdown = "Markdown"
-let uidText_AllNotes_InProgress = "In progress"
-
-let uidTextField_Email = "Email"
-let uidTextField_Password = "Password"
-
-// Alerts and Texts
-let text_AppName = "Simplenote"
-let text_AppTagline = "The simplest way to keep notes."
-let text_AlertHeading_Sorry = "Sorry!"
-let text_AlertContent_LoginFailed = "Could not login with the provided email address and password."
-let text_LoginEmailInvalid = "Your email address is not valid"
-let text_LoginPasswordShort = "Password must contain at least 4 characters"
-
-// Test Account
 let testDataExistingEmail = "simplenoteuitest@mailinator.com"
 let testDataExistingPassword = "qazxswedc"


### PR DESCRIPTION
UI Tests execution sped up by 110 seconds (~466 seconds vs ~570 seconds)

### Fix
1. Adjusted `setUp()` and `setUpWithError()` methods to avoid app launch before every test
2. For this created method that attempts returning to 'base' screen for every test: `getToAllNotes()` (for Note Editor tests)

Also (not related to speed):
3. Created several methods like `AllNotesAssert.notesExist() `on top of `AllNotesAssert.noteExists()` to allow passing an array of note names instead of calling the method N times
4. Added guard statements to several old methods

### Test
1. Running all tests and seeing no new fails introduced, with execution time being within 460 sec range.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
