### PR TITLE
PR for testing new check during secrets decryption

### DIFF
--- a/.configure
+++ b/.configure
@@ -14,6 +14,11 @@
       "encrypt": true
     },
     {
+      "file": "iOS/simplenote/ScreenshotsCredentials.swift",
+      "destination": "./ScreenshotsCredentials.swift",
+      "encrypt": true
+    },
+    {
       "file": "shared/google_cloud_keys.json",
       "destination": ".configure-files/google_cloud_keys.json",
       "encrypt": true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 413bdfd2a22e1f1371a4e2845320afb2b0559667
-  tag: 0.17.1
+  revision: 10738d03a543bdbf0c68aa0185dfd325612a6a4a
+  branch: prevent-decryption-to-path-that-is-not-ignored
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.17.1)
       activesupport (~> 5)
@@ -242,7 +242,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.11.3-x86_64-darwin)
       racc (~> 1.4)
-    octokit (4.20.0)
+    octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.11.5)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,7 +2,7 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.17.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'prevent-decryption-to-path-that-is-not-ignored'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', "1.8.0"
 


### PR DESCRIPTION
1. Checkout this branch
2. Run `bundle update` to fetch the release toolkit version from https://github.com/wordpress-mobile/release-toolkit/pull/242
3. Notice that there's an update to `.configure` to decrypt a (harmless) file in a location that's not ignored
4. Run `bundle exec fastlane run configure_apply`; it should fail showing something like:

<img width="1272" alt="Screen Shot 2021-04-28 at 1 17 10 pm" src="https://user-images.githubusercontent.com/1218433/116341341-10424680-a824-11eb-8384-21cc850da276.png">


5. Run `bundle exec fastlane run configure_update`; it should fail with something like:

![image](https://user-images.githubusercontent.com/1218433/116341379-2b14bb00-a824-11eb-9c81-c4324682d473.png)

_In my local, I noticed that `project.env.enc` was updated in this step but I wasn't prompted to override the decrypted local version. I think that has to do with the sequence in which the encrypted and decrypted files get processed, but I haven't researched it._

6. Run `bundle exec fastlane run configure_add_files_to_copy` and add a file to a path that is not ignored; it should fail with something like:

![image](https://user-images.githubusercontent.com/1218433/116348648-d5470f80-a831-11eb-95a3-758e94ffcd61.png)


7. Add the path to the `.gitignore` (`echo 'ScreenshotsCredentials.swift' >> .gitignore`) and repeat steps 4 and 6: everything should work. The file should appear in your local copy but not be part of the `git status`.
