### PR TITLE
Issue/1043 add multi select

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		BA4499B325ED8AB0000C563E /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499B225ED8AB0000C563E /* NoticeView.swift */; };
 		BA4499BC25ED95D0000C563E /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499BB25ED95D0000C563E /* Notice.swift */; };
 		BA4499C525ED95E5000C563E /* NoticeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499C425ED95E5000C563E /* NoticeAction.swift */; };
+		BA4C6CFC264C744300B723A7 /* SeparatorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6CFB264C744300B723A7 /* SeparatorsView.swift */; };
 		BA55124E2600210B00D8F882 /* TimerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA55124D2600210B00D8F882 /* TimerFactory.swift */; };
 		BA55B05A25F067DF0042582B /* NoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA55B05925F067DF0042582B /* NoticePresenter.swift */; };
 		BA55B06325F068650042582B /* NoticeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA55B06225F068650042582B /* NoticeController.swift */; };
@@ -949,6 +950,7 @@
 		BA4499B225ED8AB0000C563E /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		BA4499BB25ED95D0000C563E /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
 		BA4499C425ED95E5000C563E /* NoticeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAction.swift; sourceTree = "<group>"; };
+		BA4C6CFB264C744300B723A7 /* SeparatorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorsView.swift; sourceTree = "<group>"; };
 		BA55124D2600210B00D8F882 /* TimerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerFactory.swift; sourceTree = "<group>"; };
 		BA55B05925F067DF0042582B /* NoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticePresenter.swift; sourceTree = "<group>"; };
 		BA55B06225F068650042582B /* NoticeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeController.swift; sourceTree = "<group>"; };
@@ -1869,6 +1871,7 @@
 				A694ABAA25D1549D00CC3A2D /* FileStorage.swift */,
 				BA55124D2600210B00D8F882 /* TimerFactory.swift */,
 				BAB01791260AAE93007A9CC3 /* NoticeFactory.swift */,
+				BA4C6CFB264C744300B723A7 /* SeparatorsView.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -2843,6 +2846,7 @@
 				B59FFB43231851C700567627 /* UIGestureRecognizer+Simplenote.swift in Sources */,
 				B550F93622BA7E9100091939 /* NSUserActivity+Simplenote.swift in Sources */,
 				B5BE054E1AB75902002417BF /* NSProcessInfo+Util.m in Sources */,
+				BA4C6CFC264C744300B723A7 /* SeparatorsView.swift in Sources */,
 				375D24B821E01131007AB25A /* hash.c in Sources */,
 				A6D5AE6525483F8A00326C76 /* NSTextStorage+Simplenote.swift in Sources */,
 				A61471A825D6BC700065D849 /* NoteEditorTagSuggestionsViewController.swift in Sources */,

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -519,7 +519,7 @@ extension SPNoteEditorViewController {
         SPTracker.trackEditorNoteDeleted()
         SPObjectManager.shared().trashNote(note)
         CSSearchableIndex.default().deleteSearchableNote(note)
-        NoticeController.shared.present(NoticeFactory.noteTrashed(note, onUndo: {
+        NoticeController.shared.present(NoticeFactory.noteTrashed(onUndo: {
             SPObjectManager.shared().restoreNote(note)
         }))
     }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -572,8 +572,16 @@ extension SPNoteListViewController: UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard let cell = cell as? SPNoteTableViewCell else {
+            return
+        }
         var insets = SPNoteTableViewCell.separatorInsets
         insets.left -= cell.layoutMargins.left
+
+        if isEditing {
+            insets.left += cell.checkboxContainingView.frame.width
+        }
+
         cell.separatorInset = insets
     }
 }
@@ -666,11 +674,11 @@ extension SPNoteListViewController {
         super.setEditing(editing, animated: animated)
 
         // Reloading data ensures that no cells are selected and the current data is up to date
-        tableView.reloadData()
+        let rows = tableView.indexPathsForVisibleRows
+        tableView.reloadRows(at: rows!, with: .automatic)
 
         // Dispatches to asyncAfter because reloadData will override the animations if not complete
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
-            self.tableView.deselectSelectedRow(animated: true)
             self.tableView.setEditing(editing, animated: animated)
             self.configureNavigationToolbarButton()
         })

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -606,10 +606,18 @@ extension SPNoteListViewController: UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard let cell = cell as? SPNoteTableViewCell else {
+            return
+        }
+        
         var insets = SPNoteTableViewCell.separatorInsets
         insets.left -= cell.layoutMargins.left
 
         cell.separatorInset = insets
+
+        if indexPath.row == notesListController.numberOfObjects - 1 {
+            cell.shouldDisplayBottomSeparator = false
+        }
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -258,12 +258,8 @@ extension SPNoteListViewController {
     }
 
     func refreshSelectAllLabels() {
-        var deselect = false
         let numberOfSelectedRows = tableView.indexPathsForSelectedRows?.count ?? 0
-
-        if notesListController.numberOfObjects == numberOfSelectedRows {
-            deselect = true
-        }
+        let deselect = notesListController.numberOfObjects == numberOfSelectedRows
 
         selectAllButton.title = Localization.selectAllLabel(deselect: deselect)
         selectAllButton.isAccessibilityElement = true
@@ -388,9 +384,8 @@ extension SPNoteListViewController {
 
     @objc
     func selectAllWasTapped() {
-
         if notesListController.numberOfObjects == tableView.indexPathsForSelectedRows?.count {
-            tableView.deselectAllRows(inSection: 0, animated: false)
+            tableView.deselectAllRows(inSection: .zero, animated: false)
             refreshNavigationBarLabels()
 
             return
@@ -709,18 +704,18 @@ extension SPNoteListViewController {
     open override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
         refreshEditButtonTitle()
-        
-        tableView.deselectAllRows(inSection: 0, animated: false)
+
+        tableView.deselectAllRows(inSection: .zero, animated: false)
         updateNavigationBar()
 
         tableView.allowsMultipleSelection = editing
-        toggleMultiSelectEditingTo(editing)
+        toggleVisibleCells(to: editing)
 
         configureNavigationToolbarButton()
         setListViewTitle()
     }
 
-    func toggleMultiSelectEditingTo(_ editing: Bool) {
+    func toggleVisibleCells(to editing: Bool) {
         guard let noteCells = tableView.visibleCells as? [SPNoteTableViewCell] else {
             return
         }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -709,6 +709,7 @@ extension SPNoteListViewController {
         super.setEditing(editing, animated: animated)
         tableView.setEditing(editing, animated: animated)
         refreshEditButtonTitle()
+        refreshSelectAllLabels()
 
         tableView.deselectAllRows(inSection: .zero, animated: false)
         updateNavigationBar()

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -257,6 +257,20 @@ extension SPNoteListViewController {
         updatePlaceholderPosition()
     }
 
+    func refreshSelectAllLabels() {
+        var deselect = false
+        let numberOfSelectedRows = tableView.indexPathsForSelectedRows?.count ?? 0
+
+        if notesListController.numberOfObjects == numberOfSelectedRows {
+            deselect = true
+        }
+
+        selectAllButton.title = Localization.selectAllLabel(deselect: deselect)
+        selectAllButton.isAccessibilityElement = true
+        selectAllButton.accessibilityLabel = Localization.selectAllLabel(deselect: deselect)
+        selectAllButton.accessibilityHint = Localization.selectAllAccessibilityHint
+    }
+
     private var placeholderDisplayMode: SPPlaceholderView.DisplayMode {
         if isIndexingNotes || SPAppDelegate.shared().bSigningUserOut {
             return .generic
@@ -378,6 +392,20 @@ extension SPNoteListViewController {
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         let actionButton = isEditing ? trashButton : addButton
         setToolbarItems([flexibleSpace, actionButton], animated: true)
+    }
+
+    @objc
+    func selectAllWasTapped() {
+
+        if notesListController.numberOfObjects == tableView.indexPathsForSelectedRows?.count {
+            tableView.deselectSelectedRows(animated: true)
+            refreshSelectAllLabels()
+
+            return
+        }
+
+        tableView.selectAll(nil)
+        refreshSelectAllLabels()
     }
 }
 
@@ -532,6 +560,7 @@ extension SPNoteListViewController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if isEditing {
             setListViewTitle()
+            refreshSelectAllLabels()
             return
         }
 
@@ -552,6 +581,7 @@ extension SPNoteListViewController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         if isEditing {
             setListViewTitle()
+            refreshSelectAllLabels()
         }
     }
 
@@ -682,6 +712,7 @@ extension SPNoteListViewController {
 
     open override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
+        updateNavigationBar()
 
         // Reloading data ensures that no cells are selected and the current data is up to date
         let rows = tableView.indexPathsForVisibleRows
@@ -1097,4 +1128,12 @@ private enum Localization {
         let string = NSLocalizedString("%i Selected", comment: "Count of currently selected notes")
         return String(format: string, count)
     }
+
+    static func selectAllLabel(deselect: Bool) -> String {
+        let selectLabel = NSLocalizedString("Select All", comment: "Select all Button Label")
+        let deselectLabel = NSLocalizedString("Deselect All", comment: "Deselect all Button Label")
+        return deselect ? deselectLabel : selectLabel
+    }
+
+    static let selectAllAccessibilityHint = NSLocalizedString("Tap button to select or deselect all notes", comment: "Accessibility hint for the select/deselect all button")
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -35,6 +35,8 @@ extension SPNoteListViewController {
         tableView.register(SPNoteTableViewCell.loadNib(), forCellReuseIdentifier: SPNoteTableViewCell.reuseIdentifier)
         tableView.register(SPTagTableViewCell.loadNib(), forCellReuseIdentifier: SPTagTableViewCell.reuseIdentifier)
         tableView.register(SPSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: SPSectionHeaderView.reuseIdentifier)
+
+        tableView.allowsMultipleSelectionDuringEditing = true
     }
 
     /// Sets up the Results Controller
@@ -495,16 +497,18 @@ extension SPNoteListViewController: UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        selectedNote = nil
+        if !isEditing {
+            selectedNote = nil
 
-        switch notesListController.object(at: indexPath) {
-        case let note as Note:
-            SPRatingsHelper.sharedInstance()?.incrementSignificantEvent()
-            open(note, animated: true)
-        case let tag as Tag:
-            refreshSearchText(appendFilterFor: tag)
-        default:
-            break
+            switch notesListController.object(at: indexPath) {
+            case let note as Note:
+                SPRatingsHelper.sharedInstance()?.incrementSignificantEvent()
+                open(note, animated: true)
+            case let tag as Tag:
+                refreshSearchText(appendFilterFor: tag)
+            default:
+                break
+            }
         }
     }
 
@@ -569,6 +573,8 @@ private extension SPNoteListViewController {
         cell.keywordsTintColor = .simplenoteTintColor
 
         cell.prefixText = prefixText(for: note)
+
+        cell.multiSelectTintColor = .simplenoteNotePinStatusImageColor
 
         cell.refreshAttributedStrings()
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -405,6 +405,11 @@ extension SPNoteListViewController {
         setListViewTitle()
         refreshSelectAllLabels()
     }
+
+    @objc
+    func refreshEditButtonTitle() {
+        editButtonItem.title = isEditing ? Localization.cancelTitle : Localization.editTitle
+    }
 }
 
 
@@ -611,14 +616,7 @@ extension SPNoteListViewController: UITableViewDelegate {
         guard let cell = cell as? SPNoteTableViewCell else {
             return
         }
-        var insets = SPNoteTableViewCell.separatorInsets
-        insets.left -= cell.layoutMargins.left
-
-        if isEditing {
-            insets.left += cell.checkboxContainingView.frame.width
-        }
-
-        cell.separatorInset = insets
+        cell.refreshEdgeInsets(editing: isEditing)
     }
 }
 
@@ -710,7 +708,8 @@ extension SPNoteListViewController {
 
     open override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
-
+        refreshEditButtonTitle()
+        
         tableView.deselectAllRows(inSection: 0, animated: false)
         updateNavigationBar()
 
@@ -1143,4 +1142,8 @@ private enum Localization {
     }
 
     static let selectAllAccessibilityHint = NSLocalizedString("Tap button to select or deselect all notes", comment: "Accessibility hint for the select/deselect all button")
+
+    static let editTitle = NSLocalizedString("Edit", comment: "Edit button title")
+
+    static let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title")
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -655,6 +655,8 @@ private extension SPNoteListViewController {
 
         cell.refreshAttributedStrings()
 
+        cell.checkboxContainingView.isHidden = !isEditing
+
         return cell
     }
 
@@ -708,19 +710,14 @@ extension SPNoteListViewController {
 
     open override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
+
         tableView.deselectAll()
         updateNavigationBar()
 
-        // Reloading data ensures that no cells are selected and the current data is up to date
-        if let rows = tableView.indexPathsForVisibleRows {
-            tableView.reloadRows(at: rows, with: .automatic)
-        }
+        tableView.allowsMultipleSelection = editing
+        tableView.setMultiSelectEditing(editing)
 
-        // Dispatches to asyncAfter because reloadData will override the animations if not complete
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
-            self.tableView.setEditing(editing, animated: animated)
-            self.configureNavigationToolbarButton()
-        })
+        configureNavigationToolbarButton()
         setListViewTitle()
     }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -648,7 +648,7 @@ private extension SPNoteListViewController {
 
         cell.refreshAttributedStrings()
 
-        cell.checkboxContainingView.isHidden = !isEditing
+        cell.setMultiSelectEditing(isEditing)
 
         return cell
     }
@@ -725,14 +725,16 @@ extension SPNoteListViewController {
         }
     }
 
-    private func setListViewTitle() {
-        if isEditing {
-            let count = tableView.indexPathsForSelectedRows?.count ?? 0
-            title = count > 0 ? Localization.selectedTitle(with: count) : notesListController.filter.title
-            return
-        }
 
-        title = notesListController.filter.title
+    private func setListViewTitle() {
+        title = {
+            guard isEditing else {
+                return notesListController.filter.title
+            }
+
+            let count = tableView.indexPathsForSelectedRows?.count ?? .zero
+            return count > 0 ? Localization.selectedTitle(with: count) : notesListController.filter.title
+        }()
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -622,6 +622,11 @@ extension SPNoteListViewController {
             notesListController.object(at: indexPath) as? Note
         }
     }
+
+    open override func setEditing(_ editing: Bool, animated: Bool) {
+        super.setEditing(editing, animated: animated)
+        tableView.setEditing(editing, animated: animated)
+    }
 }
 
 // MARK: - Row Actions

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -28,9 +28,7 @@ extension SPNoteListViewController {
         tableView.tableFooterView = UIView()
 
         tableView.layoutMargins = .zero
-        tableView.separatorInset = .zero
-        tableView.separatorInsetReference = .fromAutomaticInsets
-        tableView.separatorStyle = UIDevice.sp_isPad() ? .none : .singleLine
+        tableView.separatorStyle = .none
 
         tableView.register(SPNoteTableViewCell.loadNib(), forCellReuseIdentifier: SPNoteTableViewCell.reuseIdentifier)
         tableView.register(SPTagTableViewCell.loadNib(), forCellReuseIdentifier: SPTagTableViewCell.reuseIdentifier)

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -910,14 +910,14 @@ private extension SPNoteListViewController {
         for note in notes {
             delete(note: note)
         }
-        setEditing(false, animated: true)
 
         NoticeController.shared.present(NoticeFactory.notesTrashed(notes, onUndo: {
             for note in notes {
                 SPObjectManager.shared().restoreNote(note)
             }
-            self.tableView.reloadData()
         }))
+
+        setEditing(false, animated: true)
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -346,6 +346,38 @@ extension SPNoteListViewController {
 
         emptyTrashButton.isEnabled = isTrashOnScreen && isNotEmpty
     }
+
+    /// Delete selected notes
+    ///
+    @objc
+    func trashSelectedNotes() {
+        guard let selectedIndicies = tableView.indexPathsForSelectedRows else {
+            return
+        }
+
+        var selectedNotes: [Note] = []
+
+        for indexPath in selectedIndicies {
+            if let note = notesListController.object(at: indexPath) as? Note {
+                selectedNotes.append(note)
+            }
+        }
+        
+        delete(notes: selectedNotes)
+    }
+
+    /// Setup Navigation toolbar buttons
+    ///
+    @objc
+    func configureNavigationToolbarButton() {
+        guard let trashButton = trashButton,
+              let addButton = addButton else {
+            return
+        }
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let actionButton = isEditing ? trashButton : addButton
+        setToolbarItems([flexibleSpace, actionButton], animated: true)
+    }
 }
 
 
@@ -632,6 +664,7 @@ extension SPNoteListViewController {
     open override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
         tableView.setEditing(editing, animated: animated)
+        configureNavigationToolbarButton()
     }
 }
 
@@ -792,6 +825,12 @@ private extension SPNoteListViewController {
         editorViewController.update(withSearchQuery: searchQuery)
 
         return editorViewController
+    }
+
+    func delete(notes: [Note]) {
+        for note in notes {
+            delete(note: note)
+        }
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -35,8 +35,6 @@ extension SPNoteListViewController {
         tableView.register(SPNoteTableViewCell.loadNib(), forCellReuseIdentifier: SPNoteTableViewCell.reuseIdentifier)
         tableView.register(SPTagTableViewCell.loadNib(), forCellReuseIdentifier: SPTagTableViewCell.reuseIdentifier)
         tableView.register(SPSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: SPSectionHeaderView.reuseIdentifier)
-
-        tableView.allowsMultipleSelectionDuringEditing = true
     }
 
     /// Sets up the Results Controller

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -394,7 +394,7 @@ extension SPNoteListViewController {
 
     @objc
     func refreshNavigationBarLabels() {
-        setListViewTitle()
+        refreshListViewTitle()
         refreshSelectAllLabels()
     }
 
@@ -701,13 +701,7 @@ extension SPNoteListViewController {
     }
 
     open override func setEditing(_ editing: Bool, animated: Bool) {
-        // tableView could be in edit mode already if a single cell is displaying a slide out menu
-        // Check if tableView and NoteListVC have the same isEditing value
-        // If not set them to the same before continuing
-        if tableView.isEditing != isEditing {
-            tableView.setEditing(isEditing, animated: true)
-        }
-
+        ensureTableViewEditingIsInSync()
         super.setEditing(editing, animated: animated)
         tableView.setEditing(editing, animated: animated)
         refreshEditButtonTitle()
@@ -717,11 +711,22 @@ extension SPNoteListViewController {
         updateNavigationBar()
 
         configureNavigationToolbarButton()
-        setListViewTitle()
+        refreshListViewTitle()
     }
 
+    private func ensureTableViewEditingIsInSync() {
+        // If a swipe action is active, the tableView will already be set to isEditing == true
+        // The edit button is still active while the swipe actions are active, if pressed
+        // the VC and the tableview will get set to true, but since the tableView is already
+        // editing nothind will happen.
+        // This method ensures the tableview and VC are in sync when the edit button is tapped
+        guard tableView.isEditing != isEditing else {
+            return
+        }
+        tableView.setEditing(isEditing, animated: false)
+    }
 
-    private func setListViewTitle() {
+    private func refreshListViewTitle() {
         title = {
             guard isEditing else {
                 return notesListController.filter.title

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -698,6 +698,12 @@ extension SPNoteListViewController {
     }
 
     open override func setEditing(_ editing: Bool, animated: Bool) {
+        // tableView could be in edit mode already if a single cell is displaying a slide out menu
+        // Check if tableView and NoteListVC have the same isEditing value
+        // If not set them to the same before continuing
+        if tableView.isEditing != isEditing {
+            tableView.setEditing(isEditing, animated: true)
+        }
 
         super.setEditing(editing, animated: animated)
         tableView.setEditing(editing, animated: animated)

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -390,13 +390,13 @@ extension SPNoteListViewController {
     func selectAllWasTapped() {
 
         if notesListController.numberOfObjects == tableView.indexPathsForSelectedRows?.count {
-            tableView.deselectAll()
+            tableView.deselectAllRows(inSection: 0, animated: false)
             refreshNavigationBarLabels()
 
             return
         }
 
-        tableView.selectAll(nil)
+        tableView.selectAllRows(inSection: 0, animated: false)
         refreshNavigationBarLabels()
     }
 
@@ -711,7 +711,7 @@ extension SPNoteListViewController {
     open override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
 
-        tableView.deselectAll()
+        tableView.deselectAllRows(inSection: 0, animated: false)
         updateNavigationBar()
 
         tableView.allowsMultipleSelection = editing

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -725,11 +725,13 @@ extension SPNoteListViewController {
     }
 
     private func setListViewTitle() {
-        guard let selectedIndicies = tableView.indexPathsForSelectedRows else {
-            title = notesListController.filter.title
+        if isEditing {
+            let count = tableView.indexPathsForSelectedRows?.count ?? 0
+            title = count > 0 ? Localization.selectedTitle(with: count) : notesListController.filter.title
             return
         }
-        title = Localization.selectedTitle(with: selectedIndicies.count)
+
+        title = notesListController.filter.title
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -530,18 +530,28 @@ extension SPNoteListViewController: UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if !isEditing {
-            selectedNote = nil
+        if isEditing {
+            setListViewTitle()
+            return
+        }
 
-            switch notesListController.object(at: indexPath) {
-            case let note as Note:
-                SPRatingsHelper.sharedInstance()?.incrementSignificantEvent()
-                open(note, animated: true)
-            case let tag as Tag:
-                refreshSearchText(appendFilterFor: tag)
-            default:
-                break
-            }
+        selectedNote = nil
+
+        switch notesListController.object(at: indexPath) {
+        case let note as Note:
+            SPRatingsHelper.sharedInstance()?.incrementSignificantEvent()
+            open(note, animated: true)
+        case let tag as Tag:
+            refreshSearchText(appendFilterFor: tag)
+        default:
+            break
+        }
+
+    }
+
+    public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        if isEditing {
+            setListViewTitle()
         }
     }
 
@@ -682,6 +692,15 @@ extension SPNoteListViewController {
             self.tableView.setEditing(editing, animated: animated)
             self.configureNavigationToolbarButton()
         })
+        setListViewTitle()
+    }
+
+    private func setListViewTitle() {
+        guard let selectedIndicies = tableView.indexPathsForSelectedRows else {
+            title = notesListController.filter.title
+            return
+        }
+        title = Localization.selectedTitle(with: selectedIndicies.count)
     }
 }
 
@@ -1059,5 +1078,10 @@ private enum Localization {
         static func searchAction(with searchTerm: String) -> String {
             return String(format: NSLocalizedString("Create a new note titled “%@”", comment: "Tappable message shown when no notes match a search string. Parameter: %@ - search term"), searchTerm)
         }
+    }
+
+    static func selectedTitle(with count: Int) -> String {
+        let string = NSLocalizedString("%i Selected", comment: "Count of currently selected notes")
+        return String(format: string, count)
     }
 }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -398,13 +398,19 @@ extension SPNoteListViewController {
     func selectAllWasTapped() {
 
         if notesListController.numberOfObjects == tableView.indexPathsForSelectedRows?.count {
-            tableView.deselectSelectedRows(animated: true)
-            refreshSelectAllLabels()
+            tableView.deselectAll()
+            refreshNavigationBarLabels()
 
             return
         }
 
         tableView.selectAll(nil)
+        refreshNavigationBarLabels()
+    }
+
+    @objc
+    func refreshNavigationBarLabels() {
+        setListViewTitle()
         refreshSelectAllLabels()
     }
 }
@@ -559,8 +565,7 @@ extension SPNoteListViewController: UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if isEditing {
-            setListViewTitle()
-            refreshSelectAllLabels()
+            refreshNavigationBarLabels()
             return
         }
 
@@ -580,8 +585,7 @@ extension SPNoteListViewController: UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         if isEditing {
-            setListViewTitle()
-            refreshSelectAllLabels()
+            refreshNavigationBarLabels()
         }
     }
 
@@ -712,6 +716,7 @@ extension SPNoteListViewController {
 
     open override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
+        tableView.deselectAll()
         updateNavigationBar()
 
         // Reloading data ensures that no cells are selected and the current data is up to date

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -578,7 +578,7 @@ extension SPNoteListViewController: UITableViewDelegate {
 
     @available(iOS 13.0, *)
     public func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        guard isDeletedFilterActive == false, let note = notesListController.object(at: indexPath) as? Note else {
+        guard isDeletedFilterActive == false, isEditing == false, let note = notesListController.object(at: indexPath) as? Note else {
             return nil
         }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -35,6 +35,8 @@ extension SPNoteListViewController {
         tableView.register(SPNoteTableViewCell.loadNib(), forCellReuseIdentifier: SPNoteTableViewCell.reuseIdentifier)
         tableView.register(SPTagTableViewCell.loadNib(), forCellReuseIdentifier: SPTagTableViewCell.reuseIdentifier)
         tableView.register(SPSectionHeaderView.self, forHeaderFooterViewReuseIdentifier: SPSectionHeaderView.reuseIdentifier)
+
+        tableView.allowsMultipleSelectionDuringEditing = true
     }
 
     /// Sets up the Results Controller
@@ -606,10 +608,10 @@ extension SPNoteListViewController: UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        guard let cell = cell as? SPNoteTableViewCell else {
-            return
-        }
-        cell.refreshEdgeInsets(editing: isEditing)
+        var insets = SPNoteTableViewCell.separatorInsets
+        insets.left -= cell.layoutMargins.left
+
+        cell.separatorInset = insets
     }
 }
 
@@ -642,11 +644,7 @@ private extension SPNoteListViewController {
 
         cell.prefixText = prefixText(for: note)
 
-        cell.multiSelectTintColor = .simplenoteNotePinStatusImageColor
-
         cell.refreshAttributedStrings()
-
-        cell.setMultiSelectEditing(isEditing)
 
         return cell
     }
@@ -700,27 +698,16 @@ extension SPNoteListViewController {
     }
 
     open override func setEditing(_ editing: Bool, animated: Bool) {
+
         super.setEditing(editing, animated: animated)
+        tableView.setEditing(editing, animated: animated)
         refreshEditButtonTitle()
 
         tableView.deselectAllRows(inSection: .zero, animated: false)
         updateNavigationBar()
 
-        tableView.allowsMultipleSelection = editing
-        toggleVisibleCells(to: editing)
-
         configureNavigationToolbarButton()
         setListViewTitle()
-    }
-
-    func toggleVisibleCells(to editing: Bool) {
-        guard let noteCells = tableView.visibleCells as? [SPNoteTableViewCell] else {
-            return
-        }
-
-        for cell in noteCells {
-            cell.setMultiSelectEditing(editing)
-        }
     }
 
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -362,8 +362,9 @@ extension SPNoteListViewController {
                 selectedNotes.append(note)
             }
         }
-        
+
         delete(notes: selectedNotes)
+        setEditing(false, animated: true)
     }
 
     /// Setup Navigation toolbar buttons
@@ -663,8 +664,16 @@ extension SPNoteListViewController {
 
     open override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
-        tableView.setEditing(editing, animated: animated)
-        configureNavigationToolbarButton()
+
+        // Reloading data ensures that no cells are selected and the current data is up to date
+        tableView.reloadData()
+
+        // Dispatches to asyncAfter because reloadData will override the animations if not complete
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
+            self.tableView.deselectSelectedRow(animated: true)
+            self.tableView.setEditing(editing, animated: animated)
+            self.configureNavigationToolbarButton()
+        })
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -365,19 +365,11 @@ extension SPNoteListViewController {
     ///
     @objc
     func trashSelectedNotes() {
-        guard let selectedIndicies = tableView.indexPathsForSelectedRows else {
+        guard let notes = tableView.indexPathsForSelectedRows?.compactMap({ notesListController.object(at: $0) as? Note }) else {
             return
         }
 
-        var selectedNotes: [Note] = []
-
-        for indexPath in selectedIndicies {
-            if let note = notesListController.object(at: indexPath) as? Note {
-                selectedNotes.append(note)
-            }
-        }
-
-        delete(notes: selectedNotes)
+        delete(notes: notes)
         setEditing(false, animated: true)
     }
 
@@ -720,8 +712,9 @@ extension SPNoteListViewController {
         updateNavigationBar()
 
         // Reloading data ensures that no cells are selected and the current data is up to date
-        let rows = tableView.indexPathsForVisibleRows
-        tableView.reloadRows(at: rows!, with: .automatic)
+        if let rows = tableView.indexPathsForVisibleRows {
+            tableView.reloadRows(at: rows, with: .automatic)
+        }
 
         // Dispatches to asyncAfter because reloadData will override the animations if not complete
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -609,7 +609,7 @@ extension SPNoteListViewController: UITableViewDelegate {
         guard let cell = cell as? SPNoteTableViewCell else {
             return
         }
-        
+
         var insets = SPNoteTableViewCell.separatorInsets
         insets.left -= cell.layoutMargins.left
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -384,12 +384,9 @@ extension SPNoteListViewController {
     func selectAllWasTapped() {
         if notesListController.numberOfObjects == tableView.indexPathsForSelectedRows?.count {
             tableView.deselectAllRows(inSection: .zero, animated: false)
-            refreshNavigationBarLabels()
-
-            return
+        } else {
+            tableView.selectAllRows(inSection: 0, animated: false)
         }
-
-        tableView.selectAllRows(inSection: 0, animated: false)
         refreshNavigationBarLabels()
     }
 
@@ -615,9 +612,7 @@ extension SPNoteListViewController: UITableViewDelegate {
 
         cell.separatorInset = insets
 
-        if indexPath.row == notesListController.numberOfObjects - 1 {
-            cell.shouldDisplayBottomSeparator = false
-        }
+        cell.shouldDisplayBottomSeparator = indexPath.row < notesListController.numberOfObjects - 1
     }
 }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -371,8 +371,10 @@ extension SPNoteListViewController {
     ///
     @objc
     func configureNavigationToolbarButton() {
-        guard let trashButton = trashButton,
-              let addButton = addButton else {
+        // TODO: When multi select is added to iPad, revist the conditionals here
+        guard navigationController?.isToolbarHidden == false,
+            let trashButton = trashButton,
+            let addButton = addButton else {
             return
         }
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -715,10 +715,20 @@ extension SPNoteListViewController {
         updateNavigationBar()
 
         tableView.allowsMultipleSelection = editing
-        tableView.setMultiSelectEditing(editing)
+        toggleMultiSelectEditingTo(editing)
 
         configureNavigationToolbarButton()
         setListViewTitle()
+    }
+
+    func toggleMultiSelectEditingTo(_ editing: Bool) {
+        guard let noteCells = tableView.visibleCells as? [SPNoteTableViewCell] else {
+            return
+        }
+
+        for cell in noteCells {
+            cell.setMultiSelectEditing(editing)
+        }
     }
 
     private func setListViewTitle() {

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -28,6 +28,8 @@
 @property (nonatomic) BOOL                                                  firstLaunch;
 @property (nonatomic) BOOL                                                  mustScrollToFirstRow;
 @property (nonatomic, strong) UIBarButtonItem                               *emptyTrashButton;
+@property (nonatomic, strong) UIBarButtonItem                               *trashButton;
+@property (nonatomic, strong) UIBarButtonItem                               *addButton;
 @property (nonatomic, weak) Note                                            *selectedNote;
 @property (nonatomic) BOOL                                                  navigatingUsingKeyboard;
 

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -30,6 +30,7 @@
 @property (nonatomic, strong) UIBarButtonItem                               *emptyTrashButton;
 @property (nonatomic, strong) UIBarButtonItem                               *trashButton;
 @property (nonatomic, strong) UIBarButtonItem                               *addButton;
+@property (nonatomic, strong) UIBarButtonItem                               *selectAllButton;
 @property (nonatomic, weak) Note                                            *selectedNote;
 @property (nonatomic) BOOL                                                  navigatingUsingKeyboard;
 
@@ -39,5 +40,6 @@
 - (void)setWaitingForIndex:(BOOL)waiting;
 - (void)startSearching;
 - (void)endSearching;
+- (void)updateNavigationBar;
 
 @end

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -318,6 +318,8 @@
                                                            style:UIBarButtonItemStylePlain
                                                            target:self
                                                            action:@selector(selectAllWasTapped)];
+
+    [self refreshEditButtonTitle];
 }
 
 - (void)configureNavigationBarBackground {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -257,8 +257,10 @@
     UIBarButtonItem *possibleAddButton = UIDevice.isPad ? self.addButton : self.editButtonItem;
     UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : possibleAddButton;
 
+    UIBarButtonItem *leftButton = self.isEditing ? self.selectAllButton : self.sidebarButton;
+
     [self.navigationItem setRightBarButtonItem:rightButton animated:YES];
-    [self.navigationItem setLeftBarButtonItem:self.sidebarButton animated:YES];
+    [self.navigationItem setLeftBarButtonItem:leftButton animated:YES];
 }
 
 
@@ -268,6 +270,7 @@
     NSAssert(_addButton == nil, @"_addButton is already initialized!");
     NSAssert(_sidebarButton == nil, @"_sidebarButton is already initialized!");
     NSAssert(_emptyTrashButton == nil, @"_emptyTrashButton is already initialized!");
+    NSAssert(_selectAllButton == nil, @"_selectAllButton is already initialized!");
 
     /// Button: New Note
     ///
@@ -308,6 +311,12 @@
     self.trashButton.isAccessibilityElement = YES;
     self.trashButton.accessibilityLabel = NSLocalizedString(@"Trash Notes", @"Move selected notes to trash");
     self.trashButton.accessibilityHint = NSLocalizedString(@"Move selected notes to trash", @"Accessibility hint for trash selected notes button");
+
+    NSString *selectAllTitle = NSLocalizedString(@"Select All", @"Select all button title");
+    self.selectAllButton = [[UIBarButtonItem alloc] initWithTitle: selectAllTitle
+                                                           style:UIBarButtonItemStylePlain
+                                                           target:self
+                                                           action:@selector(selectAllWasTapped)];
 }
 
 - (void)configureNavigationBarBackground {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -235,6 +235,7 @@
 }
 
 - (void)refershNavigationButtons {
+    [self refreshNavigationBarLabels];
     [self updateNavigationBar];
     [self refreshNavigationControllerToolbar];
 }

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -253,6 +253,7 @@
 }
 
 - (void)updateNavigationBar {
+    // TODO: When multi select is added to iPad, revist the conditionals here
     [self.navigationController setNavigationBarHidden: self.isSearchActive animated:YES];
     
     UIBarButtonItem *possibleAddButton = UIDevice.isPad ? self.addButton : self.editButtonItem;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -376,6 +376,7 @@
     [self reloadTableData];
     [self refreshTitle];
     [self refershNavigationButtons];
+    [self.editButtonItem setEnabled:NO];
     [self setEditing:NO animated:YES];
 }
 
@@ -394,7 +395,7 @@
     [self.notesListController endSearch];
     [self refershNavigationButtons];
     [self update];
-
+    [self.editButtonItem setEnabled:YES];
 }
 
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -28,7 +28,6 @@
 @property (nonatomic, strong) NSTimer                               *searchTimer;
 
 @property (nonatomic, strong) SPBlurEffectView                      *navigationBarBackground;
-@property (nonatomic, strong) UIBarButtonItem                       *addButton;
 @property (nonatomic, strong) UIBarButtonItem                       *sidebarButton;
 
 @property (nonatomic, strong) SearchDisplayController               *searchController;
@@ -247,9 +246,7 @@
         return;
     }
     
-    UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
-    NSArray *toolbarItems = [NSArray arrayWithObjects:flexibleSpace, self.addButton, nil];
-    [self setToolbarItems:toolbarItems animated:YES];
+    [self configureNavigationToolbarButton];
 
     [self.navigationController setToolbarHidden:self.isSearchActive animated:YES];
 }
@@ -301,6 +298,14 @@
     self.emptyTrashButton.isAccessibilityElement = YES;
     self.emptyTrashButton.accessibilityLabel = NSLocalizedString(@"Empty trash", @"Remove all notes from the trash");
     self.emptyTrashButton.accessibilityHint = NSLocalizedString(@"Remove all notes from trash", nil);
+
+    self.trashButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageWithName:UIImageNameTrash]
+                                                        style:UIBarButtonItemStylePlain
+                                                       target:self
+                                                       action:@selector(trashSelectedNotes)];
+    self.trashButton.isAccessibilityElement = YES;
+    self.trashButton.accessibilityLabel = NSLocalizedString(@"Trash Notes", @"Move selected notes to trash");
+    self.trashButton.accessibilityHint = NSLocalizedString(@"Move selected notes to trash", @"Accessibility hint for trash selected notes button");
 }
 
 - (void)configureNavigationBarBackground {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -255,7 +255,7 @@
 }
 
 - (void)updateNavigationBar {
-    UIBarButtonItem *possibleAddButton = UIDevice.isPad ? self.addButton : nil;
+    UIBarButtonItem *possibleAddButton = UIDevice.isPad ? self.addButton : self.editButtonItem;
     UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : possibleAddButton;
 
     [self.navigationItem setRightBarButtonItem:rightButton animated:YES];
@@ -500,7 +500,6 @@
 	[self.emptyTrashButton setEnabled:NO];
     [self displayPlaceholdersIfNeeded];
 }
-
 
 #pragma mark - NoteListController
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -341,7 +341,7 @@
 
 - (void)sidebarButtonAction:(id)sender {
     
-    [self.tableView setEditing:NO];
+    [self setEditing:NO];
 
     [SPTracker trackSidebarButtonPresed];
     [[[SPAppDelegate sharedDelegate] sidebarViewController] toggleSidebar];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -252,6 +252,8 @@
 }
 
 - (void)updateNavigationBar {
+    [self.navigationController setNavigationBarHidden: self.isSearchActive animated:YES];
+    
     UIBarButtonItem *possibleAddButton = UIDevice.isPad ? self.addButton : self.editButtonItem;
     UIBarButtonItem *rightButton = (self.isDeletedFilterActive) ? self.emptyTrashButton : possibleAddButton;
 

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -371,6 +371,7 @@
     [self reloadTableData];
     [self refreshTitle];
     [self refershNavigationButtons];
+    [self setEditing:NO animated:YES];
 }
 
 - (void)searchDisplayControllerDidEndSearch:(SearchDisplayController *)controller

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -25,7 +25,7 @@ class SPNoteTableViewCell: UITableViewCell {
 
     /// Multi Select Checkbox ImageView
     ///
-    @IBOutlet weak var multiSelectCheckbox: UIImageView!
+    @IBOutlet private weak var multiSelectCheckbox: UIImageView!
 
     /// Acccesory LeftImage's Height
     ///
@@ -45,6 +45,12 @@ class SPNoteTableViewCell: UITableViewCell {
             accessoryLeftImageView.image = newValue
             refreshAccessoriesVisibility()
         }
+    }
+
+    /// Multi select image
+    ///
+    var multiSelectionCheckboxImage: UIImage? {
+        isSelected ? .image(name: .taskChecked) : .image(name: .taskUnchecked)
     }
 
     /// Left AccessoryImage's Tint
@@ -78,6 +84,17 @@ class SPNoteTableViewCell: UITableViewCell {
         }
         set {
             accessoryRightImageView.tintColor = newValue
+        }
+    }
+
+    /// Multi select image tint
+    ///
+    var multiSelectTintColor: UIColor? {
+        get {
+            multiSelectCheckbox.tintColor
+        }
+        set {
+            multiSelectCheckbox.tintColor = newValue
         }
     }
 
@@ -219,6 +236,12 @@ class SPNoteTableViewCell: UITableViewCell {
                        }, completion: nil)
         setNeedsLayout()
     }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        multiSelectCheckbox.image = multiSelectionCheckboxImage
+    }
 }
 
 
@@ -248,10 +271,7 @@ private extension SPNoteTableViewCell {
 
     func setupMultiCheckbox() {
         multiSelectCheckbox.translatesAutoresizingMaskIntoConstraints = false
-
-        let image = isSelected ? UIImage(named: UIImageName.taskChecked.lightAssetFilename) : UIImage(named: (UIImageName.taskUnchecked.lightAssetFilename))
-        multiSelectCheckbox.image = image
-
+        multiSelectCheckbox.image = multiSelectionCheckboxImage
         multiSelectCheckbox.isHidden = true
     }
 }

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -224,15 +224,16 @@ class SPNoteTableViewCell: UITableViewCell {
 
         bodyLabel.attributedText = bodyString
     }
-    
+
     func setMultiSelectEditing(_ editing: Bool) {
-        selectionStyle = editing ? .none : .default
 
         UIView.animate(
             withDuration: UIKitConstants.animationQuickDuration,
             animations: {
                 self.checkboxContainingView.isHidden = !editing
+                self.checkboxContainingView.superview?.layoutIfNeeded()
             })
+
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -37,7 +37,7 @@ class SPNoteTableViewCell: UITableViewCell {
 
     /// Separator View
     ///
-    private var separatorsView: SeparatorsView!
+    private let separatorsView = SeparatorsView()
 
     /// Bottom Separator Visible
     ///
@@ -248,7 +248,6 @@ private extension SPNoteTableViewCell {
     }
 
     private func setupCellSeparatorView() {
-        separatorsView = SeparatorsView()
         separatorsView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(separatorsView)
         NSLayoutConstraint.activate([

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -224,9 +224,8 @@ class SPNoteTableViewCell: UITableViewCell {
 
         bodyLabel.attributedText = bodyString
     }
-
-    override func setEditing(_ editing: Bool, animated: Bool) {
-        super.setEditing(false, animated: true)
+    
+    func setMultiSelectEditing(_ editing: Bool) {
         selectionStyle = editing ? .none : .default
 
         UIView.animate(
@@ -234,7 +233,6 @@ class SPNoteTableViewCell: UITableViewCell {
             animations: {
                 self.checkboxContainingView.isHidden = !editing
             })
-        setNeedsLayout()
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -228,10 +228,11 @@ class SPNoteTableViewCell: UITableViewCell {
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(false, animated: true)
 
-        UIView.animate(withDuration: UIKitConstants.animationQuickDuration,
-                       animations: {
-                        self.checkboxContainingView.isHidden = !editing
-                       }, completion: nil)
+        UIView.animate(
+            withDuration: UIKitConstants.animationQuickDuration,
+            animations: {
+                self.checkboxContainingView.isHidden = !editing
+            })
         setNeedsLayout()
     }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -27,6 +27,8 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     @IBOutlet private weak var multiSelectCheckbox: UIImageView!
 
+    @IBOutlet weak var checkboxContainingView: UIView!
+
     /// Acccesory LeftImage's Height
     ///
     @IBOutlet private var accessoryLeftImageViewHeightConstraint: NSLayoutConstraint!
@@ -231,7 +233,7 @@ class SPNoteTableViewCell: UITableViewCell {
                        delay: .zero,
                        options: [.allowUserInteraction],
                        animations: {
-                        self.multiSelectCheckbox.isHidden = !editing
+                        self.checkboxContainingView.isHidden = !editing
                         self.separatorInset.left += CGFloat(57) * multiplier
                        }, completion: nil)
         setNeedsLayout()
@@ -272,7 +274,6 @@ private extension SPNoteTableViewCell {
     func setupMultiCheckbox() {
         multiSelectCheckbox.translatesAutoresizingMaskIntoConstraints = false
         multiSelectCheckbox.image = multiSelectionCheckboxImage
-        multiSelectCheckbox.isHidden = true
     }
 }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -31,6 +31,10 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var accessoryRightImageViewHeightConstraint: NSLayoutConstraint!
 
+    /// Main text area stack view
+    ///
+    @IBOutlet weak var textAreaStackView: UIStackView!
+
     /// Left Accessory Image
     ///
     var accessoryLeftImage: UIImage? {
@@ -140,6 +144,7 @@ class SPNoteTableViewCell: UITableViewCell {
         super.awakeFromNib()
         setupMargins()
         setupTextViews()
+        setupCellSeparatorView()
         refreshStyle()
         refreshConstraints()
     }
@@ -149,13 +154,6 @@ class SPNoteTableViewCell: UITableViewCell {
         refreshStyle()
         refreshConstraints()
     }
-
-//    func refreshEdgeInsets(editing: Bool = false) {
-//        var insets = SPNoteTableViewCell.separatorInsets
-//        insets.left -= layoutMargins.left
-//
-//        separatorInset = insets
-//    }
 
     /// Refreshed the Label(s) Attributed Strings: Keywords, Bullets and the Body Prefix will be taken into consideration
     ///
@@ -232,6 +230,21 @@ private extension SPNoteTableViewCell {
 
         bodyLabel.numberOfLines = Style.maximumNumberOfBodyLines
         bodyLabel.lineBreakMode = .byWordWrapping
+    }
+
+    private func setupCellSeparatorView() {
+        let separatorView = SeparatorsView()
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(separatorView)
+        NSLayoutConstraint.activate([
+            separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            separatorView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            separatorView.leadingAnchor.constraint(equalTo: textAreaStackView.leadingAnchor)
+        ])
+
+        contentView.sendSubviewToBack(separatorView)
+        separatorView.bottomVisible = true
     }
 }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -227,6 +227,7 @@ class SPNoteTableViewCell: UITableViewCell {
 
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(false, animated: true)
+        selectionStyle = editing ? .none : .default
 
         UIView.animate(
             withDuration: UIKitConstants.animationQuickDuration,

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -23,12 +23,6 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var accessoryRightImageView: UIImageView!
 
-    /// Multi Select Checkbox ImageView
-    ///
-    @IBOutlet private weak var multiSelectCheckbox: UIImageView!
-
-    @IBOutlet private weak var checkboxContainingView: UIView!
-
     /// Acccesory LeftImage's Height
     ///
     @IBOutlet private var accessoryLeftImageViewHeightConstraint: NSLayoutConstraint!
@@ -47,12 +41,6 @@ class SPNoteTableViewCell: UITableViewCell {
             accessoryLeftImageView.image = newValue
             refreshAccessoriesVisibility()
         }
-    }
-
-    /// Multi select image
-    ///
-    var multiSelectionCheckboxImage: UIImage? {
-        isSelected ? .image(name: .taskChecked) : .image(name: .taskUnchecked)
     }
 
     /// Left AccessoryImage's Tint
@@ -86,17 +74,6 @@ class SPNoteTableViewCell: UITableViewCell {
         }
         set {
             accessoryRightImageView.tintColor = newValue
-        }
-    }
-
-    /// Multi select image tint
-    ///
-    var multiSelectTintColor: UIColor? {
-        get {
-            multiSelectCheckbox.tintColor
-        }
-        set {
-            multiSelectCheckbox.tintColor = newValue
         }
     }
 
@@ -163,7 +140,6 @@ class SPNoteTableViewCell: UITableViewCell {
         super.awakeFromNib()
         setupMargins()
         setupTextViews()
-        setupMultiCheckbox()
         refreshStyle()
         refreshConstraints()
     }
@@ -174,13 +150,12 @@ class SPNoteTableViewCell: UITableViewCell {
         refreshConstraints()
     }
 
-    func refreshEdgeInsets(editing: Bool = false) {
-        var insets = SPNoteTableViewCell.separatorInsets
-        insets.left -= layoutMargins.left
-        insets.left += editing ? checkboxContainingView.frame.width : .zero
-
-        separatorInset = insets
-    }
+//    func refreshEdgeInsets(editing: Bool = false) {
+//        var insets = SPNoteTableViewCell.separatorInsets
+//        insets.left -= layoutMargins.left
+//
+//        separatorInset = insets
+//    }
 
     /// Refreshed the Label(s) Attributed Strings: Keywords, Bullets and the Body Prefix will be taken into consideration
     ///
@@ -233,23 +208,23 @@ class SPNoteTableViewCell: UITableViewCell {
         bodyLabel.attributedText = bodyString
     }
 
-    func setMultiSelectEditing(_ editing: Bool) {
-        self.refreshEdgeInsets(editing: editing)
-        self.checkboxContainingView.isHidden = !editing
+//    func setMultiSelectEditing(_ editing: Bool) {
+//        self.refreshEdgeInsets(editing: editing)
+//        self.checkboxContainingView.isHidden = !editing
+//
+//        UIView.animate(
+//            withDuration: UIKitConstants.animationQuickDuration,
+//            animations: {
+//                self.contentView.layoutIfNeeded()
+//            })
+//
+//    }
 
-        UIView.animate(
-            withDuration: UIKitConstants.animationQuickDuration,
-            animations: {
-                self.contentView.layoutIfNeeded()
-            })
-
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        multiSelectCheckbox.image = multiSelectionCheckboxImage
-    }
+//    override func setSelected(_ selected: Bool, animated: Bool) {
+//        super.setSelected(selected, animated: animated)
+//
+//        multiSelectCheckbox.image = multiSelectionCheckboxImage
+//    }
 }
 
 
@@ -275,11 +250,6 @@ private extension SPNoteTableViewCell {
 
         bodyLabel.numberOfLines = Style.maximumNumberOfBodyLines
         bodyLabel.lineBreakMode = .byWordWrapping
-    }
-
-    func setupMultiCheckbox() {
-        multiSelectCheckbox.translatesAutoresizingMaskIntoConstraints = false
-        multiSelectCheckbox.image = multiSelectionCheckboxImage
     }
 }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -35,6 +35,21 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     @IBOutlet weak var textAreaStackView: UIStackView!
 
+    /// Separator View
+    ///
+    private var separatorsView: SeparatorsView!
+
+    /// Bottom Separator Visible
+    ///
+    var shouldDisplayBottomSeparator: Bool {
+        get {
+            separatorsView.bottomVisible
+        }
+        set {
+            separatorsView.bottomVisible = newValue
+        }
+    }
+
     /// Left Accessory Image
     ///
     var accessoryLeftImage: UIImage? {
@@ -233,18 +248,18 @@ private extension SPNoteTableViewCell {
     }
 
     private func setupCellSeparatorView() {
-        let separatorView = SeparatorsView()
-        separatorView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(separatorView)
+        separatorsView = SeparatorsView()
+        separatorsView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(separatorsView)
         NSLayoutConstraint.activate([
-            separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            separatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            separatorView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            separatorView.leadingAnchor.constraint(equalTo: textAreaStackView.leadingAnchor)
+            separatorsView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            separatorsView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            separatorsView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            separatorsView.leadingAnchor.constraint(equalTo: textAreaStackView.leadingAnchor)
         ])
 
-        contentView.sendSubviewToBack(separatorView)
-        separatorView.bottomVisible = true
+        contentView.sendSubviewToBack(separatorsView)
+        separatorsView.bottomVisible = true
     }
 }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -225,15 +225,12 @@ class SPNoteTableViewCell: UITableViewCell {
 
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(false, animated: true)
-        let multiplier: CGFloat = editing ? 1 : -1
+//        let multiplier: CGFloat = editing ? 1 : -1
 
-        UIView.animate(withDuration: UIKitConstants.animationQuickDuration,
-                       delay: .zero,
-                       options: [.allowUserInteraction],
-                       animations: {
-                        self.multiSelectCheckbox.isHidden = !editing
-                        self.separatorInset.left += CGFloat(57) * multiplier
-                       }, completion: nil)
+        UIView.animate(withDuration: UIKitConstants.animationQuickDuration) {
+            self.multiSelectCheckbox.isHidden = !editing
+//            self.separatorInset.left += CGFloat(57) * multiplier
+        }
         setNeedsLayout()
     }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -23,6 +23,10 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var accessoryRightImageView: UIImageView!
 
+    /// Multi Select Checkbox ImageView
+    ///
+    @IBOutlet weak var multiSelectCheckbox: UIImageView!
+
     /// Acccesory LeftImage's Height
     ///
     @IBOutlet private var accessoryLeftImageViewHeightConstraint: NSLayoutConstraint!
@@ -140,6 +144,7 @@ class SPNoteTableViewCell: UITableViewCell {
         super.awakeFromNib()
         setupMargins()
         setupTextViews()
+        setupMultiCheckbox()
         refreshStyle()
         refreshConstraints()
     }
@@ -200,6 +205,20 @@ class SPNoteTableViewCell: UITableViewCell {
 
         bodyLabel.attributedText = bodyString
     }
+
+    override func setEditing(_ editing: Bool, animated: Bool) {
+        super.setEditing(false, animated: true)
+        let multiplier: CGFloat = editing ? 1 : -1
+
+        UIView.animate(withDuration: UIKitConstants.animationQuickDuration,
+                       delay: .zero,
+                       options: [.allowUserInteraction],
+                       animations: {
+                        self.multiSelectCheckbox.isHidden = !editing
+                        self.separatorInset.left += CGFloat(57) * multiplier
+                       }, completion: nil)
+        setNeedsLayout()
+    }
 }
 
 
@@ -225,6 +244,15 @@ private extension SPNoteTableViewCell {
 
         bodyLabel.numberOfLines = Style.maximumNumberOfBodyLines
         bodyLabel.lineBreakMode = .byWordWrapping
+    }
+
+    func setupMultiCheckbox() {
+        multiSelectCheckbox.translatesAutoresizingMaskIntoConstraints = false
+
+        let image = isSelected ? UIImage(named: UIImageName.taskChecked.lightAssetFilename) : UIImage(named: (UIImageName.taskUnchecked.lightAssetFilename))
+        multiSelectCheckbox.image = image
+
+        multiSelectCheckbox.isHidden = true
     }
 }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -174,6 +174,14 @@ class SPNoteTableViewCell: UITableViewCell {
         refreshConstraints()
     }
 
+    func refreshEdgeInsets(editing: Bool = false) {
+        var insets = SPNoteTableViewCell.separatorInsets
+        insets.left -= layoutMargins.left
+        insets.left += editing ? checkboxContainingView.frame.width : .zero
+
+        separatorInset = insets
+    }
+
     /// Refreshed the Label(s) Attributed Strings: Keywords, Bullets and the Body Prefix will be taken into consideration
     ///
     func refreshAttributedStrings() {
@@ -230,6 +238,7 @@ class SPNoteTableViewCell: UITableViewCell {
         UIView.animate(
             withDuration: UIKitConstants.animationQuickDuration,
             animations: {
+                self.refreshEdgeInsets(editing: editing)
                 self.checkboxContainingView.isHidden = !editing
                 self.checkboxContainingView.superview?.layoutIfNeeded()
             })

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -27,7 +27,7 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     @IBOutlet private weak var multiSelectCheckbox: UIImageView!
 
-    @IBOutlet weak var checkboxContainingView: UIView!
+    @IBOutlet private weak var checkboxContainingView: UIView!
 
     /// Acccesory LeftImage's Height
     ///
@@ -234,13 +234,12 @@ class SPNoteTableViewCell: UITableViewCell {
     }
 
     func setMultiSelectEditing(_ editing: Bool) {
-
         UIView.animate(
             withDuration: UIKitConstants.animationQuickDuration,
             animations: {
                 self.refreshEdgeInsets(editing: editing)
                 self.checkboxContainingView.isHidden = !editing
-                self.checkboxContainingView.superview?.layoutIfNeeded()
+                self.contentView.layoutIfNeeded()
             })
 
     }

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -207,24 +207,6 @@ class SPNoteTableViewCell: UITableViewCell {
 
         bodyLabel.attributedText = bodyString
     }
-
-//    func setMultiSelectEditing(_ editing: Bool) {
-//        self.refreshEdgeInsets(editing: editing)
-//        self.checkboxContainingView.isHidden = !editing
-//
-//        UIView.animate(
-//            withDuration: UIKitConstants.animationQuickDuration,
-//            animations: {
-//                self.contentView.layoutIfNeeded()
-//            })
-//
-//    }
-
-//    override func setSelected(_ selected: Bool, animated: Bool) {
-//        super.setSelected(selected, animated: animated)
-//
-//        multiSelectCheckbox.image = multiSelectionCheckboxImage
-//    }
 }
 
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -227,14 +227,10 @@ class SPNoteTableViewCell: UITableViewCell {
 
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(false, animated: true)
-        let multiplier: CGFloat = editing ? 1 : -1
 
         UIView.animate(withDuration: UIKitConstants.animationQuickDuration,
-                       delay: .zero,
-                       options: [.allowUserInteraction],
                        animations: {
                         self.checkboxContainingView.isHidden = !editing
-                        self.separatorInset.left += CGFloat(57) * multiplier
                        }, completion: nil)
         setNeedsLayout()
     }

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -234,11 +234,12 @@ class SPNoteTableViewCell: UITableViewCell {
     }
 
     func setMultiSelectEditing(_ editing: Bool) {
+        self.refreshEdgeInsets(editing: editing)
+        self.checkboxContainingView.isHidden = !editing
+
         UIView.animate(
             withDuration: UIKitConstants.animationQuickDuration,
             animations: {
-                self.refreshEdgeInsets(editing: editing)
-                self.checkboxContainingView.isHidden = !editing
                 self.contentView.layoutIfNeeded()
             })
 

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -24,10 +24,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="408" height="63"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uc4-Ac-K2D">
-                                        <rect key="frame" x="0.0" y="2.5" width="57" height="58"/>
+                                        <rect key="frame" x="0.0" y="2.5" width="50" height="58"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="245" verticalHuggingPriority="245" translatesAutoresizingMaskIntoConstraints="NO" id="2h3-wP-ZL8" userLabel="Checkbox">
-                                                <rect key="frame" x="19" y="20" width="18" height="18"/>
+                                                <rect key="frame" x="13" y="20" width="18" height="18"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="18" id="F5J-2l-Rl3"/>
                                                     <constraint firstAttribute="width" secondItem="2h3-wP-ZL8" secondAttribute="height" multiplier="1:1" id="dtt-xa-nTR"/>
@@ -37,13 +37,13 @@
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="2h3-wP-ZL8" secondAttribute="trailing" constant="20" symbolic="YES" id="0YH-tF-8At"/>
+                                            <constraint firstAttribute="trailing" secondItem="2h3-wP-ZL8" secondAttribute="trailing" constant="19" id="0YH-tF-8At"/>
                                             <constraint firstItem="2h3-wP-ZL8" firstAttribute="centerY" secondItem="uc4-Ac-K2D" secondAttribute="centerY" id="Nbk-jJ-Y8D"/>
-                                            <constraint firstItem="2h3-wP-ZL8" firstAttribute="leading" secondItem="uc4-Ac-K2D" secondAttribute="leading" constant="19" id="rAY-Ma-pC5"/>
+                                            <constraint firstItem="2h3-wP-ZL8" firstAttribute="leading" secondItem="uc4-Ac-K2D" secondAttribute="leading" constant="13" id="rAY-Ma-pC5"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A1G-fP-sOL" userLabel="Note Details">
-                                        <rect key="frame" x="57" y="0.0" width="351" height="63"/>
+                                        <rect key="frame" x="50" y="0.0" width="358" height="63"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
                                                 <rect key="frame" x="0.0" y="2" width="16" height="16"/>
@@ -54,19 +54,19 @@
                                                 </constraints>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
-                                                <rect key="frame" x="22" y="0.0" width="313" height="63"/>
+                                                <rect key="frame" x="22" y="0.0" width="320" height="63"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="313" height="20"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
-                                                                <rect key="frame" x="0.0" y="0.0" width="289" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="296" height="20"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                                                <rect key="frame" x="297" y="2" width="16" height="16"/>
+                                                                <rect key="frame" x="304" y="2" width="16" height="16"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
                                                                     <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
@@ -79,7 +79,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
-                                                        <rect key="frame" x="0.0" y="22" width="313" height="41"/>
+                                                        <rect key="frame" x="0.0" y="22" width="320" height="41"/>
                                                         <string key="text">Body L1
 Body L2</string>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -20,19 +20,30 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1kl-z0-0K0" userLabel="Container View">
                         <rect key="frame" x="6" y="9" width="408" height="63"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="SaO-7O-gKJ">
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="SaO-7O-gKJ">
                                 <rect key="frame" x="0.0" y="0.0" width="408" height="63"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="245" verticalHuggingPriority="245" translatesAutoresizingMaskIntoConstraints="NO" id="2h3-wP-ZL8" userLabel="Checkbox">
-                                        <rect key="frame" x="0.0" y="22.5" width="18" height="18"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uc4-Ac-K2D">
+                                        <rect key="frame" x="0.0" y="2.5" width="57" height="58"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="245" verticalHuggingPriority="245" translatesAutoresizingMaskIntoConstraints="NO" id="2h3-wP-ZL8" userLabel="Checkbox">
+                                                <rect key="frame" x="19" y="20" width="18" height="18"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="18" id="F5J-2l-Rl3"/>
+                                                    <constraint firstAttribute="width" secondItem="2h3-wP-ZL8" secondAttribute="height" multiplier="1:1" id="dtt-xa-nTR"/>
+                                                </constraints>
+                                                <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="19" bottom="8" trailing="19"/>
+                                            </imageView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="18" id="F5J-2l-Rl3"/>
-                                            <constraint firstAttribute="width" secondItem="2h3-wP-ZL8" secondAttribute="height" multiplier="1:1" id="dtt-xa-nTR"/>
+                                            <constraint firstAttribute="trailing" secondItem="2h3-wP-ZL8" secondAttribute="trailing" constant="20" symbolic="YES" id="0YH-tF-8At"/>
+                                            <constraint firstItem="2h3-wP-ZL8" firstAttribute="centerY" secondItem="uc4-Ac-K2D" secondAttribute="centerY" id="Nbk-jJ-Y8D"/>
+                                            <constraint firstItem="2h3-wP-ZL8" firstAttribute="leading" secondItem="uc4-Ac-K2D" secondAttribute="leading" constant="19" id="rAY-Ma-pC5"/>
                                         </constraints>
-                                        <edgeInsets key="layoutMargins" top="8" left="19" bottom="8" right="8"/>
-                                    </imageView>
+                                    </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A1G-fP-sOL" userLabel="Note Details">
-                                        <rect key="frame" x="37" y="0.0" width="371" height="63"/>
+                                        <rect key="frame" x="57" y="0.0" width="351" height="63"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
                                                 <rect key="frame" x="0.0" y="2" width="16" height="16"/>
@@ -43,19 +54,19 @@
                                                 </constraints>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
-                                                <rect key="frame" x="22" y="0.0" width="333" height="63"/>
+                                                <rect key="frame" x="22" y="0.0" width="313" height="63"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="333" height="20"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="313" height="20"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
-                                                                <rect key="frame" x="0.0" y="0.0" width="309" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="289" height="20"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                                                <rect key="frame" x="317" y="2" width="16" height="16"/>
+                                                                <rect key="frame" x="297" y="2" width="16" height="16"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
                                                                     <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
@@ -68,7 +79,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
-                                                        <rect key="frame" x="0.0" y="22" width="333" height="41"/>
+                                                        <rect key="frame" x="0.0" y="22" width="313" height="41"/>
                                                         <string key="text">Body L1
 Body L2</string>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -89,9 +100,6 @@ Body L2</string>
                                         </constraints>
                                     </view>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="2h3-wP-ZL8" firstAttribute="leading" secondItem="SaO-7O-gKJ" secondAttribute="leading" constant="19" id="FSY-vR-Xva"/>
-                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -148,6 +156,7 @@ Body L2</string>
                 <outlet property="accessoryRightImageView" destination="JkE-9h-IB9" id="C8T-9a-MyY"/>
                 <outlet property="accessoryRightImageViewHeightConstraint" destination="ugA-mm-Glv" id="59a-zM-gKJ"/>
                 <outlet property="bodyLabel" destination="Vjk-4O-P68" id="hJu-fn-IhG"/>
+                <outlet property="checkboxContainingView" destination="uc4-Ac-K2D" id="xnf-8s-5Rb"/>
                 <outlet property="multiSelectCheckbox" destination="2h3-wP-ZL8" id="N2q-lH-Xl1"/>
                 <outlet property="titleLabel" destination="eEk-9d-8ay" id="ZG4-CB-3jJ"/>
             </connections>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="81" id="r12-sA-Uh4" customClass="SPNoteTableViewCell" customModule="Simplenote" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="81" id="r12-sA-Uh4" customClass="SPNoteTableViewCell" customModule="Simplenote" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="81"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r12-sA-Uh4" id="D1J-20-bJ0">

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -119,6 +119,7 @@ Body L2</string>
                 <outlet property="accessoryRightImageView" destination="JkE-9h-IB9" id="C8T-9a-MyY"/>
                 <outlet property="accessoryRightImageViewHeightConstraint" destination="ugA-mm-Glv" id="59a-zM-gKJ"/>
                 <outlet property="bodyLabel" destination="Vjk-4O-P68" id="hJu-fn-IhG"/>
+                <outlet property="textAreaStackView" destination="hr4-XQ-BeJ" id="JiL-cj-4io"/>
                 <outlet property="titleLabel" destination="eEk-9d-8ay" id="ZG4-CB-3jJ"/>
             </connections>
             <point key="canvasLocation" x="135" y="166.37323943661971"/>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -89,7 +89,7 @@ Body L2</string>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstItem="hr4-XQ-BeJ" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="3b6-gJ-z8V"/>
                                             <constraint firstAttribute="trailing" secondItem="hr4-XQ-BeJ" secondAttribute="trailing" constant="16" id="76G-Nd-65P"/>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -24,12 +24,12 @@
                                 <rect key="frame" x="0.0" y="0.0" width="408" height="63"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uc4-Ac-K2D">
-                                        <rect key="frame" x="0.0" y="2.5" width="50" height="58"/>
+                                        <rect key="frame" x="0.0" y="2.5" width="56" height="58"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="245" verticalHuggingPriority="245" translatesAutoresizingMaskIntoConstraints="NO" id="2h3-wP-ZL8" userLabel="Checkbox">
-                                                <rect key="frame" x="13" y="20" width="18" height="18"/>
+                                                <rect key="frame" x="13" y="17" width="24" height="24"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="18" id="F5J-2l-Rl3"/>
+                                                    <constraint firstAttribute="width" constant="24" id="F5J-2l-Rl3"/>
                                                     <constraint firstAttribute="width" secondItem="2h3-wP-ZL8" secondAttribute="height" multiplier="1:1" id="dtt-xa-nTR"/>
                                                 </constraints>
                                                 <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="19" bottom="8" trailing="19"/>
@@ -43,7 +43,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A1G-fP-sOL" userLabel="Note Details">
-                                        <rect key="frame" x="50" y="0.0" width="358" height="63"/>
+                                        <rect key="frame" x="56" y="0.0" width="352" height="63"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
                                                 <rect key="frame" x="0.0" y="2" width="16" height="16"/>
@@ -54,19 +54,19 @@
                                                 </constraints>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
-                                                <rect key="frame" x="22" y="0.0" width="320" height="63"/>
+                                                <rect key="frame" x="22" y="0.0" width="314" height="63"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="314" height="20"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
-                                                                <rect key="frame" x="0.0" y="0.0" width="296" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="290" height="20"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                                                <rect key="frame" x="304" y="2" width="16" height="16"/>
+                                                                <rect key="frame" x="298" y="2" width="16" height="16"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
                                                                     <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
@@ -79,7 +79,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
-                                                        <rect key="frame" x="0.0" y="22" width="320" height="41"/>
+                                                        <rect key="frame" x="0.0" y="22" width="314" height="41"/>
                                                         <string key="text">Body L1
 Body L2</string>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,61 +18,89 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1kl-z0-0K0" userLabel="Container View">
-                        <rect key="frame" x="6" y="9" width="392" height="63"/>
+                        <rect key="frame" x="6" y="9" width="408" height="63"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
-                                <rect key="frame" x="0.0" y="2" width="16" height="16"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="16" id="HlN-8B-Xzh"/>
-                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="eu6-28-b8t"/>
-                                    <constraint firstAttribute="width" secondItem="TZs-9B-NXz" secondAttribute="height" multiplier="1:1" id="wnx-D6-YI9"/>
-                                </constraints>
-                            </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
-                                <rect key="frame" x="22" y="0.0" width="370" height="63"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="SaO-7O-gKJ">
+                                <rect key="frame" x="0.0" y="0.0" width="408" height="63"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
-                                        <rect key="frame" x="0.0" y="0.0" width="370" height="20"/>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="245" verticalHuggingPriority="245" translatesAutoresizingMaskIntoConstraints="NO" id="2h3-wP-ZL8" userLabel="Checkbox">
+                                        <rect key="frame" x="0.0" y="22.5" width="18" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="18" id="F5J-2l-Rl3"/>
+                                            <constraint firstAttribute="width" secondItem="2h3-wP-ZL8" secondAttribute="height" multiplier="1:1" id="dtt-xa-nTR"/>
+                                        </constraints>
+                                        <edgeInsets key="layoutMargins" top="8" left="19" bottom="8" right="8"/>
+                                    </imageView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A1G-fP-sOL" userLabel="Note Details">
+                                        <rect key="frame" x="37" y="0.0" width="371" height="63"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="346" height="20"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                                <rect key="frame" x="354" y="2" width="16" height="16"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
+                                                <rect key="frame" x="0.0" y="2" width="16" height="16"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
-                                                    <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
-                                                    <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
+                                                    <constraint firstAttribute="height" constant="16" id="HlN-8B-Xzh"/>
+                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="eu6-28-b8t"/>
+                                                    <constraint firstAttribute="width" secondItem="TZs-9B-NXz" secondAttribute="height" multiplier="1:1" id="wnx-D6-YI9"/>
                                                 </constraints>
                                             </imageView>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="JkE-9h-IB9" secondAttribute="trailing" id="f0V-J9-5xf"/>
-                                        </constraints>
-                                    </stackView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
-                                        <rect key="frame" x="0.0" y="22" width="370" height="41"/>
-                                        <string key="text">Body L1
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
+                                                <rect key="frame" x="22" y="0.0" width="333" height="63"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="333" height="20"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
+                                                                <rect key="frame" x="0.0" y="0.0" width="309" height="20"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
+                                                                <rect key="frame" x="317" y="2" width="16" height="16"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
+                                                                    <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
+                                                                    <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="trailing" secondItem="JkE-9h-IB9" secondAttribute="trailing" id="f0V-J9-5xf"/>
+                                                        </constraints>
+                                                    </stackView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
+                                                        <rect key="frame" x="0.0" y="22" width="333" height="41"/>
+                                                        <string key="text">Body L1
 Body L2</string>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="3b6-gJ-z8V"/>
+                                            <constraint firstAttribute="trailing" secondItem="hr4-XQ-BeJ" secondAttribute="trailing" constant="16" id="76G-Nd-65P"/>
+                                            <constraint firstItem="TZs-9B-NXz" firstAttribute="leading" secondItem="A1G-fP-sOL" secondAttribute="leading" id="ADo-LS-iUO"/>
+                                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="centerY" secondItem="TZs-9B-NXz" secondAttribute="centerY" id="Lgm-1E-QB9"/>
+                                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hr4-XQ-BeJ" secondAttribute="bottom" id="XwX-i5-nsL"/>
+                                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="top" secondItem="A1G-fP-sOL" secondAttribute="top" id="e9g-lX-dbm"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="2h3-wP-ZL8" firstAttribute="leading" secondItem="SaO-7O-gKJ" secondAttribute="leading" constant="19" id="FSY-vR-Xva"/>
+                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="0tK-Xg-kjU"/>
-                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="centerY" secondItem="TZs-9B-NXz" secondAttribute="centerY" id="1DO-qS-dlY"/>
-                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hr4-XQ-BeJ" secondAttribute="bottom" id="5Ty-3U-NG6"/>
                             <constraint firstAttribute="width" priority="999" constant="640" id="SKQ-O4-NUA"/>
-                            <constraint firstItem="TZs-9B-NXz" firstAttribute="leading" secondItem="1kl-z0-0K0" secondAttribute="leading" id="VNt-8A-Lx6"/>
-                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="i2g-uy-UlT"/>
-                            <constraint firstAttribute="trailing" secondItem="hr4-XQ-BeJ" secondAttribute="trailing" id="xVp-8W-gqR"/>
+                            <constraint firstItem="SaO-7O-gKJ" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="UPg-np-oYt"/>
+                            <constraint firstItem="SaO-7O-gKJ" firstAttribute="leading" secondItem="1kl-z0-0K0" secondAttribute="leading" id="aC2-mJ-4g3"/>
+                            <constraint firstAttribute="bottom" secondItem="SaO-7O-gKJ" secondAttribute="bottom" id="wvM-Gx-OJ4"/>
+                            <constraint firstAttribute="trailing" secondItem="SaO-7O-gKJ" secondAttribute="trailing" id="z8R-ws-Bdi"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
@@ -90,7 +119,7 @@ Body L2</string>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="D1J-20-bJ0" secondAttribute="leading" id="8ai-Nb-yMT"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="top" relation="greaterThanOrEqual" secondItem="D1J-20-bJ0" secondAttribute="top" constant="9" id="BLy-sw-4lE"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1kl-z0-0K0" secondAttribute="trailing" id="DVN-iO-uti"/>
-                    <constraint firstAttribute="trailing" secondItem="1kl-z0-0K0" secondAttribute="trailing" constant="16" id="Ig2-uE-hva"/>
+                    <constraint firstAttribute="trailing" secondItem="1kl-z0-0K0" secondAttribute="trailing" id="Ig2-uE-hva"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="centerY" secondItem="D1J-20-bJ0" secondAttribute="centerY" id="JRU-WG-UDj"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="centerX" secondItem="D1J-20-bJ0" secondAttribute="centerX" id="S72-c6-I0t"/>
                     <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1kl-z0-0K0" secondAttribute="bottom" constant="9" id="VZK-oO-oh0"/>
@@ -119,9 +148,15 @@ Body L2</string>
                 <outlet property="accessoryRightImageView" destination="JkE-9h-IB9" id="C8T-9a-MyY"/>
                 <outlet property="accessoryRightImageViewHeightConstraint" destination="ugA-mm-Glv" id="59a-zM-gKJ"/>
                 <outlet property="bodyLabel" destination="Vjk-4O-P68" id="hJu-fn-IhG"/>
+                <outlet property="multiSelectCheckbox" destination="2h3-wP-ZL8" id="N2q-lH-Xl1"/>
                 <outlet property="titleLabel" destination="eEk-9d-8ay" id="ZG4-CB-3jJ"/>
             </connections>
             <point key="canvasLocation" x="135" y="166.37323943661971"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -65,13 +65,13 @@ Body L2</string>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="TZs-9B-NXz" firstAttribute="centerY" secondItem="JkE-9h-IB9" secondAttribute="centerY" id="1B1-AG-fCS"/>
                             <constraint firstItem="hr4-XQ-BeJ" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="5aB-AG-6On"/>
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hr4-XQ-BeJ" secondAttribute="bottom" id="5oe-mc-CTa"/>
                             <constraint firstItem="hr4-XQ-BeJ" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="Fql-eF-1Tp"/>
                             <constraint firstAttribute="trailing" secondItem="hr4-XQ-BeJ" secondAttribute="trailing" id="Ip9-NG-4Z3"/>
                             <constraint firstItem="TZs-9B-NXz" firstAttribute="leading" secondItem="1kl-z0-0K0" secondAttribute="leading" id="PS6-m6-HsX"/>
                             <constraint firstAttribute="width" priority="999" constant="640" id="SKQ-O4-NUA"/>
+                            <constraint firstItem="TZs-9B-NXz" firstAttribute="centerY" secondItem="DcU-7T-Fcq" secondAttribute="centerY" id="zAi-4S-Irf"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,97 +17,61 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1kl-z0-0K0" userLabel="Container View">
-                        <rect key="frame" x="6" y="9" width="408" height="63"/>
+                        <rect key="frame" x="6" y="9" width="392" height="63"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="SaO-7O-gKJ">
-                                <rect key="frame" x="0.0" y="0.0" width="408" height="63"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
+                                <rect key="frame" x="0.0" y="2" width="16" height="16"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="16" id="HlN-8B-Xzh"/>
+                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="eu6-28-b8t"/>
+                                    <constraint firstAttribute="width" secondItem="TZs-9B-NXz" secondAttribute="height" multiplier="1:1" id="wnx-D6-YI9"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
+                                <rect key="frame" x="22" y="0.0" width="370" height="63"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uc4-Ac-K2D">
-                                        <rect key="frame" x="0.0" y="2.5" width="56" height="58"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
+                                        <rect key="frame" x="0.0" y="0.0" width="370" height="20"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="245" verticalHuggingPriority="245" translatesAutoresizingMaskIntoConstraints="NO" id="2h3-wP-ZL8" userLabel="Checkbox">
-                                                <rect key="frame" x="13" y="17" width="24" height="24"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
+                                                <rect key="frame" x="0.0" y="0.0" width="346" height="20"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
+                                                <rect key="frame" x="354" y="2" width="16" height="16"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="24" id="F5J-2l-Rl3"/>
-                                                    <constraint firstAttribute="width" secondItem="2h3-wP-ZL8" secondAttribute="height" multiplier="1:1" id="dtt-xa-nTR"/>
+                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
+                                                    <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
+                                                    <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
                                                 </constraints>
-                                                <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="19" bottom="8" trailing="19"/>
                                             </imageView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="2h3-wP-ZL8" secondAttribute="trailing" constant="19" id="0YH-tF-8At"/>
-                                            <constraint firstItem="2h3-wP-ZL8" firstAttribute="centerY" secondItem="uc4-Ac-K2D" secondAttribute="centerY" id="Nbk-jJ-Y8D"/>
-                                            <constraint firstItem="2h3-wP-ZL8" firstAttribute="leading" secondItem="uc4-Ac-K2D" secondAttribute="leading" constant="13" id="rAY-Ma-pC5"/>
+                                            <constraint firstAttribute="trailing" secondItem="JkE-9h-IB9" secondAttribute="trailing" id="f0V-J9-5xf"/>
                                         </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A1G-fP-sOL" userLabel="Note Details">
-                                        <rect key="frame" x="56" y="0.0" width="352" height="63"/>
-                                        <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="TZs-9B-NXz" userLabel="Left Image View">
-                                                <rect key="frame" x="0.0" y="2" width="16" height="16"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="16" id="HlN-8B-Xzh"/>
-                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="eu6-28-b8t"/>
-                                                    <constraint firstAttribute="width" secondItem="TZs-9B-NXz" secondAttribute="height" multiplier="1:1" id="wnx-D6-YI9"/>
-                                                </constraints>
-                                            </imageView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-XQ-BeJ">
-                                                <rect key="frame" x="22" y="0.0" width="314" height="63"/>
-                                                <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DcU-7T-Fcq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="314" height="20"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEk-9d-8ay" userLabel="Title Label">
-                                                                <rect key="frame" x="0.0" y="0.0" width="290" height="20"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" translatesAutoresizingMaskIntoConstraints="NO" id="JkE-9h-IB9" userLabel="Right Image View">
-                                                                <rect key="frame" x="298" y="2" width="16" height="16"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="width" constant="16" placeholder="YES" id="2SH-bw-5qa"/>
-                                                                    <constraint firstAttribute="width" secondItem="JkE-9h-IB9" secondAttribute="height" multiplier="1:1" id="Yoh-kc-uRC"/>
-                                                                    <constraint firstAttribute="height" constant="16" id="ugA-mm-Glv"/>
-                                                                </constraints>
-                                                            </imageView>
-                                                        </subviews>
-                                                        <constraints>
-                                                            <constraint firstAttribute="trailing" secondItem="JkE-9h-IB9" secondAttribute="trailing" id="f0V-J9-5xf"/>
-                                                        </constraints>
-                                                    </stackView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
-                                                        <rect key="frame" x="0.0" y="22" width="314" height="41"/>
-                                                        <string key="text">Body L1
+                                    </stackView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vjk-4O-P68" userLabel="Body Label">
+                                        <rect key="frame" x="0.0" y="22" width="370" height="41"/>
+                                        <string key="text">Body L1
 Body L2</string>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="3b6-gJ-z8V"/>
-                                            <constraint firstAttribute="trailing" secondItem="hr4-XQ-BeJ" secondAttribute="trailing" constant="16" id="76G-Nd-65P"/>
-                                            <constraint firstItem="TZs-9B-NXz" firstAttribute="leading" secondItem="A1G-fP-sOL" secondAttribute="leading" id="ADo-LS-iUO"/>
-                                            <constraint firstItem="DcU-7T-Fcq" firstAttribute="centerY" secondItem="TZs-9B-NXz" secondAttribute="centerY" id="Lgm-1E-QB9"/>
-                                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hr4-XQ-BeJ" secondAttribute="bottom" id="XwX-i5-nsL"/>
-                                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="top" secondItem="A1G-fP-sOL" secondAttribute="top" id="e9g-lX-dbm"/>
-                                        </constraints>
-                                    </view>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="TZs-9B-NXz" firstAttribute="centerY" secondItem="JkE-9h-IB9" secondAttribute="centerY" id="1B1-AG-fCS"/>
+                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="leading" secondItem="TZs-9B-NXz" secondAttribute="trailing" constant="6" id="5aB-AG-6On"/>
+                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="hr4-XQ-BeJ" secondAttribute="bottom" id="5oe-mc-CTa"/>
+                            <constraint firstItem="hr4-XQ-BeJ" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="Fql-eF-1Tp"/>
+                            <constraint firstAttribute="trailing" secondItem="hr4-XQ-BeJ" secondAttribute="trailing" id="Ip9-NG-4Z3"/>
+                            <constraint firstItem="TZs-9B-NXz" firstAttribute="leading" secondItem="1kl-z0-0K0" secondAttribute="leading" id="PS6-m6-HsX"/>
                             <constraint firstAttribute="width" priority="999" constant="640" id="SKQ-O4-NUA"/>
-                            <constraint firstItem="SaO-7O-gKJ" firstAttribute="top" secondItem="1kl-z0-0K0" secondAttribute="top" id="UPg-np-oYt"/>
-                            <constraint firstItem="SaO-7O-gKJ" firstAttribute="leading" secondItem="1kl-z0-0K0" secondAttribute="leading" id="aC2-mJ-4g3"/>
-                            <constraint firstAttribute="bottom" secondItem="SaO-7O-gKJ" secondAttribute="bottom" id="wvM-Gx-OJ4"/>
-                            <constraint firstAttribute="trailing" secondItem="SaO-7O-gKJ" secondAttribute="trailing" id="z8R-ws-Bdi"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
@@ -127,7 +90,7 @@ Body L2</string>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="D1J-20-bJ0" secondAttribute="leading" id="8ai-Nb-yMT"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="top" relation="greaterThanOrEqual" secondItem="D1J-20-bJ0" secondAttribute="top" constant="9" id="BLy-sw-4lE"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1kl-z0-0K0" secondAttribute="trailing" id="DVN-iO-uti"/>
-                    <constraint firstAttribute="trailing" secondItem="1kl-z0-0K0" secondAttribute="trailing" id="Ig2-uE-hva"/>
+                    <constraint firstAttribute="trailing" secondItem="1kl-z0-0K0" secondAttribute="trailing" constant="16" id="Ig2-uE-hva"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="centerY" secondItem="D1J-20-bJ0" secondAttribute="centerY" id="JRU-WG-UDj"/>
                     <constraint firstItem="1kl-z0-0K0" firstAttribute="centerX" secondItem="D1J-20-bJ0" secondAttribute="centerX" id="S72-c6-I0t"/>
                     <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="1kl-z0-0K0" secondAttribute="bottom" constant="9" id="VZK-oO-oh0"/>
@@ -156,16 +119,9 @@ Body L2</string>
                 <outlet property="accessoryRightImageView" destination="JkE-9h-IB9" id="C8T-9a-MyY"/>
                 <outlet property="accessoryRightImageViewHeightConstraint" destination="ugA-mm-Glv" id="59a-zM-gKJ"/>
                 <outlet property="bodyLabel" destination="Vjk-4O-P68" id="hJu-fn-IhG"/>
-                <outlet property="checkboxContainingView" destination="uc4-Ac-K2D" id="xnf-8s-5Rb"/>
-                <outlet property="multiSelectCheckbox" destination="2h3-wP-ZL8" id="N2q-lH-Xl1"/>
                 <outlet property="titleLabel" destination="eEk-9d-8ay" id="ZG4-CB-3jJ"/>
             </connections>
             <point key="canvasLocation" x="135" y="166.37323943661971"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/Simplenote/Classes/SPNoteTableViewCell.xib
+++ b/Simplenote/Classes/SPNoteTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="81" id="r12-sA-Uh4" customClass="SPNoteTableViewCell" customModule="Simplenote" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="81" id="r12-sA-Uh4" customClass="SPNoteTableViewCell" customModule="Simplenote" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="81"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r12-sA-Uh4" id="D1J-20-bJ0">

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -152,6 +152,16 @@ extension UITableView {
             deselectRow(at: indexpath, animated: true)
         }
     }
+
+    func setMultiSelectEditing(_ editing: Bool) {
+        guard let noteCells = visibleCells as? [SPNoteTableViewCell] else {
+            return
+        }
+
+        for cell in noteCells {
+            cell.setMultiSelectEditing(editing)
+        }
+    }
 }
 
 // MARK: - Navigation (Private)

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -134,6 +134,15 @@ extension UITableView {
             deselectRow(at: indexPath, animated: animated)
         }
     }
+
+    open override func selectAll(_ sender: Any?) {
+        let rows = numberOfRows(inSection: 0)
+
+        for row in 0..<rows {
+            let indexpath = IndexPath(row: row, section: 0)
+            selectRow(at: indexpath, animated: true, scrollPosition: .none)
+        }
+    }
 }
 
 // MARK: - Navigation (Private)

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -152,16 +152,6 @@ extension UITableView {
             deselectRow(at: indexpath, animated: true)
         }
     }
-
-    func setMultiSelectEditing(_ editing: Bool) {
-        guard let noteCells = visibleCells as? [SPNoteTableViewCell] else {
-            return
-        }
-
-        for cell in noteCells {
-            cell.setMultiSelectEditing(editing)
-        }
-    }
 }
 
 // MARK: - Navigation (Private)

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -135,21 +135,24 @@ extension UITableView {
         }
     }
 
-    open override func selectAll(_ sender: Any?) {
-        let rows = numberOfRows(inSection: 0)
-
-        for row in 0..<rows {
-            let indexpath = IndexPath(row: row, section: 0)
-            selectRow(at: indexpath, animated: true, scrollPosition: .none)
+    open func selectAllRows(inSection section: Int, animated: Bool) {
+        forEachIndexPathIn(section: section) { indexPath in
+            selectRow(at: indexPath, animated: animated, scrollPosition: .none)
         }
     }
 
-    func deselectAll() {
-        let rows = numberOfRows(inSection: 0)
+    func deselectAllRows(inSection section: Int, animated: Bool) {
+        forEachIndexPathIn(section: section) { indexPath in
+            deselectRow(at: indexPath, animated: animated)
+        }
+    }
 
-        for row in 0..<rows {
-            let indexpath = IndexPath(row: row, section: 0)
-            deselectRow(at: indexpath, animated: true)
+    func forEachIndexPathIn(section: Int, doAction action: (IndexPath)-> Void) {
+        let rows = numberOfRows(inSection: section)
+
+        for row in Int.zero..<rows {
+            let indexpath = IndexPath(row: row, section: section)
+            action(indexpath)
         }
     }
 }

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -124,6 +124,16 @@ extension UITableView {
 
         deselectRow(at: indexPath, animated: animated)
     }
+
+    func deselectSelectedRows(animated: Bool = false) {
+        guard let selectedIndicies = indexPathsForVisibleRows else {
+            return
+        }
+
+        for indexPath in selectedIndicies {
+            deselectRow(at: indexPath, animated: animated)
+        }
+    }
 }
 
 // MARK: - Navigation (Private)

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -136,18 +136,18 @@ extension UITableView {
     }
 
     open func selectAllRows(inSection section: Int, animated: Bool) {
-        forEachIndexPathIn(section: section) { indexPath in
+        forEachIndexPath(in: section) { indexPath in
             selectRow(at: indexPath, animated: animated, scrollPosition: .none)
         }
     }
 
     func deselectAllRows(inSection section: Int, animated: Bool) {
-        forEachIndexPathIn(section: section) { indexPath in
+        forEachIndexPath(in: section) { indexPath in
             deselectRow(at: indexPath, animated: animated)
         }
     }
 
-    func forEachIndexPathIn(section: Int, doAction action: (IndexPath)-> Void) {
+    func forEachIndexPath(in section: Int, doAction action: (IndexPath)-> Void) {
         let rows = numberOfRows(inSection: section)
 
         for row in Int.zero..<rows {

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -143,6 +143,15 @@ extension UITableView {
             selectRow(at: indexpath, animated: true, scrollPosition: .none)
         }
     }
+
+    func deselectAll() {
+        let rows = numberOfRows(inSection: 0)
+
+        for row in 0..<rows {
+            let indexpath = IndexPath(row: row, section: 0)
+            deselectRow(at: indexpath, animated: true)
+        }
+    }
 }
 
 // MARK: - Navigation (Private)

--- a/Simplenote/Images.xcassets/Icons/icon_task_checked.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_task_checked.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Simplenote/Images.xcassets/Icons/icon_task_unchecked.imageset/Contents.json
+++ b/Simplenote/Images.xcassets/Icons/icon_task_unchecked.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/Simplenote/NoticeFactory.swift
+++ b/Simplenote/NoticeFactory.swift
@@ -13,9 +13,14 @@ struct NoticeFactory {
         Notice(message: Messages.unpublishing, action: nil)
     }
 
-    static func noteTrashed(_ note: Note, onUndo: @escaping ()-> Void) -> Notice {
+    static func noteTrashed(onUndo: @escaping ()-> Void) -> Notice {
         let action = NoticeAction(title: Messages.undo, handler: onUndo)
         return Notice(message: Messages.trashed, action: action)
+    }
+
+    static func notesTrashed(_ notes: [Note], onUndo: @escaping ()-> Void) -> Notice {
+        let action = NoticeAction(title: Messages.undo, handler: onUndo)
+        return Notice(message: Messages.notesTrashed(notes.count), action: action)
     }
 
     static func unpublished(_ note: Note, onUndo: @escaping ()-> Void) -> Notice {
@@ -39,5 +44,13 @@ extension NoticeFactory {
         static let trashed = NSLocalizedString("Note Trashed", comment: "Note trashed notification")
         static let unpublished = NSLocalizedString("Unpublish successful", comment: "Notice of publishing unsuccessful")
         static let published = NSLocalizedString("Publish Successful", comment: "Notice up succesful publishing")
+
+        static let noteTrashed = NSLocalizedString("%i Note Trashed", comment: "Note trashed notification")
+        static let notesTrashed = NSLocalizedString("%i Notes Trashed", comment: "Notes trashed notification")
+
+        static func notesTrashed(_ count: Int) -> String {
+            let template = count > 1 ? notesTrashed : noteTrashed
+            return String(format: template, count)
+        }
     }
 }

--- a/Simplenote/SeparatorsView.swift
+++ b/Simplenote/SeparatorsView.swift
@@ -2,57 +2,57 @@ import Foundation
 
 open class SeparatorsView: UIView {
     // MARK: - Public Properties
-    @objc open var leftVisible = false {
+    open var leftVisible = false {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var leftColor = UIColor.simplenoteDividerColor {
+    open var leftColor = UIColor.simplenoteDividerColor {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var leftWidthInPoints = CGFloat(3) {
+     open var leftWidthInPoints = CGFloat(3) {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var topVisible = false {
+     open var topVisible = false {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var topColor = UIColor.simplenoteDividerColor {
+    open var topColor = UIColor.simplenoteDividerColor {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var topHeightInPixels = CGFloat(1) {
+    open var topHeightInPixels = CGFloat(1) {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var topInsets = UIEdgeInsets.zero {
+    open var topInsets = UIEdgeInsets.zero {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var bottomVisible = false {
+    open var bottomVisible = false {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var bottomColor = UIColor.simplenoteDividerColor {
+    open var bottomColor = UIColor.simplenoteDividerColor {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var bottomHeightInPixels = CGFloat(1) {
+    open var bottomHeightInPixels = CGFloat(1) {
         didSet {
             setNeedsDisplay()
         }
     }
-    @objc open var bottomInsets = UIEdgeInsets.zero {
+    open var bottomInsets = UIEdgeInsets.zero {
         didSet {
             setNeedsDisplay()
         }

--- a/Simplenote/SeparatorsView.swift
+++ b/Simplenote/SeparatorsView.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+open class SeparatorsView: UIView {
+    // MARK: - Public Properties
+    @objc open var leftVisible = false {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var leftColor = UIColor.simplenoteDividerColor {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var leftWidthInPoints = CGFloat(3) {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var topVisible = false {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var topColor = UIColor.simplenoteDividerColor {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var topHeightInPixels = CGFloat(1) {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var topInsets = UIEdgeInsets.zero {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var bottomVisible = false {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var bottomColor = UIColor.simplenoteDividerColor {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var bottomHeightInPixels = CGFloat(1) {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    @objc open var bottomInsets = UIEdgeInsets.zero {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    open override var frame: CGRect {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+
+
+    // MARK: - UIView methods
+    convenience init() {
+        self.init(frame: CGRect.zero)
+    }
+
+    required override public init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    required public init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)!
+        setupView()
+    }
+
+    open override func draw(_ rect: CGRect) {
+        super.draw(rect)
+
+        let scale = UIScreen.main.scale
+        let ctx = UIGraphicsGetCurrentContext()
+        ctx!.clear(rect)
+        ctx!.setShouldAntialias(false)
+
+        // Background
+        if backgroundColor != nil {
+            backgroundColor?.setFill()
+            ctx!.fill(rect)
+        }
+
+        // Left Separator
+        if leftVisible {
+            leftColor.setStroke()
+            ctx!.setLineWidth(leftWidthInPoints * scale)
+            ctx!.move(to: CGPoint(x: bounds.minX, y: bounds.minY))
+            ctx!.addLine(to: CGPoint(x: bounds.minX, y: bounds.maxY))
+            ctx!.strokePath()
+        }
+
+        // Top Separator
+        if topVisible {
+            topColor.setStroke()
+            let lineWidth = topHeightInPixels / scale
+            ctx!.setLineWidth(lineWidth)
+            ctx!.move(to: CGPoint(x: topInsets.left, y: lineWidth))
+            ctx!.addLine(to: CGPoint(x: bounds.maxX - topInsets.right, y: lineWidth))
+            ctx!.strokePath()
+        }
+
+        // Bottom Separator
+        if bottomVisible {
+            bottomColor.setStroke()
+            ctx!.setLineWidth(bottomHeightInPixels / scale)
+            ctx!.move(to: CGPoint(x: bottomInsets.left, y: bounds.height))
+            ctx!.addLine(to: CGPoint(x: bounds.maxX - bottomInsets.right, y: bounds.height))
+            ctx!.strokePath()
+        }
+    }
+
+    fileprivate func setupView() {
+        backgroundColor = UIColor.clear
+
+        // Make sure this is re-drawn if the bounds change!
+        layer.needsDisplayOnBoundsChange = true
+    }
+}

--- a/Simplenote/SeparatorsView.swift
+++ b/Simplenote/SeparatorsView.swift
@@ -82,43 +82,46 @@ open class SeparatorsView: UIView {
     open override func draw(_ rect: CGRect) {
         super.draw(rect)
 
+        guard let ctx = UIGraphicsGetCurrentContext() else {
+            return
+        }
         let scale = UIScreen.main.scale
-        let ctx = UIGraphicsGetCurrentContext()
-        ctx!.clear(rect)
-        ctx!.setShouldAntialias(false)
+
+        ctx.clear(rect)
+        ctx.setShouldAntialias(false)
 
         // Background
         if backgroundColor != nil {
             backgroundColor?.setFill()
-            ctx!.fill(rect)
+            ctx.fill(rect)
         }
 
         // Left Separator
         if leftVisible {
             leftColor.setStroke()
-            ctx!.setLineWidth(leftWidthInPoints * scale)
-            ctx!.move(to: CGPoint(x: bounds.minX, y: bounds.minY))
-            ctx!.addLine(to: CGPoint(x: bounds.minX, y: bounds.maxY))
-            ctx!.strokePath()
+            ctx.setLineWidth(leftWidthInPoints * scale)
+            ctx.move(to: CGPoint(x: bounds.minX, y: bounds.minY))
+            ctx.addLine(to: CGPoint(x: bounds.minX, y: bounds.maxY))
+            ctx.strokePath()
         }
 
         // Top Separator
         if topVisible {
             topColor.setStroke()
             let lineWidth = topHeightInPixels / scale
-            ctx!.setLineWidth(lineWidth)
-            ctx!.move(to: CGPoint(x: topInsets.left, y: lineWidth))
-            ctx!.addLine(to: CGPoint(x: bounds.maxX - topInsets.right, y: lineWidth))
-            ctx!.strokePath()
+            ctx.setLineWidth(lineWidth)
+            ctx.move(to: CGPoint(x: topInsets.left, y: lineWidth))
+            ctx.addLine(to: CGPoint(x: bounds.maxX - topInsets.right, y: lineWidth))
+            ctx.strokePath()
         }
 
         // Bottom Separator
         if bottomVisible {
             bottomColor.setStroke()
-            ctx!.setLineWidth(bottomHeightInPixels / scale)
-            ctx!.move(to: CGPoint(x: bottomInsets.left, y: bounds.height))
-            ctx!.addLine(to: CGPoint(x: bounds.maxX - bottomInsets.right, y: bounds.height))
-            ctx!.strokePath()
+            ctx.setLineWidth(bottomHeightInPixels / scale)
+            ctx.move(to: CGPoint(x: bottomInsets.left, y: bounds.height))
+            ctx.addLine(to: CGPoint(x: bounds.maxX - bottomInsets.right, y: bounds.height))
+            ctx.strokePath()
         }
     }
 


### PR DESCRIPTION
### Fix
This PR fixes #1043 

This PR is intended to add multiple selection support to Simplenote iOS.  Currently there is not way to select and trash multiple notes at a time in SNiOS.  In this PR the ability to enter an edit mode, select multiple notes at a time and then trash them is now possible!

<img src ="https://cdn-std.droplr.net/files/acc_593859/AszY2Y" />

### Test
1. enable and disable edit mode.  Make sure that the mode animates in and out.  While active ensure that you can select multiple notes, that you can't transition to seeing a note and that entering search mode dismisses edit mode
2. Make sure when you go in and out of edit mode the button in the new note bar at the bottom transitions from the new notice icon to the trash icon
3. While in edit mode, select multiple notes to make sure that the view title changes from the standard note list name to "X Selected" Exit edit mode to ensure that the note list returns to its regular name.
4. Test selecting multiple notes and then using the trash button to trash the notes
5. Test changing the note list tag while in edit mode to ensure that edit mode exits
6. While in edit mode you should see a Select All/Deselect all button in the top left where the main menu usually is.  Enable/disable edit mode to make sure that appears and disappears
7. Tap on the Select All button and confirm all notes are selected.  Tap Deselect and make sure they are deselected
8. Delete a selection of notes to see a new in app notification.  Make sure the correct number of notes is marked as being deleted in the notification.  Test the undo button to make sure that all the bulk deleted notes are restored

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
