### PR TITLE
Remove all caps on collaboration alert

### DIFF
--- a/Simplenote/Tags/NoteEditorTagListViewController.swift
+++ b/Simplenote/Tags/NoteEditorTagListViewController.swift
@@ -211,8 +211,8 @@ private struct Constants {
 //
 private struct Localization {
     enum CollaborationAlert {
-        static let title = NSLocalizedString("Collaboration has moved", comment: "")
-        static let message = NSLocalizedString("Sharing notes is now accessed through the action menu from the toolbar.", comment: "")
-        static let cancelAction = NSLocalizedString("OK", comment: "");
+        static let title = NSLocalizedString("Collaboration has moved", comment: "Alert title that collaboration has moved")
+        static let message = NSLocalizedString("Sharing notes is now accessed through the action menu from the toolbar.", comment: "Alert message that collaboration has moved")
+        static let cancelAction = NSLocalizedString("OK", comment: "Alert confirmation button title")
     }
 }

--- a/Simplenote/Tags/NoteEditorTagListViewController.swift
+++ b/Simplenote/Tags/NoteEditorTagListViewController.swift
@@ -141,7 +141,7 @@ extension NoteEditorTagListViewController: TagViewDelegate {
 
         let isEmailAddress = (tagName as NSString).isValidEmailAddress
         guard !isEmailAddress else {
-            let alertController = UIAlertController(title: Localization.CollaborationAlert.title.localizedUppercase,
+            let alertController = UIAlertController(title: Localization.CollaborationAlert.title,
                                                     message: Localization.CollaborationAlert.message,
                                                     preferredStyle: .alert)
             alertController.addCancelActionWithTitle(Localization.CollaborationAlert.cancelAction)


### PR DESCRIPTION
### Fix
This PR fixes #1259 

This is a quick PR that changes the messaging for the text alert to notify users that collaboration has moved so that it no longer appears in all caps.

<img width="300" src="https://cdn-std.droplr.net/files/acc_593859/2FCy30" />

After the change:

<img width="300" src="https://cdn-std.droplr.net/files/acc_593859/kwp5Up" />

### Test
1. open up a note
2. in the tags section, enter in an email address other than the email on your account
3. The warning that collaboration has moved should appear.  Make sure the title is not in all caps
4. Double check that there are no lint errors in file NoteEditorTagListViewController.swift

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
