### PR TITLE
Add missing 4.35 "what's new" values to AppStoreStrings.pot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 413bdfd2a22e1f1371a4e2845320afb2b0559667
-  tag: 0.17.1
+  revision: ce59a5e7b4fa75f6bb694bcfa333f85175294c3c
+  tag: 0.18.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.17.1)
+    fastlane-plugin-wpmreleasetoolkit (0.18.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -228,7 +228,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -242,7 +242,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.11.3-x86_64-darwin)
       racc (~> 1.4)
-    octokit (4.20.0)
+    octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.11.5)

--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -66,8 +66,10 @@ msgctxt "app_store_keywords"
 msgid "simplenote,note,taking,taker,notes,sync,share,simple,markdown,tag,to-do,list,lock,cloud,writing"
 msgstr ""
 
-msgctxt "v4.34-whats-new"
+msgctxt "v4.35-whats-new"
 msgid ""
-"- VoiceOver now reads note contextual actions names correctly\n"
+"- Simplenote's Icons have been revamped\n"
+"- Added in app notifications to alert users of different activities in the app\n"
+"- Changed search sort settings to use the general sort setting.\n"
 msgstr ""
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,7 +2,7 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.17.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.18.0'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', "1.8.0"
 


### PR DESCRIPTION
During the code freeze for 4.34 the `AppStoreStrings.pot` did not update because of a bug in the release toolkit and I didn't notice that.

This PR:

- Updates the toolkit to get [this fix](https://github.com/wordpress-mobile/release-toolkit/pull/237)
- Tracks the result of the `update_appstore_strings version:4.35` lane 

Within 24 hours of it being merged into develop, our automation will pick up the new strings and uploaded to GlotPress.

I'm using a dedicated PR rather than asking to merge `release/4.35` to keep the change set smaller . These changes don't necessarily need to be in the release branch anyways, because they don't affect the binary we ship to the users. Our automation should pull the right values regardless, once I'll run it after the translations come in. _And  anyways, I did make these changes in the release branch without realizing all of the above_ 😅 