### PR TITLE
UI tests helper framework proof of concept

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */; };
 		3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */; };
 		3F3CA91426255E2000F6316F /* UITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F3CA91226255E2000F6316F /* UITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F3CA93F26255F7200F6316F /* XCUIApplication+Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3CA93E26255F7200F6316F /* XCUIApplication+Device.swift */; };
+		3F3CA94926255FA800F6316F /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F3CA94826255FA800F6316F /* XCTest.framework */; };
 		3F5EDD0C2435A3AE00959576 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
 		3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */; };
@@ -555,6 +557,8 @@
 		3F3CA91026255E1F00F6316F /* UITestHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UITestHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F3CA91226255E2000F6316F /* UITestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UITestHelpers.h; sourceTree = "<group>"; };
 		3F3CA91326255E2000F6316F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3F3CA93E26255F7200F6316F /* XCUIApplication+Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+Device.swift"; sourceTree = "<group>"; };
+		3F3CA94826255FA800F6316F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
 		3F6CECDC2FEA90B9E5C920F5 /* Pods-SimplenoteTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.release.xcconfig"; sourceTree = "<group>"; };
 		3FA17B5526240FF000C11C46 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
@@ -1019,6 +1023,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F3CA94926255FA800F6316F /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1134,6 +1139,7 @@
 			children = (
 				3F3CA91226255E2000F6316F /* UITestHelpers.h */,
 				3F3CA91326255E2000F6316F /* Info.plist */,
+				3F3CA93E26255F7200F6316F /* XCUIApplication+Device.swift */,
 			);
 			path = UITestHelpers;
 			sourceTree = "<group>";
@@ -2016,6 +2022,7 @@
 		E29ADD3A17848E8500E55842 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3F3CA94826255FA800F6316F /* XCTest.framework */,
 				B5CFFFE322AA9B1900B968CD /* CoreServices.framework */,
 				B51889A31E0DB01E00E71B83 /* ContactsUI.framework */,
 				B518899F1E0D5F2200E71B83 /* Contacts.framework */,
@@ -2324,6 +2331,7 @@
 					};
 					3F3CA90F26255E1F00F6316F = {
 						CreatedOnToolsVersion = 12.4;
+						LastSwiftMigration = 1240;
 					};
 					3FA60138242C5AAD0068FC52 = {
 						CreatedOnToolsVersion = 11.3.1;
@@ -2683,6 +2691,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F3CA93F26255F7200F6316F /* XCUIApplication+Device.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3196,6 +3205,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
@@ -3240,6 +3250,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
@@ -3279,6 +3290,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
@@ -3318,6 +3330,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
@@ -3357,6 +3370,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		3F5EDD0C2435A3AE00959576 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
 		3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */; };
+		3FD88B5A262565E2000242E6 /* XCUIElementQuery+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD88B59262565E2000242E6 /* XCUIElementQuery+Sequence.swift */; };
+		3FD88B6B26256628000242E6 /* UITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F3CA91026255E1F00F6316F /* UITestHelpers.framework */; };
 		4352BA0867E0E416EB5FF6B9 /* Pods_Automattic_Simplenote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3318C36BBA08D53624E27EFC /* Pods_Automattic_Simplenote.framework */; };
 		46A3C96317DFA81A002865AE /* NSString+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 467D9C771788D0FF00785EF3 /* NSString+Metadata.m */; };
 		46A3C96617DFA81A002865AE /* SPAcitivitySafari.m in Sources */ = {isa = PBXBuildFile; fileRef = E283709917D7B46300AB562D /* SPAcitivitySafari.m */; };
@@ -566,6 +568,7 @@
 		3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplenoteScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteScreenshots.swift; sourceTree = "<group>"; };
 		3FA6013D242C5AAE0068FC52 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3FD88B59262565E2000242E6 /* XCUIElementQuery+Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElementQuery+Sequence.swift"; sourceTree = "<group>"; };
 		467D9C5D1788A4FB00785EF3 /* Simplenote 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 2.xcdatamodel"; sourceTree = "<group>"; };
 		467D9C5E1788A4FB00785EF3 /* Simplenote.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Simplenote.xcdatamodel; sourceTree = "<group>"; };
 		467D9C611788A54900785EF3 /* Note.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Note.h; path = Classes/Note.h; sourceTree = "<group>"; };
@@ -1083,6 +1086,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FD88B6B26256628000242E6 /* UITestHelpers.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1142,6 +1146,7 @@
 				3F3CA91226255E2000F6316F /* UITestHelpers.h */,
 				3F3CA91326255E2000F6316F /* Info.plist */,
 				3F3CA93E26255F7200F6316F /* XCUIApplication+Device.swift */,
+				3FD88B59262565E2000242E6 /* XCUIElementQuery+Sequence.swift */,
 			);
 			path = UITestHelpers;
 			sourceTree = "<group>";
@@ -2693,6 +2698,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FD88B5A262565E2000242E6 /* XCUIElementQuery+Sequence.swift in Sources */,
 				3F3CA93F26255F7200F6316F /* XCUIApplication+Device.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		3F3CA91426255E2000F6316F /* UITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F3CA91226255E2000F6316F /* UITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F3CA93F26255F7200F6316F /* XCUIApplication+Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3CA93E26255F7200F6316F /* XCUIApplication+Device.swift */; };
 		3F3CA94926255FA800F6316F /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F3CA94826255FA800F6316F /* XCTest.framework */; };
+		3F3CA95226255FFF00F6316F /* UITestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F3CA91026255E1F00F6316F /* UITestHelpers.framework */; };
 		3F5EDD0C2435A3AE00959576 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
 		3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */; };
@@ -1031,6 +1032,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F3CA95226255FFF00F6316F /* UITestHelpers.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		37FD30491FC4CFA2008D0B78 /* KeychainPasswordItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD30471FC4CFA2008D0B78 /* KeychainPasswordItem.swift */; };
 		3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */; };
 		3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */; };
+		3F3CA91426255E2000F6316F /* UITestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F3CA91226255E2000F6316F /* UITestHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F5EDD0C2435A3AE00959576 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
 		3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */; };
@@ -551,6 +552,9 @@
 		3D0CDFF82DFBC35A68B2C1C7 /* Pods-Automattic-SimplenoteShare.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.release.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.release.xcconfig"; sourceTree = "<group>"; };
 		3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotsCredentials.swift; sourceTree = "<group>"; };
 		3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		3F3CA91026255E1F00F6316F /* UITestHelpers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UITestHelpers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F3CA91226255E2000F6316F /* UITestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UITestHelpers.h; sourceTree = "<group>"; };
+		3F3CA91326255E2000F6316F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
 		3F6CECDC2FEA90B9E5C920F5 /* Pods-SimplenoteTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.release.xcconfig"; sourceTree = "<group>"; };
 		3FA17B5526240FF000C11C46 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
@@ -1011,6 +1015,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3F3CA90D26255E1F00F6316F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3FA60136242C5AAD0068FC52 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1116,6 +1127,15 @@
 				3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */,
 			);
 			path = Credentials;
+			sourceTree = "<group>";
+		};
+		3F3CA91126255E2000F6316F /* UITestHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				3F3CA91226255E2000F6316F /* UITestHelpers.h */,
+				3F3CA91326255E2000F6316F /* Info.plist */,
+			);
+			path = UITestHelpers;
 			sourceTree = "<group>";
 		};
 		3FA6013A242C5AAE0068FC52 /* SimplenoteScreenshots */ = {
@@ -1972,6 +1992,7 @@
 				467D9C6F1788CF2400785EF3 /* External */,
 				3FA6013A242C5AAE0068FC52 /* SimplenoteScreenshots */,
 				D864B15525CAE25000F9B73E /* SimplenoteUITests */,
+				3F3CA91126255E2000F6316F /* UITestHelpers */,
 				E29ADD3A17848E8500E55842 /* Frameworks */,
 				E29ADD3917848E8500E55842 /* Products */,
 				564CAA42AA330D16FDBDD081 /* Pods */,
@@ -1987,6 +2008,7 @@
 				B58218971FCC45170094ECA1 /* SimplenoteTests.xctest */,
 				3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */,
 				D864B15425CAE25000F9B73E /* SimplenoteUITests.xctest */,
+				3F3CA91026255E1F00F6316F /* UITestHelpers.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2149,7 +2171,36 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		3F3CA90B26255E1F00F6316F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3F3CA91426255E2000F6316F /* UITestHelpers.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		3F3CA90F26255E1F00F6316F /* UITestHelpers */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3F3CA91A26255E2000F6316F /* Build configuration list for PBXNativeTarget "UITestHelpers" */;
+			buildPhases = (
+				3F3CA90B26255E1F00F6316F /* Headers */,
+				3F3CA90C26255E1F00F6316F /* Sources */,
+				3F3CA90D26255E1F00F6316F /* Frameworks */,
+				3F3CA90E26255E1F00F6316F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = UITestHelpers;
+			productName = UITestHelpers;
+			productReference = 3F3CA91026255E1F00F6316F /* UITestHelpers.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		3FA60138242C5AAD0068FC52 /* SimplenoteScreenshots */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3FA60146242C5AAE0068FC52 /* Build configuration list for PBXNativeTarget "SimplenoteScreenshots" */;
@@ -2271,6 +2322,9 @@
 						CreatedOnToolsVersion = 11.3.1;
 						ProvisioningStyle = Automatic;
 					};
+					3F3CA90F26255E1F00F6316F = {
+						CreatedOnToolsVersion = 12.4;
+					};
 					3FA60138242C5AAD0068FC52 = {
 						CreatedOnToolsVersion = 11.3.1;
 						ProvisioningStyle = Automatic;
@@ -2365,11 +2419,19 @@
 				B5C7BF97230C59F5000DEC91 /* SimplenoteSecrets */,
 				3F1BB4AD243199FF006D1A04 /* ScreenshotsSecrets */,
 				D864B15325CAE25000F9B73E /* SimplenoteUITests */,
+				3F3CA90F26255E1F00F6316F /* UITestHelpers */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3F3CA90E26255E1F00F6316F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3FA60137242C5AAD0068FC52 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2617,6 +2679,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3F3CA90C26255E1F00F6316F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3FA60135242C5AAD0068FC52 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3118,6 +3187,206 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Distribution AppStore";
+		};
+		3F3CA91526255E2000F6316F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = UITestHelpers/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.UITestHelpers;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3F3CA91626255E2000F6316F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = UITestHelpers/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.UITestHelpers;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3F3CA91726255E2000F6316F /* Distribution Internal */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = UITestHelpers/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.UITestHelpers;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = "Distribution Internal";
+		};
+		3F3CA91826255E2000F6316F /* Distribution Alpha */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = UITestHelpers/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.UITestHelpers;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = "Distribution Alpha";
+		};
+		3F3CA91926255E2000F6316F /* Distribution AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = UITestHelpers/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.UITestHelpers;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = "Distribution AppStore";
 		};
@@ -4408,6 +4677,18 @@
 				3F1BB4B0243199FF006D1A04 /* Distribution Internal */,
 				3F1BB4B1243199FF006D1A04 /* Distribution Alpha */,
 				3F1BB4B2243199FF006D1A04 /* Distribution AppStore */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3F3CA91A26255E2000F6316F /* Build configuration list for PBXNativeTarget "UITestHelpers" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3F3CA91526255E2000F6316F /* Debug */,
+				3F3CA91626255E2000F6316F /* Release */,
+				3F3CA91726255E2000F6316F /* Distribution Internal */,
+				3F3CA91826255E2000F6316F /* Distribution Alpha */,
+				3F3CA91926255E2000F6316F /* Distribution AppStore */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -3232,7 +3232,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = UITestHelpers/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3274,7 +3274,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = UITestHelpers/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3314,7 +3314,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = UITestHelpers/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3354,7 +3354,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = UITestHelpers/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3394,7 +3394,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = UITestHelpers/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -1,3 +1,4 @@
+import UITestHelpers
 import XCTest
 
 class SimplenoteScreenshots: XCTestCase {
@@ -300,20 +301,6 @@ extension XCUIElement {
 
         if let string = previousPasteboardContents {
             UIPasteboard.general.string = string
-        }
-    }
-}
-
-extension XCUIApplication {
-
-    func isDeviceIPhone8Plus(_ device: XCUIDevice = .shared) -> Bool {
-        let iPhone8PlusScreenHeight = CGFloat(736)
-
-        let frame = windows.element(boundBy: 0).frame
-
-        switch device.orientation {
-        case .landscapeLeft, .landscapeRight: return frame.width == iPhone8PlusScreenHeight
-        case _: return frame.height == iPhone8PlusScreenHeight
         }
     }
 }

--- a/SimplenoteUITests/Extensions.swift
+++ b/SimplenoteUITests/Extensions.swift
@@ -20,21 +20,6 @@ extension XCUIElement {
     }
 }
 
-// Credits to https://github.com/onmyway133/blog/issues/628
-extension XCUIElementQuery: Sequence {
-    public typealias Iterator = AnyIterator<XCUIElement>
-    public func makeIterator() -> Iterator {
-        var index = UInt(0)
-        return AnyIterator {
-            guard index < self.count else { return nil }
-
-            let element = self.element(boundBy: Int(index))
-            index = index + 1
-            return element
-        }
-    }
-}
-
 extension String {
 
     func strippingUnicodeObjectReplacementCharacter() -> String {

--- a/SimplenoteUITests/Preview.swift
+++ b/SimplenoteUITests/Preview.swift
@@ -1,3 +1,4 @@
+import UITestHelpers
 import XCTest
 
 class Preview {

--- a/SimplenoteUITests/Preview.swift
+++ b/SimplenoteUITests/Preview.swift
@@ -3,6 +3,7 @@ import XCTest
 class Preview {
 
     class func getText() -> String {
+        // swiftlint:disable:next force_cast
         return app.webViews.descendants(matching: .staticText).element.value as! String
     }
 
@@ -53,9 +54,18 @@ class PreviewAssert {
     class func previewShown() {
         let previewNavBar = app.navigationBars[UID.NavBar.noteEditorPreview]
 
-        XCTAssertTrue(previewNavBar.waitForExistence(timeout: minLoadTimeout), UID.NavBar.noteEditorPreview + navBarNotFound)
-        XCTAssertTrue(previewNavBar.buttons[UID.Button.back].waitForExistence(timeout: minLoadTimeout), UID.Button.back + buttonNotFound)
-        XCTAssertTrue(previewNavBar.staticTexts[UID.Text.noteEditorPreview].waitForExistence(timeout: minLoadTimeout), UID.Text.noteEditorPreview + labelNotFound)
+        XCTAssertTrue(
+            previewNavBar.waitForExistence(timeout: minLoadTimeout),
+            UID.NavBar.noteEditorPreview + navBarNotFound
+        )
+        XCTAssertTrue(
+            previewNavBar.buttons[UID.Button.back].waitForExistence(timeout: minLoadTimeout),
+            UID.Button.back + buttonNotFound
+        )
+        XCTAssertTrue(
+            previewNavBar.staticTexts[UID.Text.noteEditorPreview].waitForExistence(timeout: minLoadTimeout),
+            UID.Text.noteEditorPreview + labelNotFound
+        )
     }
 
     class func wholeTextShown(text: String) {

--- a/UITestHelpers/Info.plist
+++ b/UITestHelpers/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/UITestHelpers/UITestHelpers.h
+++ b/UITestHelpers/UITestHelpers.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+//! Project version number for UITestHelpers.
+FOUNDATION_EXPORT double UITestHelpersVersionNumber;
+
+//! Project version string for UITestHelpers.
+FOUNDATION_EXPORT const unsigned char UITestHelpersVersionString[];

--- a/UITestHelpers/XCUIApplication+Device.swift
+++ b/UITestHelpers/XCUIApplication+Device.swift
@@ -2,6 +2,8 @@ import XCTest
 
 extension XCUIApplication {
 
+    // Note: I would have expected either this method or the whole extension to have public
+    // access level, but somehow the screenshots target builds anyways.
     func isDeviceIPhone8Plus(_ device: XCUIDevice = .shared) -> Bool {
         let iPhone8PlusScreenHeight = CGFloat(736)
 

--- a/UITestHelpers/XCUIApplication+Device.swift
+++ b/UITestHelpers/XCUIApplication+Device.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+extension XCUIApplication {
+
+    func isDeviceIPhone8Plus(_ device: XCUIDevice = .shared) -> Bool {
+        let iPhone8PlusScreenHeight = CGFloat(736)
+
+        let frame = windows.element(boundBy: 0).frame
+
+        switch device.orientation {
+        case .landscapeLeft, .landscapeRight: return frame.width == iPhone8PlusScreenHeight
+        case _: return frame.height == iPhone8PlusScreenHeight
+        }
+    }
+}

--- a/UITestHelpers/XCUIApplication+Device.swift
+++ b/UITestHelpers/XCUIApplication+Device.swift
@@ -2,9 +2,7 @@ import XCTest
 
 extension XCUIApplication {
 
-    // Note: I would have expected either this method or the whole extension to have public
-    // access level, but somehow the screenshots target builds anyways.
-    func isDeviceIPhone8Plus(_ device: XCUIDevice = .shared) -> Bool {
+    public func isDeviceIPhone8Plus(_ device: XCUIDevice = .shared) -> Bool {
         let iPhone8PlusScreenHeight = CGFloat(736)
 
         let frame = windows.element(boundBy: 0).frame

--- a/UITestHelpers/XCUIElementQuery+Sequence.swift
+++ b/UITestHelpers/XCUIElementQuery+Sequence.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+// Credits to https://github.com/onmyway133/blog/issues/628
+extension XCUIElementQuery: Sequence {
+
+    public typealias Iterator = AnyIterator<XCUIElement>
+
+    public func makeIterator() -> Iterator {
+
+        var index = UInt(0)
+
+        return AnyIterator {
+            guard index < self.count else { return nil }
+
+            let element = self.element(boundBy: Int(index))
+            index += 1
+            return element
+        }
+    }
+}


### PR DESCRIPTION
This PR is a first step towards the idea of having a layer of UI generic tests helper methods that we can 1) share across our projects and 2) make available to the wider community (with the caveat that general purpose, catch-all frameworks often end up being just more bloat; still, even just having all the sources in a single place would be beneficial as a reference from where to pick and choose).

In this proof of concept I created a new framework, `UITestHelpers`,  (keen on feedback on the name) in the Simplenote project, and extracted two helpers into it, one for each UI tests target.

I originally planned to make this a Swift package, but I couldn't get past a certain compilation error so I gave up, for the moment.

Another option to get started could have been to extract a page object into a shared framework. I didn't go down that route because I wanted something achievable in a few hours. Before being able to extract a page object, I'd like to define what's the pattern to follow for those, since we're doing things differently between apps.

I decided not to add a test target for the moment. When we'll extract this into a dedicated project, we shall add at least a dummy UI app to test it.

For now, since it will only contains code consumed by the test targets in this project, we can skip the tests.

### Test

Checkout this branch, then run the `SimplenoteUITests` and `SimplenoteScreenshots` target. They should both build and pass on the iPhone 12 Simulator.

_Notice I used the `*UI-tests*` branch name pattern to have CI build the main UI tests target and run the login smoke test scenario_ 👍 

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
