### PR TITLE
Added PublishingObserver class

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 		BA55B06325F068650042582B /* NoticeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA55B06225F068650042582B /* NoticeController.swift */; };
 		BA5C1C0725BF9D6C006E3820 /* SPDragBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */; };
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
+		BAF28B142606B2B800046D6F /* PublishingObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF28B132606B2B800046D6F /* PublishingObserver.swift */; };
 		D435D38FCA5863E8447D5C2C /* Pods_Automattic_SimplenoteShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */; };
 		D843AD6F25E3E633007E5B15 /* SimplenoteUITestsLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D843AD6E25E3E633007E5B15 /* SimplenoteUITestsLogin.swift */; };
 		D843AD7825E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D843AD7725E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift */; };
@@ -919,6 +920,7 @@
 		BA55B06225F068650042582B /* NoticeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeController.swift; sourceTree = "<group>"; };
 		BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPDragBar.swift; sourceTree = "<group>"; };
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
+		BAF28B132606B2B800046D6F /* PublishingObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishingObserver.swift; sourceTree = "<group>"; };
 		C07B32800E3C783BDF105B3A /* Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		D843AD6E25E3E633007E5B15 /* SimplenoteUITestsLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteUITestsLogin.swift; sourceTree = "<group>"; };
 		D843AD7725E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteUITestsTrash.swift; sourceTree = "<group>"; };
@@ -1258,6 +1260,7 @@
 			isa = PBXGroup;
 			children = (
 				A6900345253D87060087D0D2 /* VersionsController.swift */,
+				BAF28B132606B2B800046D6F /* PublishingObserver.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -2819,6 +2822,7 @@
 				74388F4422CFFA30001C5EC0 /* UIViewController+Helpers.swift in Sources */,
 				A6C3D8B7256687970042F584 /* SPObjectManager+Simplenote.swift in Sources */,
 				46A3C99817DFA81A002865AE /* SPEntryListCell.m in Sources */,
+				BAF28B142606B2B800046D6F /* PublishingObserver.swift in Sources */,
 				B5E951E124FEDAD4004B10B8 /* UIPasteboard+Note.swift in Sources */,
 				A681C73C2541AC8D00F369C2 /* HuggableTableView.swift in Sources */,
 				46A3C99917DFA81A002865AE /* SPTransitionController.m in Sources */,

--- a/Simplenote/Classes/SPObjectManager+Simplenote.swift
+++ b/Simplenote/Classes/SPObjectManager+Simplenote.swift
@@ -46,4 +46,10 @@ extension SPObjectManager {
 
         NoticeController.shared.present(notice)
     }
+
+    @objc
+    func publishObserverFor(_ note: Note, published: Bool) {
+        let event: PublishEvent = published ? .published(note) : .unpublished(note)
+        publishingObserver = PublishingObserver(event: event)
+    }
 }

--- a/Simplenote/Classes/SPObjectManager.h
+++ b/Simplenote/Classes/SPObjectManager.h
@@ -9,10 +9,13 @@
 #import <Foundation/Foundation.h>
 @class Note;
 @class Tag;
+@class PublishingObserver;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SPObjectManager : NSObject
+
+@property PublishingObserver * publishingObserver;
 
 + (SPObjectManager *)sharedManager;
 

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -18,6 +18,8 @@
 
 @implementation SPObjectManager
 
+@synthesize publishingObserver;
+
 + (SPObjectManager *)sharedManager
 {
     static SPObjectManager *sharedManager = nil;
@@ -287,7 +289,7 @@
     note.published = published;
     note.modificationDate = [NSDate date];
     [self presentNoticePublishStateChangingTo:published];
-
+    [self publishObserverFor:note published:published];
     [self save];
 }
 

--- a/Simplenote/Controllers/PublishingObserver.swift
+++ b/Simplenote/Controllers/PublishingObserver.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SimplenoteFoundation
+
+@objc
+class PublishingObserver: NSObject {
+    let event: PublishEvent
+    @objc
+    let observedNote: Note
+    var observation: NSKeyValueObservation?
+
+    init(event: PublishEvent) {
+        self.event = event
+
+        switch event {
+        case .published(let note), .unpublished(let note):
+            observedNote = note
+        }
+
+        super.init()
+
+        setupObservation(event: event)
+    }
+
+    func setupObservation(event: PublishEvent) {
+
+        observation = observe(\.observedNote.publishURL,
+                              options: [.old, .new]) { object, change in
+            if change.oldValue == change.newValue {
+                return
+            }
+            switch event {
+            case .published(let note):
+                NoticeController.shared.present(self.makePublishNotice(publishing: true, successful: true, option: .undo, note: note))
+            case .unpublished(let note):
+                NoticeController.shared.present(self.makePublishNotice(publishing: false, successful: true, option: .undo, note: note))
+            }
+
+            self.observation?.invalidate()
+        }
+    }
+
+
+
+    enum ActionOption: String {
+        case retry = "Retry"
+        case undo = "Undo"
+    }
+
+    func makePublishNotice(publishing: Bool, successful: Bool, option: ActionOption, note: Note) -> Notice {
+        var message = ""
+
+        if successful {
+            message = "Note \(publishing ? "published" : "unpublished")."
+        } else {
+            message = "Could not \(publishing ? "publish" : "unpublish") note."
+        }
+
+        let action = NoticeAction(title: option.rawValue) {
+
+            SPObjectManager.shared().updatePublishedState(!publishing, note: note)
+        }
+
+        return Notice(message: message, action: action)
+    }
+}
+
+enum PublishEvent {
+    case published(Note)
+    case unpublished(Note)
+}


### PR DESCRIPTION
### Fix
This is a concept branch for a way that we could monitor publishing of notes.  Notice that in this setup when a note is published a PublishingObserver is created, watches for a successful creation or removal of a publish link and then fires a notice to alert the user that the change succeeded

### Test
1. go to a note that is not published, go to the options controller and tap on the publish switch
2. a notice for publishing should appear, after a few seconds a new notice that says the publishing was successful appears that has an undo button
3. try disabling the switch again to see the same process but this time unpublished
4. try one more time, but use the undo buttons to disable the publish/unpublish actions

