### PR TITLE
Test notes for search are now created via paste

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 		D864B1CF25CAE61F00F9B73E /* Trash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1CE25CAE61F00F9B73E /* Trash.swift */; };
 		D864B1D825CAE63E00F9B73E /* UIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1D725CAE63E00F9B73E /* UIDs.swift */; };
 		D864B1E125CAE66A00F9B73E /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1E025CAE66A00F9B73E /* Extensions.swift */; };
-		D8D49ABB26271EC100447A18 /* XCUIElement+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D49ABA26271EC100447A18 /* XCUIElement+Extensions.swift */; };
+		D8D49ABB26271EC100447A18 /* XCUIElement+TextManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D49ABA26271EC100447A18 /* XCUIElement+TextManagement.swift */; };
 		D8E2D8E325E7DE090001315B /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E2D8E225E7DE090001315B /* Sidebar.swift */; };
 		DE7E545B214E34C8008D9928 /* NSString+Count.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E545A214E34C8008D9928 /* NSString+Count.swift */; };
 		E215C793180B115C00AD36B5 /* SPNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E215C791180B115C00AD36B5 /* SPNavigationController.m */; };
@@ -980,7 +980,7 @@
 		D864B1D725CAE63E00F9B73E /* UIDs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDs.swift; sourceTree = "<group>"; };
 		D864B1E025CAE66A00F9B73E /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		D864B1F025CAE87800F9B73E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D8D49ABA26271EC100447A18 /* XCUIElement+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Extensions.swift"; sourceTree = "<group>"; };
+		D8D49ABA26271EC100447A18 /* XCUIElement+TextManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+TextManagement.swift"; sourceTree = "<group>"; };
 		D8E2D8E225E7DE090001315B /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		DE7E545A214E34C8008D9928 /* NSString+Count.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSString+Count.swift"; path = "Classes/NSString+Count.swift"; sourceTree = "<group>"; };
 		DF3BADF5A954AA00BCF9B169 /* Pods-Automattic-Simplenote.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1181,7 +1181,7 @@
 				3F3CA91326255E2000F6316F /* Info.plist */,
 				3F3CA93E26255F7200F6316F /* XCUIApplication+Device.swift */,
 				3FD88B59262565E2000242E6 /* XCUIElementQuery+Sequence.swift */,
-				D8D49ABA26271EC100447A18 /* XCUIElement+Extensions.swift */,
+				D8D49ABA26271EC100447A18 /* XCUIElement+TextManagement.swift */,
 			);
 			path = UITestHelpers;
 			sourceTree = "<group>";
@@ -2768,7 +2768,7 @@
 			files = (
 				3FD88B5A262565E2000242E6 /* XCUIElementQuery+Sequence.swift in Sources */,
 				3F3CA93F26255F7200F6316F /* XCUIApplication+Device.swift in Sources */,
-				D8D49ABB26271EC100447A18 /* XCUIElement+Extensions.swift in Sources */,
+				D8D49ABB26271EC100447A18 /* XCUIElement+TextManagement.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -422,12 +422,12 @@
 		BA83478325F59F8B0059B797 /* markdown-default-contrast.css in Resources */ = {isa = PBXBuildFile; fileRef = BA83478225F59F8B0059B797 /* markdown-default-contrast.css */; };
 		BA83478C25F59FE90059B797 /* markdown-dark-contrast.css in Resources */ = {isa = PBXBuildFile; fileRef = BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */; };
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
+		BAA63C3325EEDA83001589D7 /* NoteLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */; };
 		BAB017722609456D007A9CC3 /* PublishController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB017712609456D007A9CC3 /* PublishController.swift */; };
 		BAB01792260AAE93007A9CC3 /* NoticeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB01791260AAE93007A9CC3 /* NoticeFactory.swift */; };
 		BAB0179B260AD591007A9CC3 /* PublishControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB0179A260AD591007A9CC3 /* PublishControllerTests.swift */; };
 		BAB017AB260ADDEB007A9CC3 /* MockTimerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB017AA260ADDEB007A9CC3 /* MockTimerFactory.swift */; };
 		BAE08626261282D1009D40CD /* Note+Publish.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE08625261282D1009D40CD /* Note+Publish.swift */; };
-		BAA63C3325EEDA83001589D7 /* NoteLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */; };
 		D435D38FCA5863E8447D5C2C /* Pods_Automattic_SimplenoteShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */; };
 		D82BFE4B2624A8AB003DFA32 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BFE4A2624A8AB003DFA32 /* Settings.swift */; };
 		D82BFE542624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BFE532624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift */; };
@@ -444,6 +444,7 @@
 		D864B1CF25CAE61F00F9B73E /* Trash.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1CE25CAE61F00F9B73E /* Trash.swift */; };
 		D864B1D825CAE63E00F9B73E /* UIDs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1D725CAE63E00F9B73E /* UIDs.swift */; };
 		D864B1E125CAE66A00F9B73E /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864B1E025CAE66A00F9B73E /* Extensions.swift */; };
+		D8D49ABB26271EC100447A18 /* XCUIElement+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D49ABA26271EC100447A18 /* XCUIElement+Extensions.swift */; };
 		D8E2D8E325E7DE090001315B /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E2D8E225E7DE090001315B /* Sidebar.swift */; };
 		DE7E545B214E34C8008D9928 /* NSString+Count.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E545A214E34C8008D9928 /* NSString+Count.swift */; };
 		E215C793180B115C00AD36B5 /* SPNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E215C791180B115C00AD36B5 /* SPNavigationController.m */; };
@@ -955,12 +956,12 @@
 		BA83478225F59F8B0059B797 /* markdown-default-contrast.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-default-contrast.css"; sourceTree = "<group>"; };
 		BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-dark-contrast.css"; sourceTree = "<group>"; };
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
+		BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteLinkTests.swift; sourceTree = "<group>"; };
 		BAB017712609456D007A9CC3 /* PublishController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishController.swift; sourceTree = "<group>"; };
 		BAB01791260AAE93007A9CC3 /* NoticeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeFactory.swift; sourceTree = "<group>"; };
 		BAB0179A260AD591007A9CC3 /* PublishControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishControllerTests.swift; sourceTree = "<group>"; };
 		BAB017AA260ADDEB007A9CC3 /* MockTimerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTimerFactory.swift; sourceTree = "<group>"; };
 		BAE08625261282D1009D40CD /* Note+Publish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Publish.swift"; sourceTree = "<group>"; };
-		BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteLinkTests.swift; sourceTree = "<group>"; };
 		C07B32800E3C783BDF105B3A /* Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		D82BFE4A2624A8AB003DFA32 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		D82BFE532624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteUISmokeTestsSettings.swift; sourceTree = "<group>"; };
@@ -979,6 +980,7 @@
 		D864B1D725CAE63E00F9B73E /* UIDs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDs.swift; sourceTree = "<group>"; };
 		D864B1E025CAE66A00F9B73E /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		D864B1F025CAE87800F9B73E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D8D49ABA26271EC100447A18 /* XCUIElement+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Extensions.swift"; sourceTree = "<group>"; };
 		D8E2D8E225E7DE090001315B /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		DE7E545A214E34C8008D9928 /* NSString+Count.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSString+Count.swift"; path = "Classes/NSString+Count.swift"; sourceTree = "<group>"; };
 		DF3BADF5A954AA00BCF9B169 /* Pods-Automattic-Simplenote.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-Simplenote.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-Simplenote/Pods-Automattic-Simplenote.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1179,6 +1181,7 @@
 				3F3CA91326255E2000F6316F /* Info.plist */,
 				3F3CA93E26255F7200F6316F /* XCUIApplication+Device.swift */,
 				3FD88B59262565E2000242E6 /* XCUIElementQuery+Sequence.swift */,
+				D8D49ABA26271EC100447A18 /* XCUIElement+Extensions.swift */,
 			);
 			path = UITestHelpers;
 			sourceTree = "<group>";
@@ -2765,6 +2768,7 @@
 			files = (
 				3FD88B5A262565E2000242E6 /* XCUIElementQuery+Sequence.swift in Sources */,
 				3F3CA93F26255F7200F6316F /* XCUIApplication+Device.swift in Sources */,
+				D8D49ABB26271EC100447A18 /* XCUIElement+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -291,16 +291,4 @@ extension XCUIElement {
         // one.
         return app.isDeviceIPhone8Plus()
     }
-
-    private func paste(text: String) -> Void {
-        let previousPasteboardContents = UIPasteboard.general.string
-        UIPasteboard.general.string = text
-
-        self.press(forDuration: 1.2)
-        XCUIApplication().menuItems.firstMatch.tap()
-
-        if let string = previousPasteboardContents {
-            UIPasteboard.general.string = string
-        }
-    }
 }

--- a/SimplenoteUITests/Extensions.swift
+++ b/SimplenoteUITests/Extensions.swift
@@ -1,25 +1,5 @@
 import XCTest
 
-extension XCUIElement {
-    /**
-     Removes any current text in the field before typing in the new value
-     - Parameter text: the text to enter into the field
-     */
-    func clearAndEnterText(text: String) {
-        guard let stringValue = self.value as? String else {
-            XCTFail("Tried to clear and enter text into a non string value")
-            return
-        }
-
-        self.tap()
-
-        let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: stringValue.count)
-
-        self.typeText(deleteString)
-        self.typeText(text)
-    }
-}
-
 extension String {
 
     func strippingUnicodeObjectReplacementCharacter() -> String {

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -25,7 +25,6 @@ class NoteEditor {
 
     class func clearAndEnterText(enteredValue: String, viaPaste: Bool = false) {
         let noteContentTextView = app.textViews.element
-        guard noteContentTextView.exists else { return }
 
         if viaPaste {
             UIPasteboard.general.strings = []

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -23,8 +23,14 @@ class NoteEditor {
         app.textViews.element.clearAndEnterText(text: "")
     }
 
-    class func clearAndEnterText(enteredValue: String) {
-        app.textViews.element.clearAndEnterText(text: enteredValue)
+    class func clearAndEnterText(enteredValue: String, viaPaste: Bool = false) {
+        if viaPaste {
+            UIPasteboard.general.strings = []
+            app.textViews.element.paste(text: enteredValue)
+            app.textViews.element.swipeUp(velocity: .fast)
+        } else {
+            app.textViews.element.clearAndEnterText(text: enteredValue)
+        }
     }
 
     class func getEditorText() -> String {

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -24,12 +24,18 @@ class NoteEditor {
     }
 
     class func clearAndEnterText(enteredValue: String, viaPaste: Bool = false) {
+        let noteContentTextView = app.textViews.element
+        guard noteContentTextView.exists else { return }
+
         if viaPaste {
             UIPasteboard.general.strings = []
-            app.textViews.element.paste(text: enteredValue)
-            app.textViews.element.swipeUp(velocity: .fast)
+            noteContentTextView.clearText()
+            noteContentTextView.paste(text: enteredValue)
+            /// Swipe up fast to show tags input, which diappears if pasted text is large
+            /// enough to push it off screen
+            noteContentTextView.swipeUp(velocity: .fast)
         } else {
-            app.textViews.element.clearAndEnterText(text: enteredValue)
+            noteContentTextView.clearAndEnterText(text: enteredValue)
         }
     }
 

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -30,8 +30,8 @@ class NoteEditor {
             UIPasteboard.general.strings = []
             noteContentTextView.clearText()
             noteContentTextView.paste(text: enteredValue)
-            /// Swipe up fast to show tags input, which diappears if pasted text is large
-            /// enough to push it off screen
+            /// Swipe up fast to show tags input, which disappears if pasted text is large
+            /// enough to push tags input off screen
             noteContentTextView.swipeUp(velocity: .fast)
         } else {
             noteContentTextView.clearAndEnterText(text: enteredValue)

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -23,15 +23,19 @@ class NoteEditor {
         app.textViews.element.clearAndEnterText(text: "")
     }
 
-    class func clearAndEnterText(enteredValue: String, viaPaste: Bool = false) {
+    class func clearAndEnterText(enteredValue: String, usingPaste: Bool = false) {
         let noteContentTextView = app.textViews.element
 
-        if viaPaste {
+        if usingPaste {
+            // Clear clipboard before usage to adress flakiness
+            // that appears when it's not done
             UIPasteboard.general.strings = []
+
             noteContentTextView.clearText()
             noteContentTextView.paste(text: enteredValue)
-            /// Swipe up fast to show tags input, which disappears if pasted text is large
-            /// enough to push tags input off screen
+
+            // Swipe up fast to show tags input, which disappears if pasted text is large
+            // enough to push tags input off screen
             noteContentTextView.swipeUp(velocity: .fast)
         } else {
             noteContentTextView.clearAndEnterText(text: enteredValue)

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -46,18 +46,18 @@ class NoteList {
         app.navigationBars.buttons[UID.Button.newNote].tap()
     }
 
-    static func createNoteThenLeaveEditor(_ note: NoteData, viaPaste: Bool = false) {
+    static func createNoteThenLeaveEditor(_ note: NoteData, usingPaste: Bool = false) {
         NoteList.createNoteAndLeaveEditor(
             noteName: note.formattedForAutomatedInput,
             tags: note.tags,
-            viaPaste: viaPaste
+            usingPaste: usingPaste
         )
     }
 
-    class func createNoteAndLeaveEditor(noteName: String, tags: [String] = [], viaPaste: Bool = false) {
+    class func createNoteAndLeaveEditor(noteName: String, tags: [String] = [], usingPaste: Bool = false) {
         print(">>> Creating a note: " + noteName)
         NoteList.addNoteTap()
-        NoteEditor.clearAndEnterText(enteredValue: noteName, viaPaste: viaPaste)
+        NoteEditor.clearAndEnterText(enteredValue: noteName, usingPaste: usingPaste)
 
         for tag in tags {
             NoteEditor.addTag(tagName: tag)
@@ -66,9 +66,9 @@ class NoteList {
         NoteEditor.leaveEditor()
     }
 
-    class func createNotes(names: [String], viaPaste: Bool = false) {
+    class func createNotes(names: [String], usingPaste: Bool = false) {
         for noteName in names {
-            createNoteAndLeaveEditor(noteName: noteName, viaPaste: viaPaste)
+            createNoteAndLeaveEditor(noteName: noteName, usingPaste: usingPaste)
         }
     }
 
@@ -247,10 +247,10 @@ class NoteListAssert {
         if let noteContent = Table.getContentOfCell(noteName: noteName) {
             XCTAssertTrue(noteContent.contains(expectedContent), "Content is different.")
         } else if expectedContent.isEmpty {
-            /// If note content is nil, but we assert for empty content, we should not fail
+            // If note content is nil, but we assert for empty content, we should not fail
             XCTAssert(true, "Content is not empty.")
         } else {
-            /// Otherwise, we should fail
+            // Otherwise, we should fail
             XCTFail("Note has no content. Only title.")
         }
     }

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -46,17 +46,18 @@ class NoteList {
         app.navigationBars.buttons[UID.Button.newNote].tap()
     }
 
-    static func createNoteThenLeaveEditor(_ note: NoteData) {
+    static func createNoteThenLeaveEditor(_ note: NoteData, viaPaste: Bool = false) {
         NoteList.createNoteAndLeaveEditor(
             noteName: note.formattedForAutomatedInput,
-            tags: note.tags
+            tags: note.tags,
+            viaPaste: viaPaste
         )
     }
 
-    class func createNoteAndLeaveEditor(noteName: String, tags: [String] = []) {
+    class func createNoteAndLeaveEditor(noteName: String, tags: [String] = [], viaPaste: Bool = false) {
         print(">>> Creating a note: " + noteName)
         NoteList.addNoteTap()
-        NoteEditor.clearAndEnterText(enteredValue: noteName)
+        NoteEditor.clearAndEnterText(enteredValue: noteName, viaPaste: viaPaste)
 
         for tag in tags {
             NoteEditor.addTag(tagName: tag)
@@ -65,9 +66,9 @@ class NoteList {
         NoteEditor.leaveEditor()
     }
 
-    class func createNotes(names: [String]) {
+    class func createNotes(names: [String], viaPaste: Bool = false) {
         for noteName in names {
-            createNoteAndLeaveEditor(noteName: noteName)
+            createNoteAndLeaveEditor(noteName: noteName, viaPaste: viaPaste)
         }
     }
 

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -47,7 +47,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         Sidebar.tagsDeleteAll()
         NoteList.openAllNotes()
 
-        allNotes.forEach { NoteList.createNoteThenLeaveEditor($0, viaPaste: true) }
+        allNotes.forEach { NoteList.createNoteThenLeaveEditor($0, usingPaste: true) }
 }
 
     override func setUpWithError() throws {

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -47,7 +47,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         Sidebar.tagsDeleteAll()
         NoteList.openAllNotes()
 
-        allNotes.forEach { NoteList.createNoteThenLeaveEditor($0) }
+        allNotes.forEach { NoteList.createNoteThenLeaveEditor($0, viaPaste: true) }
 }
 
     override func setUpWithError() throws {

--- a/UITestHelpers/XCUIElement+Extensions.swift
+++ b/UITestHelpers/XCUIElement+Extensions.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+extension XCUIElement {
+
+    public func paste(text: String) -> Void {
+        let previousPasteboardContents = UIPasteboard.general.string
+        UIPasteboard.general.string = text
+
+        self.press(forDuration: 1.2)
+        XCUIApplication().menuItems.firstMatch.tap()
+
+        if let string = previousPasteboardContents {
+            UIPasteboard.general.string = string
+        }
+    }
+
+    /**
+     Removes any current text in the field before typing in the new value
+     - Parameter text: the text to enter into the field
+     */
+    public func clearAndEnterText(text: String) {
+        guard let stringValue = self.value as? String else {
+            XCTFail("Tried to clear and enter text into a non string value")
+            return
+        }
+
+        self.tap()
+
+        let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: stringValue.count)
+
+        self.typeText(deleteString)
+        self.typeText(text)
+    }
+}

--- a/UITestHelpers/XCUIElement+Extensions.swift
+++ b/UITestHelpers/XCUIElement+Extensions.swift
@@ -14,21 +14,19 @@ extension XCUIElement {
         }
     }
 
-    /**
-     Removes any current text in the field before typing in the new value
-     - Parameter text: the text to enter into the field
-     */
     public func clearAndEnterText(text: String) {
+        self.clearText()
+        self.typeText(text)
+    }
+
+    public func clearText() {
         guard let stringValue = self.value as? String else {
             XCTFail("Tried to clear and enter text into a non string value")
             return
         }
 
         self.tap()
-
         let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: stringValue.count)
-
         self.typeText(deleteString)
-        self.typeText(text)
     }
 }

--- a/UITestHelpers/XCUIElement+TextManagement.swift
+++ b/UITestHelpers/XCUIElement+TextManagement.swift
@@ -19,6 +19,7 @@ extension XCUIElement {
         self.typeText(text)
     }
 
+    // Credits to: https://stackoverflow.com/a/32894080
     public func clearText() {
         guard let stringValue = self.value as? String else {
             XCTFail("Tried to clear and enter text into a non string value")


### PR DESCRIPTION
Since the notes used for search tests are huge, and they were created by typing the text, the time it took to create them was inappropriately long. This PR changes this and now the notes for search are created via pasting. This makes the execution 45-50 seconds faster.

All other notes are still created by typing, because it's less flaky imo, and there's no considerable speed gain for smaller notes 

### Changes
The changes are mainly:
- Moved `paste()` and `clearAndEnterText()` extensions to new `UITestHelpers/XCUIElement+Extensions.swift`. 
- Added an optional parameter to all functions that can create notes. The parameter tells if note text should be added by typing or by pasting. Default is by typing.
- `NoteList.clearAndEnterText()` will use typing or pasting based on `viaPaste` parameter.

### Test
1. Running `Screenshots` test on iPhone 8 Plus with no fails (this is a device for which `paste()` is invoked during login)
2. Running `Search` tests, seeing that notes are created via paste.
3. The rest of UI tests does not fail too.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
