### PR TITLE
Updated copy for verify email text

### DIFF
--- a/Simplenote/Classes/SignupVerificationViewController.swift
+++ b/Simplenote/Classes/SignupVerificationViewController.swift
@@ -76,7 +76,7 @@ private struct Localization {
         String(format: messageTemplate, email)
     }
 
-    private static let footerTemplate = NSLocalizedString("Didn't get an email? You may already have an account. Contact %1$@ for help.", comment: "Footer -> Sign up verification screen. Parameter: %1$@ - support email address")
+    private static let footerTemplate = NSLocalizedString("Didn't get an email? There may already be an account associated with this email address. Contact %1$@ for help.", comment: "Footer -> Sign up verification screen. Parameter: %1$@ - support email address")
 
     static func footer(with email: String) -> String {
         String(format: footerTemplate, email)


### PR DESCRIPTION
### Fix

fixes #1231 

This is a small PR that updates the copy around checking your email on sign up.  

old:
`Didn’t get an email? You may already have an account. Contact support@simplenote.com for help.`

new:
`Didn’t get an email? There may already be an account associated with this email address. Contact support@simplenote.com for help.`

<img src="https://cdn-std.droplr.net/files/acc_593859/09TKx8" />
### Test
1. While logged out, go to the sign up flow and enter an email address.  You should see the new copy.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
