### PR TITLE
Fixed tag bar getting stuck on swipe to markdown preview

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -462,6 +462,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (UIViewController *)nextViewControllerForInteractivePush
 {
+    [self endEditing];
     SPMarkdownPreviewViewController *previewViewController = [SPMarkdownPreviewViewController new];
     previewViewController.markdownText = [self.noteEditorTextView plainText];
     

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -217,6 +217,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)viewDidDisappear:(BOOL)animated
 {
+    [super viewDidDisappear:animated];
     [self stopListeningToKeyboardNotifications];
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -211,9 +211,13 @@ CGFloat const SPSelectedAreaPadding = 20;
 {
     [super viewWillDisappear:animated];
     [self.navigationController setToolbarHidden:YES animated:YES];
-    [self stopListeningToKeyboardNotifications];
 
     [self saveScrollPosition];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [self stopListeningToKeyboardNotifications];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
@@ -488,7 +492,6 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)interactivePushPopAnimationControllerWillBeginPush:(SPInteractivePushPopAnimationController *)controller
 {
-    [self endEditing];
     // This dispatch is to prevent the animations executed when ending editing
     // from happening interactively along with the push on iOS 9.
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -462,7 +462,6 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (UIViewController *)nextViewControllerForInteractivePush
 {
-    [self endEditing];
     SPMarkdownPreviewViewController *previewViewController = [SPMarkdownPreviewViewController new];
     previewViewController.markdownText = [self.noteEditorTextView plainText];
     
@@ -489,6 +488,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)interactivePushPopAnimationControllerWillBeginPush:(SPInteractivePushPopAnimationController *)controller
 {
+    [self endEditing];
     // This dispatch is to prevent the animations executed when ending editing
     // from happening interactively along with the push on iOS 9.
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
### Fix
Fixes #1211 
This PR fixes a problem with the tag bar where swiping from the note editor to markdown preview, while the keyboard was visible, would cause the tag bar to get stuck in the middle of the screen. 

<img src="https://cdn-std.droplr.net/files/acc_593859/7M8q12" />
The tag list location is animated in and out based on the changes to the keyboard, so with this PR, I have changed when the Note Editor stops listening to keyboard update notifications.  The keyboard was being dismissed after we stopped listening, so the tags bar had no way to know it needed to change locations.

<img src="https://cdn-std.droplr.net/files/acc_593859/0BL25F" />

### Test
1. go to a note that has mark down enabled.  
2. tap into the text view to make the keyboard appear
3. swipe to the left to make markdown appear
4. tap back to return to the editor
The tag bar should be at the bottom of the screen not in the middle

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer  is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
