### PR TITLE
UI automation maintenance: new locator for `Trash Note` button

### DIFF
--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -78,7 +78,6 @@ class Table {
         let noteCell = Table.getCell(label: noteName)
 
         noteCell.swipeLeft()
-        //sleep(1)
         noteCell.buttons[deleteButtonLabel].tap()
     }
 

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -72,7 +72,9 @@ class Table {
 
     class func trashCell(noteName: String) {
         // `Trash Note` and `Delete note forever` buttons have different labels
-        // since #1191. To use the correct label, we need to know where we are.
+        // since 07fcccf1039495768ecdf9909d3dbd1b255936cd
+        // (https://github.com/Automattic/simplenote-ios/pull/1191).
+        // To use the correct label, we need to know where we are.
         let deleteButtonLabel = app.navigationBars[UID.NavBar.trash].exists ?
             UID.Button.itemTrash : UID.Button.noteTrash
         let noteCell = Table.getCell(label: noteName)

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -45,14 +45,20 @@ class Table {
         return app.tables.element.children(matching: .cell)
     }
 
-    class func getVisibleLabelledCellsNumber() -> Int {
+    class func getVisibleLabelledCells() -> [XCUIElement] {
         // We need only the table cells that have X = 0 and a non-empty label
-        // otherwise we will include invisible elements from Sidebar pane, when Notes List is open
-        // or the elements from Notes List when Settings are open
-        // or the visible tags search suggestions
+        // Currently (besides using object dimentions) this is the way to
+        // locate note cells
         return Table.getAllCells()
             .filter { $0.frame.minX == 0.0 && $0.label.isEmpty == false }
-            .count
+    }
+
+    class func getVisibleLabelledCellsNames() -> [String] {
+        return Table.getVisibleLabelledCells().compactMap { $0.label }
+    }
+
+    class func getVisibleLabelledCellsNumber() -> Int {
+        return Table.getVisibleLabelledCells().count
     }
 
     class func getVisibleNonLabelledCellsNumber() -> Int {
@@ -65,9 +71,15 @@ class Table {
     }
 
     class func trashCell(noteName: String) {
-        Table.getCell(label: noteName).swipeLeft()
-        sleep(1)
-        Table.getCell(label: noteName).buttons[UID.Button.itemTrash].tap()
+        // `Trash Note` and `Delete note forever` buttons have different labels
+        // since #1191. To use the correct label, we need to know where we are.
+        let deleteButtonLabel = app.navigationBars[UID.NavBar.trash].exists ?
+            UID.Button.itemTrash : UID.Button.noteTrash
+        let noteCell = Table.getCell(label: noteName)
+
+        noteCell.swipeLeft()
+        //sleep(1)
+        noteCell.buttons[deleteButtonLabel].tap()
     }
 
     class func getCell(label: String) -> XCUIElement {

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -57,13 +57,9 @@ class Table {
         return Table.getVisibleLabelledCells().compactMap { $0.label }
     }
 
-    class func getVisibleLabelledCellsNumber() -> Int {
-        return Table.getVisibleLabelledCells().count
-    }
-
     class func getVisibleNonLabelledCellsNumber() -> Int {
         // We need only the table cells that have X = 0 and an empty label
-        // Currently (besides using object dimentions) this is the way to
+        // Currently (besides using object dimensions) this is the way to
         // locate tags search suggestions
         return Table.getAllCells()
             .filter { $0.frame.minX == 0.0 && $0.label.isEmpty == true }

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -47,7 +47,7 @@ class Table {
 
     class func getVisibleLabelledCells() -> [XCUIElement] {
         // We need only the table cells that have X = 0 and a non-empty label
-        // Currently (besides using object dimentions) this is the way to
+        // Currently (besides using object dimensions) this is the way to
         // locate note cells
         return Table.getAllCells()
             .filter { $0.frame.minX == 0.0 && $0.label.isEmpty == false }

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -69,25 +69,9 @@ class NoteList {
 
     class func trashAllNotes() {
         NoteList.openAllNotes()
-
-        let notesNumber = NoteList.getNotesNumber()
-        let cellsNum = app.tables.element.children(matching: .cell).count
-        var startingIndex: Int
-
-        if notesNumber == cellsNum {
-            // Depending on what happened before, the cells numbering
-            // might not include "All Notes", "Trash" and "Settings" cells...
-            startingIndex = 0
-        } else {
-            // Or might include them
-            startingIndex = 3
-        }
-
-        for _ in 0..<notesNumber {
-            let cell = app.tables.cells.element(boundBy: startingIndex)
-            cell.swipeLeft()
-            cell.buttons[UID.Button.itemTrash].tap()
-        }
+        let noteNames = Table.getVisibleLabelledCellsNames()
+        guard noteNames.isEmpty == false else { return }
+        noteNames.forEach { Table.trashCell(noteName: $0) }
     }
 
     class func waitForLoad() {

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -55,7 +55,7 @@ class NoteList {
     }
 
     class func getNotesNumber() -> Int {
-        return Table.getVisibleLabelledCellsNumber()
+        return Table.getVisibleLabelledCells().count
     }
 
     class func getTagsSuggestionsNumber() -> Int {
@@ -69,9 +69,9 @@ class NoteList {
 
     class func trashAllNotes() {
         NoteList.openAllNotes()
-        let noteNames = Table.getVisibleLabelledCellsNames()
-        guard noteNames.isEmpty == false else { return }
-        noteNames.forEach { Table.trashCell(noteName: $0) }
+        Table
+            .getVisibleLabelledCellsNames()
+            .forEach { Table.trashCell(noteName: $0) }
     }
 
     class func waitForLoad() {

--- a/SimplenoteUITests/Trash.swift
+++ b/SimplenoteUITests/Trash.swift
@@ -27,7 +27,7 @@ class Trash {
     }
 
     class func getNotesNumber() -> Int {
-        return Table.getVisibleLabelledCellsNumber()
+        return Table.getVisibleLabelledCells().count
     }
 }
 

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -35,6 +35,7 @@ enum UID {
         static let noteEditorInformation = "Information"
         static let noteEditorMenu = "note-menu"
         static let itemTrash = "icon trash"
+        static let noteTrash = "Move to Trash"
         static let trashRestore = "icon restore"
         static let trashEmptyTrash = "Empty"
         static let clearText = "Clear text"


### PR DESCRIPTION
Fixes the tests that started failing after [this accessibility improvement](https://github.com/Automattic/simplenote-ios/pull/1191):  'trash note' button has a `Move to Trash` title now, instead of the default identification by image name: `icon trash`. However, the 'delete note' button, shown for a note when in `Trash` still uses `icon trash` identification.

### Fix
1. Added `Move to Trash` item to `UIDs.swift`
2. Simplified the `NoteList.trashAllNotes()` function
3. To make ^ possible, added new `Table.getVisibleLabelledCells()`
3. Adjusted `Table.trashCell()` to use different titles for delete button, depending on the current note list (in `Trash` vs in other notes list)

### Test
1. Running all tests, especially the ones for `Trash`, seeing them not fail.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
