### PR TITLE
Remove search sort bar bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.35
 -----
 -   Simplenote's Icons have been revamped #919
+-   Changed search sort settings to use the general sort setting. #1209
 
 4.34
 -----

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -67,22 +67,6 @@ class NotesListController: NSObject {
         }
     }
 
-    /// SortMode to be applied to Search Results
-    ///
-    var searchSortMode: SortMode = .alphabeticallyAscending {
-        didSet {
-            guard case .searching = state else {
-                return
-            }
-
-            guard oldValue != searchSortMode else {
-                return
-            }
-
-            refreshSortDescriptors()
-        }
-    }
-
     /// Callback to be executed whenever the NotesController or TagsController were updated
     /// - NOTE: This only happens as long as the current state must render such entities!
     ///
@@ -244,7 +228,7 @@ private extension NotesListController {
     }
 
     func refreshSortDescriptors() {
-        notesController.sortDescriptors = state.descriptorsForNotes(sortMode: sortModeForActiveState)
+        notesController.sortDescriptors = state.descriptorsForNotes(sortMode: sortMode)
         tagsController.sortDescriptors = state.descriptorsForTags()
     }
 
@@ -297,16 +281,5 @@ private extension NotesListController {
         }
 
         onBatchChanges?(sectionsChangeset, objectsChangeset)
-    }
-
-    /// Sort Mode might differ in Results / Search!
-    ///
-    var sortModeForActiveState: SortMode {
-        switch state {
-        case .searching:
-            return searchSortMode
-        case .results:
-            return sortMode
-        }
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -595,7 +595,18 @@ private extension SPNoteListViewController {
                 return nil
         }
 
-        return DateFormatter.listDateFormatter.string(from: date)
+        return dateSortPrefix() + DateFormatter.listDateFormatter.string(from: date)
+    }
+
+    private func dateSortPrefix() -> String {
+        switch notesListController.sortMode {
+        case .createdNewest, .createdOldest:
+            return "Created: "
+        case .modifiedNewest, .modifiedOldest:
+            return "Modified: "
+        default:
+            return ""
+        }
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -595,18 +595,7 @@ private extension SPNoteListViewController {
                 return nil
         }
 
-        return dateSortPrefix() + DateFormatter.listDateFormatter.string(from: date)
-    }
-
-    private func dateSortPrefix() -> String {
-        switch notesListController.sortMode {
-        case .createdNewest, .createdOldest:
-            return "Created: "
-        case .modifiedNewest, .modifiedOldest:
-            return "Modified: "
-        default:
-            return ""
-        }
+        return DateFormatter.listDateFormatter.string(from: date)
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -18,12 +18,10 @@
 @property (nonatomic, strong) SPPlaceholderView                             *placeholderView;
 @property (nonatomic, strong) NSLayoutConstraint                            *placeholderViewVerticalCenterConstraint;
 @property (nonatomic, strong) NSLayoutConstraint                            *placeholderViewTopConstraint;
-@property (nonatomic, strong) SPSortBar                                     *sortBar;
 @property (nonatomic, strong) UITableView                                   *tableView;
 @property (nonatomic, strong) UIStackView                                   *searchBarStackView;
 @property (nonatomic, strong, readonly) SearchDisplayController             *searchController;
 @property (nonatomic, strong) NotesListController                           *notesListController;
-@property (nonatomic, weak) UIPopoverPresentationController                 *popoverController;
 @property (nonatomic) CGFloat                                               noteRowHeight;
 @property (nonatomic) CGFloat                                               tagRowHeight;
 @property (nonatomic) CGFloat                                               keyboardHeight;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -56,7 +56,6 @@
         [self configureTableView];
         [self configureSearchController];
         [self configureSearchStackView];
-        [self configureSortBar];
         [self configureRootView];
         [self updateTableViewMetrics];
         [self startListeningToNotifications];
@@ -193,7 +192,6 @@
     // Condensed Notes
     [nc addObserver:self selector:@selector(condensedPreferenceWasUpdated:) name:SPCondensedNoteListPreferenceChangedNotification object:nil];
     [nc addObserver:self selector:@selector(sortModePreferenceWasUpdated:) name:SPNotesListSortModeChangedNotification object:nil];
-    [nc addObserver:self selector:@selector(sortModePreferenceWasUpdated:) name:SPSearchSortModeChangedNotification object:nil];
 
     // Register for keyboard notifications
     [nc addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
@@ -336,7 +334,6 @@
     NSTimeInterval const delay = 0.2;
     self.searchTimer = [NSTimer scheduledTimerWithTimeInterval:delay repeats:NO block:^(NSTimer * _Nonnull timer) {
         [self performSearchWithKeyword:keyword];
-        [self updateSortBarVisibility];
     }];    
 }
 
@@ -348,7 +345,6 @@
     // Note: We avoid switching to SearchMode in `shouldBegin` because it might cause layout issues!
     [self.notesListController beginSearch];
     [self reloadTableData];
-    [self updateSortBarVisibility];
     [self refreshTitle];
 }
 
@@ -367,7 +363,6 @@
     [self.notesListController endSearch];
     [self update];
 
-    [self updateSortBarVisibility];
 }
 
 
@@ -488,7 +483,6 @@
     [self refreshListController];
     [self refreshTitle];
     [self refreshSearchBar];
-    [self refreshSortBarText];
 
     BOOL isTrashOnScreen = self.isDeletedFilterActive;
 

--- a/Simplenote/Classes/SPNotifications.h
+++ b/Simplenote/Classes/SPNotifications.h
@@ -15,5 +15,4 @@
 extern NSString *const SPAlphabeticalTagSortPreferenceChangedNotification;
 extern NSString *const SPCondensedNoteListPreferenceChangedNotification;
 extern NSString *const SPNotesListSortModeChangedNotification;
-extern NSString *const SPSearchSortModeChangedNotification;
 extern NSString *const SPSimplenoteThemeChangedNotification;

--- a/Simplenote/Classes/SPNotifications.m
+++ b/Simplenote/Classes/SPNotifications.m
@@ -15,5 +15,4 @@
 NSString *const SPAlphabeticalTagSortPreferenceChangedNotification  = @"SPAlphabeticalTagSortPreferenceChangedNotification";
 NSString *const SPCondensedNoteListPreferenceChangedNotification    = @"SPCondensedNoteListPreferenceChangedNotification";
 NSString *const SPNotesListSortModeChangedNotification              = @"SPNotesListSortModeChangedNotification";
-NSString *const SPSearchSortModeChangedNotification                 = @"SPSearchSortModeChangedNotification";
 NSString *const SPSimplenoteThemeChangedNotification                = @"SPSimplenoteThemeChangedNotification";

--- a/Simplenote/Classes/SPTracker.h
+++ b/Simplenote/Classes/SPTracker.h
@@ -54,7 +54,6 @@
 + (void)trackSettingsPinlockEnabled:(BOOL)isOn;
 + (void)trackSettingsListCondensedEnabled:(BOOL)isOn;
 + (void)trackSettingsNoteListSortMode:(NSString *)description;
-+ (void)trackSettingsSearchSortMode:(NSString *)description;
 + (void)trackSettingsThemeUpdated:(NSString *)themeName;
 
 #pragma mark - Sidebar

--- a/Simplenote/Classes/SPTracker.m
+++ b/Simplenote/Classes/SPTracker.m
@@ -205,11 +205,6 @@
     [self trackAutomatticEventWithName:@"settings_note_list_sort_mode" properties:@{ @"description" : description }];
 }
 
-+ (void)trackSettingsSearchSortMode:(NSString *)description
-{
-    [self trackAutomatticEventWithName:@"settings_search_sort_mode" properties:@{ @"description" : description }];
-}
-
 + (void)trackSettingsThemeUpdated:(NSString *)themeName
 {
     NSParameterAssert(themeName);

--- a/Simplenote/Classes/UserDefaults+Simplenote.swift
+++ b/Simplenote/Classes/UserDefaults+Simplenote.swift
@@ -11,7 +11,6 @@ extension UserDefaults {
         case listSortMode
         case listSortModeLegacy = "SPAlphabeticalSortPref"
         case markdown = "MarkdownDefault"
-        case searchSortMode
         case theme
         case themeLegacy = "SPThemePref"
         case wordPressSessionKey = "SPAuthSessionKey"

--- a/Simplenote/Options.swift
+++ b/Simplenote/Options.swift
@@ -85,25 +85,6 @@ extension Options {
         }
     }
 
-    /// Returns the Search's Sort Mode. When it's undefined we'll fallback to the List's Sort Mode
-    ///
-    @objc
-    var searchSortMode: SortMode {
-        get {
-            guard defaults.containsObject(forKey: .searchSortMode) else {
-                return listSortMode
-            }
-
-            let payload = defaults.integer(forKey: .searchSortMode)
-            return SortMode(rawValue: payload) ?? .alphabeticallyAscending
-        }
-        set {
-            defaults.set(newValue.rawValue, forKey: .searchSortMode)
-            SPTracker.trackSettingsSearchSortMode(newValue.description)
-            NotificationCenter.default.post(name: .SPSearchSortModeChanged, object: nil)
-        }
-    }
-
     /// Returns the selected Theme
     ///
     @objc
@@ -160,7 +141,6 @@ extension Options {
         defaults.removeObject(forKey: .theme)
         defaults.removeObject(forKey: .listSortMode)
         defaults.removeObject(forKey: .markdown)
-        defaults.removeObject(forKey: .searchSortMode)
         defaults.removeObject(forKey: .useBiometryInsteadOfPin)
     }
 

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -63,7 +63,6 @@ class NotesListControllerTests: XCTestCase {
         XCTAssertEqual(noteListController.numberOfObjects, notes.count)
 
         noteListController.sortMode = .alphabeticallyDescending
-        noteListController.searchSortMode = .alphabeticallyDescending
         noteListController.performFetch()
 
         let reversedNotes = Array(notes.reversed())
@@ -260,30 +259,6 @@ class NotesListControllerTests: XCTestCase {
             XCTAssertEqual(noteListController.indexPath(forObject: note), IndexPath(row: row, section: 1))
         }
     }
-
-    /// Verifies that the SortMode property properly applies the specified order mode to the retrieved entities
-    ///
-    func testListControllerProperlyAppliesSearchSortModeToSearchResults() {
-        let (notes, _, _) = insertSampleEntities(count: 100)
-
-        storage.save()
-        noteListController.beginSearch()
-
-        // Search Mode: Expect an inverted collection (regardless of the regular sort mode)
-        noteListController.sortMode = .alphabeticallyAscending
-        noteListController.searchSortMode = .alphabeticallyDescending
-
-        // This is a specific keyword contained by eeeevery siiiiinnnnngle entity!
-        noteListController.refreshSearchResults(keyword: "0")
-
-        let reversedNotes = Array(notes.reversed())
-        let retrievedNotes = noteListController.sections.first!.objects.compactMap { $0 as? Note }
-
-        for (index, note) in retrievedNotes.enumerated() {
-            XCTAssertEqual(note.content, reversedNotes[index].content)
-        }
-    }
-
 
     // MARK: - Tests: onBatchChanges
 

--- a/SimplenoteTests/OptionsTests.swift
+++ b/SimplenoteTests/OptionsTests.swift
@@ -26,14 +26,6 @@ class OptionsTests: XCTestCase {
         XCTAssert(options.listSortMode == .alphabeticallyAscending)
     }
 
-    func testEmptySearchSortModeYieldsListSortMode() {
-        let options = Options(defaults: defaults)
-        XCTAssertEqual(options.listSortMode, options.searchSortMode)
-
-        options.listSortMode = .alphabeticallyDescending
-        XCTAssertEqual(options.searchSortMode, .alphabeticallyDescending)
-    }
-
     func testLegacyUnspecifiedThemeIsProperlyMigrated() {
         let options = Options(defaults: defaults)
 


### PR DESCRIPTION
### Fix
Fixes #1209 

After some testing, it has been determined that the search sort bar isn't being used, so we are removing it.  Search sorting will now use the same settings as the primary sort order, set in the settings view.  

This PR removes the search sort bar and sets up for search settings to be organized by the same settings the general sorting of notes in the notes list

### Test
1. go to the settings view and choose a non date sorting options (alphabetical a-z or z-a) 
2. return to the note list, tap on the search bar, add a search query that will yield a result and tap on the enter button to dismiss the keyboard.  The sort bar will not appear and the results will be sorted by the option set in the settings window
3. Return to settings and choose one of the date sorting options
4. Preform another search and make sure that the sorting has changed to the setting you chose and that the results in the notes are now prepended with the date (modified or created depending on the option selected)

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> `RELEASE-NOTES.txt` was updated in 582d2c0 with:
> 
> > Changed search sort settings to use the general sort setting.
