### PR TITLE
"Tags&Search" tests automation MK5

### DIFF
--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -89,6 +89,11 @@ class Table {
         return cell
     }
 
+    class func getStaticText(label: String) -> XCUIElement {
+        let staticText = app.tables.staticTexts[label]
+        return staticText
+    }
+
     class func getCellsWithExactLabelCount(label: String) -> Int {
         let predicate = NSPredicate(format: "label == '" + label + "'")
         let matchingCells = app.cells.matching(predicate)

--- a/SimplenoteUITests/NotesList.swift
+++ b/SimplenoteUITests/NotesList.swift
@@ -62,6 +62,11 @@ class NoteList {
         return Table.getVisibleNonLabelledCellsNumber()
     }
 
+    class func tagSuggestionTap(tag: String) {
+        print(">>> Tapping '\(tag)' tag suggestion")
+        Table.getStaticText(label: tag).tap()
+    }
+
     class func trashAllNotes() {
         NoteList.openAllNotes()
 
@@ -217,5 +222,23 @@ class NoteListAssert {
         } else {
             XCTFail("Could not find note")
         }
+    }
+
+    class func searchStringIsShown(searchString: String) {
+        print(">>> Asserting that search string is '\(searchString)'")
+        let searchField = app.searchFields[UID.SearchField.search]
+
+        guard searchField.exists else {
+            XCTFail(">>> Search field not found")
+            return
+        }
+
+        guard let actualSearchString = searchField.value as? String else {
+            XCTFail(">>> Search field has no value")
+            return
+        }
+
+        print(">>> Actual search string is '\(actualSearchString)'")
+        XCTAssertEqual(actualSearchString, searchString)
     }
 }

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -223,6 +223,23 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         NoteListAssert.notesNumber(expectedNotesNumber: 0)
     }
 
+    func testSearchFieldUpdatesWithResultsOfTagFormatSearchString() throws {
+        trackTest()
+        let testedTag = "tag:prehistoric"
+
+        trackStep()
+        NoteList.searchForText(text: "pre")
+        NoteListAssert.tagsSearchHeaderShown()
+        NoteListAssert.tagSuggestionExists(tag: testedTag)
+
+        trackStep()
+        NoteList.tagSuggestionTap(tag: testedTag)
+        NoteListAssert.searchStringIsShown(searchString: testedTag + " ")
+        NoteListAssert.notesSearchHeaderShown()
+        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
+        NoteListAssert.notesNumber(expectedNotesNumber: 2)
+    }
+
     func testCanSeeExcerpts() throws {
         trackTest()
 

--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -48,7 +48,7 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 - [ ] Tag auto-completes appear when typing in search field (A)
 - [ ] Typing `tag:` and something else, like `tag:te` results in autocomplete tag results including that something else, e.g. `test` (A)
 - [ ] Tag suggestions suggest tags regardless of case (A)
-- [ ] Search field updates with results of `tag:test` format search string
+- [ ] Search field updates with results of `tag:test` format search string (A)
 
 ### Trash
 


### PR DESCRIPTION
Automated one test:
- [x]  Search field updates with results of `tag:test` format search string

This is the last test from 'Tags&Search' from easily automate-able ones. The remaining two are testing keywords highlighting during search, which promises to be quite challenging to automate.

### Fix
1. New method to tap a tag suggestion during search: `NoteList.tagSuggestionTap(tag)`
2. Asserting method that checks the search field content: `NoteListAssert.searchStringIsShown(searchString)`

### Test
1. Running new `testSearchFieldUpdatesWithResultsOfTagFormatSearchString()` along with the old ones.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.