### PR TITLE
Refactor search flow UI tests to use value type for fake data

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */; };
 		3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */; };
 		3F5EDD0C2435A3AE00959576 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */; };
+		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
 		3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */; };
 		4352BA0867E0E416EB5FF6B9 /* Pods_Automattic_Simplenote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3318C36BBA08D53624E27EFC /* Pods_Automattic_Simplenote.framework */; };
 		46A3C96317DFA81A002865AE /* NSString+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 467D9C771788D0FF00785EF3 /* NSString+Metadata.m */; };
@@ -552,6 +553,7 @@
 		3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
 		3F6CECDC2FEA90B9E5C920F5 /* Pods-SimplenoteTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.release.xcconfig"; sourceTree = "<group>"; };
+		3FA17B5526240FF000C11C46 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
 		3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplenoteScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteScreenshots.swift; sourceTree = "<group>"; };
 		3FA6013D242C5AAE0068FC52 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1887,6 +1889,7 @@
 				D864B1AA25CAE59400F9B73E /* EmailLogin.swift */,
 				D864B16825CAE47C00F9B73E /* Generic.swift */,
 				D864B1F025CAE87800F9B73E /* Info.plist */,
+				3FA17B5526240FF000C11C46 /* NoteData.swift */,
 				D864B1B325CAE5C900F9B73E /* NoteEditor.swift */,
 				D864B19125CAE54300F9B73E /* NoteList.swift */,
 				D864B1C525CAE5F800F9B73E /* Preview.swift */,
@@ -2979,6 +2982,7 @@
 				D864B18225CAE4BE00F9B73E /* SimplenoteUITestsNoteEditor.swift in Sources */,
 				D864B1E125CAE66A00F9B73E /* Extensions.swift in Sources */,
 				D864B1CF25CAE61F00F9B73E /* Trash.swift in Sources */,
+				3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */,
 				D864B1C625CAE5F800F9B73E /* Preview.swift in Sources */,
 				D843AD8F25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift in Sources */,
 				D864B19225CAE54300F9B73E /* NoteList.swift in Sources */,

--- a/SimplenoteUITests/NoteData.swift
+++ b/SimplenoteUITests/NoteData.swift
@@ -1,0 +1,8 @@
+/// Value-type to describe the elements that represent a not as seen from the UI.
+struct NoteData {
+    let name: String
+    let content: String
+    let tags: [String]
+
+    var formattedForAutomatedInput: String { "\(name)\n\n\(content)" }
+}

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -32,6 +32,13 @@ class NoteList {
         app.navigationBars.buttons[UID.Button.newNote].tap()
     }
 
+    static func createNoteThenLeaveEditor(_ note: NoteData) {
+        NoteList.createNoteAndLeaveEditor(
+            noteName: note.formattedForAutomatedInput,
+            tags: note.tags
+        )
+    }
+
     class func createNoteAndLeaveEditor(noteName: String, tags: [String] = []) {
         print(">>> Creating a note: " + noteName)
         NoteList.addNoteTap()
@@ -150,6 +157,14 @@ class NoteListAssert {
         for tag in tags {
             NoteListAssert.tagSuggestionExists(tag: tag)
         }
+    }
+
+    static func noteExists(_ note: NoteData) {
+        notesExist([note])
+    }
+
+    static func notesExist(_ notes: [NoteData]) {
+        notesExist(names: notes.map { $0.name })
     }
 
     class func noteExists(noteName: String) {

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -1,22 +1,43 @@
 import XCTest
 
-let godzillaNoteName = "Godzilla"
-let godzillaInfo = "Godzilla (Japanese: ゴジラ, Hepburn: Gojira, /ɡɒdˈzɪlə/; [ɡoꜜdʑiɾa] (About this soundlisten)) is a fictional monster, or kaiju, originating from a series of Japanese films. The character first appeared in the 1954 film Godzilla and became a worldwide pop culture icon, appearing in various media, including 32 films produced by Toho, four Hollywood films and numerous video games, novels, comic books and television shows. Godzilla has been dubbed the'King of the Monsters', a phrase first used in Godzilla, King of the Monsters! (1956), the Americanized version of the original film."
+// swiftlint:disable line_length
+let godzilla = NoteData(
+    name: "Godzilla",
+    content: "Godzilla (Japanese: ゴジラ, Hepburn: Gojira, /ɡɒdˈzɪlə/; [ɡoꜜdʑiɾa] (About this soundlisten)) is a fictional monster, or kaiju, originating from a series of Japanese films. The character first appeared in the 1954 film Godzilla and became a worldwide pop culture icon, appearing in various media, including 32 films produced by Toho, four Hollywood films and numerous video games, novels, comic books and television shows. Godzilla has been dubbed the'King of the Monsters', a phrase first used in Godzilla, King of the Monsters! (1956), the Americanized version of the original film.",
+    tags: ["sea-monster", "reptile", "prehistoric"]
+)
 
-let kingKongNoteName = "King Kong"
-let kingKongInfo = "King Kong is a film monster, resembling an enormous gorilla, that has appeared in various media since 1933. He has been dubbed The Eighth Wonder of the World, a phrase commonly used within the films. The character first appeared in the novelization of the 1933 film King Kong from RKO Pictures, with the film premiering a little over two months later. The film received universal acclaim upon its initial release and re-releases. A sequel quickly followed that same year with The Son of Kong, featuring Little Kong. In the 1960s, Toho produced King Kong vs. Godzilla (1962), pitting a larger Kong against Toho's own Godzilla, and King Kong Escapes (1967), based on The King Kong Show (1966–1969) from Rankin/Bass Productions. In 1976, Dino De Laurentiis produced a modern remake of the original film directed by John Guillermin."
+let kingGong = NoteData(
+    name: "King Kong",
+    content: "King Kong is a film monster, resembling an enormous gorilla, that has appeared in various media since 1933. He has been dubbed The Eighth Wonder of the World, a phrase commonly used within the films. The character first appeared in the novelization of the 1933 film King Kong from RKO Pictures, with the film premiering a little over two months later. The film received universal acclaim upon its initial release and re-releases. A sequel quickly followed that same year with The Son of Kong, featuring Little Kong. In the 1960s, Toho produced King Kong vs. Godzilla (1962), pitting a larger Kong against Toho's own Godzilla, and King Kong Escapes (1967), based on The King Kong Show (1966–1969) from Rankin/Bass Productions. In 1976, Dino De Laurentiis produced a modern remake of the original film directed by John Guillermin.",
+    tags: ["ape", "prehistoric"]
+)
 
-let mechagodzillaNoteName = "Mechagodzilla"
-let mechagodzillaInfo = "Mechagodzilla (メカゴジラ, Mekagojira) is a fictional mecha character that first appeared in the 1974 film Godzilla vs. Mechagodzilla. In its debut appearance, Mechagodzilla is depicted as an extraterrestrial villain that confronts Godzilla. In subsequent iterations, Mechagodzilla is usually depicted as a man-made weapon designed to defend Japan from Godzilla. In all incarnations, the character is portrayed as a robotic doppelgänger with a vast array of weaponry, and along with King Ghidorah, is commonly considered to be an archenemy of Godzilla."
+let mechagodzilla = NoteData(
+    name: "Mechagodzilla",
+    content: "Mechagodzilla (メカゴジラ, Mekagojira) is a fictional mecha character that first appeared in the 1974 film Godzilla vs. Mechagodzilla. In its debut appearance, Mechagodzilla is depicted as an extraterrestrial villain that confronts Godzilla. In subsequent iterations, Mechagodzilla is usually depicted as a man-made weapon designed to defend Japan from Godzilla. In all incarnations, the character is portrayed as a robotic doppelgänger with a vast array of weaponry, and along with King Ghidorah, is commonly considered to be an archenemy of Godzilla.",
+    tags: ["man-made", "robot"]
+)
 
-let diacriticNoteName = "Diacritic"
-let diacriticInfo = "A diacritic (also diacritical mark, diacritical point, diacritical sign, or accent) is a glyph added to a letter or basic glyph. The term derives from the Ancient Greek διακριτικός (diakritikós, \"distinguishing\"), from διακρίνω (diakrī́nō, \"to distinguish\"). Some diacritical marks, such as the acute ( ´ ) and grave ( ` ), are often called accents. Examples are the diaereses in the borrowed French words naïve and Noël, which show that the vowel with the diaeresis mark is pronounced separately from the preceding vowel; the acute and grave accents, which can indicate that a final vowel is to be pronounced, as in saké and poetic breathèd; and the cedilla under the \"c\" in the borrowed French word façade, which shows it is pronounced /s/ rather than /k/. In other Latin-script alphabets, they may distinguish between homonyms, such as the French là (\"there\") versus la (\"the\") that are both pronounced /la/. In Gaelic type, a dot over a consonant indicates lenition of the consonant in question."
+let diacritic = NoteData(
+    name: "Diacritic",
+    content: "A diacritic (also diacritical mark, diacritical point, diacritical sign, or accent) is a glyph added to a letter or basic glyph. The term derives from the Ancient Greek διακριτικός (diakritikós, \"distinguishing\"), from διακρίνω (diakrī́nō, \"to distinguish\"). Some diacritical marks, such as the acute ( ´ ) and grave ( ` ), are often called accents. Examples are the diaereses in the borrowed French words naïve and Noël, which show that the vowel with the diaeresis mark is pronounced separately from the preceding vowel; the acute and grave accents, which can indicate that a final vowel is to be pronounced, as in saké and poetic breathèd; and the cedilla under the \"c\" in the borrowed French word façade, which shows it is pronounced /s/ rather than /k/. In other Latin-script alphabets, they may distinguish between homonyms, such as the French là (\"there\") versus la (\"the\") that are both pronounced /la/. In Gaelic type, a dot over a consonant indicates lenition of the consonant in question.",
+    tags: ["language", "diacritic"]
+)
+// swiftlint:enable line_length
+
+let allNotes: [NoteData] = [
+    godzilla,
+    kingGong,
+    mechagodzilla,
+    diacritic
+]
 
 class SimplenoteUISmokeTestsSearch: XCTestCase {
 
     override class func setUp() {
         app.launch()
-        let _ = attemptLogOut()
+        _ = attemptLogOut()
         EmailLogin.open()
         EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
         NoteList.waitForLoad()
@@ -25,10 +46,8 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         Sidebar.open()
         Sidebar.tagsDeleteAll()
         NoteList.openAllNotes()
-        NoteList.createNoteAndLeaveEditor(noteName: godzillaNoteName + "\n\n" + godzillaInfo, tags: ["sea-monster", "reptile", "prehistoric"])
-        NoteList.createNoteAndLeaveEditor(noteName: kingKongNoteName + "\n\n" + kingKongInfo, tags: ["ape", "prehistoric"])
-        NoteList.createNoteAndLeaveEditor(noteName: mechagodzillaNoteName + "\n\n" + mechagodzillaInfo, tags: ["man-made", "robot"])
-        NoteList.createNoteAndLeaveEditor(noteName: diacriticNoteName + "\n\n" + diacriticInfo, tags: ["language", "diacritic"])
+
+        allNotes.forEach { NoteList.createNoteThenLeaveEditor($0) }
 }
 
     override func setUpWithError() throws {
@@ -41,26 +60,26 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
 
         trackStep()
         NoteList.openAllNotes()
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesExist(allNotes)
         NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
         NoteList.searchForText(text: "Japan")
-        NoteListAssert.notesExist(names: [godzillaNoteName, mechagodzillaNoteName])
+        NoteListAssert.notesExist([godzilla, mechagodzilla])
 
         trackStep()
         NoteList.searchCancel()
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesExist(allNotes)
         NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
         NoteList.searchForText(text: "weapon")
-        NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.noteExists(mechagodzilla)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
         NoteList.searchForText(text: "")
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesExist(allNotes)
         NoteListAssert.notesNumber(expectedNotesNumber: 4)
     }
 
@@ -71,21 +90,21 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         var testedTag = "prehistoric"
         Sidebar.tagSelect(tagName: testedTag)
         NoteListAssert.noteListShown(forSelection: testedTag)
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
+        NoteListAssert.notesExist([godzilla, kingGong])
         NoteListAssert.notesNumber(expectedNotesNumber: 2)
 
         trackStep()
         testedTag = "reptile"
         Sidebar.tagSelect(tagName: testedTag)
         NoteListAssert.noteListShown(forSelection: testedTag)
-        NoteListAssert.noteExists(noteName: godzillaNoteName)
+        NoteListAssert.noteExists(godzilla)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
         testedTag = "robot"
         Sidebar.tagSelect(tagName: testedTag)
         NoteListAssert.noteListShown(forSelection: testedTag)
-        NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.noteExists(mechagodzilla)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
 
@@ -96,13 +115,13 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         var testedTag = "prehistoric"
         Sidebar.tagSelect(tagName: testedTag)
         NoteListAssert.noteListShown(forSelection: testedTag)
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
+        NoteListAssert.notesExist([godzilla, kingGong])
         NoteListAssert.notesNumber(expectedNotesNumber: 2)
 
         trackStep()
         NoteList.openAllNotes()
         NoteListAssert.allNotesShown()
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesExist(allNotes)
         NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
@@ -114,7 +133,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         testedTag = "language"
         Sidebar.tagSelect(tagName: testedTag)
         NoteListAssert.noteListShown(forSelection: testedTag)
-        NoteListAssert.noteExists(noteName: diacriticNoteName)
+        NoteListAssert.noteExists(diacritic)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
 
@@ -123,22 +142,22 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
 
         trackStep()
         NoteList.openAllNotes()
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesExist(allNotes)
         NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
         NoteList.searchForText(text: "Godzilla")
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName])
+        NoteListAssert.notesExist([godzilla, kingGong, mechagodzilla])
         NoteListAssert.notesNumber(expectedNotesNumber: 3)
 
         trackStep()
         NoteList.searchForText(text: "Gorilla")
-        NoteListAssert.notesExist(names: [kingKongNoteName])
+        NoteListAssert.notesExist([kingGong])
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
         NoteList.searchForText(text: "Gaelic")
-        NoteListAssert.notesExist(names: [diacriticNoteName])
+        NoteListAssert.notesExist([diacritic])
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
     }
 
@@ -151,7 +170,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         NoteListAssert.tagSuggestionExists(tag: "tag:robot")
         NoteListAssert.tagsSuggestionsNumber(number: 1)
         NoteListAssert.notesSearchHeaderShown()
-        NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.noteExists(mechagodzilla)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
@@ -160,7 +179,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         NoteListAssert.tagSuggestionExists(tag: "tag:robot")
         NoteListAssert.tagsSuggestionsNumber(number: 1)
         NoteListAssert.notesSearchHeaderShown()
-        NoteListAssert.noteExists(noteName: mechagodzillaNoteName)
+        NoteListAssert.noteExists(mechagodzilla)
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
@@ -178,14 +197,18 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         trackStep()
         NoteList.searchForText(text: "t")
         NoteListAssert.tagsSearchHeaderShown()
-        NoteListAssert.tagSuggestionsExist(tags: ["tag:diacritic", "tag:prehistoric", "tag:reptile", "tag:robot", "tag:sea-monster"])
+        NoteListAssert.tagSuggestionsExist(
+            tags: ["tag:diacritic", "tag:prehistoric", "tag:reptile", "tag:robot", "tag:sea-monster"]
+        )
         NoteListAssert.tagsSuggestionsNumber(number: 5)
         NoteListAssert.notesSearchHeaderShown()
 
         trackStep()
         NoteList.searchForText(text: "a")
         NoteListAssert.tagsSearchHeaderShown()
-        NoteListAssert.tagSuggestionsExist(tags: ["tag:ape", "tag:diacritic", "tag:language", "tag:man-made", "tag:sea-monster"])
+        NoteListAssert.tagSuggestionsExist(
+            tags: ["tag:ape", "tag:diacritic", "tag:language", "tag:man-made", "tag:sea-monster"]
+        )
         NoteListAssert.tagsSuggestionsNumber(number: 5)
         NoteListAssert.notesSearchHeaderShown()
 
@@ -236,7 +259,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         NoteList.tagSuggestionTap(tag: testedTag)
         NoteListAssert.searchStringIsShown(searchString: testedTag + " ")
         NoteListAssert.notesSearchHeaderShown()
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName])
+        NoteListAssert.notesExist([godzilla, kingGong])
         NoteListAssert.notesNumber(expectedNotesNumber: 2)
     }
 
@@ -245,19 +268,22 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
 
         trackStep()
         NoteList.openAllNotes()
-        NoteListAssert.notesExist(names: [godzillaNoteName, kingKongNoteName, mechagodzillaNoteName, diacriticNoteName])
+        NoteListAssert.notesExist(allNotes)
         NoteListAssert.notesNumber(expectedNotesNumber: 4)
 
         trackStep()
         NoteList.searchForText(text: "Hepburn")
-        NoteListAssert.noteContentIsShownInSearch(noteName: godzillaNoteName, expectedContent: "Godzilla (Japanese: ゴジラ, Hepburn: Gojira, /ɡɒdˈzɪlə/; [ɡoꜜdʑiɾa] (About this soundlisten)) is a fictional monster, or kaiju, originating from a series of Japanese films. The character first appeared in the 1954 film Godzilla and became a worldwide pop culture icon, appearing in various media, including 32 films produced by Toho")
+        // swiftlint:disable:next line_length
+        NoteListAssert.noteContentIsShownInSearch(noteName: godzilla.name, expectedContent: "Godzilla (Japanese: ゴジラ, Hepburn: Gojira, /ɡɒdˈzɪlə/; [ɡoꜜdʑiɾa] (About this soundlisten)) is a fictional monster, or kaiju, originating from a series of Japanese films. The character first appeared in the 1954 film Godzilla and became a worldwide pop culture icon, appearing in various media, including 32 films produced by Toho")
 
         trackStep()
         NoteList.searchForText(text: "1962")
-        NoteListAssert.noteContentIsShownInSearch(noteName: kingKongNoteName, expectedContent: "…King Kong vs. Godzilla (1962), pitting a larger Kong against Toho's own Godzilla, and King Kong Escapes (1967), based on The King Kong Show (1966–1969) from Rankin/Bass Productions. In 1976, Dino De Laurentiis produced a modern remake of the original film directed by John Guillermin")
+        // swiftlint:disable:next line_length
+        NoteListAssert.noteContentIsShownInSearch(noteName: kingGong.name, expectedContent: "…King Kong vs. Godzilla (1962), pitting a larger Kong against Toho's own Godzilla, and King Kong Escapes (1967), based on The King Kong Show (1966–1969) from Rankin/Bass Productions. In 1976, Dino De Laurentiis produced a modern remake of the original film directed by John Guillermin")
 
         trackStep()
         NoteList.searchForText(text: "archenemy")
-        NoteListAssert.noteContentIsShownInSearch(noteName: mechagodzillaNoteName, expectedContent: "…commonly considered to be an archenemy of Godzilla")
+        // swiftlint:disable:next line_length
+        NoteListAssert.noteContentIsShownInSearch(noteName: mechagodzilla.name, expectedContent: "…commonly considered to be an archenemy of Godzilla")
     }
 }


### PR DESCRIPTION
As I mentioned, I'm keen to keep the discussion going on UI testing improvements and code sharing between our projects.

This was a quick win I had in my list. It replaces individual `static let` values for each note name, content, and tags with a `NoteData` [value type](https://www.objc.io/issues/16-swift/swift-classes-vs-structs/) to make the tests more readable and easier to maintain.
I think this pattern is valuable and adopting it whenever possible will help us in the long run.

### Test

Checkout this branch and run the UI tests.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.