### PR TITLE
"Tags&Search" tests automation MK4

### DIFF
--- a/SimplenoteUITests/AssertGeneric.swift
+++ b/SimplenoteUITests/AssertGeneric.swift
@@ -5,6 +5,7 @@ let notExpectedEnding = " is NOT as expected",
     notAbsentEnding = " NOT absent"
 
 let inAllNotesEnding = " in \"All Notes\"",
+    inNoteListEnding = " in \"Note List\"",
     inTrashEnding = " in \"Trash\"",
     inEditorEnding = " in Note Editor",
     inNotePreviewEnding = " in Note Preview",
@@ -30,7 +31,8 @@ let noteNotFoundInAllNotes = "\" Note" + notFoundEnding + inAllNotesEnding,
     noteNotAbsentInTrash = " Note" + notAbsentEnding + inTrashEnding
 
 let numberOfNotesInAllNotesNotExpected = "Notes Number" + inAllNotesEnding + notExpectedEnding,
-    numberOfNotesInTrashNotExpected = "Notes Number" + inTrashEnding + notExpectedEnding
+    numberOfNotesInTrashNotExpected = "Notes Number" + inTrashEnding + notExpectedEnding,
+    numberOfTagsSuggestionsNotExpected = "Tags search suggestions " + inNoteListEnding + notExpectedEnding
 
 let linkContainerNotFoundInEditor = "\" link container" + notFoundEnding + inEditorEnding,
     linkNotFoundInEditor = "\" link" + notFoundEnding + inEditorEnding,
@@ -46,6 +48,8 @@ let numberOfBoxesInPreviewNotExpected = "Boxes number" + inNotePreviewEnding + n
 
 let checkboxFoundMoreThanOnce = "Checkbox found more than once"
 let assertNavBarIdentifier = ">>> Asserting that currenly active navigation bar is: "
+let assertSearchHeaderShown = ">>> Asserting that search results header is shown: "
+let assertSearchHeaderNotShown = ">>> Asserting that search results header is NOT shown: "
 let foundNoNavBar = "Could not find any navigation bar"
 
 let maxLoadTimeout = 20.0,

--- a/SimplenoteUITests/AssertGeneric.swift
+++ b/SimplenoteUITests/AssertGeneric.swift
@@ -4,8 +4,8 @@ let notExpectedEnding = " is NOT as expected",
     notFoundEnding = " NOT found",
     notAbsentEnding = " NOT absent"
 
-let inAllNotesEnding = " in \"All Notes\"",
-    inNoteListEnding = " in \"Note List\"",
+let inAllNotesEnding = #" in "All Notes""#,
+    inNoteListEnding = #" in "Note List""#,
     inTrashEnding = " in \"Trash\"",
     inEditorEnding = " in Note Editor",
     inNotePreviewEnding = " in Note Preview",

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -41,26 +41,41 @@ func getToAllNotes() {
 
 class Table {
 
-    class func getCellsNumber() -> Int {
-        // We need to count only the table cells that have X = 0
+    class func getVisibleLabelledCellsNumber() -> Int {
+        // We need only the table cells that have X = 0 and a non-empty label
         // otherwise we will include invisible elements from Sidebar pane, when Notes List is open
         // or the elements from Notes List when Settings are open
+        // or the visible tags search suggestrions
         let cellsNum = app.tables.element.children(matching: .cell).count
-        var notesNum: Int = 0
-
-        if cellsNum == 0 {
-            return notesNum
-        }
+        var matchesNum: Int = 0
+        guard cellsNum > 0 else { return matchesNum }
 
         for index in 0...cellsNum - 1 {
             let cell = app.tables.cells.element(boundBy: index)
-
-            if cell.frame.minX == 0.0 {
-                notesNum += 1
+            if cell.frame.minX == 0.0 && cell.label.count > 0 {
+                matchesNum += 1
             }
         }
 
-        return notesNum
+        return matchesNum
+    }
+
+    class func getVisibleNonLabelledCellsNumber() -> Int {
+        // We need only the table cells that have X = 0 and an empty label
+        // Currently (besides using object dimentions) this is the way to
+        // locate tags search suggestions
+        let cellsNum = app.tables.element.children(matching: .cell).count
+        var matchesNum: Int = 0
+        guard cellsNum > 0 else { return matchesNum }
+
+        for index in 0...cellsNum - 1 {
+            let cell = app.tables.cells.element(boundBy: index)
+            if cell.frame.minX == 0.0 && cell.label.count == 0 {
+                matchesNum += 1
+            }
+        }
+
+        return matchesNum
     }
 
     class func trashCell(noteName: String) {
@@ -79,6 +94,16 @@ class Table {
         let matchingCells = app.cells.matching(predicate)
         let matchesCount = matchingCells.count
         print(">>> Found " + String(matchesCount) + " Cell(s) with '" + label + "' label")
+        return matchesCount
+    }
+
+    class func getStaticTextsWithExactLabelCount(label: String) -> Int {
+        let predicate = NSPredicate(format: "label == '" + label + "'")
+        let table = app.tables
+        print(table.debugDescription)
+        let matchingCells = app.tables.staticTexts.matching(predicate)
+        let matchesCount = matchingCells.count
+        print(">>> Found " + String(matchesCount) + " StaticText(s) with '" + label + "' label")
         return matchesCount
     }
 

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -45,7 +45,7 @@ class Table {
         // We need only the table cells that have X = 0 and a non-empty label
         // otherwise we will include invisible elements from Sidebar pane, when Notes List is open
         // or the elements from Notes List when Settings are open
-        // or the visible tags search suggestrions
+        // or the visible tags search suggestions
         let cellsNum = app.tables.element.children(matching: .cell).count
         var matchesNum: Int = 0
         guard cellsNum > 0 else { return matchesNum }

--- a/SimplenoteUITests/NotesList.swift
+++ b/SimplenoteUITests/NotesList.swift
@@ -55,7 +55,11 @@ class NoteList {
     }
 
     class func getNotesNumber() -> Int {
-        return Table.getCellsNumber()
+        return Table.getVisibleLabelledCellsNumber()
+    }
+
+    class func getTagsSuggestionsNumber() -> Int {
+        return Table.getVisibleNonLabelledCellsNumber()
     }
 
     class func trashAllNotes() {
@@ -116,6 +120,49 @@ class NoteList {
 
 class NoteListAssert {
 
+    class func searchHeaderShown(header: String, numberOfOccurences: Int) {
+        switch numberOfOccurences {
+        case 0:
+            print(assertSearchHeaderNotShown + header)
+        case 1:
+            print(assertSearchHeaderShown + header)
+        default:
+            print("Invalid value of \"numberOfOccurences\". Valid values are 0 or 1")
+            return
+        }
+
+        let matchesCount = Table.getStaticTextsWithExactLabelCount(label: header)
+        XCTAssertEqual(matchesCount, numberOfOccurences)
+    }
+
+    class func tagsSearchHeaderShown() {
+        NoteListAssert.searchHeaderShown(header: UID.Text.searchByTag, numberOfOccurences: 1)
+    }
+
+    class func tagsSearchHeaderNotShown() {
+        NoteListAssert.searchHeaderShown(header: UID.Text.searchByTag, numberOfOccurences: 0)
+    }
+
+    class func notesSearchHeaderShown() {
+        NoteListAssert.searchHeaderShown(header: UID.Text.notes, numberOfOccurences: 1)
+    }
+
+    class func notesSearchHeaderNotShown() {
+        NoteListAssert.searchHeaderShown(header: UID.Text.notes, numberOfOccurences: 0)
+    }
+
+    class func tagSuggestionExists(tag: String) {
+        print(">>> Asserting that \"\(tag)\" tag suggestion is shown once")
+        let matchesCount = Table.getStaticTextsWithExactLabelCount(label: tag)
+        XCTAssertEqual(matchesCount, 1)
+    }
+
+    class func tagSuggestionsExist(tags: [String]) {
+        for tag in tags {
+            NoteListAssert.tagSuggestionExists(tag: tag)
+        }
+    }
+
     class func noteExists(noteName: String) {
         print(">>> Asserting that note is shown once: " + noteName)
         let matchesCount = Table.getCellsWithExactLabelCount(label: noteName)
@@ -135,6 +182,11 @@ class NoteListAssert {
     class func notesNumber(expectedNotesNumber: Int) {
         let actualNotesNumber = NoteList.getNotesNumber()
         XCTAssertEqual(actualNotesNumber, expectedNotesNumber, numberOfNotesInAllNotesNotExpected)
+    }
+
+    class func tagsSuggestionsNumber(number: Int) {
+        let actualNumber = NoteList.getTagsSuggestionsNumber()
+        XCTAssertEqual(actualNumber, number, numberOfTagsSuggestionsNotExpected)
     }
 
     class func noteListShown(forSelection selection: String ) {

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -142,6 +142,87 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
 
+    func testTagSuggestionsSuggestTagsRegardlessOfCase() throws {
+        trackTest()
+
+        trackStep()
+        NoteList.searchForText(text: "robot")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionExists(tag: "tag:robot")
+        NoteListAssert.tagsSuggestionsNumber(number: 1)
+        NoteListAssert.notesSearchHeaderShown()
+        NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
+
+        trackStep()
+        NoteList.searchForText(text: "ROBOT")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionExists(tag: "tag:robot")
+        NoteListAssert.tagsSuggestionsNumber(number: 1)
+        NoteListAssert.notesSearchHeaderShown()
+        NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
+
+        trackStep()
+        NoteList.searchForText(text: "PrEhIsToRiC")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionExists(tag: "tag:prehistoric")
+        NoteListAssert.tagsSuggestionsNumber(number: 1)
+        NoteListAssert.notesSearchHeaderNotShown()
+        NoteListAssert.notesNumber(expectedNotesNumber: 0)
+    }
+
+    func testTagAutoCompletesAppearWhenTypingInSearchField() throws {
+        trackTest()
+
+        trackStep()
+        NoteList.searchForText(text: "t")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionsExist(tags: ["tag:diacritic", "tag:prehistoric", "tag:reptile", "tag:robot", "tag:sea-monster"])
+        NoteListAssert.tagsSuggestionsNumber(number: 5)
+        NoteListAssert.notesSearchHeaderShown()
+
+        trackStep()
+        NoteList.searchForText(text: "a")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionsExist(tags: ["tag:ape", "tag:diacritic", "tag:language", "tag:man-made", "tag:sea-monster"])
+        NoteListAssert.tagsSuggestionsNumber(number: 5)
+        NoteListAssert.notesSearchHeaderShown()
+
+        trackStep()
+        NoteList.searchForText(text: "ic")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionsExist(tags: ["tag:diacritic", "tag:prehistoric"])
+        NoteListAssert.tagsSuggestionsNumber(number: 2)
+        NoteListAssert.notesSearchHeaderShown()
+
+        trackStep()
+        NoteList.searchForText(text: "abc")
+        NoteListAssert.tagsSearchHeaderNotShown()
+        NoteListAssert.notesSearchHeaderNotShown()
+        NoteListAssert.notesNumber(expectedNotesNumber: 0)
+    }
+
+    func testTypingTagAndSomethingElseResultsInAutocompleteTagResultsIncludingThatSomethingElse() throws {
+        trackTest()
+
+        trackStep()
+        NoteList.searchForText(text: "tag:re")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionsExist(tags: ["tag:prehistoric", "tag:reptile"])
+        NoteListAssert.tagsSuggestionsNumber(number: 2)
+        NoteListAssert.notesSearchHeaderNotShown()
+        NoteListAssert.notesNumber(expectedNotesNumber: 0)
+
+        trackStep()
+        NoteList.searchForText(text: "tag:-")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionsExist(tags: ["tag:man-made", "tag:sea-monster"])
+        NoteListAssert.tagsSuggestionsNumber(number: 2)
+        NoteListAssert.notesSearchHeaderNotShown()
+        NoteListAssert.notesNumber(expectedNotesNumber: 0)
+    }
+
     func testCanSeeExcerpts() throws {
         trackTest()
 

--- a/SimplenoteUITests/Trash.swift
+++ b/SimplenoteUITests/Trash.swift
@@ -27,7 +27,7 @@ class Trash {
     }
 
     class func getNotesNumber() -> Int {
-        return Table.getCellsNumber()
+        return Table.getVisibleLabelledCellsNumber()
     }
 }
 

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -47,6 +47,8 @@ enum UID {
         static let noteEditorPreview = "Preview"
         static let noteEditorOptionsMarkdown = "Markdown"
         static let allNotesInProgress = "In progress"
+        static let searchByTag = "Search by Tag"
+        static let notes = "Notes"
     }
 
     enum TextField {

--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -45,9 +45,9 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] Clearing the search field immediately updates filtered notes (A)
 - [ ] Clicking on different tags or All Notes or Trash immediately updates filtered notes (A)
 - [ ] Can search by keyword (A)
-- [ ] Tag auto-completes appear when typing in search field
-- [ ] Typing `tag:` and something else, like `tag:te` results in autocomplete tag results including that something else, e.g. `test`
-- [ ] Tag suggestions suggest tags regardless of case
+- [ ] Tag auto-completes appear when typing in search field (A)
+- [ ] Typing `tag:` and something else, like `tag:te` results in autocomplete tag results including that something else, e.g. `test` (A)
+- [ ] Tag suggestions suggest tags regardless of case (A)
 - [ ] Search field updates with results of `tag:test` format search string
 
 ### Trash


### PR DESCRIPTION
Three more tests automated:
- [x] Tag auto-completes appear when typing in search field
- [x] Typing `tag:` and something else, like `tag:te` results in autocomplete tag results including that something else, e.g. `test`
- [x] Tag suggestions suggest tags regardless of case

### Fix
For this to happen, I needed to create a number of simple methods:
1. `NoteListAssert.tagsSuggestionsNumber(number)` which calls new `NoteList.getTagsSuggestionsNumber()`
2. `NoteListAssert.tagSuggestionExists(tag)` which is extended by new `NoteListAssert.tagSuggestionsExist([tags])`
3. Four one-line methods: `NoteListAssert.tagsSearchHeaderShown()` / `NoteListAssert.tagsSearchHeaderNotShown()` / `NoteListAssert.notesSearchHeaderShown()` / `NoteListAssert.notesSearchHeaderNotShown()` which really call one same new method `NoteListAssert.searchHeaderShown(header, numberOfOccurences)`
4. All methods from above really end up using more generic `Table.getStaticTextsWithExactLabelCount(label)`, `Table.getVisibleNonLabelledCellsNumber()` 
5. Old `Table.getCellsNumber()` was renamed to `Table.getVisibleLabelledCellsNumber()`to better reflect what it does
6. Several new string constants for logging / locating elements.

### Test
1. Running three new tests:
 - `testTagSuggestionsSuggestTagsRegardlessOfCase()`
 - `testTagAutoCompletesAppearWhenTypingInSearchField()`
 - `testTypingTagAndSomethingElseResultsInAutocompleteTagResultsIncludingThatSomethingElse()` 
 
⬆️ Oh my, I don't feel good about the length of the names, but I found no better way to link the code to corresponding tests from [testing-checklist](https://github.com/Automattic/simplenote-ios/blob/develop/TESTING-CHECKLIST.md). Other than that, we'd need to add IDs to the testing checklist, which will add more maintenance. tbh, I have no better ideas atm.

2. Making sure other tests are not affected 

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
