### PR TITLE
New lane and functions managing test accounts for UI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
       # END: Swift Package Manager Workaround
       - run:
           name: Fastlane
-          command: bundle exec fastlane run_ui_tests device:'<< parameters.device >>'
+          command: bundle exec fastlane pick_test_account_and_run_ui_tests device:'<< parameters.device >>'
       - store_artifacts:
           path: output/scan/report.html
       - store_artifacts:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -893,9 +893,9 @@ end
 # expected to look like a series of Fs and Ts.
 # Example:
 #   get_test_accounts_state
-#     => "TFF"
+#     => "TFFFF"
 def get_test_accounts_state
-  uri = URI.parse(UI_TESTS_ACCOUNTS_KEY)
+  uri = URI.parse(UI_TEST_ACCOUNTS_KEY)
   response = Net::HTTP.get_response(uri)
   accounts_state = response.body.gsub("\n","")
   UI.message("State of test accounts: #{accounts_state}")
@@ -916,7 +916,7 @@ end
 # Replaces a character at `index` with `availability` value.
 # Example:
 #   change_test_account_availability("F")
-#     => FTT 
+#     => FFFFF
 def change_test_account_availability(availability)
   accounts_state = get_test_accounts_state
   accounts_state[$used_test_account_index] = availability

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -895,7 +895,7 @@ end
 #   get_test_accounts_state
 #     => "TFFFF"
 def get_test_accounts_state
-  uri = URI.parse(UI_TEST_ACCOUNTS_KEY)
+  uri = URI.parse(UI_TESTS_ACCOUNTS_KEY)
   response = Net::HTTP.get_response(uri)
   accounts_state = response.body.gsub("\n","")
   UI.message("State of test accounts: #{accounts_state}")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,8 @@ end
 USER_ENV_FILE_PATH = File.join(Dir.home, '.simplenoteios-env.default')
 PROJECT_ENV_FILE_PATH = File.expand_path(File.join(Dir.pwd, '../.configure-files/project.env'))
 UI_TESTS_SCHEME = "SimplenoteUITests"
+UI_TESTS_ACCOUNTS_KEY = "https://api.keyvalue.xyz/82649691/simplenoteuitest-ios"
+$used_test_account_index = nil
 
 before_all do
   # Check that the env files exist
@@ -24,6 +26,14 @@ before_all do
   # It is skipped if this isn't running on CI
   # See https://circleci.com/docs/2.0/ios-codesigning/
   setup_circle_ci
+end
+
+after_each do |lane, options|
+  free_occupied_test_account if lane == :run_ui_tests
+end
+
+error do |lane, exception, options|
+  free_occupied_test_account if lane == :run_ui_tests
 end
 
 platform :ios do
@@ -715,6 +725,25 @@ end
       xcargs: { UI_TEST_ACCOUNT: options[:test_account] || '' }
     )
   end
+
+  #####################################################################################
+  # pick_test_account_and_run_ui_tests
+  # -----------------------------------------------------------------------------------
+  # Firstly tries to occupy a free test account, and then passes the account to 
+  # `run_ui_tests` lane. Frees up the account afterwards.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane pick_test_account_and_run_ui_tests [device:<Name of the iOS Simulator>]
+  #
+  # Example:
+  # bundle exec fastlane pick_test_account_and_run_ui_tests device:"iPhone 12"
+  #####################################################################################
+  desc "Occupy a free test account and run UI tests with it"
+  lane :pick_test_account_and_run_ui_tests do | options |
+    occupy_test_account
+    run_ui_tests(options.merge({ test_account: "simplenoteuitest-ios-#{$used_test_account_index+1}@a8c.com" }))
+    free_occupied_test_account
+  end
 end
 
 ########################################################################
@@ -849,4 +878,63 @@ end
 
 def simulator_version
   '14.4'
+end
+
+def occupy_test_account
+  UI.message("Looking for a free test account...")
+  find_free_test_account
+  change_test_account_availability("T")
+end
+
+def free_occupied_test_account
+  return if $used_test_account_index == nil
+  UI.message("Freeing used test account")
+  change_test_account_availability("F")
+  $used_test_account_index = nil
+end
+
+# Returns the value of test accounts key, which is 
+# expected to look like a series of Fs and Ts.
+# Example:
+#   get_test_accounts_state
+#     => "TFF"
+def get_test_accounts_state
+  uri = URI.parse(UI_TESTS_ACCOUNTS_KEY)
+  response = Net::HTTP.get_response(uri)
+  accounts_state = response.body.gsub("\n","")
+  UI.message("State of test accounts: #{accounts_state}")
+  accounts_state
+end
+
+# Returns the index of first "F" (Free) occurence in the test
+# accounts keyvalue, or crashes fastlane if it was not found.
+# Example:
+#   get_free_test_account_index
+#     => 2
+def find_free_test_account
+  $used_test_account_index = get_test_accounts_state.index("F")
+  UI.user_error!("Could not find free UI Test account. Quitting.") if $used_test_account_index.nil? 
+  UI.message("Free account index: #{$used_test_account_index}")
+end
+
+# Replaces a character at `index` with `availability` value.
+# Example:
+#   change_test_account_availability("F")
+#     => FTT 
+def change_test_account_availability(availability)
+  accounts_state = get_test_accounts_state
+  accounts_state[$used_test_account_index] = availability
+  UI.message("Writing new account state: #{accounts_state}")
+  uri = URI.parse(UI_TESTS_ACCOUNTS_KEY + "/" + accounts_state)
+  request = Net::HTTP::Post.new(uri)
+
+  req_options = {
+    use_ssl: uri.scheme == "https",
+  }
+
+  response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+    http.request(request)
+  end
+
+  get_test_accounts_state
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,7 @@ end
 USER_ENV_FILE_PATH = File.join(Dir.home, '.simplenoteios-env.default')
 PROJECT_ENV_FILE_PATH = File.expand_path(File.join(Dir.pwd, '../.configure-files/project.env'))
 UI_TESTS_SCHEME = "SimplenoteUITests"
-UI_TESTS_ACCOUNTS_KEY = "https://api.keyvalue.xyz/82649691/simplenoteuitest-ios"
+UI_TESTS_ACCOUNTS_URL = "https://api.keyvalue.xyz/82649691/simplenoteuitest-ios"
 $used_test_account_index = nil
 
 before_all do
@@ -737,7 +737,7 @@ end
   desc "Occupy a free test account and run UI tests with it"
   lane :pick_test_account_and_run_ui_tests do | options |
     occupy_test_account
-    run_ui_tests(options.merge({ test_account: "simplenoteuitest-ios-#{$used_test_account_index+1}@a8c.com" }))
+    run_ui_tests(options.merge({ test_account: "simplenoteuitest-ios-#{$used_test_account_index}@a8c.com" }))
     deoccupy_test_account
   end
 end
@@ -895,7 +895,7 @@ end
 #   get_test_accounts_state
 #     => "TFFFF"
 def get_test_accounts_state
-  uri = URI.parse(UI_TESTS_ACCOUNTS_KEY)
+  uri = URI.parse(UI_TESTS_ACCOUNTS_URL)
   response = Net::HTTP.get_response(uri)
   accounts_state = response.body.chomp
   UI.message("State of test accounts: #{accounts_state}")
@@ -905,7 +905,7 @@ end
 # Returns the index of first "F" (Free) occurence in the test
 # accounts keyvalue, or crashes fastlane if it was not found.
 # Example:
-#   get_free_test_account_index
+#   find_free_test_account
 #     => 2
 def find_free_test_account
   $used_test_account_index = get_test_accounts_state.index("F")
@@ -921,7 +921,7 @@ def change_test_account_availability(availability)
   accounts_state = get_test_accounts_state
   accounts_state[$used_test_account_index] = availability
   UI.message("Writing new account state: #{accounts_state}")
-  uri = URI.parse(UI_TESTS_ACCOUNTS_KEY + "/" + accounts_state)
+  uri = URI.parse(UI_TESTS_ACCOUNTS_URL + "/" + accounts_state)
   request = Net::HTTP::Post.new(uri)
 
   req_options = {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -897,7 +897,7 @@ end
 def get_test_accounts_state
   uri = URI.parse(UI_TESTS_ACCOUNTS_KEY)
   response = Net::HTTP.get_response(uri)
-  accounts_state = response.body.gsub("\n","")
+  accounts_state = response.body.chomp
   UI.message("State of test accounts: #{accounts_state}")
   accounts_state
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,12 +28,8 @@ before_all do
   setup_circle_ci
 end
 
-after_each do |lane, options|
-  free_occupied_test_account if lane == :run_ui_tests
-end
-
 error do |lane, exception, options|
-  free_occupied_test_account if lane == :run_ui_tests
+  deoccupy_test_account if lane == :run_ui_tests
 end
 
 platform :ios do
@@ -742,7 +738,7 @@ end
   lane :pick_test_account_and_run_ui_tests do | options |
     occupy_test_account
     run_ui_tests(options.merge({ test_account: "simplenoteuitest-ios-#{$used_test_account_index+1}@a8c.com" }))
-    free_occupied_test_account
+    deoccupy_test_account
   end
 end
 
@@ -886,7 +882,7 @@ def occupy_test_account
   change_test_account_availability("T")
 end
 
-def free_occupied_test_account
+def deoccupy_test_account
   return if $used_test_account_index == nil
   UI.message("Freeing used test account")
   change_test_account_availability("F")


### PR DESCRIPTION
The PR adds a new lane and several supporting functions in `Fastfile` that manage the test accounts' availability, in order to prevent the account race condition when UI tests are executed on CI.

The information about test account state (free/taken) is stored at the online key-value [service](https://keyvalue.xyz/). I found no better means to have this information shared between different runs on CI.

The state is represented by a string of `TFFFF` format, where `T` is 'taken' and `F` is 'free'. In the given example, the account with index 0 is currently in use, so the new parallel run will occupy the next account. This solution provides easy scalability: the string can be lengthened to match the number of test accounts created for the purpose.

If this approach in overall is acceptable, the next step will be making the address of key-value and accounts credentials less exposed.

### What's new
Changes in `Fastfile`:
- New `pick_test_account_and_run_ui_tests` lane.
- Added `error` block, that is executed after an error occurs in a lane. This block is needed to make sure an occupied test account is always freed even if the tests fail (this causes an error in lane). `after_each` block is not executed in the case of error.
- A number of functions that take care of getting/setting test account state.

Changes in `config.yml`:
- `pick_test_account_and_run_ui_tests` lane runs instead of `run_ui_tests`

### Test
1. Running `bundle exec fastlane pick_test_account_and_run_ui_tests` and seeing in fastlane log that it uses a free account, and deoccupies it at the end of execution.
2. Doing the same, but messing up the execution of UI tests by navigating to unexpected area of the app (e.g. Settings), which results in several tests fail. Test account should be freed in this case as well via `error` block.
3. Optionally committing something here, just to trigger the `UI Tests` job while 1 or 2 from above runs, and seeing that parallel execution causes no issues.
4. Checking the latest `UI Tests` execution in this PR and seeing that it was selecting the test account using the key-value.

**Hint**: to make testing of account states easier, it's possible to get the current value by running `curl https://api.keyvalue.xyz/82649691/simplenoteuitest-ios`

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
