### PR TITLE
UI Tests Refactor: Renaming AllNotes to NoteList

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -407,7 +407,7 @@
 		D843AD8F25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D843AD8E25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift */; };
 		D864B16925CAE47C00F9B73E /* Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B16825CAE47C00F9B73E /* Generic.swift */; };
 		D864B18225CAE4BE00F9B73E /* SimplenoteUITestsNoteEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B18125CAE4BE00F9B73E /* SimplenoteUITestsNoteEditor.swift */; };
-		D864B19225CAE54300F9B73E /* AllNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B19125CAE54300F9B73E /* AllNotes.swift */; };
+		D864B19225CAE54300F9B73E /* NotesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B19125CAE54300F9B73E /* NotesList.swift */; };
 		D864B1A225CAE57100F9B73E /* AssertGeneric.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1A125CAE57100F9B73E /* AssertGeneric.swift */; };
 		D864B1AB25CAE59400F9B73E /* EmailLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1AA25CAE59400F9B73E /* EmailLogin.swift */; };
 		D864B1B425CAE5C900F9B73E /* NoteEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1B325CAE5C900F9B73E /* NoteEditor.swift */; };
@@ -912,7 +912,7 @@
 		D864B15425CAE25000F9B73E /* SimplenoteUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplenoteUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D864B16825CAE47C00F9B73E /* Generic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generic.swift; sourceTree = "<group>"; };
 		D864B18125CAE4BE00F9B73E /* SimplenoteUITestsNoteEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimplenoteUITestsNoteEditor.swift; sourceTree = "<group>"; };
-		D864B19125CAE54300F9B73E /* AllNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllNotes.swift; sourceTree = "<group>"; };
+		D864B19125CAE54300F9B73E /* NotesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesList.swift; sourceTree = "<group>"; };
 		D864B1A125CAE57100F9B73E /* AssertGeneric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertGeneric.swift; sourceTree = "<group>"; };
 		D864B1AA25CAE59400F9B73E /* EmailLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailLogin.swift; sourceTree = "<group>"; };
 		D864B1B325CAE5C900F9B73E /* NoteEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditor.swift; sourceTree = "<group>"; };
@@ -1865,12 +1865,12 @@
 		D864B15525CAE25000F9B73E /* SimplenoteUITests */ = {
 			isa = PBXGroup;
 			children = (
-				D864B19125CAE54300F9B73E /* AllNotes.swift */,
 				D864B1A125CAE57100F9B73E /* AssertGeneric.swift */,
 				D864B1AA25CAE59400F9B73E /* EmailLogin.swift */,
 				D864B16825CAE47C00F9B73E /* Generic.swift */,
 				D864B1F025CAE87800F9B73E /* Info.plist */,
 				D864B1B325CAE5C900F9B73E /* NoteEditor.swift */,
+				D864B19125CAE54300F9B73E /* NotesList.swift */,
 				D864B1C525CAE5F800F9B73E /* Preview.swift */,
 				D8E2D8E225E7DE090001315B /* Sidebar.swift */,
 				D843AD6E25E3E633007E5B15 /* SimplenoteUITestsLogin.swift */,
@@ -2957,7 +2957,7 @@
 				D864B1CF25CAE61F00F9B73E /* Trash.swift in Sources */,
 				D864B1C625CAE5F800F9B73E /* Preview.swift in Sources */,
 				D843AD8F25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift in Sources */,
-				D864B19225CAE54300F9B73E /* AllNotes.swift in Sources */,
+				D864B19225CAE54300F9B73E /* NotesList.swift in Sources */,
 				D864B1D825CAE63E00F9B73E /* UIDs.swift in Sources */,
 				D864B16925CAE47C00F9B73E /* Generic.swift in Sources */,
 				D8E2D8E325E7DE090001315B /* Sidebar.swift in Sources */,

--- a/SimplenoteUITests/NotesList.swift
+++ b/SimplenoteUITests/NotesList.swift
@@ -1,20 +1,17 @@
 import XCTest
 
-class AllNotes {
+class NoteList {
 
     class func openNote(noteName: String) {
         app.tables.cells[noteName].tap()
     }
 
-    class func isOpen() -> Bool {
-        //Warning for future: this works only for 'All Notes' obviously
-        //Will not work when a tag is selected.
+    class func isAllNotesListOpen() -> Bool {
         return app.navigationBars[UID.NavBar.allNotes].exists
     }
 
-    class func open() {
-        guard !isOpen() else { return }
-
+    class func openAllNotes() {
+        guard !NoteList.isAllNotesListOpen() else { return }
         Sidebar.open()
         app.tables.staticTexts[UID.Button.allNotes].tap()
     }
@@ -25,7 +22,7 @@ class AllNotes {
 
     class func createNoteAndLeaveEditor(noteName: String, tags: [String] = []) {
         print(">>> Creating a note: " + noteName)
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditor.clearAndEnterText(enteredValue: noteName)
 
         for tag in tags {
@@ -49,10 +46,10 @@ class AllNotes {
         return Table.getCellsNumber()
     }
 
-    class func clearAllNotes() {
-        AllNotes.open()
+    class func trashAllNotes() {
+        NoteList.openAllNotes()
 
-        let notesNumber = AllNotes.getNotesNumber()
+        let notesNumber = NoteList.getNotesNumber()
         let cellsNum = app.tables.element.children(matching: .cell).count
         var startingIndex: Int
 
@@ -105,7 +102,7 @@ class AllNotes {
     }
 }
 
-class AllNotesAssert {
+class NoteListAssert {
 
     class func noteExists(noteName: String) {
         print(">>> Asserting that note is shown once: " + noteName)
@@ -115,7 +112,7 @@ class AllNotesAssert {
 
     class func notesExist(names: [String]) {
         for noteName in names {
-            AllNotesAssert.noteExists(noteName: noteName)
+            NoteListAssert.noteExists(noteName: noteName)
         }
     }
 
@@ -124,11 +121,11 @@ class AllNotesAssert {
     }
 
     class func notesNumber(expectedNotesNumber: Int) {
-        let actualNotesNumber = AllNotes.getNotesNumber()
+        let actualNotesNumber = NoteList.getNotesNumber()
         XCTAssertEqual(actualNotesNumber, expectedNotesNumber, numberOfNotesInAllNotesNotExpected)
     }
 
-    class func screenShown() {
+    class func allNotesScreenShown() {
         XCTAssertTrue(app.navigationBars[UID.NavBar.allNotes].waitForExistence(timeout: maxLoadTimeout), UID.NavBar.allNotes + navBarNotFound)
     }
 

--- a/SimplenoteUITests/SimplenoteUITestsLogin.swift
+++ b/SimplenoteUITests/SimplenoteUITestsLogin.swift
@@ -65,14 +65,14 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
     func testLogInWithCorrectCredentials() throws {
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
-        AllNotesAssert.screenShown()
+        NoteListAssert.allNotesScreenShown()
     }
 
     func testLogOut() throws {
         // Step 1
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
-        AllNotesAssert.screenShown()
+        NoteListAssert.allNotesScreenShown()
 
         // Step 2
         _ = logOut()

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -16,20 +16,20 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let _ = attemptLogOut()
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
-        AllNotes.waitForLoad()
+        NoteList.waitForLoad()
     }
 
     override func setUpWithError() throws {
         getToAllNotes()
-        AllNotes.clearAllNotes()
+        NoteList.trashAllNotes()
         Trash.empty()
-        AllNotes.open()
+        NoteList.openAllNotes()
     }
 
     func testCanPreviewMarkdownBySwiping() throws {
 
         // Step 1
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         // Step 2
@@ -47,7 +47,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
     func testCanFlipToEditMode() throws {
 
         // Step 1
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         // Step 2
@@ -77,16 +77,16 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         trackTest()
 
         trackStep()
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         trackStep()
         NoteEditor.clearAndEnterText(enteredValue: noteTextInitial)
         NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: noteNameInitial)
+        NoteListAssert.noteExists(noteName: noteNameInitial)
 
         trackStep()
-        AllNotes.openNote(noteName: noteNameInitial)
+        NoteList.openNote(noteName: noteNameInitial)
         NoteEditor.markdownEnable()
         NoteEditorAssert.textViewWithExactValueShownOnce(value: noteTextInitial)
 
@@ -100,11 +100,11 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         NoteEditor.setFocus()
         NoteEditor.insertChecklist()
         NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: noteNameWithCheckbox)
-        AllNotesAssert.noteAbsent(noteName: noteNameInitial)
+        NoteListAssert.noteExists(noteName: noteNameWithCheckbox)
+        NoteListAssert.noteAbsent(noteName: noteNameInitial)
 
         trackStep()
-        AllNotes.openNote(noteName: noteNameWithCheckbox)
+        NoteList.openNote(noteName: noteNameWithCheckbox)
         NoteEditorAssert.textViewWithExactValueShownOnce(value: noteTextWithCheckbox)
 
         trackStep()
@@ -117,7 +117,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let editorText = "ABCD"
 
         // Step 1
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         // Step 2
@@ -133,7 +133,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
     func testAddedURLIsLinkified() throws {
 
         // Step 1
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         // Step 2
@@ -143,17 +143,17 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         // Step 3
         NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: usualLinkText)
+        NoteListAssert.noteExists(noteName: usualLinkText)
 
         // Step 4
-        AllNotes.openNote(noteName: usualLinkText)
+        NoteList.openNote(noteName: usualLinkText)
         NoteEditorAssert.linkifiedURL(containerText: usualLinkText, linkifiedText: usualLinkText)
     }
 
     func testLongTappingOnLinkOpensLinkInNewWindow() throws {
 
         // Step 1
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         // Step 2
@@ -163,10 +163,10 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         // Step 3
         NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: usualLinkText)
+        NoteListAssert.noteExists(noteName: usualLinkText)
 
         // Step 4
-        AllNotes.openNote(noteName: usualLinkText)
+        NoteList.openNote(noteName: usualLinkText)
         //NoteEditorAssert.editorText(text: usualURL)
         NoteEditorAssert.linkifiedURL(containerText: usualLinkText, linkifiedText: usualLinkText)
 
@@ -180,7 +180,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
     func testTappingOnLinkInPreviewOpensLinkInNewWindow() throws {
 
         // Step 1
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         // Step 2
@@ -204,7 +204,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let completeText = "- [x]" + checklistText
 
         // Step 1
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         // Step 2
@@ -213,10 +213,10 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         // Step 3
         NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: completeText)
+        NoteListAssert.noteExists(noteName: completeText)
 
         // Step 4
-        AllNotes.openNote(noteName: completeText)
+        NoteList.openNote(noteName: completeText)
         NoteEditorAssert.textViewWithExactValueShownOnce(value: checklistText)
         NoteEditorAssert.checkboxForTextShownOnce(text: checklistText)
 
@@ -232,7 +232,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let completeText = "- [ ]" + checklistText
 
         // Step 1
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         // Step 2
@@ -241,10 +241,10 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         // Step 3
         NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: completeText)
+        NoteListAssert.noteExists(noteName: completeText)
 
         // Step 4
-        AllNotes.openNote(noteName: completeText)
+        NoteList.openNote(noteName: completeText)
         NoteEditorAssert.textViewWithExactValueShownOnce(value: checklistText)
         NoteEditorAssert.checkboxForTextShownOnce(text: checklistText)
 
@@ -264,16 +264,16 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         trackTest()
 
         trackStep()
-        AllNotes.addNoteTap()
+        NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
 
         trackStep()
         NoteEditor.clearAndEnterText(enteredValue: noteTitle + noteContent)
         NoteEditor.leaveEditor()
-        AllNotesAssert.noteExists(noteName: noteTitle)
+        NoteListAssert.noteExists(noteName: noteTitle)
 
         trackStep()
-        AllNotes.openNote(noteName: noteTitle)
+        NoteList.openNote(noteName: noteTitle)
         NoteEditorAssert.textViewWithExactLabelsShownOnce(labels: ["- Minus1", "- Minus2", "- Minus3"])
         NoteEditorAssert.textViewWithExactLabelsShownOnce(labels: ["+ Plus1", "+ Plus2", "+ Plus3"])
         NoteEditorAssert.textViewWithExactLabelsShownOnce(labels: ["* Asterisk1", "* Asterisk2", "* Asterisk3"])

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -19,49 +19,49 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         let _ = attemptLogOut()
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
-        AllNotes.waitForLoad()
-        AllNotes.clearAllNotes()
+        NoteList.waitForLoad()
+        NoteList.trashAllNotes()
         Trash.empty()
         Sidebar.open()
         Sidebar.tagsDeleteAll()
-        AllNotes.open()
-        AllNotes.createNoteAndLeaveEditor(noteName: godzillaNoteName + "\n\n" + godzillaInfo, tags: ["sea-monster", "reptile", "prehistoric"])
-        AllNotes.createNoteAndLeaveEditor(noteName: kingKongNoteName + "\n\n" + kingKongInfo, tags: ["ape", "prehistoric"])
-        AllNotes.createNoteAndLeaveEditor(noteName: mechagodzillaNoteName + "\n\n" + mechagodzillaInfo, tags: ["man-made", "robot"])
-        AllNotes.createNoteAndLeaveEditor(noteName: diacriticNoteName + "\n\n" + diacriticInfo, tags: ["language", "diacritic"])
+        NoteList.openAllNotes()
+        NoteList.createNoteAndLeaveEditor(noteName: godzillaNoteName + "\n\n" + godzillaInfo, tags: ["sea-monster", "reptile", "prehistoric"])
+        NoteList.createNoteAndLeaveEditor(noteName: kingKongNoteName + "\n\n" + kingKongInfo, tags: ["ape", "prehistoric"])
+        NoteList.createNoteAndLeaveEditor(noteName: mechagodzillaNoteName + "\n\n" + mechagodzillaInfo, tags: ["man-made", "robot"])
+        NoteList.createNoteAndLeaveEditor(noteName: diacriticNoteName + "\n\n" + diacriticInfo, tags: ["language", "diacritic"])
 }
 
     override func setUpWithError() throws {
-        AllNotes.searchForText(text: "")
-        AllNotes.searchCancel()
+        NoteList.searchForText(text: "")
+        NoteList.searchCancel()
     }
 
     func testClearingSearchFieldUpdatesFilteredNotes() throws {
         trackTest()
 
         trackStep()
-        AllNotes.open()
-        AllNotesAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
-        AllNotesAssert.notesNumber(expectedNotesNumber: 4)
+        NoteList.openAllNotes()
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
-        AllNotes.searchForText(text: "Japan")
-        AllNotesAssert.notesExist(names: [godzillaNoteName, mechagodzillaNoteName])
+        NoteList.searchForText(text: "Japan")
+        NoteListAssert.notesExist(names: [godzillaNoteName, mechagodzillaNoteName])
 
         trackStep()
-        AllNotes.searchCancel()
-        AllNotesAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
-        AllNotesAssert.notesNumber(expectedNotesNumber: 4)
+        NoteList.searchCancel()
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
-        AllNotes.searchForText(text: "weapon")
-        AllNotesAssert.noteExists(noteName: mechagodzillaNoteName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+        NoteList.searchForText(text: "weapon")
+        NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
-        AllNotes.searchForText(text: "")
-        AllNotesAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
-        AllNotesAssert.notesNumber(expectedNotesNumber: 4)
+        NoteList.searchForText(text: "")
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 4)
     }
 
     func testTagsTapping() throws {
@@ -69,59 +69,59 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
 
         trackStep()
         Sidebar.tagSelect(tagName: "ape")
-        AllNotesAssert.noteExists(noteName: kingKongNoteName)
+        NoteListAssert.noteExists(noteName: kingKongNoteName)
 
         trackStep()
         Sidebar.tagSelect(tagName: "reptile")
-        AllNotesAssert.noteExists(noteName: godzillaNoteName)
+        NoteListAssert.noteExists(noteName: godzillaNoteName)
 
         trackStep()
         Sidebar.tagSelect(tagName: "robot")
-        AllNotesAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
     }
 
     func testCanSearchByKeyword() throws {
         trackTest()
 
         trackStep()
-        AllNotes.open()
-        AllNotesAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
-        AllNotesAssert.notesNumber(expectedNotesNumber: 4)
+        NoteList.openAllNotes()
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
-        AllNotes.searchForText(text: "Godzilla")
-        AllNotesAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName])
-        AllNotesAssert.notesNumber(expectedNotesNumber: 3)
+        NoteList.searchForText(text: "Godzilla")
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 3)
 
         trackStep()
-        AllNotes.searchForText(text: "Gorilla")
-        AllNotesAssert.notesExist(names: [kingKongNoteName])
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+        NoteList.searchForText(text: "Gorilla")
+        NoteListAssert.notesExist(names: [kingKongNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
-        AllNotes.searchForText(text: "Gaelic")
-        AllNotesAssert.notesExist(names: [diacriticNoteName])
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+        NoteList.searchForText(text: "Gaelic")
+        NoteListAssert.notesExist(names: [diacriticNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
 
     func testCanSeeExcerpts() throws {
         trackTest()
 
         trackStep()
-        AllNotes.open()
-        AllNotesAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
-        AllNotesAssert.notesNumber(expectedNotesNumber: 4)
+        NoteList.openAllNotes()
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
-        AllNotes.searchForText(text: "Hepburn")
-        AllNotesAssert.noteContentIsShownInSearch(noteName: godzillaNoteName, expectedContent: "Godzilla (Japanese: ゴジラ, Hepburn: Gojira, /ɡɒdˈzɪlə/; [ɡoꜜdʑiɾa] (About this soundlisten)) is a fictional monster, or kaiju, originating from a series of Japanese films. The character first appeared in the 1954 film Godzilla and became a worldwide pop culture icon, appearing in various media, including 32 films produced by Toho")
+        NoteList.searchForText(text: "Hepburn")
+        NoteListAssert.noteContentIsShownInSearch(noteName: godzillaNoteName, expectedContent: "Godzilla (Japanese: ゴジラ, Hepburn: Gojira, /ɡɒdˈzɪlə/; [ɡoꜜdʑiɾa] (About this soundlisten)) is a fictional monster, or kaiju, originating from a series of Japanese films. The character first appeared in the 1954 film Godzilla and became a worldwide pop culture icon, appearing in various media, including 32 films produced by Toho")
 
         trackStep()
-        AllNotes.searchForText(text: "1962")
-        AllNotesAssert.noteContentIsShownInSearch(noteName: kingKongNoteName, expectedContent: "…King Kong vs. Godzilla (1962), pitting a larger Kong against Toho's own Godzilla, and King Kong Escapes (1967), based on The King Kong Show (1966–1969) from Rankin/Bass Productions. In 1976, Dino De Laurentiis produced a modern remake of the original film directed by John Guillermin")
+        NoteList.searchForText(text: "1962")
+        NoteListAssert.noteContentIsShownInSearch(noteName: kingKongNoteName, expectedContent: "…King Kong vs. Godzilla (1962), pitting a larger Kong against Toho's own Godzilla, and King Kong Escapes (1967), based on The King Kong Show (1966–1969) from Rankin/Bass Productions. In 1976, Dino De Laurentiis produced a modern remake of the original film directed by John Guillermin")
 
         trackStep()
-        AllNotes.searchForText(text: "archenemy")
-        AllNotesAssert.noteContentIsShownInSearch(noteName: mechagodzillaNoteName, expectedContent: "…commonly considered to be an archenemy of Godzilla")
+        NoteList.searchForText(text: "archenemy")
+        NoteListAssert.noteContentIsShownInSearch(noteName: mechagodzillaNoteName, expectedContent: "…commonly considered to be an archenemy of Godzilla")
     }
 }

--- a/SimplenoteUITests/SimplenoteUITestsTrash.swift
+++ b/SimplenoteUITests/SimplenoteUITestsTrash.swift
@@ -7,13 +7,13 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         let _ = attemptLogOut()
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
-        AllNotes.waitForLoad()
+        NoteList.waitForLoad()
     }
 
     override func setUpWithError() throws {
-        AllNotes.clearAllNotes()
+        NoteList.trashAllNotes()
         Trash.empty()
-        AllNotes.open()
+        NoteList.openAllNotes()
     }
 
     func testCanViewTrashedNotes() throws {
@@ -27,17 +27,17 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         TrashAssert.notesNumber(expectedNotesNumber: 0)
 
         // Step 2
-        AllNotes.open()
-        AllNotes.createNotes(names: noteNamesArray)
-        AllNotesAssert.notesExist(names: noteNamesArray)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 3)
+        NoteList.openAllNotes()
+        NoteList.createNotes(names: noteNamesArray)
+        NoteListAssert.notesExist(names: noteNamesArray)
+        NoteListAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
-        AllNotes.trashNote(noteName: noteOneName)
-        AllNotesAssert.noteAbsent(noteName: noteOneName)
-        AllNotesAssert.noteExists(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 2)
+        NoteList.trashNote(noteName: noteOneName)
+        NoteListAssert.noteAbsent(noteName: noteOneName)
+        NoteListAssert.noteExists(noteName: noteTwoName)
+        NoteListAssert.noteExists(noteName: noteThreeName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 2)
 
         //Step 4
         Trash.open()
@@ -56,18 +56,18 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         TrashAssert.notesNumber(expectedNotesNumber: 0)
 
         // Step 2
-        AllNotes.open()
-        AllNotes.createNotes(names: noteNamesArray)
-        AllNotesAssert.notesExist(names: noteNamesArray)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 3)
+        NoteList.openAllNotes()
+        NoteList.createNotes(names: noteNamesArray)
+        NoteListAssert.notesExist(names: noteNamesArray)
+        NoteListAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
-        AllNotes.trashNote(noteName: noteOneName)
-        AllNotes.trashNote(noteName: noteTwoName)
-        AllNotesAssert.noteAbsent(noteName: noteOneName)
-        AllNotesAssert.noteAbsent(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+        NoteList.trashNote(noteName: noteOneName)
+        NoteList.trashNote(noteName: noteTwoName)
+        NoteListAssert.noteAbsent(noteName: noteOneName)
+        NoteListAssert.noteAbsent(noteName: noteTwoName)
+        NoteListAssert.noteExists(noteName: noteThreeName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         //Step 4
         Trash.open()
@@ -82,11 +82,11 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         TrashAssert.notesNumber(expectedNotesNumber: 1)
 
         // Step 6
-        AllNotes.open()
-        AllNotesAssert.noteAbsent(noteName: noteOneName)
-        AllNotesAssert.noteAbsent(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+        NoteList.openAllNotes()
+        NoteListAssert.noteAbsent(noteName: noteOneName)
+        NoteListAssert.noteAbsent(noteName: noteTwoName)
+        NoteListAssert.noteExists(noteName: noteThreeName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
 
     func testCanDeleteNotesForeverViaEmpty() throws {
@@ -100,18 +100,18 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         TrashAssert.notesNumber(expectedNotesNumber: 0)
 
         // Step 2
-        AllNotes.open()
-        AllNotes.createNotes(names: noteNamesArray)
-        AllNotesAssert.notesExist(names: noteNamesArray)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 3)
+        NoteList.openAllNotes()
+        NoteList.createNotes(names: noteNamesArray)
+        NoteListAssert.notesExist(names: noteNamesArray)
+        NoteListAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
-        AllNotes.trashNote(noteName: noteOneName)
-        AllNotes.trashNote(noteName: noteTwoName)
-        AllNotesAssert.noteAbsent(noteName: noteOneName)
-        AllNotesAssert.noteAbsent(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+        NoteList.trashNote(noteName: noteOneName)
+        NoteList.trashNote(noteName: noteTwoName)
+        NoteListAssert.noteAbsent(noteName: noteOneName)
+        NoteListAssert.noteAbsent(noteName: noteTwoName)
+        NoteListAssert.noteExists(noteName: noteThreeName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         //Step 4
         Trash.open()
@@ -124,11 +124,11 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         TrashAssert.notesNumber(expectedNotesNumber: 0)
 
         // Step 6
-        AllNotes.open()
-        AllNotesAssert.noteAbsent(noteName: noteOneName)
-        AllNotesAssert.noteAbsent(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+        NoteList.openAllNotes()
+        NoteListAssert.noteAbsent(noteName: noteOneName)
+        NoteListAssert.noteAbsent(noteName: noteTwoName)
+        NoteListAssert.noteExists(noteName: noteThreeName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
 
     func testCanRestoreNote() throws {
@@ -142,17 +142,17 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         TrashAssert.notesNumber(expectedNotesNumber: 0)
 
         // Step 2
-        AllNotes.open()
-        AllNotes.createNotes(names: noteNamesArray)
-        AllNotesAssert.notesExist(names: noteNamesArray)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 3)
+        NoteList.openAllNotes()
+        NoteList.createNotes(names: noteNamesArray)
+        NoteListAssert.notesExist(names: noteNamesArray)
+        NoteListAssert.notesNumber(expectedNotesNumber: 3)
 
         // Step 3
-        AllNotes.trashNote(noteName: noteOneName)
-        AllNotesAssert.noteAbsent(noteName: noteOneName)
-        AllNotesAssert.noteExists(noteName: noteTwoName)
-        AllNotesAssert.noteExists(noteName: noteThreeName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 2)
+        NoteList.trashNote(noteName: noteOneName)
+        NoteListAssert.noteAbsent(noteName: noteOneName)
+        NoteListAssert.noteExists(noteName: noteTwoName)
+        NoteListAssert.noteExists(noteName: noteThreeName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 2)
 
         //Step 4
         Trash.open()
@@ -164,9 +164,9 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         TrashAssert.notesNumber(expectedNotesNumber: 0)
 
         //Step 6
-        AllNotes.open()
-        AllNotesAssert.notesExist(names: noteNamesArray)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 3)
+        NoteList.openAllNotes()
+        NoteListAssert.notesExist(names: noteNamesArray)
+        NoteListAssert.notesNumber(expectedNotesNumber: 3)
     }
 
     func testCanTrashNote() throws {
@@ -177,15 +177,15 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         TrashAssert.notesNumber(expectedNotesNumber: 0)
 
         // Step 2
-        AllNotes.open()
-        AllNotes.createNoteAndLeaveEditor(noteName: noteName)
-        AllNotesAssert.noteExists(noteName: noteName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 1)
+        NoteList.openAllNotes()
+        NoteList.createNoteAndLeaveEditor(noteName: noteName)
+        NoteListAssert.noteExists(noteName: noteName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         // Step 3
-        AllNotes.trashNote(noteName: noteName)
-        AllNotesAssert.noteAbsent(noteName: noteName)
-        AllNotesAssert.notesNumber(expectedNotesNumber: 0)
+        NoteList.trashNote(noteName: noteName)
+        NoteListAssert.noteAbsent(noteName: noteName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 0)
 
         //Step 4
         Trash.open()


### PR DESCRIPTION
Because of the introduction of tags support, the names of methods in `AllNotes` and `AllNotesAssert` classes (and the names of classes) become no longer descriptive for a case when a tag is selected. 80% of methods will work no matter if `All Notes` or `<tagName>` is selected. For methods that are meant to be used for 'All Notes' only: this is reflected with renaming too.

### Fix
Renaming:
1. `AllNotes.swift` -> `NotesList.swift`
2. `AllNotes` class -> `NoteList`
3. `AllNotesAssert` class -> `NoteListAssert`
4. `NoteList.isOpen()` -> `NoteList.isAllNotesListOpen()`
5. `NoteList.open()` -> `NoteList.openAllNotes()`
6. `NoteList.clearAllNotes()` -> `NoteList.trashAllNotes()`
7. `NoteListAssert.screenShown()` -> `NoteListAssert.allNotesScreenShown()`

### Test
1. Running all tests, seeing no fails (a man can dream)

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
