### PR TITLE
Feature: New Note Bar

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -115,22 +115,6 @@ extension SPNoteEditorViewController {
                                 viewportProvider: viewportProvider,
                                 siblingView: navigationBarBackground)
     }
-
-    /// Configures New Note Bar
-    ///
-    @objc
-    func configureNewNoteBar() {
-        let newNoteImage = UIImage(named: UIImageName.newNote.lightAssetFilename)
-        let newNoteButton = UIBarButtonItem.init(image: newNoteImage,
-                                            style: .plain,
-                                            target: self,
-                                            action: #selector(handleTapOnCreateNewNoteButton))
-        newNoteButton.accessibilityLabel = NSLocalizedString("New note", comment: "Label to create a new note")
-
-        let flexibleSpace = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-
-        setToolbarItems([flexibleSpace, newNoteButton], animated: true)
-    }
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -49,6 +49,14 @@ extension SPNoteEditorViewController {
         keyboardButton.accessibilityLabel = NSLocalizedString("Dismiss keyboard", comment: "Dismiss Keyboard Button")
     }
 
+    /// Setups the bottom toolbar in navigation contorller.
+    /// Will show search navigation bar if search enabled, and new notebar if not search
+    ///
+    @objc
+    func configureNewNoteBar() {
+        configureNewNoteBar(with: #selector(handleTapOnCreateNewNoteButton))
+    }
+
     /// Sets up the Root ViewController
     ///
     @objc

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -45,9 +45,6 @@ extension SPNoteEditorViewController {
         informationButton = UIBarButtonItem(image: .image(name: .info), style: .plain, target: self, action: #selector(noteInformationWasPressed(_:)))
         informationButton.accessibilityLabel = NSLocalizedString("Information", comment: "Note Information Button (metrics + references)")
 
-        createNoteButton = UIBarButtonItem(image: .image(name: .newNote), style: .plain, target: self, action: #selector(handleTapOnCreateNewNoteButton))
-        createNoteButton.accessibilityLabel = NSLocalizedString("New note", comment: "Label to create a new note")
-
         keyboardButton = UIBarButtonItem(image: .image(name: .hideKeyboard), style: .plain, target: self, action: #selector(keyboardButtonAction(_:)))
         keyboardButton.accessibilityLabel = NSLocalizedString("Dismiss keyboard", comment: "Dismiss Keyboard Button")
     }
@@ -133,7 +130,6 @@ extension SPNoteEditorViewController {
         let flexibleSpace = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
         setToolbarItems([flexibleSpace, newNoteButton], animated: true)
-        
     }
 }
 
@@ -750,7 +746,7 @@ extension SPNoteEditorViewController {
         tagListViewController = NoteEditorTagListViewController(note: note, popoverPresenter: popoverPresenter)
 
         addChild(tagListViewController)
-        
+
         tagView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tagView)
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -118,6 +118,23 @@ extension SPNoteEditorViewController {
                                 viewportProvider: viewportProvider,
                                 siblingView: navigationBarBackground)
     }
+
+    /// Configures New Note Bar
+    ///
+    @objc
+    func configureNewNoteBar() {
+        let newNoteImage = UIImage(named: UIImageName.newNote.lightAssetFilename)
+        let newNoteButton = UIBarButtonItem.init(image: newNoteImage,
+                                            style: .plain,
+                                            target: self,
+                                            action: #selector(handleTapOnCreateNewNoteButton))
+        newNoteButton.accessibilityLabel = NSLocalizedString("New note", comment: "Label to create a new note")
+
+        let flexibleSpace = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+
+        setToolbarItems([flexibleSpace, newNoteButton], animated: true)
+        
+    }
 }
 
 

--- a/Simplenote/Classes/SPNoteEditorViewController.h
+++ b/Simplenote/Classes/SPNoteEditorViewController.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) UIBarButtonItem *actionButton;
 @property (nonatomic, strong) UIBarButtonItem *checklistButton;
 @property (nonatomic, strong) UIBarButtonItem *keyboardButton;
-@property (nonatomic, strong) UIBarButtonItem *createNoteButton;
 @property (nonatomic, strong) UIBarButtonItem *informationButton;
 
 @property (nonatomic, strong, readonly) Note *note;

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -97,11 +97,9 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self configureNavigationBarItems];
     [self configureNavigationBarBackground];
     [self configureRootView];
-    [self configureSearchToolbar];
     [self configureLayout];
     [self configureTagListViewController];
     [self configureInterlinksProcessor];
-    [self configureNewNoteBar];
     
     [self configureTextViewKeyboard];
 
@@ -152,7 +150,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     if (self.searching) {
         [self configureSearchToolbar];
     } else {
-        [self configureNewNoteBar];
+        [self addNewNoteBarWith: @selector(handleTapOnCreateNewNoteButton)];
     }
 
     [self.navigationController setToolbarHidden:NO animated:YES];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -101,6 +101,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self configureLayout];
     [self configureTagListViewController];
     [self configureInterlinksProcessor];
+    [self configureNewNoteBar];
     
     [self configureTextViewKeyboard];
 
@@ -147,7 +148,14 @@ CGFloat const SPSelectedAreaPadding = 20;
 {
     // Note: Our navigationBar *may* be hidden, as per SPSearchController in the Notes List
     [self.navigationController setNavigationBarHidden:NO animated:YES];
-    [self.navigationController setToolbarHidden:!self.searching animated:YES];
+
+    if (self.searching) {
+        [self configureSearchToolbar];
+    } else {
+        [self configureNewNoteBar];
+    }
+
+    [self.navigationController setToolbarHidden:NO animated:YES];
 }
 
 - (void)ensureEditorIsFirstResponder
@@ -574,7 +582,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     
     self.searching = NO;
 
-    [self.navigationController setToolbarHidden:YES animated:YES];
+    [self setupNavigationController];
     self.searchDetailLabel.text = nil;
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -100,7 +100,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self configureLayout];
     [self configureTagListViewController];
     [self configureInterlinksProcessor];
-    [self configureNavigationToolbar];
+    [self configureNavigationControllerToolbar];
     
     [self configureTextViewKeyboard];
 
@@ -143,9 +143,9 @@ CGFloat const SPSelectedAreaPadding = 20;
     self.navigationBarBackground = [SPBlurEffectView navigationBarBlurView];
 }
 
-- (void)configureNavigationToolbar
+- (void)configureNavigationControllerToolbar
 {
-    [self refreshNavigationToolbar];
+    [self refreshNavigationControllerToolbar];
 }
 
 - (void)setupNavigationController
@@ -425,7 +425,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     self.navigationItem.rightBarButtonItems = buttons;
 }
 
-- (void)refreshNavigationToolbar
+- (void)refreshNavigationControllerToolbar
 {
     if (self.searching) {
         [self configureSearchToolbar];
@@ -586,7 +586,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     
     self.searching = NO;
 
-    [self refreshNavigationToolbar];
+    [self refreshNavigationControllerToolbar];
     self.searchDetailLabel.text = nil;
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -414,9 +414,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 {
     NSMutableArray *buttons = [NSMutableArray array];
 
-    if (self.shouldHideKeyboardButton) {
-        [buttons addObject:self.createNoteButton];
-    } else {
+    if (!self.shouldHideKeyboardButton) {
         [buttons addObject:self.keyboardButton];
     }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -100,6 +100,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self configureLayout];
     [self configureTagListViewController];
     [self configureInterlinksProcessor];
+    [self configureNavigationToolbar];
     
     [self configureTextViewKeyboard];
 
@@ -142,17 +143,15 @@ CGFloat const SPSelectedAreaPadding = 20;
     self.navigationBarBackground = [SPBlurEffectView navigationBarBlurView];
 }
 
+- (void)configureNavigationToolbar
+{
+    [self refreshNavigationToolbar];
+}
+
 - (void)setupNavigationController
 {
     // Note: Our navigationBar *may* be hidden, as per SPSearchController in the Notes List
     [self.navigationController setNavigationBarHidden:NO animated:YES];
-
-    if (self.searching) {
-        [self configureSearchToolbar];
-    } else {
-        [self addNewNoteBarWith: @selector(handleTapOnCreateNewNoteButton)];
-    }
-
     [self.navigationController setToolbarHidden:NO animated:YES];
 }
 
@@ -426,6 +425,15 @@ CGFloat const SPSelectedAreaPadding = 20;
     self.navigationItem.rightBarButtonItems = buttons;
 }
 
+- (void)refreshNavigationToolbar
+{
+    if (self.searching) {
+        [self configureSearchToolbar];
+    } else {
+        [self configureNewNoteBar];
+    }
+}
+
 - (BOOL)shouldHideKeyboardButton
 {
     if ([UIDevice isPad]) {
@@ -578,7 +586,7 @@ CGFloat const SPSelectedAreaPadding = 20;
     
     self.searching = NO;
 
-    [self setupNavigationController];
+    [self refreshNavigationToolbar];
     self.searchDetailLabel.text = nil;
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -344,19 +344,6 @@ extension SPNoteListViewController {
 
         emptyTrashButton.isEnabled = isTrashOnScreen && isNotEmpty
     }
-
-    /// Configures navigation controller toolbar to display new note button
-    ///
-    @objc
-    func configureToolbarAsNewNoteBar() {
-        let image = UIImage(named: UIImageName.newNote.lightAssetFilename)
-        let newNoteButton = UIBarButtonItem.init(image: image, style: .plain, target: self, action: #selector(createNewNote))
-
-        let flexibleSpace = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-
-        setToolbarItems([flexibleSpace, newNoteButton], animated: true)
-        navigationController?.setToolbarHidden(false, animated: true)
-    }
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -344,6 +344,19 @@ extension SPNoteListViewController {
 
         emptyTrashButton.isEnabled = isTrashOnScreen && isNotEmpty
     }
+
+    /// Configures navigation controller toolbar to display new note button
+    ///
+    @objc
+    func configureToolbarAsNewNoteBar() {
+        let image = UIImage(named: UIImageName.newNote.lightAssetFilename)
+        let newNoteButton = UIBarButtonItem.init(image: image, style: .plain, target: self, action: #selector(createNewNote))
+
+        let flexibleSpace = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+
+        setToolbarItems([flexibleSpace, newNoteButton], animated: true)
+        navigationController?.setToolbarHidden(false, animated: true)
+    }
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -51,6 +51,7 @@
         [self configureImpactGenerator];
         [self configureNavigationButtons];
         [self configureNavigationBarBackground];
+        [self configureNavigationToolbar];
         [self configureResultsController];
         [self configurePlaceholderView];
         [self configureTableView];
@@ -90,7 +91,6 @@
 {
     [super viewWillAppear:animated];
     [self.searchController hideNavigationBarIfNecessary];
-    [self addNewNoteBarWith:@selector(createNewNote)];
     [self.navigationController setToolbarHidden:NO];
     if (!self.navigatingUsingKeyboard) {
         [self.tableView deselectSelectedRowAnimated:YES];
@@ -278,6 +278,10 @@
     //  -   Therefore we must inject the blur on a VC per VC basis.
     //
     self.navigationBarBackground = [SPBlurEffectView navigationBarBlurView];
+}
+
+- (void)configureNavigationToolbar {
+    [self configureNewNoteBarWith:@selector(createNewNote)];
 }
 
 - (void)configureSearchController {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -28,7 +28,6 @@
 @property (nonatomic, strong) NSTimer                               *searchTimer;
 
 @property (nonatomic, strong) SPBlurEffectView                      *navigationBarBackground;
-@property (nonatomic, strong) UIBarButtonItem                       *addButton;
 @property (nonatomic, strong) UIBarButtonItem                       *sidebarButton;
 @property (nonatomic, strong) UIBarButtonItem                       *toolbarActionButton;
 
@@ -233,7 +232,7 @@
 }
 
 - (void)updateNavigationBar {
-    UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : self.addButton;
+    UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : nil;
 
     [self.navigationItem setRightBarButtonItem:rightButton animated:YES];
     [self.navigationItem setLeftBarButtonItem:self.sidebarButton animated:YES];
@@ -243,19 +242,8 @@
 #pragma mark - Interface Initialization
 
 - (void)configureNavigationButtons {
-    NSAssert(_addButton == nil, @"_addButton is already initialized!");
     NSAssert(_sidebarButton == nil, @"_sidebarButton is already initialized!");
     NSAssert(_emptyTrashButton == nil, @"_emptyTrashButton is already initialized!");
-
-    /// Button: New Note
-    ///
-    self.addButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageWithName:UIImageNameNewNote]
-                                                      style:UIBarButtonItemStylePlain
-                                                     target:self
-                                                     action:@selector(addButtonAction:)];
-    self.addButton.isAccessibilityElement = YES;
-    self.addButton.accessibilityLabel = NSLocalizedString(@"New note", nil);
-    self.addButton.accessibilityHint = NSLocalizedString(@"Create a new note", nil);
 
     /// Button: Display Tags
     ///
@@ -305,10 +293,6 @@
 }
 
 #pragma mark - BarButtonActions
-
-- (void)addButtonAction:(id)sender {
-    [self createNewNote];
-}
 
 - (void)sidebarButtonAction:(id)sender {
     

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -90,7 +90,8 @@
 {
     [super viewWillAppear:animated];
     [self.searchController hideNavigationBarIfNecessary];
-    [self configureToolbarAsNewNoteBar];
+    [self addNewNoteBarWith:@selector(createNewNote)];
+    [self.navigationController setToolbarHidden:NO];
     if (!self.navigatingUsingKeyboard) {
         [self.tableView deselectSelectedRowAnimated:YES];
         self.selectedNote = nil;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -51,7 +51,7 @@
         [self configureImpactGenerator];
         [self configureNavigationButtons];
         [self configureNavigationBarBackground];
-        [self configureNavigationToolbar];
+        [self configureNavigationControllerToolbar];
         [self configureResultsController];
         [self configurePlaceholderView];
         [self configureTableView];
@@ -280,7 +280,7 @@
     self.navigationBarBackground = [SPBlurEffectView navigationBarBlurView];
 }
 
-- (void)configureNavigationToolbar {
+- (void)configureNavigationControllerToolbar {
     [self configureNewNoteBarWith:@selector(createNewNote)];
 }
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -304,21 +304,6 @@
     self.searchController.searchBar.accessibilityIdentifier = @"search-bar";
 }
 
-- (void)configureNewNoteBar {
-    UIImage *newNoteIcon = [UIImage imageWithName:UIImageNameNewNote];
-    UIBarButtonItem *newNoteBar = [[UIBarButtonItem alloc] initWithImage:newNoteIcon
-                                                                   style:UIBarButtonItemStylePlain
-                                                                  target:self
-                                                                  action:@selector(newNote)];
-
-    [self setToolbarItems:@[newNoteBar] animated:NO];
-    [self.navigationController setToolbarHidden:NO];
-}
-
-- (void)newNote {
-
-}
-
 #pragma mark - BarButtonActions
 
 - (void)addButtonAction:(id)sender {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -30,6 +30,7 @@
 @property (nonatomic, strong) SPBlurEffectView                      *navigationBarBackground;
 @property (nonatomic, strong) UIBarButtonItem                       *addButton;
 @property (nonatomic, strong) UIBarButtonItem                       *sidebarButton;
+@property (nonatomic, strong) UIBarButtonItem                       *toolbarActionButton;
 
 @property (nonatomic, strong) SearchDisplayController               *searchController;
 @property (nonatomic, strong) UIActivityIndicatorView               *activityIndicator;
@@ -90,7 +91,7 @@
 {
     [super viewWillAppear:animated];
     [self.searchController hideNavigationBarIfNecessary];
-
+    [self configureToolbarAsNewNoteBar];
     if (!self.navigatingUsingKeyboard) {
         [self.tableView deselectSelectedRowAnimated:YES];
         self.selectedNote = nil;
@@ -303,6 +304,20 @@
     self.searchController.searchBar.accessibilityIdentifier = @"search-bar";
 }
 
+- (void)configureNewNoteBar {
+    UIImage *newNoteIcon = [UIImage imageWithName:UIImageNameNewNote];
+    UIBarButtonItem *newNoteBar = [[UIBarButtonItem alloc] initWithImage:newNoteIcon
+                                                                   style:UIBarButtonItemStylePlain
+                                                                  target:self
+                                                                  action:@selector(newNote)];
+
+    [self setToolbarItems:@[newNoteBar] animated:NO];
+    [self.navigationController setToolbarHidden:NO];
+}
+
+- (void)newNote {
+
+}
 
 #pragma mark - BarButtonActions
 

--- a/Simplenote/Classes/UIViewController+Simplenote.swift
+++ b/Simplenote/Classes/UIViewController+Simplenote.swift
@@ -91,7 +91,7 @@ extension UIViewController {
     /// Sets up a new note bar with given selector
     ///
     @objc
-    func addNewNoteBar(with selector: Selector) {
+    func configureNewNoteBar(with selector: Selector) {
         let newNoteImage = UIImage(named: UIImageName.newNote.lightAssetFilename)
         let newNoteButton = UIBarButtonItem.init(image: newNoteImage,
                                             style: .plain,

--- a/Simplenote/Classes/UIViewController+Simplenote.swift
+++ b/Simplenote/Classes/UIViewController+Simplenote.swift
@@ -87,4 +87,24 @@ extension UIViewController {
             taskBlock()
         }
     }
+
+    /// Sets up a new note bar with given selector
+    ///
+    @objc
+    func addNewNoteBar(with selector: Selector) {
+        let newNoteImage = UIImage(named: UIImageName.newNote.lightAssetFilename)
+        let newNoteButton = UIBarButtonItem.init(image: newNoteImage,
+                                            style: .plain,
+                                            target: self,
+                                            action: selector)
+        newNoteButton.accessibilityLabel = Strings.newNoteLabel
+
+        let flexibleSpace = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+
+        setToolbarItems([flexibleSpace, newNoteButton], animated: true)
+    }
+}
+
+private struct Strings {
+    static let newNoteLabel = NSLocalizedString("New note", comment: "Label to create a new note")
 }


### PR DESCRIPTION
### Fix
Fixes #1044 

This PR serves a dual purpose of Adding the new note bar feature and removing the current add new note button from the top navigation bar.

This new note bar will appear on both the note list and the note editor, making it easy for a user to create a new note where ever they are in Simplenote iOS.  This is added using the navigationController bottom toolbar, same as the search navigation bar, so there is some logic added to switch between the two in the note editor.  This will also share ui with the multiple edit delete mode (the next step in this process) but that is not covered in this PR

Note list:
<img src="https://cdn-std.droplr.net/files/acc_593859/ZC9D6W" />

Note Editor:
<img src="https://cdn-std.droplr.net/files/acc_593859/hV0uwl" />


### Test
1. Open up the note list and see the new note bar.  Tap on the button and a new note will be created and the editor will load
2. Exit that new note, select one of your notes to see the new note bar there.  Again test tapping on the button to see a new note be created
3. Return to the note list and do a search.  Select a note from your search, you will see the note editor load with the search results navigation.  Tap done to see the toolbar transition to the new note bar
4. Make sure that the new note button no longer appears in the top toolbar in the editor. Check that when the keyboard appears the dismiss keyboard button still appears
5. Go to the trash, check to see that the delete button still appears.  Return to the note list (not trash mode) to see there is no button in the top right.
6. test dark mode to make sure colors/images are correct

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
