### PR TITLE
Use private(set) for var tags property in NoteData

### DIFF
--- a/SimplenoteUITests/NoteData.swift
+++ b/SimplenoteUITests/NoteData.swift
@@ -2,7 +2,7 @@
 struct NoteData {
     let name: String
     let content: String
-    var tags: [String] = []
+    private(set) var tags: [String] = []
 
     var formattedForAutomatedInput: String { "\(name)\n\n\(content)" }
 }


### PR DESCRIPTION
This way, we can use the compiler-generated initializer while also keeping the instance immutable for consumers, which is appropriate for a DTO-like type such as this one.

See https://github.com/Automattic/simplenote-ios/pull/1240#discussion_r612848495

### Test
A green CI is all the validation we need for this compiler-level change.

### Review
Only one developer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.