### PR TITLE
Added support for accessibility three finger navigation

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -244,19 +244,36 @@ extension SPNoteEditorViewController: KeyboardObservable {
 
 // MARK: - Voiceover Support
 //
-private extension SPNoteEditorViewController {
+extension SPNoteEditorViewController {
 
     /// Indicates if VoiceOver is running
     ///
-    var isVoiceOverEnabled: Bool {
+    private var isVoiceOverEnabled: Bool {
         UIAccessibility.isVoiceOverRunning
     }
 
     /// Whenver VoiceOver is enabled, this API will lock the Tags List in position
     ///
     @objc
-    func refreshVoiceOverSupport() {
+    private func refreshVoiceOverSupport() {
         updateTagListPosition()
+    }
+
+    /// Sets behavior for accessibility three finger scroll
+    ///
+    open override func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
+        switch direction {
+        case .left:
+            presentMarkdownPreview()
+        case .right:
+            navigationController?.popViewController(animated: true)
+        default:
+            // With VoiceOver on, three finger scroll up and down will cause a page up/page down action
+            // If this method returns true that is disabled.  Returning false to maintain page up/page down
+            return false
+        }
+
+        return true
     }
 }
 


### PR DESCRIPTION
### Fix
This PR fixes #1172 

This is a small PR that deals with a problem in SNiOS where if you are using Voiceover there is no way to open markdown preview mode.

With accessibility voiceover enabled, single finger swipe does not work like a standard swipe.  Generally this is replaced with a 3 finger swipe.  I have added actions in the note editor where 3 finger swipe left will open markdown preview and three finger swipe right will dismiss the note and return to the note list.

### Test
1. enable voiceover on the device that you are testing with
2. navigate to a note that has markdown enabled
3. in voiceover select some text in the note (if navigation is selected the swipe actions don't work)
4. do a three finger swipe from right to left, this will should open markdown
5. tap on the back button to return to the note, now three finger swipe from left to right, this should dismiss the note

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
