### PR TITLE
Issue/1248 contexual menu sizing issue

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -656,28 +656,33 @@ private extension SPNoteListViewController {
         let pinImageName: UIImageName = note.pinned ? .unpin : .pin
         let pinActionTitle: String = note.pinned ? ActionTitle.unpin : ActionTitle.pin
 
-        return [
-            UIContextualAction(style: .destructive, title: ActionTitle.delete, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { [weak self] (_, _, completion) in
+        let trashAction = UIContextualAction(style: .destructive, title: nil, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { [weak self] (_, _, completion) in
                 self?.delete(note: note)
                 completion(true)
-            },
+        }
+        trashAction.accessibilityLabel = ActionTitle.trash
 
-            UIContextualAction(style: .normal, title: pinActionTitle, image: .image(name: pinImageName), backgroundColor: .simplenoteSecondaryActionColor) { [weak self] (_, _, completion) in
+        let pinAction = UIContextualAction(style: .normal, title: nil, image: .image(name: pinImageName), backgroundColor: .simplenoteSecondaryActionColor) { [weak self] (_, _, completion) in
                 self?.togglePinnedState(note: note)
                 completion(true)
-            },
+            }
+        pinAction.accessibilityLabel = pinActionTitle
 
-            UIContextualAction(style: .normal, title: ActionTitle.copyLink, image: .image(name: .link), backgroundColor: .simplenoteTertiaryActionColor) { [weak self] (_, _, completion) in
+        let copyAction = UIContextualAction(style: .normal, title: nil, image: .image(name: .link), backgroundColor: .simplenoteTertiaryActionColor) { [weak self] (_, _, completion) in
                 self?.copyInternalLink(to: note)
                 NoticeController.shared.present(NoticeFactory.linkCopied())
                 completion(true)
-            },
+            }
+        copyAction.accessibilityLabel = ActionTitle.copyLink
 
-            UIContextualAction(style: .normal, title: ActionTitle.share, image: .image(name: .share), backgroundColor: .simplenoteQuaternaryActionColor) { [weak self] (_, _, completion) in
+        let shareAction = UIContextualAction(style: .normal, title: nil, image: .image(name: .share), backgroundColor: .simplenoteQuaternaryActionColor) { [weak self] (_, _, completion) in
                 self?.share(note: note)
                 completion(true)
             }
-        ]
+        shareAction.accessibilityLabel = ActionTitle.share
+
+
+        return [trashAction, pinAction, copyAction, shareAction]
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -637,19 +637,22 @@ private extension SPNoteListViewController {
     }
 
     func deletedContextActions(for note: Note) -> [UIContextualAction] {
-        return [
-            UIContextualAction(style: .normal, image: .image(name: .restore), backgroundColor: .simplenoteRestoreActionColor) { (_, _, completion) in
+
+        let restoreAction = UIContextualAction(style: .normal, image: .image(name: .restore), backgroundColor: .simplenoteRestoreActionColor) { (_, _, completion) in
                 SPObjectManager.shared().restoreNote(note)
                 CSSearchableIndex.default().indexSearchableNote(note)
                 completion(true)
-            },
+            }
+        restoreAction.accessibilityLabel = ActionTitle.restore
 
-            UIContextualAction(style: .destructive, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { (_, _, completion) in
+        let deleteAction = UIContextualAction(style: .destructive, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { (_, _, completion) in
                 SPTracker.trackListNoteDeleted()
                 SPObjectManager.shared().permenentlyDeleteNote(note)
                 completion(true)
             }
-        ]
+        deleteAction.accessibilityLabel = ActionTitle.delete
+
+        return [restoreAction, deleteAction]
     }
 
     func regularContextActions(for note: Note) -> [UIContextualAction] {
@@ -941,10 +944,12 @@ private extension SPNoteListViewController {
 private enum ActionTitle {
     static let cancel = NSLocalizedString("Cancel", comment: "Dismissing an interface")
     static let copyLink = NSLocalizedString("Copy Internal Link", comment: "Copies Link to a Note")
-    static let delete = NSLocalizedString("Move to Trash", comment: "Deletes a note")
+    static let trash = NSLocalizedString("Move to Trash", comment: "Deletes a note")
     static let pin = NSLocalizedString("Pin to Top", comment: "Pins a note")
     static let share = NSLocalizedString("Share...", comment: "Shares a note")
     static let unpin = NSLocalizedString("Unpin", comment: "Unpins a note")
+    static let restore = NSLocalizedString("Restore Note", comment: "Restore a note from trash")
+    static let delete = NSLocalizedString("Delete Note", comment: "Delet a note from trash")
 }
 
 private enum Constants {


### PR DESCRIPTION
### Fix
This PR fixes #1248 

After a recent change to the note list contextual menu, labels were added to each menu item.  Under certain circumstances it was possible for these menu labels to appear, and that was causing the buttons to have uneven sizing:
<img height="400px" src="https://camo.githubusercontent.com/bfe9c9f831cd1934fada38bdbf047cab4ccfd370d00b4a8db7740c6b7ac48ea6/68747470733a2f2f63646e2d7374642e64726f706c722e6e65742f66696c65732f6163635f3539333835392f4673354e394a" />

This PR changes the labels on the buttons from generic labels to accessibility labels.  This way they will not physically appear on screen but will still give correct labels to the users who use voiceover.

<img height="400px" src="https://cdn-std.droplr.net/files/acc_593859/Be4Pwc" />

### Test
1. Enable voice over on your device and go to the notes list
2. Change the rotor to actions, and select a note.  Listen to the different actions they should be "move to trash, pin to top, share, delete note"
3. Now disable voiceover, return to the note list and swipe to the right to see the contextual menu options. They should be all the same size
4. Enable dynamic type on the device and choose a text size over XL (this would make the labels appear and cause the button sizing issue) make sure the labels to not appear and the buttons are equally sized

### Review
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
