### PR TITLE
Lowercase signup emails before sending to server

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 		BA55B05A25F067DF0042582B /* NoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA55B05925F067DF0042582B /* NoticePresenter.swift */; };
 		BA55B06325F068650042582B /* NoticeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA55B06225F068650042582B /* NoticeController.swift */; };
 		BA5C1C0725BF9D6C006E3820 /* SPDragBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */; };
+		BA5E5B7D264A148C00D0EE19 /* URLRequest+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5E5B7C264A148C00D0EE19 /* URLRequest+Simplenote.swift */; };
 		BA83478325F59F8B0059B797 /* markdown-default-contrast.css in Resources */ = {isa = PBXBuildFile; fileRef = BA83478225F59F8B0059B797 /* markdown-default-contrast.css */; };
 		BA83478C25F59FE90059B797 /* markdown-dark-contrast.css in Resources */ = {isa = PBXBuildFile; fileRef = BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */; };
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
@@ -955,6 +956,7 @@
 		BA55B05925F067DF0042582B /* NoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticePresenter.swift; sourceTree = "<group>"; };
 		BA55B06225F068650042582B /* NoticeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeController.swift; sourceTree = "<group>"; };
 		BA5C1C0625BF9D6C006E3820 /* SPDragBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPDragBar.swift; sourceTree = "<group>"; };
+		BA5E5B7C264A148C00D0EE19 /* URLRequest+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Simplenote.swift"; sourceTree = "<group>"; };
 		BA83478225F59F8B0059B797 /* markdown-default-contrast.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-default-contrast.css"; sourceTree = "<group>"; };
 		BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-dark-contrast.css"; sourceTree = "<group>"; };
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
@@ -1700,6 +1702,7 @@
 				A6C0DFB425C1581D00B9BE39 /* UIScrollView+Simplenote.swift */,
 				A6A8968D25D5779D00A7B390 /* FileManager+Simplenote.swift */,
 				BAE08625261282D1009D40CD /* Note+Publish.swift */,
+				BA5E5B7C264A148C00D0EE19 /* URLRequest+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2891,6 +2894,7 @@
 				B56E763622BD565700C5AA47 /* UIView+Simplenote.swift in Sources */,
 				B5E4082D235DE41A00D4E1DF /* UIColor+Studio.swift in Sources */,
 				A6CDF900256B9CB900CF2F27 /* ViewSpinner.swift in Sources */,
+				BA5E5B7D264A148C00D0EE19 /* URLRequest+Simplenote.swift in Sources */,
 				375D24B721E01131007AB25A /* stack.c in Sources */,
 				373AD30821C4739500A4EA89 /* NSMutableAttributedString+Styling.m in Sources */,
 				B524AE112352CC7900EA11D4 /* UIScreen+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		B5EB1EFF1C205A800080A1B3 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */; };
 		B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F3000123F4502C007A7C59 /* SPSortBar.xib */; };
 		B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */; };
+		BA18532826488DBC00D9A347 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */; };
 		BA2D82C6261522F100A1695B /* PublishNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */; };
 		BA3FB8CF25FEA0C500EA9A1B /* NoticeControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3FB8CE25FEA0C500EA9A1B /* NoticeControllerTests.swift */; };
 		BA4499AA25ED8821000C563E /* NoticeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BA4499A925ED8821000C563E /* NoticeView.xib */; };
@@ -943,6 +944,7 @@
 		B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = ../Icons.xcassets; sourceTree = "<group>"; };
 		B5F3000123F4502C007A7C59 /* SPSortBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSortBar.xib; path = Classes/SPSortBar.xib; sourceTree = "<group>"; };
 		B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortBar.swift; path = Classes/SPSortBar.swift; sourceTree = "<group>"; };
+		BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
 		BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishNoticePresenter.swift; sourceTree = "<group>"; };
 		BA3FB8CE25FEA0C500EA9A1B /* NoticeControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeControllerTests.swift; sourceTree = "<group>"; };
 		BA4499A925ED8821000C563E /* NoticeView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoticeView.xib; sourceTree = "<group>"; };
@@ -1631,6 +1633,7 @@
 				A6344AD8255952C70072FA07 /* NoteContentPreviewTests.swift */,
 				A694ABB225D1687200CC3A2D /* NoteScrollPositionCacheTests.swift */,
 				BAB0179A260AD591007A9CC3 /* PublishControllerTests.swift */,
+				BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -3086,6 +3089,7 @@
 				A6E6CE9125A5B970005A92DB /* PinLockRemoveControllerTests.swift in Sources */,
 				B57401A025B7D9960058960E /* EmailVerificationTests.swift in Sources */,
 				A6E6CEC925A6053A005A92DB /* MockApplication.swift in Sources */,
+				BA18532826488DBC00D9A347 /* SignupRemoteTests.swift in Sources */,
 				BA3FB8CF25FEA0C500EA9A1B /* NoticeControllerTests.swift in Sources */,
 				A645FA70254C5E69008A1519 /* NoteContentHelperTests.swift in Sources */,
 				BAB0179B260AD591007A9CC3 /* PublishControllerTests.swift in Sources */,

--- a/Simplenote/Classes/SignupRemote.swift
+++ b/Simplenote/Classes/SignupRemote.swift
@@ -8,8 +8,8 @@ class SignupRemote {
             switch (lhs, rhs) {
             case (.success, .success):
                 return true
-            case (.failure(let code1, let error1), .failure(let code2, let error2)):
-                return code1 == code2 && error1?.localizedDescription == error2?.localizedDescription
+            case (.failure(let code1, _), .failure(let code2, _)):
+                return code1 == code2
             default:
                 return false
             }

--- a/Simplenote/Classes/SignupRemote.swift
+++ b/Simplenote/Classes/SignupRemote.swift
@@ -3,7 +3,19 @@ import Foundation
 // MARK: - SignupRemote
 //
 class SignupRemote {
-    enum Result {
+    enum Result: Equatable {
+        static func == (lhs: SignupRemote.Result, rhs: SignupRemote.Result) -> Bool {
+            switch (lhs, rhs) {
+            case (.success, .success):
+                return true
+            case (.failure(let code1, let error1), .failure(let code2, let error2)):
+                return code1 == code2 && error1?.localizedDescription == error2?.localizedDescription
+            default:
+                return false
+            }
+
+        }
+
         case success
         case failure(_ statusCode: Int, _ error: Error?)
     }

--- a/Simplenote/Classes/SignupRemote.swift
+++ b/Simplenote/Classes/SignupRemote.swift
@@ -49,7 +49,7 @@ class SignupRemote {
                                  timeoutInterval: RemoteConstants.timeout)
         request.httpMethod = RemoteConstants.Method.POST
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try? JSONEncoder().encode(["username": email])
+        request.httpBody = try? JSONEncoder().encode(["username": email.lowercased()])
 
         return request
     }

--- a/Simplenote/URLRequest+Simplenote.swift
+++ b/Simplenote/URLRequest+Simplenote.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension URLRequest {
+    func decodeHtmlBody<T: Decodable>() throws -> T? {
+          guard let _ = httpBody else {
+              return nil
+          }
+
+          return try httpBody.map {
+            try JSONDecoder().decode(T.self, from: $0)
+          }
+      }
+}

--- a/SimplenoteTests/Network/MockURLSession.swift
+++ b/SimplenoteTests/Network/MockURLSession.swift
@@ -4,10 +4,21 @@ import Foundation
 //
 class MockURLSession: URLSession {
     var data: (Data?, URLResponse?, Error?)?
+    var lastRequest: URLRequest?
 
     override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        lastRequest = request
         return MockURLSessionDataTask {
             completionHandler(self.data?.0, self.data?.1, self.data?.2)
         }
+    }
+
+    func decodedHtmlBodyInLastRequest<T: Decodable>(outputType: T.Type) throws -> T? {
+        guard let lastRequest = lastRequest,
+              let data = lastRequest.httpBody else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(outputType, from: data)
     }
 }

--- a/SimplenoteTests/Network/MockURLSession.swift
+++ b/SimplenoteTests/Network/MockURLSession.swift
@@ -12,13 +12,4 @@ class MockURLSession: URLSession {
             completionHandler(self.data?.0, self.data?.1, self.data?.2)
         }
     }
-
-    func decodedHtmlBodyInLastRequest<T: Decodable>(outputType: T.Type) throws -> T? {
-        guard let lastRequest = lastRequest,
-              let data = lastRequest.httpBody else {
-            return nil
-        }
-
-        return try JSONDecoder().decode(outputType, from: data)
-    }
 }

--- a/SimplenoteTests/SignupRemoteTests.swift
+++ b/SimplenoteTests/SignupRemoteTests.swift
@@ -22,8 +22,8 @@ class SignupRemoteTests: XCTestCase {
         signupRemote.signup(with: "EMAIL@gmail.com", completion: { _ in })
 
         let expecation = "email@gmail.com"
-        let body = try XCTUnwrap(urlSession.decodedHtmlBodyInLastRequest(outputType: Dictionary<String, String>.self))
-        let decodedEmail = body["username"]
+        let body: Dictionary<String, String> = try XCTUnwrap(urlSession.lastRequest?.decodeHtmlBody())
+        let decodedEmail = try XCTUnwrap(body["username"])
 
         XCTAssertEqual(expecation, decodedEmail)
     }
@@ -32,8 +32,8 @@ class SignupRemoteTests: XCTestCase {
         signupRemote.signup(with: "EMAIL123456@#$%^@gmail.com", completion: { _ in })
 
         let expecation = "email123456@#$%^@gmail.com"
-        let body = try XCTUnwrap(urlSession.decodedHtmlBodyInLastRequest(outputType: Dictionary<String, String>.self))
-        let decodedEmail = body["username"]
+        let body: Dictionary<String, String> = try XCTUnwrap(urlSession.lastRequest?.decodeHtmlBody())
+        let decodedEmail = try XCTUnwrap(body["username"])
 
         XCTAssertEqual(expecation, decodedEmail)
     }
@@ -42,8 +42,8 @@ class SignupRemoteTests: XCTestCase {
         signupRemote.signup(with: "eMaIl@gmail.com", completion: { _ in })
 
         let expecation = "email@gmail.com"
-        let body = try XCTUnwrap(urlSession.decodedHtmlBodyInLastRequest(outputType: Dictionary<String, String>.self))
-        let decodedEmail = body["username"]
+        let body: Dictionary<String, String> = try XCTUnwrap(urlSession.lastRequest?.decodeHtmlBody())
+        let decodedEmail = try XCTUnwrap(body["username"])
 
         XCTAssertEqual(expecation, decodedEmail)
     }

--- a/SimplenoteTests/SignupRemoteTests.swift
+++ b/SimplenoteTests/SignupRemoteTests.swift
@@ -60,7 +60,7 @@ class SignupRemoteTests: XCTestCase {
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
     }
 
     private func response(with statusCode: Int?) -> HTTPURLResponse? {

--- a/SimplenoteTests/SignupRemoteTests.swift
+++ b/SimplenoteTests/SignupRemoteTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Simplenote
+
+class SignupRemoteTests: XCTestCase {
+    private lazy var urlSession = MockURLSession()
+    private lazy var signupRemote = SignupRemote(urlSession: urlSession)
+
+    func testSuccessWhenStatusCodeIs2xx() {
+        for _ in 0..<5 {
+            test(withStatusCode: Int.random(in: 200..<300), email: "email@gmail.com", expectedResult: SignupRemote.Result.success)
+        }
+    }
+
+    func testFailureWhenStatusCodeIs4xxOr5xx() {
+        for _ in 0..<5 {
+            let statusCode = Int.random(in: 400..<600)
+            test(withStatusCode: statusCode, email: "email@gmail.com", expectedResult: SignupRemote.Result.failure(statusCode, nil))
+        }
+    }
+
+    func testRequestSetsEmailToCorrectCase() throws {
+        signupRemote.signup(with: "EMAIL@gmail.com", completion: { _ in })
+
+        let expecation = "email@gmail.com"
+        let body = try XCTUnwrap(urlSession.decodedHtmlBodyInLastRequest(outputType: Dictionary<String, String>.self))
+        let decodedEmail = body["username"]
+
+        XCTAssertEqual(expecation, decodedEmail)
+    }
+
+    func testRequestSetsEmailToCorrectCaseWithSpecialCharacters() throws {
+        signupRemote.signup(with: "EMAIL123456@#$%^@gmail.com", completion: { _ in })
+
+        let expecation = "email123456@#$%^@gmail.com"
+        let body = try XCTUnwrap(urlSession.decodedHtmlBodyInLastRequest(outputType: Dictionary<String, String>.self))
+        let decodedEmail = body["username"]
+
+        XCTAssertEqual(expecation, decodedEmail)
+    }
+
+    func testRequestSetsEmailToCorrectCaseWithMixedCase() throws {
+        signupRemote.signup(with: "eMaIl@gmail.com", completion: { _ in })
+
+        let expecation = "email@gmail.com"
+        let body = try XCTUnwrap(urlSession.decodedHtmlBodyInLastRequest(outputType: Dictionary<String, String>.self))
+        let decodedEmail = body["username"]
+
+        XCTAssertEqual(expecation, decodedEmail)
+    }
+
+    private func test(withStatusCode statusCode: Int?, email: String, expectedResult: SignupRemote.Result) {
+        urlSession.data = (nil,
+                           response(with: statusCode),
+                           nil)
+
+        let expectation = self.expectation(description: "Verify is called")
+
+        signupRemote.signup(with: email) { (result) in
+            XCTAssertEqual(result, expectedResult)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    private func response(with statusCode: Int?) -> HTTPURLResponse? {
+        guard let statusCode = statusCode else {
+            return nil
+        }
+        return HTTPURLResponse(url: URL(fileURLWithPath: "/"),
+                               statusCode: statusCode,
+                               httpVersion: nil,
+                               headerFields: nil)
+    }
+}


### PR DESCRIPTION
### Fix
fixes #1252 

This PR changes the case on email addresses before they are sent to the server during signup.  Previously there was an issue where mixed case email addresses where causing accounts to be created immediately borked.  Setting the emails to lowercase on signup is part of fixing this problem.

There isn't much to see in this PR as the email case is being set just before being sent to the server.  As such to verify the changes I have created unit tests to confirm what is being sent.  While I was there I also wrote tests for the rest of SignupRemote

### Test
1. run the unit tests for SNiOS
2. Check the tests on SignupRemoteTests.swift, they should all pass and confirm the correct casing of the email address.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
