### PR TITLE
Automated first test from `Settings`

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -409,6 +409,8 @@
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		BAA63C3325EEDA83001589D7 /* NoteLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */; };
 		D435D38FCA5863E8447D5C2C /* Pods_Automattic_SimplenoteShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */; };
+		D82BFE4B2624A8AB003DFA32 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BFE4A2624A8AB003DFA32 /* Settings.swift */; };
+		D82BFE542624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BFE532624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift */; };
 		D843AD6F25E3E633007E5B15 /* SimplenoteUITestsLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D843AD6E25E3E633007E5B15 /* SimplenoteUITestsLogin.swift */; };
 		D843AD7825E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D843AD7725E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift */; };
 		D843AD8F25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D843AD8E25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift */; };
@@ -920,6 +922,8 @@
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteLinkTests.swift; sourceTree = "<group>"; };
 		C07B32800E3C783BDF105B3A /* Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; sourceTree = "<group>"; };
+		D82BFE4A2624A8AB003DFA32 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
+		D82BFE532624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteUISmokeTestsSettings.swift; sourceTree = "<group>"; };
 		D843AD6E25E3E633007E5B15 /* SimplenoteUITestsLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteUITestsLogin.swift; sourceTree = "<group>"; };
 		D843AD7725E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteUITestsTrash.swift; sourceTree = "<group>"; };
 		D843AD8E25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteUITestsSearch.swift; sourceTree = "<group>"; };
@@ -1887,20 +1891,22 @@
 			children = (
 				D864B1A125CAE57100F9B73E /* AssertGeneric.swift */,
 				D864B1AA25CAE59400F9B73E /* EmailLogin.swift */,
+				D864B1E025CAE66A00F9B73E /* Extensions.swift */,
 				D864B16825CAE47C00F9B73E /* Generic.swift */,
 				D864B1F025CAE87800F9B73E /* Info.plist */,
 				3FA17B5526240FF000C11C46 /* NoteData.swift */,
 				D864B1B325CAE5C900F9B73E /* NoteEditor.swift */,
 				D864B19125CAE54300F9B73E /* NoteList.swift */,
 				D864B1C525CAE5F800F9B73E /* Preview.swift */,
+				D82BFE4A2624A8AB003DFA32 /* Settings.swift */,
 				D8E2D8E225E7DE090001315B /* Sidebar.swift */,
+				D82BFE532624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift */,
 				D843AD6E25E3E633007E5B15 /* SimplenoteUITestsLogin.swift */,
 				D864B18125CAE4BE00F9B73E /* SimplenoteUITestsNoteEditor.swift */,
 				D843AD8E25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift */,
 				D843AD7725E3E7F9007E5B15 /* SimplenoteUITestsTrash.swift */,
 				D864B1CE25CAE61F00F9B73E /* Trash.swift */,
 				D864B1D725CAE63E00F9B73E /* UIDs.swift */,
-				D864B1E025CAE66A00F9B73E /* Extensions.swift */,
 			);
 			path = SimplenoteUITests;
 			sourceTree = "<group>";
@@ -2984,7 +2990,9 @@
 				D864B1CF25CAE61F00F9B73E /* Trash.swift in Sources */,
 				3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */,
 				D864B1C625CAE5F800F9B73E /* Preview.swift in Sources */,
+				D82BFE542624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift in Sources */,
 				D843AD8F25E3EB16007E5B15 /* SimplenoteUITestsSearch.swift in Sources */,
+				D82BFE4B2624A8AB003DFA32 /* Settings.swift in Sources */,
 				D864B19225CAE54300F9B73E /* NoteList.swift in Sources */,
 				D864B1D825CAE63E00F9B73E /* UIDs.swift in Sources */,
 				D864B16925CAE47C00F9B73E /* Generic.swift in Sources */,

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -39,6 +39,14 @@ func getToAllNotes() {
     NoteEditor.leaveEditor()
 }
 
+func toggleSwitchIfNeeded(_ switchElement: XCUIElement, _ value: String) {
+    let switchValue = switchElement.value as? String
+
+    guard switchValue != value else { return }
+
+    switchElement.tap()
+}
+
 class Table {
 
     class func getAllCells() -> XCUIElementQuery {

--- a/SimplenoteUITests/NoteData.swift
+++ b/SimplenoteUITests/NoteData.swift
@@ -2,7 +2,7 @@
 struct NoteData {
     let name: String
     let content: String
-    let tags: [String]
+    var tags: [String] = []
 
     var formattedForAutomatedInput: String { "\(name)\n\n\(content)" }
 }

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -13,6 +13,12 @@ class NoteList {
         return navBar.identifier
     }
 
+    class func isAllNotesListOpen() -> Bool {
+        let navBar = app.navigationBars[UID.NavBar.allNotes]
+        guard navBar.exists else { return false}
+        return navBar.frame.minX == 0.0
+    }
+
     class func isNoteListOpen(forTag tag: String) -> Bool {
         return app.navigationBars[tag].exists
     }
@@ -30,6 +36,7 @@ class NoteList {
     }
 
     class func openAllNotes() {
+        guard !NoteList.isAllNotesListOpen() else { return }
         print(">>> Opening \"All Notes\"")
         Sidebar.open()
         app.tables.staticTexts[UID.Button.allNotes].tap()

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -202,7 +202,7 @@ class NoteListAssert {
         XCTAssertEqual(actualNotesNumber, expectedNotesNumber, numberOfNotesInAllNotesNotExpected)
     }
 
-    class func noteHeight(_ note: NoteData, _ noteHeight: CGFloat) {
+    class func note(_ note: NoteData, hasHeight height: CGFloat) {
         print(">>> Asserting that note height is \(noteHeight)")
         XCTAssertEqual(NoteList.getNoteCellHeight(note.name), noteHeight)
     }

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -231,7 +231,7 @@ class NoteListAssert {
         NoteListAssert.noteListShown(forSelection: UID.NavBar.trash)
     }
 
-    class func noteContentIsShown(_ note: NoteData) {
+    class func contentIsShown(for note: NoteData) {
         noteContentIsShownInSearch(noteName: note.name, expectedContent: note.content)
     }
 

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -203,8 +203,8 @@ class NoteListAssert {
     }
 
     class func note(_ note: NoteData, hasHeight height: CGFloat) {
-        print(">>> Asserting that note height is \(noteHeight)")
-        XCTAssertEqual(NoteList.getNoteCellHeight(note.name), noteHeight)
+        print(">>> Asserting that note height is \(height)")
+        XCTAssertEqual(NoteList.getNoteCellHeight(note.name), height)
     }
 
     class func tagsSuggestionsNumber(number: Int) {

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -240,8 +240,7 @@ class NoteListAssert {
         print(">>>> \"\(expectedContent)\"")
 
         guard NoteList.isNotePresent(noteName) else {
-            XCTFail(">>>> Note not found")
-            return
+            return XCTFail(">>>> Note not found")
         }
 
         if let noteContent = Table.getContentOfCell(noteName: noteName) {

--- a/SimplenoteUITests/Settings.swift
+++ b/SimplenoteUITests/Settings.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+let screenName = "Settings"
+
+enum SettingsScreen: String {
+
+    case doneButton = "Done"
+    case condensedModeSwitch = "Condensed Note List"
+
+    var element: XCUIElement {
+        switch self {
+        case .doneButton:
+            return app.navigationBars[screenName].buttons[self.rawValue]
+        case .condensedModeSwitch:
+            return app.tables.cells.containing(.staticText, identifier: self.rawValue).firstMatch
+        }
+    }
+}
+
+class Settings {
+    class func condensedModeEnable() {
+        let condensedModeSwitch = SettingsScreen.condensedModeSwitch.element
+        let switchValue = condensedModeSwitch.value as? String
+
+        if switchValue == "0" {
+            condensedModeSwitch.tap()
+        }
+    }
+
+    class func condensedModeDisable() {
+        let condensedModeSwitch = SettingsScreen.condensedModeSwitch.element
+        let switchValue = condensedModeSwitch.value as? String
+
+        if switchValue == "1" {
+            condensedModeSwitch.tap()
+        }
+    }
+
+    class func close() {
+        SettingsScreen.doneButton.element.tap()
+    }
+
+    class func open() {
+        Sidebar.open()
+        Sidebar.getButtonSettings().tap()
+    }
+}

--- a/SimplenoteUITests/Settings.swift
+++ b/SimplenoteUITests/Settings.swift
@@ -18,7 +18,8 @@ enum SettingsScreen: String {
 }
 
 class Settings {
-    class func condensedModeEnable() {
+
+    static func condensedModeEnable() {
         let condensedModeSwitch = SettingsScreen.condensedModeSwitch.element
         let switchValue = condensedModeSwitch.value as? String
 
@@ -27,7 +28,7 @@ class Settings {
         }
     }
 
-    class func condensedModeDisable() {
+    static func condensedModeDisable() {
         let condensedModeSwitch = SettingsScreen.condensedModeSwitch.element
         let switchValue = condensedModeSwitch.value as? String
 
@@ -36,11 +37,11 @@ class Settings {
         }
     }
 
-    class func close() {
+    static func close() {
         SettingsScreen.doneButton.element.tap()
     }
 
-    class func open() {
+    static func open() {
         Sidebar.open()
         Sidebar.getButtonSettings().tap()
     }

--- a/SimplenoteUITests/Settings.swift
+++ b/SimplenoteUITests/Settings.swift
@@ -2,43 +2,37 @@ import XCTest
 
 let screenName = "Settings"
 
-enum SettingsScreen: String {
-
-    case doneButton = "Done"
-    case condensedModeSwitch = "Condensed Note List"
-
-    var element: XCUIElement {
-        switch self {
-        case .doneButton:
-            return app.navigationBars[screenName].buttons[self.rawValue]
-        case .condensedModeSwitch:
-            return app.tables.cells.containing(.staticText, identifier: self.rawValue).firstMatch
-        }
-    }
-}
-
 class Settings {
 
-    static func condensedModeEnable() {
-        let condensedModeSwitch = SettingsScreen.condensedModeSwitch.element
-        let switchValue = condensedModeSwitch.value as? String
+    enum Elements: String {
 
-        if switchValue == "0" {
-            condensedModeSwitch.tap()
+        case doneButton = "Done"
+        case condensedModeSwitch = "Condensed Note List"
+
+        var element: XCUIElement {
+            switch self {
+            case .doneButton:
+                return app.navigationBars[screenName].buttons[self.rawValue]
+            case .condensedModeSwitch:
+                return app.tables.cells.containing(.staticText, identifier: self.rawValue).firstMatch
+            }
         }
+    }
+
+    static func condensedModeEnable() {
+        switchCondensedModeIfNeeded(value: "1")
     }
 
     static func condensedModeDisable() {
-        let condensedModeSwitch = SettingsScreen.condensedModeSwitch.element
-        let switchValue = condensedModeSwitch.value as? String
+        switchCondensedModeIfNeeded(value: "0")
+    }
 
-        if switchValue == "1" {
-            condensedModeSwitch.tap()
-        }
+    static func switchCondensedModeIfNeeded(value: String) {
+        toggleSwitchIfNeeded(Elements.condensedModeSwitch.element, value)
     }
 
     static func close() {
-        SettingsScreen.doneButton.element.tap()
+        Elements.doneButton.element.tap()
     }
 
     static func open() {

--- a/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
+++ b/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+class SimplenoteUISmokeTestsSettings: XCTestCase {
+
+    override class func setUp() {
+        app.launch()
+        getToAllNotes()
+        _ = attemptLogOut()
+        EmailLogin.open()
+        EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
+        NoteList.waitForLoad()
+    }
+
+    override func setUpWithError() throws {
+        getToAllNotes()
+        NoteList.trashAllNotes()
+        Trash.empty()
+        NoteList.openAllNotes()
+    }
+
+    func testUsingCondensedNoteList() throws {
+        trackTest()
+        let note = NoteData(
+            name: "Condensed Mode Test",
+            content: "Condensed Mode Content",
+            tags: []
+        )
+
+        trackStep()
+        NoteList.openAllNotes()
+        NoteList.createNoteThenLeaveEditor(note)
+        NoteListAssert.noteContentIsShown(note)
+
+        trackStep()
+        Settings.open()
+        Settings.condensedModeEnable()
+        Settings.close()
+        NoteList.openAllNotes()
+        NoteListAssert.noteContentIsShownInSearch(noteName: note.name, expectedContent: "")
+        NoteListAssert.noteHeight(note, 44.0)
+
+        trackStep()
+        Settings.open()
+        Settings.condensedModeDisable()
+        Settings.close()
+        NoteList.openAllNotes()
+        NoteListAssert.noteContentIsShown(note)
+        NoteListAssert.noteHeight(note, 81.0)
+    }
+}

--- a/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
+++ b/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
@@ -18,6 +18,12 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         NoteList.openAllNotes()
     }
 
+    override class func tearDown() {
+        Settings.open()
+        Settings.condensedModeDisable()
+        Settings.close()
+    }
+
     func testUsingCondensedNoteList() throws {
         trackTest()
         let note = NoteData(

--- a/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
+++ b/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
@@ -36,7 +36,7 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         trackStep()
         NoteList.openAllNotes()
         NoteList.createNoteThenLeaveEditor(note)
-        NoteListAssert.noteContentIsShown(note)
+        NoteListAssert.contentIsShown(for: note)
 
         trackStep()
         Settings.open()
@@ -51,7 +51,7 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         Settings.condensedModeDisable()
         Settings.close()
         NoteList.openAllNotes()
-        NoteListAssert.noteContentIsShown(note)
+        NoteListAssert.contentIsShown(for: note)
         NoteListAssert.note(note, hasHeight: cellHeightUsual)
     }
 

--- a/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
+++ b/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
@@ -26,10 +26,11 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
 
     func testUsingCondensedNoteList() throws {
         trackTest()
+        let cellHeightCondensed: CGFloat = 44.0
+        let cellHeightUsual: CGFloat = 81.0
         let note = NoteData(
             name: "Condensed Mode Test",
-            content: "Condensed Mode Content",
-            tags: []
+            content: "Condensed Mode Content"
         )
 
         trackStep()
@@ -43,7 +44,7 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         Settings.close()
         NoteList.openAllNotes()
         NoteListAssert.noteContentIsShownInSearch(noteName: note.name, expectedContent: "")
-        NoteListAssert.noteHeight(note, 44.0)
+        NoteListAssert.noteHeight(note, cellHeightCondensed)
 
         trackStep()
         Settings.open()
@@ -51,6 +52,8 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         Settings.close()
         NoteList.openAllNotes()
         NoteListAssert.noteContentIsShown(note)
-        NoteListAssert.noteHeight(note, 81.0)
+        NoteListAssert.noteHeight(note, cellHeightUsual)
     }
+
+
 }

--- a/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
+++ b/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
@@ -44,7 +44,7 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         Settings.close()
         NoteList.openAllNotes()
         NoteListAssert.noteContentIsShownInSearch(noteName: note.name, expectedContent: "")
-        NoteListAssert.noteHeight(note, cellHeightCondensed)
+        NoteListAssert.note(note, hasHeight: cellHeightCondensed)
 
         trackStep()
         Settings.open()
@@ -52,7 +52,7 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         Settings.close()
         NoteList.openAllNotes()
         NoteListAssert.noteContentIsShown(note)
-        NoteListAssert.noteHeight(note, cellHeightUsual)
+        NoteListAssert.note(note, hasHeight: cellHeightUsual)
     }
 
 

--- a/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
+++ b/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
@@ -36,7 +36,7 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         trackStep()
         NoteList.openAllNotes()
         NoteList.createNoteThenLeaveEditor(note)
-        NoteListAssert.contentIsShown(for: note)
+        NoteListAssert.noteExists(note)
 
         trackStep()
         Settings.open()

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -45,9 +45,6 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         Trash.empty()
         Sidebar.open()
         Sidebar.tagsDeleteAll()
-        Settings.open()
-        Settings.condensedModeDisable()
-        Settings.close()
         NoteList.openAllNotes()
 
         allNotes.forEach { NoteList.createNoteThenLeaveEditor($0) }

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -45,6 +45,9 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         Trash.empty()
         Sidebar.open()
         Sidebar.tagsDeleteAll()
+        Settings.open()
+        Settings.condensedModeDisable()
+        Settings.close()
         NoteList.openAllNotes()
 
         allNotes.forEach { NoteList.createNoteThenLeaveEditor($0) }

--- a/TESTING-CHECKLIST.md
+++ b/TESTING-CHECKLIST.md
@@ -60,7 +60,7 @@ Note: (A) means Automated Test. If automated UI tests were executed for the app,
 ### Settings
 
 - [ ] Can change analytics sharing setting
-- [ ] Changing `Condensed Note List` mode immediately updates and reflects in note list
+- [ ] Changing `Condensed Note List` mode immediately updates and reflects in note list (A)
 - [ ] For each sort type the pinned notes appear first in the note list
 - [ ] Changing `Theme` immediately updates app for desired color scheme
 - [ ] After setting a passcode, passcode (or Touch/Face ID if also enabled) is required to resume the app


### PR DESCRIPTION
Automates the first test from `Settings`: 
`Changing "Condensed Note List" mode immediately updates and reflects in note list`

### Changes:
1. New `Settings.swift` where I tried using enumerations for element locators (as seen [here](https://bitbar.com/blog/best-practices-for-organizing-locators-for-xcuitest/))
2. New `SimplenoteUISmokeTestsSettings.swift` with the test itself
3. `NoteList.swift` contains several new functions

I'll attempt to give more details by commenting on specific parts of the code below.

### Test
The way the test checks the condensed mode is: checking note cell height and presence of the note content preview in note list (should be absent under condensed mode).

1. Running the new test, along with previously existing ones.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
