### PR TITLE
NoticeController tests

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		B5EB1EFF1C205A800080A1B3 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */; };
 		B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F3000123F4502C007A7C59 /* SPSortBar.xib */; };
 		B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */; };
+		BA3FB8CF25FEA0C500EA9A1B /* NoticeContorllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3FB8CE25FEA0C500EA9A1B /* NoticeContorllerTests.swift */; };
 		BA4499AA25ED8821000C563E /* NoticeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA4499A925ED8821000C563E /* NoticeView.xib */; };
 		BA4499B325ED8AB0000C563E /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499B225ED8AB0000C563E /* NoticeView.swift */; };
 		BA4499BC25ED95D0000C563E /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499BB25ED95D0000C563E /* Notice.swift */; };
@@ -909,6 +910,7 @@
 		B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = ../Icons.xcassets; sourceTree = "<group>"; };
 		B5F3000123F4502C007A7C59 /* SPSortBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSortBar.xib; path = Classes/SPSortBar.xib; sourceTree = "<group>"; };
 		B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortBar.swift; path = Classes/SPSortBar.swift; sourceTree = "<group>"; };
+		BA3FB8CE25FEA0C500EA9A1B /* NoticeContorllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeContorllerTests.swift; sourceTree = "<group>"; };
 		BA4499A925ED8821000C563E /* NoticeView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoticeView.xib; sourceTree = "<group>"; };
 		BA4499B225ED8AB0000C563E /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		BA4499BB25ED95D0000C563E /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
@@ -1670,6 +1672,7 @@
 		B58218981FCC45170094ECA1 /* SimplenoteTests */ = {
 			isa = PBXGroup;
 			children = (
+				BA3FB8CD25FEA09F00EA9A1B /* Notice */,
 				A6CC0B0E25B83FC800F12A85 /* Verification */,
 				A6F4883025A891900050CFA8 /* Tags */,
 				A6E6CE5425A5A6CC005A92DB /* PinLock */,
@@ -1874,6 +1877,14 @@
 				B5F3000123F4502C007A7C59 /* SPSortBar.xib */,
 			);
 			name = SortBar;
+			sourceTree = "<group>";
+		};
+		BA3FB8CD25FEA09F00EA9A1B /* Notice */ = {
+			isa = PBXGroup;
+			children = (
+				BA3FB8CE25FEA0C500EA9A1B /* NoticeContorllerTests.swift */,
+			);
+			name = Notice;
 			sourceTree = "<group>";
 		};
 		BA4499A825ED87F8000C563E /* Notices */ = {
@@ -2926,6 +2937,7 @@
 				A6E6CE9125A5B970005A92DB /* PinLockRemoveControllerTests.swift in Sources */,
 				B57401A025B7D9960058960E /* EmailVerificationTests.swift in Sources */,
 				A6E6CEC925A6053A005A92DB /* MockApplication.swift in Sources */,
+				BA3FB8CF25FEA0C500EA9A1B /* NoticeContorllerTests.swift in Sources */,
 				A645FA70254C5E69008A1519 /* NoteContentHelperTests.swift in Sources */,
 				A6E6CE6425A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift in Sources */,
 				B51F6DD72460D7C20074DDD9 /* NSPredicateEmailTests.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -399,7 +399,7 @@
 		B5EB1EFF1C205A800080A1B3 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */; };
 		B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F3000123F4502C007A7C59 /* SPSortBar.xib */; };
 		B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */; };
-		BA3FB8CF25FEA0C500EA9A1B /* NoticeContorllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3FB8CE25FEA0C500EA9A1B /* NoticeContorllerTests.swift */; };
+		BA3FB8CF25FEA0C500EA9A1B /* NoticeControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3FB8CE25FEA0C500EA9A1B /* NoticeControllerTests.swift */; };
 		BA4499AA25ED8821000C563E /* NoticeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA4499A925ED8821000C563E /* NoticeView.xib */; };
 		BA4499B325ED8AB0000C563E /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499B225ED8AB0000C563E /* NoticeView.swift */; };
 		BA4499BC25ED95D0000C563E /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499BB25ED95D0000C563E /* Notice.swift */; };
@@ -911,7 +911,7 @@
 		B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = ../Icons.xcassets; sourceTree = "<group>"; };
 		B5F3000123F4502C007A7C59 /* SPSortBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSortBar.xib; path = Classes/SPSortBar.xib; sourceTree = "<group>"; };
 		B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortBar.swift; path = Classes/SPSortBar.swift; sourceTree = "<group>"; };
-		BA3FB8CE25FEA0C500EA9A1B /* NoticeContorllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeContorllerTests.swift; sourceTree = "<group>"; };
+		BA3FB8CE25FEA0C500EA9A1B /* NoticeControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeControllerTests.swift; sourceTree = "<group>"; };
 		BA4499A925ED8821000C563E /* NoticeView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoticeView.xib; sourceTree = "<group>"; };
 		BA4499B225ED8AB0000C563E /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		BA4499BB25ED95D0000C563E /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
@@ -1885,7 +1885,7 @@
 		BA3FB8CD25FEA09F00EA9A1B /* Notice */ = {
 			isa = PBXGroup;
 			children = (
-				BA3FB8CE25FEA0C500EA9A1B /* NoticeContorllerTests.swift */,
+				BA3FB8CE25FEA0C500EA9A1B /* NoticeControllerTests.swift */,
 			);
 			name = Notice;
 			sourceTree = "<group>";
@@ -2941,7 +2941,7 @@
 				A6E6CE9125A5B970005A92DB /* PinLockRemoveControllerTests.swift in Sources */,
 				B57401A025B7D9960058960E /* EmailVerificationTests.swift in Sources */,
 				A6E6CEC925A6053A005A92DB /* MockApplication.swift in Sources */,
-				BA3FB8CF25FEA0C500EA9A1B /* NoticeContorllerTests.swift in Sources */,
+				BA3FB8CF25FEA0C500EA9A1B /* NoticeControllerTests.swift in Sources */,
 				A645FA70254C5E69008A1519 /* NoteContentHelperTests.swift in Sources */,
 				A6E6CE6425A5AAA8005A92DB /* PinLockControllerConfiguration+Tests.swift in Sources */,
 				B51F6DD72460D7C20074DDD9 /* NSPredicateEmailTests.swift in Sources */,

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -7,7 +7,7 @@ class NoticeController {
 
     private var notices: [Notice] = []
     private var current: Notice?
-    private let noticePresenter = NoticePresenter()
+    private var noticePresenter: NoticePresenter
     private let timerFactory: TimerFactory
 
     private var timer: Timer? {
@@ -22,13 +22,14 @@ class NoticeController {
 
     // MARK: Life Cycle
     //
-    private init() {
-        self.timerFactory = TimerFactory()
-        self.noticePresenter = NoticePresenter()
+    private init(presenter: NoticePresenter = NoticePresenter(), timerFactory: TimerFactory = TimerFactory()) {
+        self.timerFactory = timerFactory
+        self.noticePresenter = presenter
     }
 
-    internal init(presenter: NoticePresentable) {
+    init(presenter: NoticePresenter, timerFactor: TimerFactory) {
         self.noticePresenter = presenter
+        self.timerFactory = timerFactor
     }
 
     func setupNoticeController() {

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -16,7 +16,7 @@ class NoticeController {
         }
     }
 
-    internal var isPresenting: Bool {
+    var isPresenting: Bool {
         current != nil
     }
 

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -95,7 +95,7 @@ class NoticeController {
 
 // MARK: NoticePresenting Delegate
 //
-extension NoticeController: NoticePresentingDelegate {
+extension NoticeController: NoticeInteractionDelegate {
     func noticePressBegan() {
         if !isPresenting {
             return

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -12,7 +12,7 @@ class NoticeController {
     private var activeViewIsBeingTouched: Bool = false
     private var timer: Timer?
 
-    private var isPresenting: Bool {
+    internal var isPresenting: Bool {
         current != nil
     }
 
@@ -60,6 +60,10 @@ class NoticeController {
         notices.append(notice)
     }
 
+    var pendingNotices: Int {
+        notices.count
+    }
+
     func startTimer(timer: Timer? = nil) {
         if timer != nil {
             self.timer = timer
@@ -69,6 +73,7 @@ class NoticeController {
         let delay = current?.action == nil ? Times.shortDelay : Times.longDelay
         self.timer = Timer.scheduledTimer(timeInterval: delay, target: self, selector: #selector(dismiss), userInfo: nil, repeats: false)
     }
+
     private func makeNoticeView(from notice: Notice) -> NoticeView {
         let noticeView: NoticeView = NoticeView.instantiateFromNib()
         noticeView.message = notice.message

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -7,7 +7,7 @@ class NoticeController {
 
     private var notices: [Notice] = []
     private var current: Notice?
-    private var noticePresenter: NoticePresenter
+    private let noticePresenter: NoticePresenter
     private let timerFactory: TimerFactory
 
     private var timer: Timer? {
@@ -16,7 +16,7 @@ class NoticeController {
         }
     }
 
-    var isPresenting: Bool {
+    private var isPresenting: Bool {
         current != nil
     }
 

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -64,10 +64,6 @@ class NoticeController {
         notices.append(notice)
     }
 
-    var pendingNotices: Int {
-        notices.count
-    }
-
     private func makeNoticeView(from notice: Notice) -> NoticeView {
         let noticeView: NoticeView = NoticeView.instantiateFromNib()
         noticeView.message = notice.message

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -7,7 +7,7 @@ class NoticeController {
 
     private var notices: [Notice] = []
     private var current: Notice?
-    private let noticePresenter = NoticePresenter()
+    private var noticePresenter: NoticePresentable
 
     private var activeViewIsBeingTouched: Bool = false
     private var timer: Timer?
@@ -18,7 +18,13 @@ class NoticeController {
 
     // MARK: Life Cycle
     //
-    private init() { }
+    private init() {
+        self.noticePresenter = NoticePresenter()
+    }
+
+    internal init(presenter: NoticePresentable) {
+        self.noticePresenter = presenter
+    }
 
     func setupNoticeController() {
         noticePresenter.startListeningToKeyboardNotifications()

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -22,14 +22,9 @@ class NoticeController {
 
     // MARK: Life Cycle
     //
-    private init(presenter: NoticePresenter = NoticePresenter(), timerFactory: TimerFactory = TimerFactory()) {
+    init(presenter: NoticePresenter = NoticePresenter(), timerFactory: TimerFactory = TimerFactory()) {
         self.timerFactory = timerFactory
         self.noticePresenter = presenter
-    }
-
-    init(presenter: NoticePresenter, timerFactor: TimerFactory) {
-        self.noticePresenter = presenter
-        self.timerFactory = timerFactor
     }
 
     func setupNoticeController() {

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -81,7 +81,7 @@ class NoticeController {
     // MARK: Dismissing
     //
     @objc
-    func dismiss() {
+    private func dismiss() {
         noticePresenter.dismissNotification {
             self.current = nil
 

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -1,16 +1,10 @@
 import UIKit
 
-protocol NoticePresentable {
-    func startListeningToKeyboardNotifications()
-    func presentNoticeView(_ noticeView: NoticeView, completion: @escaping (Bool) -> Void)
-    func dismissNotification(completion: @escaping () -> Void)
-}
-
-class NoticePresenter: NoticePresentable {
+class NoticePresenter {
 
     // MARK: Properties
     //
-    private var noticeView: UIView?
+    var noticeView: UIView?
     private var containerView: PassthruView?
     private var noticeVariableConstraint: NSLayoutConstraint?
 
@@ -39,6 +33,19 @@ class NoticePresenter: NoticePresentable {
     //
     deinit {
         stopListeningToKeyboardNotifications()
+    }
+
+    func startListeningToKeyboardNotifications() {
+        keyboardNotificationTokens = addKeyboardObservers()
+    }
+
+    func stopListeningToKeyboardNotifications() {
+        guard let tokens = keyboardNotificationTokens else {
+            return
+        }
+
+        removeKeyboardObservers(with: tokens)
+        keyboardNotificationTokens = nil
     }
 
     // MARK: Presenting Methods
@@ -154,19 +161,6 @@ extension NoticePresenter: KeyboardObservable {
         UIView.animate(withDuration: animationDuration, delay: .zero, options: animationOptions) {
             containerView.layoutIfNeeded()
         }
-    }
-
-    func startListeningToKeyboardNotifications() {
-        keyboardNotificationTokens = addKeyboardObservers()
-    }
-
-    func stopListeningToKeyboardNotifications() {
-        guard let tokens = keyboardNotificationTokens else {
-            return
-        }
-
-        removeKeyboardObservers(with: tokens)
-        keyboardNotificationTokens = nil
     }
 }
 

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -1,6 +1,12 @@
 import UIKit
 
-class NoticePresenter {
+protocol NoticePresentable {
+    func startListeningToKeyboardNotifications()
+    func presentNoticeView(_ noticeView: NoticeView, completion: @escaping (Bool) -> Void)
+    func dismissNotification(completion: @escaping () -> Void)
+}
+
+class NoticePresenter: NoticePresentable {
 
     // MARK: Properties
     //

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -4,7 +4,7 @@ class NoticePresenter {
 
     // MARK: Properties
     //
-    var noticeView: UIView?
+    private var noticeView: UIView?
     private var containerView: PassthruView?
     private var noticeVariableConstraint: NSLayoutConstraint?
 

--- a/Simplenote/NoticeView.swift
+++ b/Simplenote/NoticeView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol NoticePresentingDelegate: class {
+protocol NoticeInteractionDelegate: class {
     func noticePressBegan()
     func noticePressEnded()
     func noticeWasTapped()
@@ -34,7 +34,7 @@ class NoticeView: UIView {
         }
     }
 
-    weak var delegate: NoticePresentingDelegate?
+    weak var delegate: NoticeInteractionDelegate?
 
 
     // MARK: Initialization

--- a/Simplenote/NoticeView.swift
+++ b/Simplenote/NoticeView.swift
@@ -26,7 +26,7 @@ class NoticeView: UIView {
     var handler: (() -> Void)?
     var actionTitle: String? {
         get {
-            noticeButton.titleLabel?.text
+            noticeButton.title(for: .normal)
         }
         set {
             noticeButton.setTitle(newValue, for: .normal)

--- a/SimplenoteTests/NoticeContorllerTests.swift
+++ b/SimplenoteTests/NoticeContorllerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class NoticeContorllerTests: XCTestCase {
     private lazy var presenter = MockNoticePresenter()
     private lazy var timerFactory = MockTimerFactory()
-    private lazy var controller = NoticeController(presenter: presenter, timerFactor: timerFactory)
+    private lazy var controller = NoticeController(presenter: presenter, timerFactory: timerFactory)
 
     func testSetupNoticeContoller() {
         controller.setupNoticeController()

--- a/SimplenoteTests/NoticeContorllerTests.swift
+++ b/SimplenoteTests/NoticeContorllerTests.swift
@@ -160,12 +160,20 @@ class MockTimerFactory: TimerFactory {
     var timer: Timer?
 
     override func scheduledTimer(with timeInterval: TimeInterval, completion: @escaping () -> Void) -> Timer {
-        if let timer = timer {
-            timer.fire()
+        let timer = MockTimer()
+        timer.completion = completion
+        return timer
+    }
+}
 
-            return timer
-        } else {
-            return Timer.scheduledTimer(withTimeInterval: NoticeContorllerTests.timeInterval, repeats: false, block: NoticeContorllerTests.timerNoActionCompletionHandler)
-        }
+class MockTimer: Timer {
+    var completion: (() -> Void)?
+
+    override func fire() {
+        completion?()
+    }
+
+    override func invalidate() {
+        completion = nil
     }
 }

--- a/SimplenoteTests/NoticeContorllerTests.swift
+++ b/SimplenoteTests/NoticeContorllerTests.swift
@@ -1,33 +1,142 @@
-//
-//  NoticeContorllerTests.swift
-//  SimplenoteTests
-//
-//  Created by Charlie Scheer on 3/15/21.
-//  Copyright © 2021 Automattic. All rights reserved.
-//
-
 import XCTest
+@testable import Simplenote
 
 class NoticeContorllerTests: XCTestCase {
+    private lazy var presenter = MockNoticePresenter()
+    private lazy var controller = NoticeController(presenter: presenter)
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+func testSetupNoticeContoller() {
+    controller.setupNoticeController()
+
+    XCTAssertTrue(presenter.listeningToKeyboard == true)
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func testPresentNotice() throws {
+        let notice = Notice(message: "Message", action: nil)
+        controller.present(notice, withTimer: NoticeContorllerTests.noActionTimer)
+
+        XCTAssertTrue(presenter.presented)
+
+        let presentedNoticeView = try XCTUnwrap(presenter.noticeView)
+        XCTAssertEqual(presentedNoticeView.message, notice.message)
+        XCTAssertTrue(presentedNoticeView.handler == nil)
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testAppendToQueueIfNew() {
+        let noticeA = Notice(message: "Message A", action: nil)
+        let noticeB = Notice(message: "Message B", action: nil)
+
+        controller.present(noticeA)
+        XCTAssertEqual(controller.pendingNotices, 0)
+
+        controller.present(noticeA)
+        XCTAssertEqual(controller.pendingNotices, 0)
+
+        controller.present(noticeB)
+        XCTAssertEqual(controller.pendingNotices, 1)
+
+        controller.present(noticeB)
+        XCTAssertEqual(controller.pendingNotices, 1)
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func testControllerPresent() {
+        let expectation = XCTestExpectation(description: "Did dismiss notice")
+        let timer = Timer.scheduledTimer(withTimeInterval: TimeInterval(0.5), repeats: false) { (_) in
+            expectation.fulfill()
         }
+
+        let notice = Notice(message: "Message", action: nil)
+        controller.present(notice, withTimer: timer)
+
+        wait(for: [expectation], timeout: TimeInterval(3))
+
     }
 
+    func testMakeNoticeView() {
+        let notice = Notice(message: "Message", action: nil)
+
+        controller.present(notice)
+        XCTAssertEqual(notice.message, presenter.noticeView?.message)
+        XCTAssertNil(presenter.noticeView?.handler)
+    }
+
+    func testMakeNoticeViewWithAction() {
+        let action = NoticeAction(title: "Title") {
+            print("Action")
+        }
+        let notice = Notice(message: "Message ", action: action)
+
+        controller.present(notice)
+        XCTAssertEqual(notice.message, presenter.noticeView?.message)
+        XCTAssertEqual(notice.action?.title, presenter.noticeView?.actionTitle)
+        XCTAssertNotNil(presenter.noticeView?.handler)
+    }
+
+    func testMakeNoticeViewEmptyNotice() {
+        let action = NoticeAction(title: "") {
+            print("")
+        }
+        let notice = Notice(message: "", action: action)
+
+        controller.present(notice)
+        XCTAssertEqual(notice.message, presenter.noticeView?.message)
+        XCTAssertNotEqual(notice.action?.title, presenter.noticeView?.actionTitle)
+        XCTAssertNotNil(presenter.noticeView?.handler)
+    }
+
+    func testDismiss() {
+        let noticeA = Notice(message: "Message A", action: nil)
+
+        controller.present(noticeA, withTimer: NoticeContorllerTests.noActionTimer)
+
+        controller.dismiss()
+
+        XCTAssertTrue(presenter.dismissed)
+        XCTAssertFalse(controller.isPresenting)
+    }
+
+    func testDismissContinuesToNextNotice() {
+        let noticeA = Notice(message: "Message A", action: nil)
+        let noticeB = Notice(message: "Message B", action: nil)
+        controller.present(noticeA, withTimer: NoticeContorllerTests.noActionTimer)
+        controller.present(noticeB, withTimer: NoticeContorllerTests.noActionTimer)
+
+        XCTAssertEqual(controller.pendingNotices, 1)
+
+        controller.dismiss()
+
+        XCTAssertTrue(presenter.dismissed)
+        XCTAssertTrue(controller.isPresenting)
+        XCTAssertEqual(controller.pendingNotices, 0)
+    }
+}
+
+extension NoticeContorllerTests {
+    static var noActionTimer = Timer.scheduledTimer(withTimeInterval: .zero, repeats: false) { (success) in
+        print("timer finished")
+    }
+}
+
+class MockNoticePresenter: NoticePresentable {
+    var presented: Bool = false
+    var dismissed: Bool = false
+    var listeningToKeyboard: Bool = false
+
+    var noticeView: NoticeView?
+
+    func presentNoticeView(_ noticeView: NoticeView, completion: @escaping (Bool) -> Void) {
+        self.noticeView = noticeView
+        presented = true
+
+        completion(true)
+    }
+
+    func dismissNotification(completion: @escaping () -> Void) {
+        dismissed = true
+        completion()
+    }
+
+    func startListeningToKeyboardNotifications() {
+        listeningToKeyboard = true
+    }
 }

--- a/SimplenoteTests/NoticeControllerTests.swift
+++ b/SimplenoteTests/NoticeControllerTests.swift
@@ -158,17 +158,15 @@ class NoticeControllerTests: XCTestCase {
         let noticeA = Notice(message: "Message A", action: nil)
 
         controller.present(noticeA)
-        var expectedActions: [MockNoticePresenter.Action] = [
-            .present(noticeA.message)
-        ]
-
         controller.noticePressBegan()
+        controller.noticePressEnded()
 
         try XCTUnwrap(timerFactory.timer).fire()
 
-        controller.noticePressEnded()
-        timerFactory.timer?.fire()
-        expectedActions.append(.dismiss(noticeA.message))
+        let expectedActions: [MockNoticePresenter.Action] = [
+            .present(noticeA.message),
+            .dismiss(noticeA.message)
+        ]
 
         XCTAssertEqual(expectedActions, presenter.actionLog)
     }

--- a/SimplenoteTests/NoticeControllerTests.swift
+++ b/SimplenoteTests/NoticeControllerTests.swift
@@ -60,6 +60,7 @@ class NoticeControllerTests: XCTestCase {
         controller.present(notice)
 
         XCTAssertEqual(notice.message, presenter.lastNoticeView?.message)
+        XCTAssertEqual(notice.action?.title, presenter.lastNoticeView?.actionTitle)
         XCTAssertNil(presenter.lastNoticeView?.handler)
     }
 
@@ -69,21 +70,21 @@ class NoticeControllerTests: XCTestCase {
         }
         let notice = Notice(message: "Message ", action: action)
 
-        controller.present(notice)
-
-        XCTAssertEqual(notice.message, presenter.lastNoticeView?.message)
-        XCTAssertEqual(notice.action?.title, presenter.lastNoticeView?.actionTitle)
-        XCTAssertNotNil(presenter.lastNoticeView?.handler)
+        checkNoticeViewPropertiesCreatedCorrectly(notice)
     }
 
     func testMakeNoticeViewWithEmptyNotice() {
         let action = NoticeAction(title: "") { }
         let notice = Notice(message: "", action: action)
 
+        checkNoticeViewPropertiesCreatedCorrectly(notice)
+    }
+
+    private func checkNoticeViewPropertiesCreatedCorrectly(_ notice: Notice) {
         controller.present(notice)
 
         XCTAssertEqual(notice.message, presenter.lastNoticeView?.message)
-        XCTAssertNotEqual(notice.action?.title, presenter.lastNoticeView?.actionTitle)
+        XCTAssertEqual(notice.action?.title, presenter.lastNoticeView?.actionTitle)
         XCTAssertNotNil(presenter.lastNoticeView?.handler)
     }
 

--- a/SimplenoteTests/NoticeControllerTests.swift
+++ b/SimplenoteTests/NoticeControllerTests.swift
@@ -87,7 +87,7 @@ class NoticeControllerTests: XCTestCase {
         XCTAssertNotNil(presenter.lastNoticeView?.handler)
     }
 
-    func testDismiss() {
+    func testDismiss() throws {
         let noticeA = Notice(message: "Message A", action: nil)
 
         controller.present(noticeA)
@@ -95,13 +95,13 @@ class NoticeControllerTests: XCTestCase {
             .present(noticeA.message)
         ]
 
-        timerFactory.timer?.fire()
+        try XCTUnwrap(timerFactory.timer).fire()
         expectedActions.append(.dismiss(noticeA.message))
 
         XCTAssertEqual(expectedActions, presenter.actionLog)
     }
 
-    func testDismissContinuesToNextNotice() {
+    func testDismissContinuesToNextNotice() throws {
         let noticeA = Notice(message: "Message A", action: nil)
         let noticeB = Notice(message: "Message B", action: nil)
 
@@ -113,13 +113,13 @@ class NoticeControllerTests: XCTestCase {
         ]
         XCTAssertEqual(presenter.actionLog, expectedActions)
 
-        timerFactory.timer?.fire()
+        try XCTUnwrap(timerFactory.timer).fire()
 
         expectedActions.append(.dismiss(noticeA.message))
         expectedActions.append(.present(noticeB.message))
         XCTAssertEqual(presenter.actionLog, expectedActions)
 
-        timerFactory.timer?.fire()
+        try XCTUnwrap(timerFactory.timer).fire()
 
         expectedActions.append(.dismiss(noticeB.message))
         XCTAssertEqual(presenter.actionLog, expectedActions)
@@ -154,7 +154,7 @@ class NoticeControllerTests: XCTestCase {
         XCTAssertNil(timerFactory.timer?.completion)
     }
 
-    func testLongPressReleasedDismissesTimer() {
+    func testLongPressReleasedDismissesTimer() throws {
         let noticeA = Notice(message: "Message A", action: nil)
 
         controller.present(noticeA)
@@ -164,8 +164,7 @@ class NoticeControllerTests: XCTestCase {
 
         controller.noticePressBegan()
 
-        XCTAssertEqual(expectedActions, presenter.actionLog)
-        XCTAssertNil(timerFactory.timer?.completion)
+        try XCTUnwrap(timerFactory.timer).fire()
 
         controller.noticePressEnded()
         timerFactory.timer?.fire()

--- a/SimplenoteTests/NoticeControllerTests.swift
+++ b/SimplenoteTests/NoticeControllerTests.swift
@@ -101,6 +101,10 @@ class NoticeControllerTests: XCTestCase {
     func testDismissContinuesToNextNotice() {
         let noticeA = Notice(message: "Message A", action: nil)
         let noticeB = Notice(message: "Message B", action: nil)
+        timerFactory.timer = MockTimer {
+            self.controller.dismiss()
+        }
+
         controller.present(noticeA)
         controller.present(noticeB)
 
@@ -168,6 +172,11 @@ class MockTimerFactory: TimerFactory {
 
 class MockTimer: Timer {
     var completion: (() -> Void)?
+
+    convenience init(completion: (() -> Void)? = nil) {
+        self.init()
+        self.completion = completion
+    }
 
     override func fire() {
         completion?()

--- a/SimplenoteTests/NoticeControllerTests.swift
+++ b/SimplenoteTests/NoticeControllerTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Simplenote
 
-class NoticeContorllerTests: XCTestCase {
+class NoticeControllerTests: XCTestCase {
     private lazy var presenter = MockNoticePresenter()
     private lazy var timerFactory = MockTimerFactory()
     private lazy var controller = NoticeController(presenter: presenter, timerFactory: timerFactory)

--- a/SimplenoteTests/NoticeControllerTests.swift
+++ b/SimplenoteTests/NoticeControllerTests.swift
@@ -91,19 +91,19 @@ class NoticeControllerTests: XCTestCase {
         let noticeA = Notice(message: "Message A", action: nil)
 
         controller.present(noticeA)
+        var expectedActions: [MockNoticePresenter.Action] = [
+            .present(noticeA.message)
+        ]
 
-        controller.dismiss()
+        timerFactory.timer?.fire()
+        expectedActions.append(.dismiss(noticeA.message))
 
-//        XCTAssertTrue(presenter.dismissed)
-        XCTAssertFalse(controller.isPresenting)
+        XCTAssertEqual(expectedActions, presenter.actionLog)
     }
 
     func testDismissContinuesToNextNotice() {
         let noticeA = Notice(message: "Message A", action: nil)
         let noticeB = Notice(message: "Message B", action: nil)
-        timerFactory.timer = MockTimer {
-            self.controller.dismiss()
-        }
 
         controller.present(noticeA)
         controller.present(noticeB)
@@ -161,10 +161,13 @@ class MockNoticePresenter: NoticePresenter {
 }
 
 class MockTimerFactory: TimerFactory {
-    var timer: Timer?
+    var timer: MockTimer?
 
     override func scheduledTimer(with timeInterval: TimeInterval, completion: @escaping () -> Void) -> Timer {
-        let timer = MockTimer()
+        timer = MockTimer()
+        guard let timer = timer else {
+            return MockTimer()
+        }
         timer.completion = completion
         return timer
     }


### PR DESCRIPTION
### Fix
This PR is a beginning attempt at adding unit tests for the NoticeController class.  This makes a few changes to access in the NoticeController class and writes some basic unit tests for the functionality of the controller methods.

One thing that I particularly could use some advice on is the internal init that I created so I can override the NoticePresenter with a mock.  Since the NoticeController is a singleton, I feel like it is a bad idea to have an initializer that is exposed, but I couldn't find another way around that.  Would be happy to find a way to be able to override the presenter without exposing an initializer to the controller.

### Test
***(Required)*** List the steps to test the behavior.  For example:
1. look over the access changes and make sure that  I am not exposing too much
2. run the tests to ensure they all pass


### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one develope is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
