### PR TITLE
Deleted Tag crash

### DIFF
--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -697,17 +697,11 @@ private extension TagListViewController {
 
             // If the change includes deleting the tag that is currently being edited
             // remove the reselect rename tag, disable editing and reload tableView
-            if self.isEditing && self.renameTag != nil {
-                guard let renameTag = self.renameTag else {
-                    return
-                }
-
-                if !self.resultsController.fetchedObjects.contains(renameTag) {
-                    self.renameTag = nil
-                    self.setEditing(false)
-                    self.reloadTableView()
-                    return
-                }
+            if let renameTag = self.renameTag, !self.resultsController.fetchedObjects.contains(renameTag) {
+                self.renameTag = nil
+                self.setEditing(false)
+                self.reloadTableView()
+                return
             }
 
             self.reloadTable(with: sectionsChangeset.transposed(toSection: Section.tags.rawValue),

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -695,6 +695,21 @@ private extension TagListViewController {
                 return
             }
 
+            // If the change includes deleting the tag that is currently being edited
+            // remove the reselect rename tag, disable editing and reload tableView
+            if self.isEditing && self.renameTag != nil {
+                guard let renameTag = self.renameTag else {
+                    return
+                }
+
+                if !self.resultsController.fetchedObjects.contains(renameTag) {
+                    self.renameTag = nil
+                    self.setEditing(false)
+                    self.reloadTableView()
+                    return
+                }
+            }
+
             self.reloadTable(with: sectionsChangeset.transposed(toSection: Section.tags.rawValue),
                              objectsChangeset: objectsChangeset.transposed(toSection: Section.tags.rawValue))
         }


### PR DESCRIPTION
### Fix
This PR fixes #1161 

This PR adds a check against updates to the tags list, where a note is being edited on one device and then deleted on another, causing a crash.

Currently if you:
1. edit a tag on iOS, leave the tag list in edit mode
2. Go to another device and delete the tag being edited
3. iOS will crash

This happens because the tag that is being edited is held onto by the TagListViewController and is removed from the context by Simperium, so when the tag list tries to update to reflect the changes there is a note being managed in the VC that no longer exists.  This PR fixes the issue by adding a check in `resultsController.onDidChangeContent` to remove the reference to the deleted tag from the VC

### Test
1. On iOS, go to the tags list
2. Tag on Edit, and then tap on the name of a tag to enter edit mode
3. While in edit mode on iOS, go to another device and delete the tag that is being edited
4. The app should not crash

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
