### PR TITLE
UI Automation Refactor: Using optionals in return values

### DIFF
--- a/SimplenoteUITests/AssertGeneric.swift
+++ b/SimplenoteUITests/AssertGeneric.swift
@@ -46,6 +46,7 @@ let numberOfBoxesInPreviewNotExpected = "Boxes number" + inNotePreviewEnding + n
 
 let checkboxFoundMoreThanOnce = "Checkbox found more than once"
 let assertNavBarIdentifier = ">>> Asserting that currenly active navigation bar is: "
+let foundNoNavBar = "Could not find any navigation bar"
 
 let maxLoadTimeout = 20.0,
     minLoadTimeout = 1.0

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -82,7 +82,7 @@ class Table {
         return matchesCount
     }
 
-    class func getContentOfCell(noteName: String) -> String {
+    class func getContentOfCell(noteName: String) -> String? {
         let cell = Table.getCell(label: noteName)
         guard cell.exists else { return "" }
 
@@ -91,7 +91,7 @@ class Table {
         // this is the one we need.
         let predicate = NSPredicate(format: "label != '" + noteName + "'")
         let staticTextWithContent = cell.staticTexts.element(matching: predicate)
-        guard staticTextWithContent.exists else { return "" }
+        guard staticTextWithContent.exists else { return .none }
 
         return staticTextWithContent.label
     }

--- a/SimplenoteUITests/NotesList.swift
+++ b/SimplenoteUITests/NotesList.swift
@@ -144,7 +144,7 @@ class NoteListAssert {
         if let navBarID = NoteList.getNavBarIdentifier() {
             XCTAssertEqual(navBarID, selection, selection + navBarNotFound)
         } else {
-            XCTAssertTrue(false, foundNoNavBar)
+            XCTFail(foundNoNavBar)
         }
     }
 
@@ -163,7 +163,7 @@ class NoteListAssert {
         if let noteContent = Table.getContentOfCell(noteName: noteName) {
             XCTAssertTrue(noteContent.contains(expectedContent), "Content NOT found")
         } else {
-            XCTAssertTrue(false, "Could not find note")
+            XCTFail("Could not find note")
         }
     }
 }

--- a/SimplenoteUITests/NotesList.swift
+++ b/SimplenoteUITests/NotesList.swift
@@ -6,9 +6,9 @@ class NoteList {
         app.tables.cells[noteName].tap()
     }
 
-    class func getNavBarIdentifier() -> String {
+    class func getNavBarIdentifier() -> String? {
         let navBar = app.navigationBars.element
-        guard navBar.exists else { return "" }
+        guard navBar.exists else { return .none }
         print(">>> Currently active navigation bar: " + navBar.identifier)
         return navBar.identifier
     }
@@ -137,27 +137,33 @@ class NoteListAssert {
         XCTAssertEqual(actualNotesNumber, expectedNotesNumber, numberOfNotesInAllNotesNotExpected)
     }
 
-    class func allNotesScreenShown() {
-        print(assertNavBarIdentifier + UID.NavBar.allNotes)
-        XCTAssertTrue(app.navigationBars[UID.NavBar.allNotes].waitForExistence(timeout: maxLoadTimeout))
-        XCTAssertEqual(NoteList.getNavBarIdentifier(), UID.NavBar.allNotes, UID.NavBar.allNotes + navBarNotFound)
+    class func noteListShown(forSelection selection: String ) {
+        print(assertNavBarIdentifier + selection)
+        XCTAssertTrue(app.navigationBars[selection].waitForExistence(timeout: maxLoadTimeout))
+
+        if let navBarID = NoteList.getNavBarIdentifier() {
+            XCTAssertEqual(navBarID, selection, selection + navBarNotFound)
+        } else {
+            XCTAssertTrue(false, foundNoNavBar)
+        }
+    }
+
+    class func allNotesShown() {
+        NoteListAssert.noteListShown(forSelection: UID.NavBar.allNotes)
     }
 
     class func trashShown() {
-        let expectedNavbar = "Trash"
-        print(assertNavBarIdentifier + expectedNavbar)
-        XCTAssertEqual(NoteList.getNavBarIdentifier(), expectedNavbar, expectedNavbar + navBarNotFound)
-    }
-
-    class func noteListForTagOpen(tag: String) {
-        print(assertNavBarIdentifier + tag)
-        XCTAssertEqual(NoteList.getNavBarIdentifier(), tag, tag + navBarNotFound)
+        NoteListAssert.noteListShown(forSelection: UID.NavBar.trash)
     }
 
     class func noteContentIsShownInSearch(noteName: String, expectedContent: String) {
         print(">>> Asserting that note '\(noteName)' shows the following content:")
         print(">>>> " + expectedContent)
-        let noteContent = Table.getContentOfCell(noteName: noteName)
-        XCTAssertTrue(noteContent.contains(expectedContent), "Content NOT found")
+
+        if let noteContent = Table.getContentOfCell(noteName: noteName) {
+            XCTAssertTrue(noteContent.contains(expectedContent), "Content NOT found")
+        } else {
+            XCTAssertTrue(false, "Could not find note")
+        }
     }
 }

--- a/SimplenoteUITests/SimplenoteUITestsLogin.swift
+++ b/SimplenoteUITests/SimplenoteUITestsLogin.swift
@@ -65,14 +65,14 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
     func testLogInWithCorrectCredentials() throws {
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
-        NoteListAssert.allNotesScreenShown()
+        NoteListAssert.allNotesShown()
     }
 
     func testLogOut() throws {
         // Step 1
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
-        NoteListAssert.allNotesScreenShown()
+        NoteListAssert.allNotesShown()
 
         // Step 2
         _ = logOut()

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -70,21 +70,21 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         trackStep()
         var testedTag = "prehistoric"
         Sidebar.tagSelect(tagName: testedTag)
-        NoteListAssert.noteListForTagOpen(tag: testedTag)
+        NoteListAssert.noteListShown(forSelection: testedTag)
         NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
         NoteListAssert.notesNumber(expectedNotesNumber: 2)
 
         trackStep()
         testedTag = "reptile"
         Sidebar.tagSelect(tagName: testedTag)
-        NoteListAssert.noteListForTagOpen(tag: testedTag)
+        NoteListAssert.noteListShown(forSelection: testedTag)
         NoteListAssert.noteExists(noteName: godzillaNoteName)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
         testedTag = "robot"
         Sidebar.tagSelect(tagName: testedTag)
-        NoteListAssert.noteListForTagOpen(tag: testedTag)
+        NoteListAssert.noteListShown(forSelection: testedTag)
         NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
@@ -95,13 +95,13 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         trackStep()
         var testedTag = "prehistoric"
         Sidebar.tagSelect(tagName: testedTag)
-        NoteListAssert.noteListForTagOpen(tag: testedTag)
+        NoteListAssert.noteListShown(forSelection: testedTag)
         NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
         NoteListAssert.notesNumber(expectedNotesNumber: 2)
 
         trackStep()
         NoteList.openAllNotes()
-        NoteListAssert.allNotesScreenShown()
+        NoteListAssert.allNotesShown()
         NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
         NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
@@ -113,7 +113,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         trackStep()
         testedTag = "language"
         Sidebar.tagSelect(tagName: testedTag)
-        NoteListAssert.noteListForTagOpen(tag: testedTag)
+        NoteListAssert.noteListShown(forSelection: testedTag)
         NoteListAssert.noteExists(noteName: diacriticNoteName)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -13,6 +13,7 @@ enum UID {
         static let logIn = "Log In"
         static let noteEditorPreview = "Preview"
         static let noteEditorOptions = "Options"
+        static let trash = "Trash"
     }
 
     enum Button {


### PR DESCRIPTION
- Using optional strings in return values instead of returning empty strings
- Renamed two methods

### Fix
1. `Table.getContentOfCell()` and `NoteList.getNavBarIdentifier()` now return optional strings
2. Two methods: `NoteListAssert.noteListShown()` and `NoteListAssert.noteContentIsShownInSearch()` that are using the methods from 1 now include unwrapping of optional strings
3. Renamed `allNotesScreenShown()` to `allNotesShown()`
4. Since there were three painfully similar methods: `allNotesShown()` , `trashShown()` and `noteListForTagOpen()` which do the same, but with different inputs, I created `noteListShown(forSelection selection: String)`, which now replaces 'noteListForTagOpen()' and also now called by `allNotesShown()` and `trashShown()`

### Test
1. Running all tests

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
