### PR TITLE
Accessibility Color updates

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -405,6 +405,8 @@
 		B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F3000123F4502C007A7C59 /* SPSortBar.xib */; };
 		B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */; };
 		BA5C1C0725BF9D6C006E3820 /* SPDragBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */; };
+		BA83478325F59F8B0059B797 /* markdown-default-contrast.css in Resources */ = {isa = PBXBuildFile; fileRef = BA83478225F59F8B0059B797 /* markdown-default-contrast.css */; };
+		BA83478C25F59FE90059B797 /* markdown-dark-contrast.css in Resources */ = {isa = PBXBuildFile; fileRef = BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */; };
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		BAA63C3325EEDA83001589D7 /* NoteLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */; };
 		D435D38FCA5863E8447D5C2C /* Pods_Automattic_SimplenoteShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */; };
@@ -915,6 +917,8 @@
 		B5F3000123F4502C007A7C59 /* SPSortBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSortBar.xib; path = Classes/SPSortBar.xib; sourceTree = "<group>"; };
 		B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortBar.swift; path = Classes/SPSortBar.swift; sourceTree = "<group>"; };
 		BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPDragBar.swift; sourceTree = "<group>"; };
+		BA83478225F59F8B0059B797 /* markdown-default-contrast.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-default-contrast.css"; sourceTree = "<group>"; };
+		BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-dark-contrast.css"; sourceTree = "<group>"; };
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteLinkTests.swift; sourceTree = "<group>"; };
 		C07B32800E3C783BDF105B3A /* Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; sourceTree = "<group>"; };
@@ -1074,6 +1078,8 @@
 			children = (
 				1748382E1BC1CC2D00E834AF /* markdown-default.css */,
 				17BC3D461BC46BA800535DF3 /* markdown-dark.css */,
+				BA83478225F59F8B0059B797 /* markdown-default-contrast.css */,
+				BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */,
 			);
 			name = CSS;
 			sourceTree = "<group>";
@@ -2393,6 +2399,7 @@
 				B5C2EDD2255ACB4900C09B32 /* InterlinkViewController.xib in Resources */,
 				B5EB1EFE1C205A800080A1B3 /* Icons.xcassets in Resources */,
 				A68DA85D25DBE1F20003657B /* SortModePickerViewController.xib in Resources */,
+				BA83478325F59F8B0059B797 /* markdown-default-contrast.css in Resources */,
 				B53929492398642800ACEE00 /* SPRatingsPromptView.xib in Resources */,
 				B537732B252E176C00BC78C5 /* OptionsViewController.xib in Resources */,
 				B56A696222F9D53400B90398 /* SPAuthViewController.xib in Resources */,
@@ -2407,6 +2414,7 @@
 				B546BE97234E64F200A126DA /* TagListViewCell.xib in Resources */,
 				B56C8CA2234CEAF100FE55F4 /* TagListViewController.xib in Resources */,
 				B50789FF1C1F5592009F097A /* markdown-default.css in Resources */,
+				BA83478C25F59FE90059B797 /* markdown-dark-contrast.css in Resources */,
 				B5476BB423D89035000E7723 /* SPTagTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -50,13 +50,13 @@
             "<style media=\"screen\" type=\"text/css\">\n";
     NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\">";
 
-    NSString *css = [SPMarkdownParser loadCSSAtPath:self.cssPath];
+    NSString *css = [self loadCSSAtPath:self.cssPath];
 
     // Check if increase contrast is enabled.  If enabled amend CSS to include high contrast colors
     //
     if (@available(iOS 13.0, *)) {
         if ([[UITraitCollection currentTraitCollection] accessibilityContrast] == UIAccessibilityContrastHigh) {
-            NSString *contrast = [SPMarkdownParser loadCSSAtPath:self.contrastCssPath];
+            NSString *contrast = [self loadCSSAtPath:self.contrastCssPath];
             css = [css stringByAppendingString:contrast];
         }
     }

--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -50,19 +50,24 @@
             "<style media=\"screen\" type=\"text/css\">\n";
     NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\">";
 
-    NSString *css = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:self.cssPath withExtension:nil]
-                                             encoding:NSUTF8StringEncoding error:nil];
+    NSString *css = [SPMarkdownParser loadCSSAtPath:self.cssPath];
 
     // Check if increase contrast is enabled.  If enabled amend CSS to include high contrast colors
     //
     if (@available(iOS 13.0, *)) {
         if ([[UITraitCollection currentTraitCollection] accessibilityContrast] == UIAccessibilityContrastHigh) {
-            NSString *contrast = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:self.contrastCssPath withExtension:nil]
-                                                         encoding:NSUTF8StringEncoding error:nil];
-            css = [css stringByAppendingString:contrast];        }
+            NSString *contrast = [SPMarkdownParser loadCSSAtPath:self.contrastCssPath];
+            css = [css stringByAppendingString:contrast];
+        }
     }
     
     return [[headerStart stringByAppendingString:css] stringByAppendingString:headerEnd];
+}
+
++ (NSString *)loadCSSAtPath:(NSString *)path
+{
+    return [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:path withExtension:nil]
+                                    encoding:NSUTF8StringEncoding error:nil];
 }
 
 + (NSString *)cssPath

--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -52,6 +52,15 @@
 
     NSString *css = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:self.cssPath withExtension:nil]
                                              encoding:NSUTF8StringEncoding error:nil];
+
+    // Check if increase contrast is enabled.  If enabled amend CSS to include high contrast colors
+    //
+    if (@available(iOS 13.0, *)) {
+        if ([[UITraitCollection currentTraitCollection] accessibilityContrast] == UIAccessibilityContrastHigh) {
+            NSString *contrast = [NSString stringWithContentsOfURL:[[NSBundle mainBundle] URLForResource:self.contrastCssPath withExtension:nil]
+                                                         encoding:NSUTF8StringEncoding error:nil];
+            css = [css stringByAppendingString:contrast];        }
+    }
     
     return [[headerStart stringByAppendingString:css] stringByAppendingString:headerEnd];
 }
@@ -63,6 +72,15 @@
     }
 
     return @"markdown-default.css";
+}
+
++ (NSString *)contrastCssPath
+{
+    if (SPUserInterface.isDark) {
+        return @"markdown-dark-contrast.css";
+    }
+
+    return @"markdown-default-contrast.css";
 }
 
 + (NSString *)htmlFooter

--- a/Simplenote/Resources/markdown-dark-contrast.css
+++ b/Simplenote/Resources/markdown-dark-contrast.css
@@ -1,0 +1,5 @@
+
+/* Accessibility high contrast blue */
+.note-detail-markdown a {
+    color: #85aaff;
+}

--- a/Simplenote/Resources/markdown-dark-contrast.css
+++ b/Simplenote/Resources/markdown-dark-contrast.css
@@ -1,5 +1,5 @@
 
 /* Accessibility high contrast blue */
 .note-detail-markdown a {
-    color: #85aaff;
+    color: #85aaff !important;
 }

--- a/Simplenote/Resources/markdown-dark.css
+++ b/Simplenote/Resources/markdown-dark.css
@@ -104,7 +104,7 @@ html {
 }
 
 .note-detail-markdown a {
-    color: #4895d9;
+    color: #618df2;
 }
 
 .note-detail-markdown hr {

--- a/Simplenote/Resources/markdown-default-contrast.css
+++ b/Simplenote/Resources/markdown-default-contrast.css
@@ -1,5 +1,5 @@
 
 /* Accessibility high contrast blue */
 .note-detail-markdown a {
-    color: #284da2;
+    color: #284da2 !important;
 }

--- a/Simplenote/Resources/markdown-default-contrast.css
+++ b/Simplenote/Resources/markdown-default-contrast.css
@@ -1,0 +1,5 @@
+
+/* Accessibility high contrast blue */
+.note-detail-markdown a {
+    color: #284da2;
+}

--- a/Simplenote/Resources/markdown-default.css
+++ b/Simplenote/Resources/markdown-default.css
@@ -104,7 +104,7 @@ html {
 }
 
 .note-detail-markdown a {
-    color: #4895d9;
+    color: #3361cc;
 }
 
 .note-detail-markdown hr {


### PR DESCRIPTION
### Fix
mostly fixes #760 
This is a small PR that fixes some issues with colors.

In this PR I have updated the color that markdown preview uses for links, which was out of sync with the current design colors. 

<img height="300px" src="https://cdn-std.droplr.net/files/acc_593859/on3fdE" />

This also adjusts the markdown preview link colors when accessibility contrast is enabled so that the link colors there also update

<img height="300px"  src="https://cdn-std.droplr.net/files/acc_593859/XBUFIl" />

Note that these changes will only work on iOS 13 and later

Note that this PR does not fix one of the issues referenced in the original issue where in high contrast, the search results highlighting and the search cancel button don't have the same color.  The high contrast settings is done automatically by iOS, and because the size and boldness of the cancel button it will always change to a higher contrast color where the search results won't.  To interrupt that was gonna be a pretty big lift, after some discussion we decided to leave it as is.


### Test
On a device with iOS 13 or later:
1. create a note with a link in it and activate markdown
2. enter the markdown preview and confirm that the color for the back button and the link are the same
3. Enable dark mode on check the colors match
4. Enable high contrast and make sure the colors still match
5. disable dark mode (so you are now in high contrast/light mode) and check the colors again

### Review
> Only one developer and one designer are  required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
