### PR TITLE
Fixes crash when editor loads in search mode but can not highlight search value

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -182,6 +182,11 @@ CGFloat const SPSelectedAreaPadding = 20;
 
         self.searchResultRanges = [self searchResultRangesIn:(searchText ?: @"")
                                                 withKeywords:self.searchQuery.keywords];
+
+        // If there are no found ranges, bail out
+        if (self.searchResultRanges.count < 1) {
+            return;
+        }
         
         dispatch_async(dispatch_get_main_queue(), ^{
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -183,10 +183,10 @@ CGFloat const SPSelectedAreaPadding = 20;
         self.searchResultRanges = [self searchResultRangesIn:(searchText ?: @"")
                                                 withKeywords:self.searchQuery.keywords];
 
-        // If there are no found ranges, bail out
-        if (self.searchResultRanges.count < 1) {
-            return;
-        }
+//        // If there are no found ranges, bail out
+//        if (self.searchResultRanges.count < 1) {
+//            return;
+//        }
         
         dispatch_async(dispatch_get_main_queue(), ^{
 
@@ -539,6 +539,10 @@ CGFloat const SPSelectedAreaPadding = 20;
 - (void)highlightSearchResultAtIndex:(NSInteger)index animated:(BOOL)animated
 {
     NSInteger searchResultCount = self.searchResultRanges.count;
+
+    if (searchResultCount < 1) {
+        return;
+    }
 
     index = MIN(index, searchResultCount - 1);
     index = MAX(index, 0);

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -183,11 +183,6 @@ CGFloat const SPSelectedAreaPadding = 20;
         self.searchResultRanges = [self searchResultRangesIn:(searchText ?: @"")
                                                 withKeywords:self.searchQuery.keywords];
 
-//        // If there are no found ranges, bail out
-//        if (self.searchResultRanges.count < 1) {
-//            return;
-//        }
-        
         dispatch_async(dispatch_get_main_queue(), ^{
 
             [self showSearchMapWith:self.searchResultRanges];


### PR DESCRIPTION
### Fix
This issue fixes #1193 

If you search for a note in Simplenote, and then open that note from search with values that can not be highlighted, Simplenote will crash when the SPNoteEditorViewController opens.  This crash can be replicated in two ways:
Tag search:
Create a new note and give it a tag.  Make sure that the tag value can not be found in the note text
Search for the tag, select the tag
select the note from the search results
when editor loads it will crash

Multi language character search:
Create a note with a combination of English + Japanese/Chinese characters (e.g. Abc中文）
Search the note with this keyword: Abc中文
Tap the search result and the app crashes

This PR puts in a guard against invalid search result highlight terms

### Test
1. create a new note, give it a tag of "A" and in the text body add the text "Abc中文"
2. exit the note and go to search, search for "A"
3. select the tag search from the options, then select the note you just created.
4. The note should load fine without crashing
5. Exit the note, return to the search and type in "Abc中文"
6. Select the note from the search results
7. The note should load fine without crashing

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
