### PR TITLE
Remove lane to trim keywords text files longer than 100 chars

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -106,44 +106,6 @@ end
       release_version: options[:version])
   end
 
-  # This lane lacks documentation because it ought to be part of the localized
-  # metadata download script instead!
-  desc "Updates the files with the localized keywords values for App Store Connect to match the 100 characters requirement"
-  lane :sanitize_appstore_keywords do | options |
-    Dir["./metadata/**"].each do |locale_dir|
-      keywords_path = File.join(locale_dir, 'keywords.txt')
-
-      unless File.exists?(keywords_path)
-        UI.message "Could not find keywords file in #{locale_dir}. Skipping."
-        next
-      end
-
-      keywords = File.read(keywords_path)
-      app_store_connect_keywords_length_limit = 100
-
-      if keywords.length <= app_store_connect_keywords_length_limit
-        UI.verbose "#{keywords_path} has less than #{app_store_connect_keywords_length_limit} characters. Not trimming."
-        next
-      end
-
-      UI.message "#{keywords_path} has more than #{app_store_connect_keywords_length_limit} characters. Trimming it..."
-
-      case File.basename(locale_dir)
-      when 'ar-SA'
-        separator = '،'
-      else
-        separator = ','
-      end
-
-      until keywords.length <= app_store_connect_keywords_length_limit do
-        keywords = keywords.split(separator)[0...-1].join(separator)
-        puts keywords
-      end
-
-      File.write(keywords_path, keywords)
-    end
-  end
-
   #####################################################################################
   # new_beta_release
   # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Trimming too long keywords client side is the wrong solution to the problem of having keywords that are too long.

Because keywords change sporadically, it's much better to edit the localization source on the GlotPress end.

And even better long term fix would be to add a character limit to GlotPress. I don't know how to do that know but I'll get in touch with folks that might help with that.

See discussion at https://github.com/Automattic/simplenote-ios/pull/1201#discussion_r590997663

**I'd like to leave this as a draft until the matter is addressed at the root. See pxLjZ-6mD.** Just in case I need to trim them again when it comes time for the next submission 🙉 

### Test
No test required.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release

These changes do not require release notes.