### PR TITLE
Fixed an issue where tags would not be deleted on trashed notes

### DIFF
--- a/Simplenote/Classes/SPObjectManager+Simplenote.swift
+++ b/Simplenote/Classes/SPObjectManager+Simplenote.swift
@@ -25,7 +25,7 @@ extension SPObjectManager {
     }
 
     @objc
-    func notesWithTag(_ tag: Tag?) -> [Note] {
+    func notesWithTag(_ tag: Tag?, includeDeleted: Bool) -> [Note] {
         guard let tagName = tag?.name else {
             return []
         }
@@ -33,9 +33,14 @@ extension SPObjectManager {
         let request = NSFetchRequest<Note>(entityName: Note.entityName)
         request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
             .predicateForNotes(tag: tagName),
-            .predicateForNotes(deleted: false)
+            .predicateForNotes(deleted: includeDeleted)
         ])
 
         return (try? managedObjectContext.fetch(request)) ?? []
+    }
+
+    @objc
+    func notesWithTag(_ tag: Tag?) -> [Note] {
+        return notesWithTag(tag, includeDeleted: false)
     }
 }

--- a/Simplenote/Classes/SPObjectManager.m
+++ b/Simplenote/Classes/SPObjectManager.m
@@ -108,7 +108,7 @@
         return tagRemoved;
     }
     
-    NSArray *notes = [self notesWithTag: tag];
+    NSArray *notes = [self notesWithTag: tag includeDeleted:YES];
 	
     // Strip this tag from all notes
 	for (Note *note in notes) {


### PR DESCRIPTION
### Fix
This PR fixes #1234 

Currently if you delete a note that has a tag on it, and then later delete that tag, the trashed note will continue being associated with the deleted tag.  If later you restore that note to the note list it will still have reference to the tag, but the tag will not appear in the tag list.

With this PR, when removing a tag, the tag will be removed from all notes including notes that are in the trash.

### Test
1. Go to a note and give it a tag.
2. Trash that same note
3. Go to the tag list and delete the tag
4. Restore the deleted note
5. If you edit that note the tag that was removed will not appear in the notes tag list.

<img src="https://cdn-std.droplr.net/files/acc_593859/7hIHYa" />

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
