### PR TITLE
Improve Note Contextual Action VoiceOver Titles

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -700,24 +700,25 @@ private extension SPNoteListViewController {
 
     func regularContextActions(for note: Note) -> [UIContextualAction] {
         let pinImageName: UIImageName = note.pinned ? .unpin : .pin
+        let pinActionTitle: String = note.pinned ? ActionTitle.unpin : ActionTitle.pin
 
         return [
-            UIContextualAction(style: .destructive, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { [weak self] (_, _, completion) in
+            UIContextualAction(style: .destructive, title: ActionTitle.delete, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { [weak self] (_, _, completion) in
                 self?.delete(note: note)
                 completion(true)
             },
 
-            UIContextualAction(style: .normal, image: .image(name: pinImageName), backgroundColor: .simplenoteSecondaryActionColor) { [weak self] (_, _, completion) in
+            UIContextualAction(style: .normal, title: pinActionTitle, image: .image(name: pinImageName), backgroundColor: .simplenoteSecondaryActionColor) { [weak self] (_, _, completion) in
                 self?.togglePinnedState(note: note)
                 completion(true)
             },
 
-            UIContextualAction(style: .normal, image: .image(name: .link), backgroundColor: .simplenoteTertiaryActionColor) { [weak self] (_, _, completion) in
+            UIContextualAction(style: .normal, title: ActionTitle.copyLink, image: .image(name: .link), backgroundColor: .simplenoteTertiaryActionColor) { [weak self] (_, _, completion) in
                 self?.copyInternalLink(to: note)
                 completion(true)
             },
 
-            UIContextualAction(style: .normal, image: .image(name: .share), backgroundColor: .simplenoteQuaternaryActionColor) { [weak self] (_, _, completion) in
+            UIContextualAction(style: .normal, title: ActionTitle.share, image: .image(name: .share), backgroundColor: .simplenoteQuaternaryActionColor) { [weak self] (_, _, completion) in
                 self?.share(note: note)
                 completion(true)
             }


### PR DESCRIPTION
### Fix
This is a small PR that fixes the issue #1018 

When you are in Simplenote iOS using VoiceOver, there are not currently titles or accessibility labels set for the actions, so Simplenote defaults to the title of the icon being used on the image. In this PR I have added titles to the UIContextualActions so that they will have a title when accessed via VoiceOver.

### Test
1. Activate Voiceover on your device
2. Go to the Note list
3. Tap on a note once to select it
4. Make repeated swipe down actions to hear the different options in the contextual menu

The old titles were:
"icon_trash"
"icon_pin" or "icon_unpin"
"icon_share"
"icon_link"

I updated them to the existing action titles so now they should be:
"Move to Trash"
"Pin to Top" or "Unpin"
"Share"
"Copy Internal Link"

### Review
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

In the ticket that alerted us to this issue, the user asked for very basic descriptions trash, pin, share, link.  I put in more verbose descriptions, partly because they were already there and partly because I thought they might be more helpful if they were more descriptive. @SylvesterWilmott can you take a look and see if you have any suggestions for updating these accessibility labels?

### Release
> These changes do not require release notes.
