### PR TITLE
Test PR for release toolkit localization fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 155ad828760d8aba998690116cbba6638b55c7fe
+  revision: 0239b8d6f9b2a79d0e8a7588c8341accbd5d8f03
   branch: return-full-path-from-localized-glob
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.18.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: ce59a5e7b4fa75f6bb694bcfa333f85175294c3c
-  tag: 0.18.0
+  revision: 155ad828760d8aba998690116cbba6638b55c7fe
+  branch: return-full-path-from-localized-glob
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.18.0)
       activesupport (~> 5)

--- a/Simplenote/en.lproj/Localizable.strings
+++ b/Simplenote/en.lproj/Localizable.strings
@@ -121,7 +121,7 @@
 /* Opens the Collaborate UI */
 "Collaborate" = "Collaborate";
 
-/* No comment provided by engineer. */
+/* Alert title that collaboration has moved */
 "Collaboration has moved" = "Collaboration has moved";
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
@@ -206,6 +206,9 @@
 
 /* PinLock screen \"delete\" button */
 "Delete" = "Delete";
+
+/* Delet a note from trash */
+"Delete Note" = "Delete Note";
 
 /* Verb: Delete notes and log out of the app */
 "Delete Notes" = "Delete Notes";
@@ -422,7 +425,8 @@
 /* Instant passcode lock timeout */
 "Off" = "Off";
 
-/* Closes alert controller for spinner on About view
+/* Alert confirmation button title
+   Closes alert controller for spinner on About view
    Dismisses an AlertController */
 "OK" = "OK";
 
@@ -535,7 +539,8 @@
 /* Response Title */
 "Response" = "Response";
 
-/* Restore a note to a previous version */
+/* Restore a note from trash
+   Restore a note to a previous version */
 "Restore Note" = "Restore Note";
 
 /* Title -> Review you account screen */
@@ -579,7 +584,7 @@
 /* Shares a note */
 "Share..." = "Share...";
 
-/* No comment provided by engineer. */
+/* Alert message that collaboration has moved */
 "Sharing notes is now accessed through the action menu from the toolbar." = "Sharing notes is now accessed through the action menu from the toolbar.";
 
 /* UI region to the left of the note list which shows all of a users tags */

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,6 +79,10 @@ end
     get_prs_list(repository:GHHELPER_REPO, milestone:"#{old_version}", report_path:"#{File.expand_path('~')}/simplenoteios_prs_list_#{old_version}_#{new_version}.txt")
   end
 
+  lane :test_update_localizations do
+    ios_localize_project()
+  end
+
   #####################################################################################
   # update_appstore_strings
   # -----------------------------------------------------------------------------------
@@ -248,8 +252,8 @@ end
   # it for both internal and external distribution
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_beta_release [skip_confirm:<skip confirm>] 
-  #   [create_gh_release:<create release on GH>] 
+  # bundle exec fastlane build_and_upload_beta_release [skip_confirm:<skip confirm>]
+  #   [create_gh_release:<create release on GH>]
   #
   # Example:
   # bundle exec fastlane build_and_upload_beta_release
@@ -259,7 +263,7 @@ end
   desc "Builds and uploads a beta release for distribution"
   lane :build_and_upload_beta_release do | options |
     build_and_upload_release(
-      skip_confirm: options[:skip_confirm], 
+      skip_confirm: options[:skip_confirm],
       create_gh_release: options[:create_gh_release],
       beta_release: true)
   end
@@ -271,8 +275,8 @@ end
   # it for distribution
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_stable_release [skip_confirm:<skip confirm>] 
-  #   [create_gh_release:<create release on GH>] 
+  # bundle exec fastlane build_and_upload_stable_release [skip_confirm:<skip confirm>]
+  #   [create_gh_release:<create release on GH>]
   #
   # Example:
   # bundle exec fastlane build_and_upload_stable_release
@@ -282,7 +286,7 @@ end
   desc "Builds and uploads a stable release for distribution"
   lane :build_and_upload_stable_release do | options |
     build_and_upload_release(
-      skip_confirm: options[:skip_confirm], 
+      skip_confirm: options[:skip_confirm],
       create_gh_release: options[:create_gh_release],
       beta_release: false)
   end
@@ -293,7 +297,7 @@ end
   # This lane builds the app and uploads it for both internal and external distribution
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>] 
+  # bundle exec fastlane build_and_upload_release [skip_confirm:<skip confirm>]
   #   [create_gh_release:<create release on GH>] [beta_release:<is a beta release>]
   #
   # Example:
@@ -439,8 +443,8 @@ end
   #####################################################################################
   lane :trigger_beta_build do | options |
     circleci_trigger_job(
-      circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"], 
-      repository: REPOSITORY_NAME, 
+      circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"],
+      repository: REPOSITORY_NAME,
       organization: "Automattic",
       branch: options[:branch_to_build],
       job_params: {"beta_build" => true}
@@ -458,8 +462,8 @@ end
   #####################################################################################
   lane :trigger_release_build do | options |
     circleci_trigger_job(
-      circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"], 
-      repository: REPOSITORY_NAME, 
+      circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"],
+      repository: REPOSITORY_NAME,
       organization: "Automattic",
       branch: options[:branch_to_build],
       job_params: {"release_build" => true}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :ios do
 Dotenv.load(USER_ENV_FILE_PATH)
 Dotenv.load(PROJECT_ENV_FILE_PATH)
 ENV[GHHELPER_REPO="Automattic/simplenote-ios"]
-# ENV["PROJECT_NAME"]="Simplenote"
+ENV["PROJECT_NAME"]="Simplenote"
 ENV["PROJECT_ROOT_FOLDER"]="./"
 ENV['APP_STORE_STRINGS_FILE_NAME']='AppStoreStrings.pot'
 ENV["PUBLIC_CONFIG_FILE"]="./config/Version.Public.xcconfig"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,8 +33,8 @@ platform :ios do
 Dotenv.load(USER_ENV_FILE_PATH)
 Dotenv.load(PROJECT_ENV_FILE_PATH)
 ENV[GHHELPER_REPO="Automattic/simplenote-ios"]
-ENV["PROJECT_NAME"]="Simplenote"
-ENV["PROJECT_ROOT_FOLDER"]="./"
+# ENV["PROJECT_NAME"]="Simplenote"
+# ENV["PROJECT_ROOT_FOLDER"]="./"
 ENV['APP_STORE_STRINGS_FILE_NAME']='AppStoreStrings.pot'
 ENV["PUBLIC_CONFIG_FILE"]="./config/Version.Public.xcconfig"
 ENV["DOWNLOAD_METADATA"]="./fastlane/download_metadata.swift"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,7 +34,7 @@ Dotenv.load(USER_ENV_FILE_PATH)
 Dotenv.load(PROJECT_ENV_FILE_PATH)
 ENV[GHHELPER_REPO="Automattic/simplenote-ios"]
 # ENV["PROJECT_NAME"]="Simplenote"
-# ENV["PROJECT_ROOT_FOLDER"]="./"
+ENV["PROJECT_ROOT_FOLDER"]="./"
 ENV['APP_STORE_STRINGS_FILE_NAME']='AppStoreStrings.pot'
 ENV["PUBLIC_CONFIG_FILE"]="./config/Version.Public.xcconfig"
 ENV["DOWNLOAD_METADATA"]="./fastlane/download_metadata.swift"

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,7 +2,7 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.18.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'return-full-path-from-localized-glob'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', "1.8.0"
 


### PR DESCRIPTION
See https://github.com/wordpress-mobile/release-toolkit/pull/236

Looks like it picked up all the files:

<img width="1857" alt="Screen Shot 2021-05-04 at 6 51 32 am" src="https://user-images.githubusercontent.com/1218433/116932244-57f22380-aca5-11eb-9e38-5b15d81722e1.png">

```
➜ ls Simplenote/**/*.strings
Simplenote/ar.lproj/Localizable.strings         Simplenote/it.lproj/Localizable.strings
Simplenote/cy.lproj/Localizable.strings         Simplenote/ja.lproj/Localizable.strings
Simplenote/de.lproj/Localizable.strings         Simplenote/ko.lproj/Localizable.strings
Simplenote/el.lproj/Localizable.strings         Simplenote/nl.lproj/Localizable.strings
Simplenote/en.lproj/InfoPlist.strings           Simplenote/pt-BR.lproj/Localizable.strings
Simplenote/en.lproj/Localizable.strings         Simplenote/ru.lproj/Localizable.strings
Simplenote/es.lproj/Localizable.strings         Simplenote/sv.lproj/Localizable.strings
Simplenote/fa.lproj/Localizable.strings         Simplenote/tr.lproj/Localizable.strings
Simplenote/fr.lproj/Localizable.strings         Simplenote/zh-Hans-CN.lproj/Localizable.strings
Simplenote/he.lproj/Localizable.strings         Simplenote/zh-Hant-TW.lproj/Localizable.strings
Simplenote/id.lproj/Localizable.strings
```