### PR TITLE
Automated two more Search tests

### DIFF
--- a/SimplenoteUITests/AssertGeneric.swift
+++ b/SimplenoteUITests/AssertGeneric.swift
@@ -45,6 +45,7 @@ let numberOfBoxesInPreviewNotExpected = "Boxes number" + inNotePreviewEnding + n
     numberOfEmptyBoxesInPreviewNotExpected = "Empty boxes number" + inNotePreviewEnding + notExpectedEnding
 
 let checkboxFoundMoreThanOnce = "Checkbox found more than once"
+let assertNavBarIdentifier = ">>> Asserting that currenly active navigation bar is: "
 
 let maxLoadTimeout = 20.0,
     minLoadTimeout = 1.0

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -9,7 +9,7 @@ class EmailLogin {
 
     class func close() {
         let backButton = app.navigationBars[UID.NavBar.logIn].buttons[UID.Button.back]
-        guard backButton.exists else { return }
+        guard backButton.isHittable else { return }
 
         backButton.tap()
     }

--- a/SimplenoteUITests/NotesList.swift
+++ b/SimplenoteUITests/NotesList.swift
@@ -6,12 +6,24 @@ class NoteList {
         app.tables.cells[noteName].tap()
     }
 
+    class func getNavBarIdentifier() -> String {
+        let navBar = app.navigationBars.element
+        guard navBar.exists else { return "" }
+        print(">>> Currently active navigation bar: " + navBar.identifier)
+        return navBar.identifier
+    }
+
     class func isAllNotesListOpen() -> Bool {
         return app.navigationBars[UID.NavBar.allNotes].exists
     }
 
+    class func isNoteListForTagOpen(tag: String) -> Bool {
+        return app.navigationBars[tag].exists
+    }
+
     class func openAllNotes() {
         guard !NoteList.isAllNotesListOpen() else { return }
+        print(">>> Opening \"All Notes\"")
         Sidebar.open()
         app.tables.staticTexts[UID.Button.allNotes].tap()
     }
@@ -126,11 +138,24 @@ class NoteListAssert {
     }
 
     class func allNotesScreenShown() {
-        XCTAssertTrue(app.navigationBars[UID.NavBar.allNotes].waitForExistence(timeout: maxLoadTimeout), UID.NavBar.allNotes + navBarNotFound)
+        print(assertNavBarIdentifier + UID.NavBar.allNotes)
+        XCTAssertTrue(app.navigationBars[UID.NavBar.allNotes].waitForExistence(timeout: maxLoadTimeout))
+        XCTAssertEqual(NoteList.getNavBarIdentifier(), UID.NavBar.allNotes, UID.NavBar.allNotes + navBarNotFound)
+    }
+
+    class func trashShown() {
+        let expectedNavbar = "Trash"
+        print(assertNavBarIdentifier + expectedNavbar)
+        XCTAssertEqual(NoteList.getNavBarIdentifier(), expectedNavbar, expectedNavbar + navBarNotFound)
+    }
+
+    class func noteListForTagOpen(tag: String) {
+        print(assertNavBarIdentifier + tag)
+        XCTAssertEqual(NoteList.getNavBarIdentifier(), tag, tag + navBarNotFound)
     }
 
     class func noteContentIsShownInSearch(noteName: String, expectedContent: String) {
-        print(">>> Asserting that note '" + noteName + "' shows the following content:")
+        print(">>> Asserting that note '\(noteName)' shows the following content:")
         print(">>>> " + expectedContent)
         let noteContent = Table.getContentOfCell(noteName: noteName)
         XCTAssertTrue(noteContent.contains(expectedContent), "Content NOT found")

--- a/SimplenoteUITests/NotesList.swift
+++ b/SimplenoteUITests/NotesList.swift
@@ -17,7 +17,7 @@ class NoteList {
         return app.navigationBars[UID.NavBar.allNotes].exists
     }
 
-    class func isNoteListForTagOpen(tag: String) -> Bool {
+    class func isNoteListOpen(forTag tag: String) -> Bool {
         return app.navigationBars[tag].exists
     }
 

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -64,20 +64,58 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         NoteListAssert.notesNumber(expectedNotesNumber: 4)
     }
 
-    func testTagsTapping() throws {
+    func testCanFilterByTagWhenClickingOnTagInTagDrawer() throws {
         trackTest()
 
         trackStep()
-        Sidebar.tagSelect(tagName: "ape")
-        NoteListAssert.noteExists(noteName: kingKongNoteName)
+        var testedTag = "prehistoric"
+        Sidebar.tagSelect(tagName: testedTag)
+        NoteListAssert.noteListForTagOpen(tag: testedTag)
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 2)
 
         trackStep()
-        Sidebar.tagSelect(tagName: "reptile")
+        testedTag = "reptile"
+        Sidebar.tagSelect(tagName: testedTag)
+        NoteListAssert.noteListForTagOpen(tag: testedTag)
         NoteListAssert.noteExists(noteName: godzillaNoteName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
-        Sidebar.tagSelect(tagName: "robot")
+        testedTag = "robot"
+        Sidebar.tagSelect(tagName: testedTag)
+        NoteListAssert.noteListForTagOpen(tag: testedTag)
         NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
+    }
+
+    func testClickingOnDifferentTagsOrAllNotesOrTrashImmediatelyUpdatesFilteredNotes() throws {
+        trackTest()
+
+        trackStep()
+        var testedTag = "prehistoric"
+        Sidebar.tagSelect(tagName: testedTag)
+        NoteListAssert.noteListForTagOpen(tag: testedTag)
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 2)
+
+        trackStep()
+        NoteList.openAllNotes()
+        NoteListAssert.allNotesScreenShown()
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 4)
+
+        trackStep()
+        Trash.open()
+        NoteListAssert.trashShown()
+        TrashAssert.notesNumber(expectedNotesNumber: 0)
+
+        trackStep()
+        testedTag = "language"
+        Sidebar.tagSelect(tagName: testedTag)
+        NoteListAssert.noteListForTagOpen(tag: testedTag)
+        NoteListAssert.noteExists(noteName: diacriticNoteName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
 
     func testCanSearchByKeyword() throws {

--- a/SimplenoteUITests/Trash.swift
+++ b/SimplenoteUITests/Trash.swift
@@ -3,6 +3,7 @@ import XCTest
 class Trash {
 
     class func open() {
+        print(">>> Opening \"Trash\"")
         Sidebar.open()
         app.tables.staticTexts[UID.Button.trash].tap()
     }

--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -39,11 +39,11 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 
 ### Tags & search
 
-- [ ] Can filter by tag when clicking on tag in tag drawer
+- [ ] Can filter by tag when clicking on tag in tag drawer (A)
 - [ ] Searching in the search field highlights matches in note list
 - [ ] Searching in the search field highlights matches in the note editor
 - [ ] Clearing the search field immediately updates filtered notes (A)
-- [ ] Clicking on different tags or All Notes or Trash immediately updates filtered notes
+- [ ] Clicking on different tags or All Notes or Trash immediately updates filtered notes (A)
 - [ ] Can search by keyword (A)
 - [ ] Tag auto-completes appear when typing in search field
 - [ ] Typing `tag:` and something else, like `tag:te` results in autocomplete tag results including that something else, e.g. `test`


### PR DESCRIPTION
Automated two more tests:
`Can filter by tag when clicking on tag in tag drawer`
`Clicking on different tags or All Notes or Trash immediately updates filtered notes`

### Fix
In order to automate tests from above in a better way, I added a few methods related to navbars:

1. `NoteList.getNavBarIdentifier()`
2. `isNoteListForTagOpen(tag)`
3. `NoteListAssert.trashShown()`
4. `NoteListAssert.noteListForTagOpen()`

Also, minor improvements to logging.

### Test
1. Running two new tests from `SimplenoteUISmokeTestsSearch`:
 - `testCanFilterByTagWhenClickingOnTagInTagDrawer`
 - `testClickingOnDifferentTagsOrAllNotesOrTrashImmediatelyUpdatesFilteredNotes`
2. All other tests are not affected

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
