### PR TITLE
Parameterising the test account for UI Tests

### DIFF
--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/SimplenoteUITests.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/SimplenoteUITests.xcscheme
@@ -44,6 +44,13 @@
             ReferencedContainer = "container:Simplenote.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "UI_TEST_ACCOUNT"
+            value = "$(UI_TEST_ACCOUNT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -14,7 +14,18 @@ class EmailLogin {
         backButton.tap()
     }
 
-    class func logIn(email: String, password: String) {
+    class func logIn() {
+        var testAccount = ProcessInfo.processInfo.environment["UI_TEST_ACCOUNT"]!
+
+        // Use 'default' account if test account was not passed via environment variable
+        if testAccount.isEmpty {
+            testAccount = testDataEmail
+        }
+
+        EmailLogin.logIn(testAccount, testDataPassword)
+    }
+
+    class func logIn(_ email: String, _ password: String) {
         enterEmail(enteredValue: email)
         enterPassword(enteredValue: password)
         app.buttons[UID.Button.logIn].tap()

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -15,11 +15,15 @@ class EmailLogin {
     }
 
     class func logIn() {
-        var testAccount = ProcessInfo.processInfo.environment["UI_TEST_ACCOUNT"]!
+        let testAccountKey = "UI_TEST_ACCOUNT"
+        let testAccount: String
 
-        // Use 'default' account if test account was not passed via environment variable
-        if testAccount.isEmpty {
-            testAccount = testDataEmail
+        switch ProcessInfo.processInfo.environment[testAccountKey] {
+        case .none:
+            fatalError("Expected \(testAccountKey) environment variable to be defined in the scheme")
+        case .some(let value):
+            // Use 'default' account if test account was not passed via environment variable
+            testAccount = value.isEmpty ? testDataEmail : value
         }
 
         EmailLogin.logIn(testAccount, testDataPassword)

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -26,10 +26,10 @@ class EmailLogin {
             testAccount = value.isEmpty ? testDataEmail : value
         }
 
-        EmailLogin.logIn(testAccount, testDataPassword)
+        EmailLogin.logIn(email: testAccount, password: testDataPassword)
     }
 
-    class func logIn(_ email: String, _ password: String) {
+    class func logIn(email: String, password: String) {
         enterEmail(enteredValue: email)
         enterPassword(enteredValue: password)
         app.buttons[UID.Button.logIn].tap()

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -89,7 +89,7 @@ class Table {
 
     class func getCell(label: String) -> XCUIElement {
         let predicate = NSPredicate(format: "label LIKE '\(label)'")
-        let cell = app.tables.cells.element(matching: predicate)
+        let cell = app.tables.cells.element(matching: predicate).firstMatch
         return cell
     }
 

--- a/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
+++ b/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
@@ -7,7 +7,7 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         getToAllNotes()
         _ = attemptLogOut()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
+        EmailLogin.logIn()
         NoteList.waitForLoad()
     }
 

--- a/SimplenoteUITests/SimplenoteUITestsLogin.swift
+++ b/SimplenoteUITests/SimplenoteUITestsLogin.swift
@@ -21,7 +21,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: "", password: "")
+        EmailLogin.logIn("", "")
         Assert.labelExists(labelText: Text.loginEmailInvalid)
         Assert.labelExists(labelText: Text.loginPasswordShort)
     }
@@ -31,7 +31,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: "", password: testDataExistingPassword)
+        EmailLogin.logIn("", testDataPassword)
         Assert.labelExists(labelText: Text.loginEmailInvalid)
         Assert.labelAbsent(labelText: Text.loginPasswordShort)
     }
@@ -41,7 +41,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataInvalidEmail, password: testDataExistingPassword)
+        EmailLogin.logIn(testDataInvalidEmail, testDataPassword)
         Assert.labelExists(labelText: Text.loginEmailInvalid)
         Assert.labelAbsent(labelText: Text.loginPasswordShort)
     }
@@ -51,7 +51,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: "")
+        EmailLogin.logIn(testDataEmail, "")
         Assert.labelAbsent(labelText: Text.loginEmailInvalid)
         Assert.labelExists(labelText: Text.loginPasswordShort)
     }
@@ -61,7 +61,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: testDataInvalidPassword)
+        EmailLogin.logIn(testDataEmail, testDataInvalidPassword)
         Assert.labelAbsent(labelText: Text.loginEmailInvalid)
         Assert.labelExists(labelText: Text.loginPasswordShort)
     }
@@ -71,7 +71,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: testDataNotExistingPassword)
+        EmailLogin.logIn(testDataEmail, testDataNotExistingPassword)
         Assert.alertExistsAndClose(headingText: Text.alertHeadingSorry, content: Text.alertContentLoginFailed, buttonText: UID.Button.accept)
     }
 
@@ -80,7 +80,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
+        EmailLogin.logIn(testDataEmail, testDataPassword)
         NoteListAssert.allNotesShown()
     }
 
@@ -89,7 +89,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
+        EmailLogin.logIn(testDataEmail, testDataPassword)
         NoteListAssert.allNotesShown()
 
         trackStep()

--- a/SimplenoteUITests/SimplenoteUITestsLogin.swift
+++ b/SimplenoteUITests/SimplenoteUITestsLogin.swift
@@ -21,7 +21,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn("", "")
+        EmailLogin.logIn(email: "", password: "")
         Assert.labelExists(labelText: Text.loginEmailInvalid)
         Assert.labelExists(labelText: Text.loginPasswordShort)
     }
@@ -31,7 +31,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn("", testDataPassword)
+        EmailLogin.logIn(email: "", password: testDataPassword)
         Assert.labelExists(labelText: Text.loginEmailInvalid)
         Assert.labelAbsent(labelText: Text.loginPasswordShort)
     }
@@ -41,7 +41,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(testDataInvalidEmail, testDataPassword)
+        EmailLogin.logIn(email: testDataInvalidEmail, password: testDataPassword)
         Assert.labelExists(labelText: Text.loginEmailInvalid)
         Assert.labelAbsent(labelText: Text.loginPasswordShort)
     }
@@ -51,7 +51,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(testDataEmail, "")
+        EmailLogin.logIn(email: testDataEmail, password: "")
         Assert.labelAbsent(labelText: Text.loginEmailInvalid)
         Assert.labelExists(labelText: Text.loginPasswordShort)
     }
@@ -61,7 +61,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(testDataEmail, testDataInvalidPassword)
+        EmailLogin.logIn(email: testDataEmail, password: testDataInvalidPassword)
         Assert.labelAbsent(labelText: Text.loginEmailInvalid)
         Assert.labelExists(labelText: Text.loginPasswordShort)
     }
@@ -71,7 +71,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(testDataEmail, testDataNotExistingPassword)
+        EmailLogin.logIn(email: testDataEmail, password: testDataNotExistingPassword)
         Assert.alertExistsAndClose(headingText: Text.alertHeadingSorry, content: Text.alertContentLoginFailed, buttonText: UID.Button.accept)
     }
 
@@ -80,7 +80,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(testDataEmail, testDataPassword)
+        EmailLogin.logIn(email: testDataEmail, password: testDataPassword)
         NoteListAssert.allNotesShown()
     }
 
@@ -89,7 +89,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(testDataEmail, testDataPassword)
+        EmailLogin.logIn(email: testDataEmail, password: testDataPassword)
         NoteListAssert.allNotesShown()
 
         trackStep()

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -15,7 +15,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         getToAllNotes()
         let _ = attemptLogOut()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
+        EmailLogin.logIn()
         NoteList.waitForLoad()
     }
 

--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -39,7 +39,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         app.launch()
         _ = attemptLogOut()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
+        EmailLogin.logIn()
         NoteList.waitForLoad()
         NoteList.trashAllNotes()
         Trash.empty()

--- a/SimplenoteUITests/SimplenoteUITestsTrash.swift
+++ b/SimplenoteUITests/SimplenoteUITestsTrash.swift
@@ -6,7 +6,7 @@ class SimplenoteUISmokeTestsTrash: XCTestCase {
         app.launch()
         let _ = attemptLogOut()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataExistingEmail, password: testDataExistingPassword)
+        EmailLogin.logIn()
         NoteList.waitForLoad()
     }
 

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -73,5 +73,5 @@ enum Text {
     static let loginPasswordShort = "Password must contain at least 4 characters"
 }
 
-let testDataExistingEmail = "simplenoteuitest@mailinator.com"
-let testDataExistingPassword = "qazxswedc"
+let testDataEmail = "simplenoteuitest@mailinator.com"
+let testDataPassword = "qazxswedc"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -713,7 +713,7 @@ end
         prelaunch_simulator: true,
         reset_simulator: true,
         only_testing: "SimplenoteUITests/SimplenoteUISmokeTestsTrash",
-        xcargs: "UI_TEST_ACCOUNT='#{options[:test_account] || ""}'"
+        xcargs: { UI_TEST_ACCOUNT: #{options[:test_account] || '' }
       )
     rescue => ex
        UI.error(ex)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -713,7 +713,7 @@ end
         prelaunch_simulator: true,
         reset_simulator: true,
         only_testing: "SimplenoteUITests/SimplenoteUISmokeTestsTrash",
-        xcargs: { UI_TEST_ACCOUNT: #{options[:test_account] || '' }
+        xcargs: { UI_TEST_ACCOUNT: options[:test_account] || '' }
       )
     rescue => ex
        UI.error(ex)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -705,19 +705,15 @@ end
   #####################################################################################
   desc "Run UI tests"
   lane :run_ui_tests do | options |
-    begin
-      scan(
-        workspace: workspace_name,
-        scheme: UI_TESTS_SCHEME,
-        device: options[:device] || "iPhone 12",
-        prelaunch_simulator: true,
-        reset_simulator: true,
-        only_testing: "SimplenoteUITests/SimplenoteUISmokeTestsTrash",
-        xcargs: { UI_TEST_ACCOUNT: options[:test_account] || '' }
-      )
-    rescue => ex
-       UI.error(ex)
-    end
+    scan(
+      workspace: workspace_name,
+      scheme: UI_TESTS_SCHEME,
+      device: options[:device] || "iPhone 12",
+      prelaunch_simulator: true,
+      reset_simulator: true,
+      only_testing: "SimplenoteUITests/SimplenoteUISmokeTestsTrash",
+      xcargs: { UI_TEST_ACCOUNT: options[:test_account] || '' }
+    )
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -698,21 +698,26 @@ end
   # selected for now, there will be no credentials race condition.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane run_ui_tests [device:<Name of the iOS Simulator >]
+  # bundle exec fastlane run_ui_tests [device:<Name of the iOS Simulator>] [test_account:<Test account email>]
   #
   # Example:
-  # bundle exec fastlane run_ui_tests device:"iPhone 12"
+  # bundle exec fastlane run_ui_tests device:"iPhone 12" test_account:"test.account@test.com"
   #####################################################################################
   desc "Run UI tests"
   lane :run_ui_tests do | options |
-  scan(
-    workspace: workspace_name,
-    scheme: UI_TESTS_SCHEME,
-    device: options[:device] || "iPhone 12",
-    prelaunch_simulator: true,
-    reset_simulator: true,
-    only_testing: "SimplenoteUITests/SimplenoteUISmokeTestsLogin"
-  )
+    begin
+      scan(
+        workspace: workspace_name,
+        scheme: UI_TESTS_SCHEME,
+        device: options[:device] || "iPhone 12",
+        prelaunch_simulator: true,
+        reset_simulator: true,
+        only_testing: "SimplenoteUITests/SimplenoteUISmokeTestsTrash",
+        xcargs: "UI_TEST_ACCOUNT='#{options[:test_account] || ""}'"
+      )
+    rescue => ex
+       UI.error(ex)
+    end
   end
 end
 


### PR DESCRIPTION
This is a preliminary PR before a PR that will attempt to solve the account race condition.
Dividing it in two in order to keep the noise down for the next PR.

### Changes:

1. `run_ui_tests` lane now accepts a `test_account` parameter, and passes it to `SimplenoteUITests` scheme
2. `SimplenoteUITests` scheme contains an environment variable for test account
3. `EmailLogin.logIn()` method can now be used with no parameters. In such case, it will check if the test account was passed via environment variable. Otherwise, it will use the 'default' credentials that were used previously.

### Test
1. Run `bundle exec fastlane run_ui_tests` (alternatively, run the `SimplenoteUISmokeTestsTrash` tests from Xcode) and make sure they are executed using the 'default' credentials
2. Run `bundle exec fastlane run_ui_tests test_account:"<test_account_email>"` and make sure same tests are executed using the email passed as a parameter.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
