### PR TITLE
Don't create a welcome note

### DIFF
--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -161,9 +161,9 @@
     [self loadSelectedTheme];
     
     // Check to see if first time user
-    if ([self isFirstLaunch]) {        
+    if ([self isFirstLaunch]) {
+        _noteListViewController.firstLaunch = YES;
         [[SPPinLockManager shared] removePin];
-        [self createWelcomeNoteAfterDelay];
         [self markFirstLaunch];
     } else {
         [self showPasscodeLockIfNecessary];
@@ -261,30 +261,6 @@
 - (void)markFirstLaunch
 {
     [[Options shared] setFirstLaunch:YES];
-}
-
-- (void)createWelcomeNoteAfterDelay
-{
-    [self performSelector:@selector(createWelcomeNote) withObject:nil afterDelay:0.5];
-}
-
-- (void)createWelcomeNote
-{
-    NSString *welcomeKey = @"welcomeNote-iOS";
-    SPBucket *noteBucket = [_simperium bucketForName:@"Note"];
-    Note *welcomeNote = [noteBucket objectForKey:welcomeKey];
-    
-    if (welcomeNote) {
-        return;
-	}
-    
-    welcomeNote = [noteBucket insertNewObjectForKey:welcomeKey];
-    welcomeNote.modificationDate = [NSDate date];
-    welcomeNote.creationDate = [NSDate date];
-    welcomeNote.content = NSLocalizedString(@"welcomeNote-iOS", @"A welcome note for new iOS users");
-    [self save];
-    
-    _noteListViewController.firstLaunch = YES;
 }
 
 


### PR DESCRIPTION
### Fix
In this PR we're removing Welcome Note creation logic from the client. Welcome Note will be created by the backend.

### Test
1. Make sure it's a clean install (delete and install the app)
2. Sign up with a new account

- [ ] Check that there is only one welcome note

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
