### PR TITLE
Adding `XCUIElementQuery: Sequence` extension

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 		D864B1C625CAE5F800F9B73E /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1C525CAE5F800F9B73E /* Preview.swift */; };
 		D864B1CF25CAE61F00F9B73E /* Trash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1CE25CAE61F00F9B73E /* Trash.swift */; };
 		D864B1D825CAE63E00F9B73E /* UIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1D725CAE63E00F9B73E /* UIDs.swift */; };
-		D864B1E125CAE66A00F9B73E /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1E025CAE66A00F9B73E /* XCTest+Extensions.swift */; };
+		D864B1E125CAE66A00F9B73E /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1E025CAE66A00F9B73E /* Extensions.swift */; };
 		D8E2D8E325E7DE090001315B /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E2D8E225E7DE090001315B /* Sidebar.swift */; };
 		DE7E545B214E34C8008D9928 /* NSString+Count.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E545A214E34C8008D9928 /* NSString+Count.swift */; };
 		E215C793180B115C00AD36B5 /* SPNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E215C791180B115C00AD36B5 /* SPNavigationController.m */; };
@@ -919,7 +919,7 @@
 		D864B1C525CAE5F800F9B73E /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		D864B1CE25CAE61F00F9B73E /* Trash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trash.swift; sourceTree = "<group>"; };
 		D864B1D725CAE63E00F9B73E /* UIDs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDs.swift; sourceTree = "<group>"; };
-		D864B1E025CAE66A00F9B73E /* XCTest+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
+		D864B1E025CAE66A00F9B73E /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		D864B1F025CAE87800F9B73E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D8E2D8E225E7DE090001315B /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		DE7E545A214E34C8008D9928 /* NSString+Count.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSString+Count.swift"; path = "Classes/NSString+Count.swift"; sourceTree = "<group>"; };
@@ -1879,7 +1879,7 @@
 				D843AD7725E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift */,
 				D864B1CE25CAE61F00F9B73E /* Trash.swift */,
 				D864B1D725CAE63E00F9B73E /* UIDs.swift */,
-				D864B1E025CAE66A00F9B73E /* XCTest+Extensions.swift */,
+				D864B1E025CAE66A00F9B73E /* Extensions.swift */,
 			);
 			path = SimplenoteUITests;
 			sourceTree = "<group>";
@@ -2953,7 +2953,7 @@
 				D843AD7825E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift in Sources */,
 				D864B1AB25CAE59400F9B73E /* EmailLogin.swift in Sources */,
 				D864B18225CAE4BE00F9B73E /* SimplenoteUITestsNoteEditor.swift in Sources */,
-				D864B1E125CAE66A00F9B73E /* XCTest+Extensions.swift in Sources */,
+				D864B1E125CAE66A00F9B73E /* Extensions.swift in Sources */,
 				D864B1CF25CAE61F00F9B73E /* Trash.swift in Sources */,
 				D864B1C625CAE5F800F9B73E /* Preview.swift in Sources */,
 				D843AD8F25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift in Sources */,

--- a/SimplenoteUITests/Extensions.swift
+++ b/SimplenoteUITests/Extensions.swift
@@ -34,3 +34,10 @@ extension XCUIElementQuery: Sequence {
         }
     }
 }
+
+extension String {
+
+    func strippingUnicodeObjectReplacementCharacter() -> String {
+        replacingOccurrences(of: "\u{fffc}", with: "")
+    }
+}

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -29,7 +29,7 @@ func trackTest(_ function: String = #function) {
 }
 
 func trackStep() {
-    print(">> Step " + String(stepIndex))
+    print(">> Step \(stepIndex)")
     stepIndex += 1
 }
 
@@ -50,34 +50,18 @@ class Table {
         // otherwise we will include invisible elements from Sidebar pane, when Notes List is open
         // or the elements from Notes List when Settings are open
         // or the visible tags search suggestions
-        let cells = Table.getAllCells()
-        var matches = 0
-        guard cells.count > 0 else { return matches }
-
-        for cell in cells {
-            if cell.frame.minX == 0.0 && cell.label.count > 0 {
-                matches += 1
-            }
-        }
-
-        return matches
+        return Table.getAllCells()
+            .filter { $0.frame.minX == 0.0 && $0.label.isEmpty == false }
+            .count
     }
 
     class func getVisibleNonLabelledCellsNumber() -> Int {
         // We need only the table cells that have X = 0 and an empty label
         // Currently (besides using object dimentions) this is the way to
         // locate tags search suggestions
-        let cells = Table.getAllCells()
-        var matches = 0
-        guard cells.count > 0 else { return matches }
-
-        for cell in cells {
-            if cell.frame.minX == 0.0 && cell.label.count == 0 {
-                matches += 1
-            }
-        }
-
-        return matches
+        return Table.getAllCells()
+            .filter { $0.frame.minX == 0.0 && $0.label.isEmpty == true }
+            .count
     }
 
     class func trashCell(noteName: String) {
@@ -138,11 +122,17 @@ class WebView {
 
 class WebViewAssert {
 
-    class func textShownOnScreen(textToFind: String) {
-        let textPredicate = NSPredicate(format: "label MATCHES '" + textToFind + "'")
+    class func textShownOnScreen(text: String) {
+        let textPredicate = NSPredicate(format: "label MATCHES '" + text + "'")
         let staticText = app.staticTexts.element(matching: textPredicate)
 
-        XCTAssertTrue(staticText.exists, "\"" + textToFind + textNotFoundInWebView)
+        XCTAssertTrue(staticText.exists, "\"" + text + textNotFoundInWebView)
+    }
+
+    class func textsShownOnScreen(texts: [String]) {
+        for text in texts {
+            WebViewAssert.textShownOnScreen(text: text)
+        }
     }
 }
 

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -41,41 +41,43 @@ func getToAllNotes() {
 
 class Table {
 
+    class func getAllCells() -> XCUIElementQuery {
+        return app.tables.element.children(matching: .cell)
+    }
+
     class func getVisibleLabelledCellsNumber() -> Int {
         // We need only the table cells that have X = 0 and a non-empty label
         // otherwise we will include invisible elements from Sidebar pane, when Notes List is open
         // or the elements from Notes List when Settings are open
         // or the visible tags search suggestions
-        let cellsNum = app.tables.element.children(matching: .cell).count
-        var matchesNum: Int = 0
-        guard cellsNum > 0 else { return matchesNum }
+        let cells = Table.getAllCells()
+        var matches = 0
+        guard cells.count > 0 else { return matches }
 
-        for index in 0...cellsNum - 1 {
-            let cell = app.tables.cells.element(boundBy: index)
+        for cell in cells {
             if cell.frame.minX == 0.0 && cell.label.count > 0 {
-                matchesNum += 1
+                matches += 1
             }
         }
 
-        return matchesNum
+        return matches
     }
 
     class func getVisibleNonLabelledCellsNumber() -> Int {
         // We need only the table cells that have X = 0 and an empty label
         // Currently (besides using object dimentions) this is the way to
         // locate tags search suggestions
-        let cellsNum = app.tables.element.children(matching: .cell).count
-        var matchesNum: Int = 0
-        guard cellsNum > 0 else { return matchesNum }
+        let cells = Table.getAllCells()
+        var matches = 0
+        guard cells.count > 0 else { return matches }
 
-        for index in 0...cellsNum - 1 {
-            let cell = app.tables.cells.element(boundBy: index)
+        for cell in cells {
             if cell.frame.minX == 0.0 && cell.label.count == 0 {
-                matchesNum += 1
+                matches += 1
             }
         }
 
-        return matchesNum
+        return matches
     }
 
     class func trashCell(noteName: String) {
@@ -97,19 +99,17 @@ class Table {
     class func getCellsWithExactLabelCount(label: String) -> Int {
         let predicate = NSPredicate(format: "label == '" + label + "'")
         let matchingCells = app.cells.matching(predicate)
-        let matchesCount = matchingCells.count
-        print(">>> Found " + String(matchesCount) + " Cell(s) with '" + label + "' label")
-        return matchesCount
+        let matches = matchingCells.count
+        print(">>> Found \(matches) Cell(s) with '\(label)' label")
+        return matches
     }
 
     class func getStaticTextsWithExactLabelCount(label: String) -> Int {
         let predicate = NSPredicate(format: "label == '" + label + "'")
-        let table = app.tables
-        print(table.debugDescription)
         let matchingCells = app.tables.staticTexts.matching(predicate)
-        let matchesCount = matchingCells.count
-        print(">>> Found " + String(matchesCount) + " StaticText(s) with '" + label + "' label")
-        return matchesCount
+        let matches = matchingCells.count
+        print(">>> Found \(matches) StaticText(s) with '\(label)' label")
+        return matches
     }
 
     class func getContentOfCell(noteName: String) -> String? {

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -96,35 +96,35 @@ class NoteEditor {
     }
 
     class func getCheckboxesForTextCount(text: String) -> Int {
-        let matchesCount = NoteEditor.getTextViewsWithExactLabelCount(label: text)
-        print(">>> ^ Found " + String(matchesCount) + " Checkboxe(s) for '" + text + "'")
-        return matchesCount
+        let matches = NoteEditor.getTextViewsWithExactLabelCount(label: text)
+        print(">>> ^ Found " + String(matches) + " Checkbox(es) for '" + text + "'")
+        return matches
     }
 
     class func getTextViewsWithExactValueCount(value: String) -> Int {
         let textViews = getAllTextViews()
-        var matchesCounter = 0
+        var matches = 0
 
-        for index in 0...textViews.count - 1 {
-            let currentValue = textViews.element(boundBy: index).value as! String
+        for textView in textViews {
+            let currentValue = textView.value as! String
             let currentValueStripped = currentValue.replacingOccurrences(of: "\u{fffc}", with: "")
 
             if currentValueStripped == value {
-                matchesCounter += 1
+                matches += 1
             }
         }
 
-        print(">>> Found " + String(matchesCounter) + " TextView(s) with '" + value + "' value")
-        return matchesCounter
+        print(">>> Found \(matches) TextView(s) with '\(value)' value")
+        return matches
     }
 
     class func getTextViewsWithExactLabelCount(label: String) -> Int {
         let _ = getAllTextViews()// To initialize the editor
         let predicate = NSPredicate(format: "label == '" + label + "'")
         let matchingTextViews = app.textViews.matching(predicate)
-        let matchesCount = matchingTextViews.count
-        print(">>> Found " + String(matchesCount) + " TextView(s) with '" + label + "' label")
-        return matchesCount
+        let matches = matchingTextViews.count
+        print(">>> Found \(matches) TextView(s) with '\(label)' label")
+        return matches
     }
 
 }
@@ -148,18 +148,18 @@ class NoteEditorAssert {
     }
 
     class func textViewWithExactValueShownOnce(value: String) {
-        let matchesCount = NoteEditor.getTextViewsWithExactValueCount(value: value)
-        XCTAssertEqual(matchesCount, 1)
+        let matches = NoteEditor.getTextViewsWithExactValueCount(value: value)
+        XCTAssertEqual(matches, 1)
     }
 
     class func textViewWithExactValueNotShown(value: String) {
-        let matchesCount = NoteEditor.getTextViewsWithExactValueCount(value: value)
-        XCTAssertEqual(matchesCount, 0)
+        let matches = NoteEditor.getTextViewsWithExactValueCount(value: value)
+        XCTAssertEqual(matches, 0)
     }
 
     class func textViewWithExactLabelShownOnce(label: String) {
-        let matchesCount = NoteEditor.getTextViewsWithExactLabelCount(label: label)
-        XCTAssertEqual(matchesCount, 1)
+        let matches = NoteEditor.getTextViewsWithExactLabelCount(label: label)
+        XCTAssertEqual(matches, 1)
     }
 
     class func textViewWithExactLabelsShownOnce(labels: [String]) {
@@ -169,12 +169,12 @@ class NoteEditorAssert {
     }
 
     class func checkboxForTextShownOnce(text: String) {
-        let matchesCount = NoteEditor.getCheckboxesForTextCount(text: text)
-        XCTAssertEqual(matchesCount, 1)
+        let matches = NoteEditor.getCheckboxesForTextCount(text: text)
+        XCTAssertEqual(matches, 1)
     }
 
     class func checkboxForTextNotShown(text: String) {
-        let matchesCount = NoteEditor.getCheckboxesForTextCount(text: text)
-        XCTAssertEqual(matchesCount, 0)
+        let matches = NoteEditor.getCheckboxesForTextCount(text: text)
+        XCTAssertEqual(matches, 0)
     }
 }

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -97,7 +97,7 @@ class NoteEditor {
 
     class func getCheckboxesForTextCount(text: String) -> Int {
         let matches = NoteEditor.getTextViewsWithExactLabelCount(label: text)
-        print(">>> ^ Found " + String(matches) + " Checkbox(es) for '" + text + "'")
+        print(">>> ^ Found \(matches) Checkbox(es) for '\(text)'")
         return matches
     }
 

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -102,18 +102,11 @@ class NoteEditor {
     }
 
     class func getTextViewsWithExactValueCount(value: String) -> Int {
-        let textViews = getAllTextViews()
-        var matches = 0
+        let matchingTextViews = getAllTextViews()
+            .compactMap { ($0.value as? String)?.strippingUnicodeObjectReplacementCharacter() }
+            .filter { $0 == value }
 
-        for textView in textViews {
-            let currentValue = textView.value as! String
-            let currentValueStripped = currentValue.replacingOccurrences(of: "\u{fffc}", with: "")
-
-            if currentValueStripped == value {
-                matches += 1
-            }
-        }
-
+        let matches = matchingTextViews.count
         print(">>> Found \(matches) TextView(s) with '\(value)' value")
         return matches
     }

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -101,7 +101,7 @@ class NoteList {
     }
 
     class func searchForText(text: String) {
-        print(">>> Searching for '" + text + "'")
+        print(">>> Searching for '\(text)'")
         let searchField = app.searchFields[UID.SearchField.search]
         guard searchField.exists else { return }
         searchField.tap()
@@ -136,8 +136,8 @@ class NoteListAssert {
             return
         }
 
-        let matchesCount = Table.getStaticTextsWithExactLabelCount(label: header)
-        XCTAssertEqual(matchesCount, numberOfOccurences)
+        let matches = Table.getStaticTextsWithExactLabelCount(label: header)
+        XCTAssertEqual(matches, numberOfOccurences)
     }
 
     class func tagsSearchHeaderShown() {
@@ -157,9 +157,9 @@ class NoteListAssert {
     }
 
     class func tagSuggestionExists(tag: String) {
-        print(">>> Asserting that \"\(tag)\" tag suggestion is shown once")
-        let matchesCount = Table.getStaticTextsWithExactLabelCount(label: tag)
-        XCTAssertEqual(matchesCount, 1)
+        print(">>> Asserting that '\(tag)' tag suggestion is shown once")
+        let matches = Table.getStaticTextsWithExactLabelCount(label: tag)
+        XCTAssertEqual(matches, 1)
     }
 
     class func tagSuggestionsExist(tags: [String]) {
@@ -170,8 +170,8 @@ class NoteListAssert {
 
     class func noteExists(noteName: String) {
         print(">>> Asserting that note is shown once: " + noteName)
-        let matchesCount = Table.getCellsWithExactLabelCount(label: noteName)
-        XCTAssertEqual(matchesCount, 1)
+        let matches = Table.getCellsWithExactLabelCount(label: noteName)
+        XCTAssertEqual(matches, 1)
     }
 
     class func notesExist(names: [String]) {

--- a/SimplenoteUITests/Preview.swift
+++ b/SimplenoteUITests/Preview.swift
@@ -27,17 +27,17 @@ class Preview {
     class func getStaticTextsWithExactValueCount(value: String) -> Int {
         let predicate = NSPredicate(format: "value == '" + value + "'")
         let matchingStaticTexts = app.webViews.descendants(matching: .staticText).matching(predicate)
-        let matchesCount = matchingStaticTexts.count
-        print(">>> Found " + String(matchesCount) + " StaticTexts(s) with '" + value + "' value")
-        return matchesCount
+        let matches = matchingStaticTexts.count
+        print(">>> Found \(matches) StaticTexts(s) with '\(value)' value")
+        return matches
     }
 
     class func getStaticTextsWithExactLabelCount(label: String) -> Int {
         let predicate = NSPredicate(format: "label == '" + label + "'")
         let matchingStaticTexts = app.webViews.descendants(matching: .staticText).matching(predicate)
-        let matchesCount = matchingStaticTexts.count
-        print(">>> Found " + String(matchesCount) + " StaticTexts(s) with '" + label + "' label")
-        return matchesCount
+        let matches = matchingStaticTexts.count
+        print(">>> Found \(matches) StaticTexts(s) with '\(label)' label")
+        return matches
     }
 }
 
@@ -63,13 +63,13 @@ class PreviewAssert {
     }
 
     class func staticTextWithExactLabelShownOnce(label: String) {
-        let matchesCount = Preview.getStaticTextsWithExactLabelCount(label: label)
-        XCTAssertEqual(matchesCount, 1)
+        let matches = Preview.getStaticTextsWithExactLabelCount(label: label)
+        XCTAssertEqual(matches, 1)
     }
 
     class func staticTextWithExactValueShownOnce(value: String) {
-        let matchesCount = Preview.getStaticTextsWithExactValueCount(value: value)
-        XCTAssertEqual(matchesCount, 1)
+        let matches = Preview.getStaticTextsWithExactValueCount(value: value)
+        XCTAssertEqual(matches, 1)
     }
 
     class func staticTextWithExactValuesShownOnce(values: [String]) {
@@ -83,21 +83,21 @@ class PreviewAssert {
     }
 
     class func boxesStates(expectedCheckedBoxesNumber: Int, expectedEmptyBoxesNumber: Int) {
-        let expectedBoxesCount = expectedCheckedBoxesNumber + expectedEmptyBoxesNumber,
-            actualBoxesCount = app.switches.count
+        let expectedBoxesCount = expectedCheckedBoxesNumber + expectedEmptyBoxesNumber
+        let boxes = app.switches
+        let actualBoxesCount = boxes.count
 
         var actualCheckedBoxesCount = 0,
             actualEmptyBoxesCount = 0
 
-        print("Number of boxes found: " + String(actualBoxesCount))
+        print(">>> Number of boxes found: " + String(actualBoxesCount))
 
-        XCTAssertEqual(expectedBoxesCount, actualBoxesCount, numberOfBoxesInPreviewNotExpected)
+        XCTAssertEqual(actualBoxesCount, expectedBoxesCount, numberOfBoxesInPreviewNotExpected)
 
         if actualBoxesCount < 1 { return }
 
-        for index in 0...actualBoxesCount - 1 {
-            let box = app.descendants(matching: .switch).element(boundBy: index)
-            print("Current box debug description: " + box.value.debugDescription)
+        for box in boxes {
+            print(">>> Current box debug description: " + box.value.debugDescription)
 
             if box.value.debugDescription == "Optional(1)" {
                 actualCheckedBoxesCount += 1

--- a/SimplenoteUITests/Preview.swift
+++ b/SimplenoteUITests/Preview.swift
@@ -86,25 +86,12 @@ class PreviewAssert {
         let expectedBoxesCount = expectedCheckedBoxesNumber + expectedEmptyBoxesNumber
         let boxes = app.switches
         let actualBoxesCount = boxes.count
-
-        var actualCheckedBoxesCount = 0,
-            actualEmptyBoxesCount = 0
-
-        print(">>> Number of boxes found: " + String(actualBoxesCount))
-
+        print(">>> Number of boxes found: \(actualBoxesCount)")
         XCTAssertEqual(actualBoxesCount, expectedBoxesCount, numberOfBoxesInPreviewNotExpected)
 
-        if actualBoxesCount < 1 { return }
-
-        for box in boxes {
-            print(">>> Current box debug description: " + box.value.debugDescription)
-
-            if box.value.debugDescription == "Optional(1)" {
-                actualCheckedBoxesCount += 1
-            } else if box.value.debugDescription == "Optional(0)" {
-                actualEmptyBoxesCount += 1
-            }
-        }
+        guard actualBoxesCount > 0 else { return }
+        let actualCheckedBoxesCount = boxes.filter { $0.value.debugDescription == "Optional(1)" }.count
+        let actualEmptyBoxesCount = boxes.filter { $0.value.debugDescription == "Optional(0)" }.count
 
         XCTAssertEqual(actualCheckedBoxesCount, expectedCheckedBoxesNumber, numberOfCheckedBoxesInPreviewNotExpected)
         XCTAssertEqual(actualEmptyBoxesCount, expectedEmptyBoxesNumber, numberOfEmptyBoxesInPreviewNotExpected)

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -173,9 +173,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         trackStep()
         NoteEditor.pressLink(containerText: usualLinkText, linkifiedText: usualLinkText)
-        for text in webViewTexts {
-            WebViewAssert.textShownOnScreen(textToFind: text)
-        }
+        WebViewAssert.textsShownOnScreen(texts: webViewTexts)
     }
 
     func testTappingOnLinkInPreviewOpensLinkInNewWindow() throws {
@@ -196,9 +194,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         trackStep()
         Preview.tapLink(linkText: usualLinkText)
-        for text in webViewTexts {
-            WebViewAssert.textShownOnScreen(textToFind: text)
-        }
+        WebViewAssert.textsShownOnScreen(texts: webViewTexts)
     }
 
     func testCreateCheckedItem() throws {

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -66,10 +66,9 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
 
     func testCanFilterByTagWhenClickingOnTagInTagDrawer() throws {
         trackTest()
-        var testedTag = String()
 
         trackStep()
-        testedTag = "prehistoric"
+        var testedTag = "prehistoric"
         Sidebar.tagSelect(tagName: testedTag)
         NoteListAssert.noteListShown(forSelection: testedTag)
         NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
@@ -92,10 +91,9 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
 
     func testClickingOnDifferentTagsOrAllNotesOrTrashImmediatelyUpdatesFilteredNotes() throws {
         trackTest()
-        var testedTag = String()
 
         trackStep()
-        testedTag = "prehistoric"
+        var testedTag = "prehistoric"
         Sidebar.tagSelect(tagName: testedTag)
         NoteListAssert.noteListShown(forSelection: testedTag)
         NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])

--- a/SimplenoteUITests/XCTest+Extensions.swift
+++ b/SimplenoteUITests/XCTest+Extensions.swift
@@ -20,6 +20,7 @@ extension XCUIElement {
     }
 }
 
+// Credits to https://github.com/onmyway133/blog/issues/628
 extension XCUIElementQuery: Sequence {
     public typealias Iterator = AnyIterator<XCUIElement>
     public func makeIterator() -> Iterator {

--- a/SimplenoteUITests/XCTest+Extensions.swift
+++ b/SimplenoteUITests/XCTest+Extensions.swift
@@ -19,3 +19,17 @@ extension XCUIElement {
         self.typeText(text)
     }
 }
+
+extension XCUIElementQuery: Sequence {
+    public typealias Iterator = AnyIterator<XCUIElement>
+    public func makeIterator() -> Iterator {
+        var index = UInt(0)
+        return AnyIterator {
+            guard index < self.count else { return nil }
+
+            let element = self.element(boundBy: Int(index))
+            index = index + 1
+            return element
+        }
+    }
+}


### PR DESCRIPTION
The only functional change: adding the `XCUIElementQuery: Sequence` [extension](https://github.com/onmyway133/blog/issues/628) to `XCTest+Extensions.swift`, which allows iterating through query with:

```
for cell in cells {
    cell.doStuff...
```
instead of
```
for index in 0...cellsNum - 1 {
    let cell = app.tables.cells.element(boundBy: index)
    cell.doStuff...
```

### Fix
1. Added extension that allows iterating through XCUIElementQuery
2. Renamed `matchesNum`, `matchesCount` etc to `matches` in various places
3. Applying String Interpolation in several methods
4. Added `Table.getAllCells()` method

### Test
1. Running the tests, no unexpected fails should occur.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
