### PR TITLE
Make In app notifications take new note bar into account

### DIFF
--- a/Simplenote/Classes/SPNavigationController.m
+++ b/Simplenote/Classes/SPNavigationController.m
@@ -29,6 +29,11 @@ static const NSInteger SPNavigationBarBackgroundPositionZ = -1000;
     }
 }
 
+//- (void)viewDidDisappear:(BOOL)animated
+//{
+//    [[NSNotificationCenter defaultCenter] postNotificationName:@"SPNavigationControllerDidChangeView" object:nil];
+//}
+
 - (void)setDisplaysBlurEffect:(BOOL)displaysBlurEffect
 {
     if (_displaysBlurEffect == displaysBlurEffect) {

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -828,6 +828,8 @@ extension SPNoteEditorViewController {
         noteEditorTextView.keyboardAppearance = .simplenoteKeyboardAppearance
         noteEditorTextView.checklistsFont = .preferredFont(forTextStyle: .headline)
         noteEditorTextView.checklistsTintColor = .simplenoteNoteBodyPreviewColor
+        navigationController?.toolbar.isTranslucent = false
+        navigationController?.toolbar.barTintColor = .simplenoteSortBarBackgroundColor
     }
 
     private func refreshTagsEditor() {

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -478,6 +478,7 @@ private extension SPNoteEditorViewController {
         let oldMarkdownState = note.markdown
         navigationController.onWillDismiss = { [weak self] in
             self?.bounceMarkdownPreviewIfNeeded(note: note, oldMarkdownState: oldMarkdownState)
+            NotificationCenter.default.post(name: .SPNavigationControllerWillDismiss, object: nil)
         }
 
         dismissKeyboardAndSave()

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -109,6 +109,15 @@ extension SPNoteEditorViewController {
         }
     }
 
+    /// Sets up new note bar
+    ///
+    @objc
+    func configureNewNoteBar() {
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let navigationItems = [flexibleSpace, createNoteButton]
+        setToolbarItems(navigationItems, animated: true)
+    }
+
     private var popoverPresenter: PopoverPresenter {
         let viewportProvider = { [weak self] () -> CGRect in
             self?.noteEditorTextView.editingRectInWindow() ?? .zero

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -97,7 +97,6 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self configureNavigationBarItems];
     [self configureNavigationBarBackground];
     [self configureRootView];
-    [self configureSearchToolbar];
     [self configureLayout];
     [self configureTagListViewController];
     [self configureInterlinksProcessor];
@@ -120,9 +119,9 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self setupNavigationController];
     [self highlightSearchResultsIfNeeded];
     [self startListeningToKeyboardNotifications];
-
     [self refreshNavigationBarButtons];
-
+    [self configureNavigationControllerToolbar];
+    [self setupNavigationController];
     // Async here to make sure all the frames are correct
     dispatch_async(dispatch_get_main_queue(), ^{
         [self restoreScrollPosition];
@@ -132,7 +131,6 @@ CGFloat const SPSelectedAreaPadding = 20;
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-
     self.userActivity = [NSUserActivity openNoteActivityFor:self.note];
     [self ensureEditorIsFirstResponder];
 }
@@ -147,7 +145,13 @@ CGFloat const SPSelectedAreaPadding = 20;
 {
     // Note: Our navigationBar *may* be hidden, as per SPSearchController in the Notes List
     [self.navigationController setNavigationBarHidden:NO animated:YES];
-    [self.navigationController setToolbarHidden:!self.searching animated:YES];
+
+    if (UIDevice.isPad) {
+        [self.navigationController setToolbarHidden:!self.searching animated:YES];
+    } else {
+        [self.navigationController setToolbarHidden:NO animated:YES];
+    }
+
 }
 
 - (void)ensureEditorIsFirstResponder
@@ -304,6 +308,20 @@ CGFloat const SPSelectedAreaPadding = 20;
     [self setToolbarItems:@[self.doneSearchButton, flexibleSpace, detailButton, flexibleSpaceTwo, self.prevSearchButton, self.nextSearchButton] animated:NO];
 }
 
+- (void)configureNavigationControllerToolbar
+{
+    if (UIDevice.isPad) {
+        [self configureSearchToolbar];
+        return;
+    }
+
+    if (self.searching) {
+        [self configureSearchToolbar];
+    } else {
+        [self configureNewNoteBar];
+    }
+}
+
 - (void)ensureNoteIsVisibleInList
 {
     // TODO: This should definitely be handled by the Note List itself. Please!
@@ -407,7 +425,9 @@ CGFloat const SPSelectedAreaPadding = 20;
     NSMutableArray *buttons = [NSMutableArray array];
 
     if (self.shouldHideKeyboardButton) {
-        [buttons addObject:self.createNoteButton];
+        if (UIDevice.isPad) {
+            [buttons addObject:self.createNoteButton];
+        }
     } else {
         [buttons addObject:self.keyboardButton];
     }
@@ -574,7 +594,11 @@ CGFloat const SPSelectedAreaPadding = 20;
     
     self.searching = NO;
 
-    [self.navigationController setToolbarHidden:YES animated:YES];
+    if (UIDevice.isPad) {
+        [self.navigationController setToolbarHidden:YES animated:YES];
+    } else {
+        [self configureNavigationControllerToolbar];
+    }
     self.searchDetailLabel.text = nil;
 }
 

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -116,7 +116,6 @@ CGFloat const SPSelectedAreaPadding = 20;
 {
     [super viewWillAppear:animated];
 
-    [self setupNavigationController];
     [self highlightSearchResultsIfNeeded];
     [self startListeningToKeyboardNotifications];
     [self refreshNavigationBarButtons];
@@ -214,7 +213,6 @@ CGFloat const SPSelectedAreaPadding = 20;
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [self.navigationController setToolbarHidden:YES animated:YES];
 
     [self saveScrollPosition];
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -90,7 +90,7 @@
 {
     [super viewWillAppear:animated];
 
-    [self refreshNavigationControllerToolbar];
+    [self refershNavigationButtons];
     if (!self.navigatingUsingKeyboard) {
         [self.tableView deselectSelectedRowAnimated:YES];
         self.selectedNote = nil;
@@ -231,6 +231,11 @@
     [self.searchBar applySimplenoteStyle];
 }
 
+- (void)refershNavigationButtons {
+    [self updateNavigationBar];
+    [self refreshNavigationControllerToolbar];
+}
+
 - (void)refreshNavigationControllerToolbar
 {
     if (!UIDevice.isPad) {
@@ -238,13 +243,14 @@
         NSArray *toolbarItems = [NSArray arrayWithObjects:flexibleSpace, self.addButton, nil];
         [self setToolbarItems:toolbarItems animated:YES];
 
-        [self.navigationController setToolbarHidden:self.isSearchActive animated:YES];
+        BOOL toolbarShouldHide = self.isSearchActive || self.isDeletedFilterActive;
+        [self.navigationController setToolbarHidden:toolbarShouldHide animated:YES];
     }
 }
 
 - (void)updateNavigationBar {
-    UIBarButtonItem *ipadAddButton = UIDevice.isPad ? self.addButton : nil;
-    UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : ipadAddButton;
+    UIBarButtonItem *possibleAddButton = UIDevice.isPad ? self.addButton : nil;
+    UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : possibleAddButton;
 
     [self.navigationItem setRightBarButtonItem:rightButton animated:YES];
     [self.navigationItem setLeftBarButtonItem:self.sidebarButton animated:YES];
@@ -358,7 +364,7 @@
     [self.notesListController beginSearch];
     [self reloadTableData];
     [self refreshTitle];
-    [self refreshNavigationControllerToolbar];
+    [self refershNavigationButtons];
 }
 
 - (void)searchDisplayControllerDidEndSearch:(SearchDisplayController *)controller
@@ -374,7 +380,7 @@
     /// Ref. https://github.com/Automattic/simplenote-ios/issues/777
     ///
     [self.notesListController endSearch];
-    [self refreshNavigationControllerToolbar];
+    [self refershNavigationButtons];
     [self update];
 
 }
@@ -504,7 +510,7 @@
     self.tableView.allowsSelection = !isTrashOnScreen;
     
     [self displayPlaceholdersIfNeeded];
-    [self updateNavigationBar];
+    [self refershNavigationButtons];
     [self hideRatingViewIfNeeded];
 }
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -245,6 +245,8 @@
 
         BOOL toolbarShouldHide = self.isSearchActive || self.isDeletedFilterActive;
         [self.navigationController setToolbarHidden:toolbarShouldHide animated:YES];
+    } else {
+        [self.navigationController setToolbarHidden:YES animated:YES];
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -89,8 +89,8 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [self.searchController hideNavigationBarIfNecessary];
 
+    [self refreshNavigationControllerToolbar];
     if (!self.navigatingUsingKeyboard) {
         [self.tableView deselectSelectedRowAnimated:YES];
         self.selectedNote = nil;
@@ -231,8 +231,20 @@
     [self.searchBar applySimplenoteStyle];
 }
 
+- (void)refreshNavigationControllerToolbar
+{
+    if (!UIDevice.isPad) {
+        UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
+        NSArray *toolbarItems = [NSArray arrayWithObjects:flexibleSpace, self.addButton, nil];
+        [self setToolbarItems:toolbarItems animated:YES];
+
+        [self.navigationController setToolbarHidden:self.isSearchActive animated:YES];
+    }
+}
+
 - (void)updateNavigationBar {
-    UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : self.addButton;
+    UIBarButtonItem *ipadAddButton = UIDevice.isPad ? self.addButton : nil;
+    UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : ipadAddButton;
 
     [self.navigationItem setRightBarButtonItem:rightButton animated:YES];
     [self.navigationItem setLeftBarButtonItem:self.sidebarButton animated:YES];
@@ -346,6 +358,7 @@
     [self.notesListController beginSearch];
     [self reloadTableData];
     [self refreshTitle];
+    [self refreshNavigationControllerToolbar];
 }
 
 - (void)searchDisplayControllerDidEndSearch:(SearchDisplayController *)controller
@@ -361,6 +374,7 @@
     /// Ref. https://github.com/Automattic/simplenote-ios/issues/777
     ///
     [self.notesListController endSearch];
+    [self refreshNavigationControllerToolbar];
     [self update];
 
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -242,15 +242,14 @@
 
 - (void)refreshNavigationControllerToolbar
 {
-    if (!UIDevice.isPad) {
+    if (UIDevice.isPad) {
+        [self.navigationController setToolbarHidden:YES animated:YES];
+    } else {
         UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
         NSArray *toolbarItems = [NSArray arrayWithObjects:flexibleSpace, self.addButton, nil];
         [self setToolbarItems:toolbarItems animated:YES];
 
-        BOOL toolbarShouldHide = self.isSearchActive || self.isDeletedFilterActive;
-        [self.navigationController setToolbarHidden:toolbarShouldHide animated:YES];
-    } else {
-        [self.navigationController setToolbarHidden:YES animated:YES];
+        [self.navigationController setToolbarHidden:self.isSearchActive animated:YES];
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -97,6 +97,7 @@
     }
 
     self.navigatingUsingKeyboard = NO;
+    [self refreshStyle];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -229,6 +230,9 @@
 
     // Refresh the SearchBar's UI
     [self.searchBar applySimplenoteStyle];
+
+    self.navigationController.toolbar.translucent = false;
+    self.navigationController.toolbar.barTintColor = [UIColor simplenoteSortBarBackgroundColor];
 }
 
 - (void)refershNavigationButtons {

--- a/Simplenote/Classes/SPNotifications.h
+++ b/Simplenote/Classes/SPNotifications.h
@@ -16,3 +16,4 @@ extern NSString *const SPAlphabeticalTagSortPreferenceChangedNotification;
 extern NSString *const SPCondensedNoteListPreferenceChangedNotification;
 extern NSString *const SPNotesListSortModeChangedNotification;
 extern NSString *const SPSimplenoteThemeChangedNotification;
+extern NSString *const SPNavigationControllerWillDismissNotification;

--- a/Simplenote/Classes/SPNotifications.m
+++ b/Simplenote/Classes/SPNotifications.m
@@ -16,3 +16,4 @@ NSString *const SPAlphabeticalTagSortPreferenceChangedNotification  = @"SPAlphab
 NSString *const SPCondensedNoteListPreferenceChangedNotification    = @"SPCondensedNoteListPreferenceChangedNotification";
 NSString *const SPNotesListSortModeChangedNotification              = @"SPNotesListSortModeChangedNotification";
 NSString *const SPSimplenoteThemeChangedNotification                = @"SPSimplenoteThemeChangedNotification";
+NSString *const SPNavigationControllerWillDismissNotification       = @"SPNavigationControllerWillDismissNotification";

--- a/Simplenote/Classes/SPTransitionController.m
+++ b/Simplenote/Classes/SPTransitionController.m
@@ -70,6 +70,15 @@ NSString *const SPTransitionControllerPopGestureTriggeredNotificationName = @"SP
     return self.pushPopAnimationController.interactiveTransition;
 }
 
+//- (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
+//{
+//    printf("view did show");
+//}
+//
+//- (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
+//{
+//    [[NSNotificationCenter defaultCenter] postNotificationName:@"SPNavigationControllerDidChangeView" object:nil];
+//}
 
 #pragma mark - Gesture Recognizers
 

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -29,6 +29,7 @@ class NoticeController {
 
     func setupNoticeController() {
         noticePresenter.startListeningToKeyboardNotifications()
+        noticePresenter.setupNavigationControllerNotification()
     }
 
     // MARK: Presenting


### PR DESCRIPTION
### Fix
This is a process PR to test a possible implementation for the new note bar where the in app notifications will take into account the bar if present.

### Test
1. from the note list, trigger a notification, it will appear higher than the new note bar
2. go to the options menu and trigger a publish notification, it will appear at the normal height
3. trigger a publish notification and while it is on screen dismiss the options menu.  The notification will not adjust it's location.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
