### PR TITLE
Issue/1229 quick dissmiss notices

### DIFF
--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -64,8 +64,8 @@ class NoticeController {
     // MARK: Dismissing
     //
     private func dismiss(withDuration duration: TimeInterval = UIKitConstants.animationLongDuration, completion: (() -> Void)? = nil) {
-        self.timer = nil
-        self.current = nil
+        timer = nil
+        current = nil
 
         noticePresenter.dismissNotification(withDuration: duration) {
             completion?()

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -34,9 +34,8 @@ class NoticeController {
     //
     func present(_ notice: Notice) {
         if isPresenting {
-            dismiss {
+            dismiss(withDuration: UIKitConstants.animationQuickDuration) {
                 self.present(notice)
-                print("canceled")
             }
             return
         }
@@ -48,7 +47,6 @@ class NoticeController {
             let delay = self.current?.action == nil ? Times.shortDelay : Times.longDelay
             self.timer = self.timerFactory.scheduledTimer(with: delay, completion: {
                 self.dismiss {
-                    print("full process")
                 }
             })
         }
@@ -67,10 +65,10 @@ class NoticeController {
     // MARK: Dismissing
     //
     @objc
-    private func dismiss(completion: (() -> Void)? = nil) {
+    private func dismiss(withDuration duration: TimeInterval = UIKitConstants.animationLongDuration, completion: (() -> Void)? = nil) {
         self.timer = nil
 
-        noticePresenter.dismissNotification {
+        noticePresenter.dismissNotification(withDuration: duration) {
             self.current = nil
             completion?()
         }

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -15,7 +15,7 @@ class NoticeController {
         }
     }
 
-    private var isPresenting: Bool {
+    private var presenting: Bool {
         current != nil
     }
 
@@ -43,11 +43,10 @@ class NoticeController {
         current = notice
         let noticeView = makeNoticeView(from: notice)
 
-        noticePresenter.presentNoticeView(noticeView) { () in
+        noticePresenter.presentNoticeView(noticeView) {
             let delay = self.current?.action == nil ? Times.shortDelay : Times.longDelay
             self.timer = self.timerFactory.scheduledTimer(with: delay, completion: {
-                self.dismiss {
-                }
+                self.dismiss()
             })
         }
     }
@@ -64,7 +63,6 @@ class NoticeController {
 
     // MARK: Dismissing
     //
-    @objc
     private func dismiss(withDuration duration: TimeInterval = UIKitConstants.animationLongDuration, completion: (() -> Void)? = nil) {
         self.timer = nil
 
@@ -73,15 +71,18 @@ class NoticeController {
             completion?()
         }
     }
+
+    private func dismiss(_ noticeView: NoticeView) {
+        self.timer = nil
+        current = nil
+        noticePresenter.dismiss(noticeView)
+    }
 }
 
 // MARK: NoticePresenting Delegate
 //
 extension NoticeController: NoticeInteractionDelegate {
     func noticePressBegan() {
-        if !isPresenting {
-            return
-        }
         timer = nil
     }
 

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -71,12 +71,6 @@ class NoticeController {
             completion?()
         }
     }
-
-    private func dismiss(_ noticeView: NoticeView) {
-        self.timer = nil
-        current = nil
-        noticePresenter.dismiss(noticeView)
-    }
 }
 
 // MARK: NoticePresenting Delegate
@@ -94,12 +88,6 @@ extension NoticeController: NoticeInteractionDelegate {
 
     func actionWasTapped() {
         dismiss()
-    }
-
-    func noticeWasTapped(_ noticeView: NoticeView) {
-        if !presenting {
-            dismiss(noticeView)
-        }
     }
 }
 

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -94,6 +94,12 @@ extension NoticeController: NoticeInteractionDelegate {
     func actionWasTapped() {
         dismiss()
     }
+
+    func noticeWasTapped(_ noticeView: NoticeView) {
+        if !isPresenting {
+            noticePresenter.dismiss(noticeView)
+        }
+    }
 }
 
 private struct Times {

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -33,8 +33,8 @@ class NoticeController {
     // MARK: Presenting
     //
     func present(_ notice: Notice) {
-        if isPresenting {
-            dismiss(withDuration: UIKitConstants.animationQuickDuration) {
+        if presenting {
+            dismiss(withDuration: .zero) {
                 self.present(notice)
             }
             return
@@ -97,8 +97,8 @@ extension NoticeController: NoticeInteractionDelegate {
     }
 
     func noticeWasTapped(_ noticeView: NoticeView) {
-        if !isPresenting {
-            noticePresenter.dismiss(noticeView)
+        if !presenting {
+            dismiss(noticeView)
         }
     }
 }

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -35,7 +35,10 @@ class NoticeController {
     //
     func present(_ notice: Notice) {
         if isPresenting {
-            appendToQueueIfNew(notice)
+            dismiss {
+                self.present(notice)
+                print("canceled")
+            }
             return
         }
 
@@ -45,7 +48,9 @@ class NoticeController {
         noticePresenter.presentNoticeView(noticeView) { () in
             let delay = self.current?.action == nil ? Times.shortDelay : Times.longDelay
             self.timer = self.timerFactory.scheduledTimer(with: delay, completion: {
-                self.dismiss()
+                self.dismiss {
+                    print("full process")
+                }
             })
         }
     }
@@ -77,15 +82,12 @@ class NoticeController {
     // MARK: Dismissing
     //
     @objc
-    private func dismiss() {
+    private func dismiss(completion: (() -> Void)? = nil) {
         self.timer = nil
 
         noticePresenter.dismissNotification {
             self.current = nil
-
-            if !self.notices.isEmpty {
-                self.present(self.notices.removeFirst())
-            }
+            completion?()
         }
     }
 }

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -5,7 +5,6 @@ class NoticeController {
     //
     static let shared = NoticeController()
 
-    private var notices: [Notice] = []
     private var current: Notice?
     private let noticePresenter: NoticePresenter
     private let timerFactory: TimerFactory
@@ -53,20 +52,6 @@ class NoticeController {
                 }
             })
         }
-    }
-
-    /// Confirms if a notice is already contained in notices queue. Appends to queue if new
-    ///
-    private func appendToQueueIfNew(_ notice: Notice) {
-        if notices.contains(notice) {
-            return
-        }
-
-        if notice == current {
-            return
-        }
-
-        notices.append(notice)
     }
 
     private func makeNoticeView(from notice: Notice) -> NoticeView {

--- a/Simplenote/NoticeController.swift
+++ b/Simplenote/NoticeController.swift
@@ -65,9 +65,9 @@ class NoticeController {
     //
     private func dismiss(withDuration duration: TimeInterval = UIKitConstants.animationLongDuration, completion: (() -> Void)? = nil) {
         self.timer = nil
+        self.current = nil
 
         noticePresenter.dismissNotification(withDuration: duration) {
-            self.current = nil
             completion?()
         }
     }

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -118,10 +118,11 @@ class NoticePresenter {
         } completion: { (_) in
             noticeView.removeFromSuperview()
             containerView.removeFromSuperview()
-            self.noticeView = nil
-            self.containerView = nil
             completion()
         }
+
+        self.noticeView = nil
+        self.containerView = nil
     }
 }
 

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -125,10 +125,14 @@ class NoticePresenter {
     }
 
     func dismiss(_ noticeView: NoticeView) {
+        let containerView = noticeView.superview as? PassthruView
+
         UIView.animate(withDuration: UIKitConstants.animationQuickDuration) {
+            containerView?.alpha = .zero
             noticeView.alpha = .zero
         } completion: { (_) in
             noticeView.removeFromSuperview()
+            containerView?.removeFromSuperview()
             self.noticeView = nil
             self.containerView = nil
         }

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -123,20 +123,6 @@ class NoticePresenter {
             completion()
         }
     }
-
-    func dismiss(_ noticeView: NoticeView) {
-        let containerView = noticeView.superview as? PassthruView
-
-        UIView.animate(withDuration: UIKitConstants.animationQuickDuration) {
-            containerView?.alpha = .zero
-            noticeView.alpha = .zero
-        } completion: { (_) in
-            noticeView.removeFromSuperview()
-            containerView?.removeFromSuperview()
-            self.noticeView = nil
-            self.containerView = nil
-        }
-    }
 }
 
 // MARK: Keyboard Observable

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -121,6 +121,16 @@ class NoticePresenter {
             completion()
         }
     }
+
+    func dismiss(_ noticeView: NoticeView) {
+        UIView.animate(withDuration: UIKitConstants.animationQuickDuration) {
+            noticeView.alpha = .zero
+        } completion: { (_) in
+            noticeView.removeFromSuperview()
+            self.noticeView = nil
+            self.containerView = nil
+        }
+    }
 }
 
 // MARK: Keyboard Observable

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -105,13 +105,14 @@ class NoticePresenter {
 
     // MARK: Dismissing Methods
     //
-    func dismissNotification(completion: @escaping () -> Void) {
+    func dismissNotification(withDuration duration: TimeInterval, completion: @escaping () -> Void) {
         guard let containerView = containerView,
               let noticeView = noticeView else {
             return
         }
-        UIView.animate(withDuration: UIKitConstants.animationLongDuration) {
+        UIView.animate(withDuration: duration) {
             noticeView.alpha = .zero
+            containerView.alpha = .zero
         } completion: { (_) in
             noticeView.removeFromSuperview()
             containerView.removeFromSuperview()

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -110,7 +110,9 @@ class NoticePresenter {
               let noticeView = noticeView else {
             return
         }
-        UIView.animate(withDuration: duration) {
+        UIView.animate(withDuration: duration,
+                       delay: .zero,
+                       options: [.allowUserInteraction]) {
             noticeView.alpha = .zero
             containerView.alpha = .zero
         } completion: { (_) in

--- a/Simplenote/NoticeView.swift
+++ b/Simplenote/NoticeView.swift
@@ -4,6 +4,7 @@ protocol NoticeInteractionDelegate: class {
     func noticePressBegan()
     func noticePressEnded()
     func actionWasTapped()
+    func noticeWasTapped(_ noticeView: NoticeView)
 }
 
 class NoticeView: UIView {
@@ -56,7 +57,9 @@ class NoticeView: UIView {
 
     private func setupGestureRecognizers() {
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(viewWasLongPressed(_:)))
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(noticeWasTapped))
         addGestureRecognizer(longPressGesture)
+        addGestureRecognizer(tapGesture)
     }
 
     private func setupViewStyles() {
@@ -82,13 +85,12 @@ class NoticeView: UIView {
     }
 }
 
-// NOTE: long press recognizing has not been connected to anything yet
-// Currently just prints to log that a press event happened.
 extension NoticeView {
 
-    // MARK: Long Press Gesture Recognizer
+    // MARK: Gesture Recognizers
     //
-    @objc private func viewWasLongPressed(_ gesture: UIGestureRecognizer) {
+    @objc
+    private func viewWasLongPressed(_ gesture: UIGestureRecognizer) {
         switch gesture.state {
         case .began:
             longPressBegan()
@@ -105,6 +107,11 @@ extension NoticeView {
 
     private func longPressEnded() {
         delegate?.noticePressEnded()
+    }
+
+    @objc
+    private func noticeWasTapped() {
+        delegate?.noticeWasTapped(self)
     }
 }
 

--- a/Simplenote/NoticeView.swift
+++ b/Simplenote/NoticeView.swift
@@ -4,7 +4,6 @@ protocol NoticeInteractionDelegate: class {
     func noticePressBegan()
     func noticePressEnded()
     func actionWasTapped()
-    func noticeWasTapped(_ noticeView: NoticeView)
 }
 
 class NoticeView: UIView {
@@ -57,9 +56,7 @@ class NoticeView: UIView {
 
     private func setupGestureRecognizers() {
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(viewWasLongPressed(_:)))
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(noticeWasTapped))
         addGestureRecognizer(longPressGesture)
-        addGestureRecognizer(tapGesture)
     }
 
     private func setupViewStyles() {
@@ -107,11 +104,6 @@ extension NoticeView {
 
     private func longPressEnded() {
         delegate?.noticePressEnded()
-    }
-
-    @objc
-    private func noticeWasTapped() {
-        delegate?.noticeWasTapped(self)
     }
 }
 


### PR DESCRIPTION
### Fix
This PR Fixes #1229 
is a continuation of #1230 

Currently it is possible to make a series of changes in simplenote iOS that would create more notices, however because you can't queue several of the same notices at once, the subsequent actions receive no notification.  This could be problematic in the case that a user deletes multiple notes really quickly.  In that case the "restore" button on the trashed notice would refer to the first note trashed, not the last note trashed.

In this PR, I have made a change so that if the passthru view that the notice is contained in is interacted with, the notice will be dismissed.  That way you would never be able to create multiple notices at once, as they are dismissed once you interact with the rest of the app in anyway.

<img src= "https://cdn-std.droplr.net/files/acc_593859/coOBEq" />

### Test
1. From the note list try to delete a note using the contextual actions, a note will appear
2. now delete a another note, you will see the first notice is dismissed before the second one can be trashed.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
