### PR TITLE
Change how notices auto size

### DIFF
--- a/Simplenote/NoticeView.swift
+++ b/Simplenote/NoticeView.swift
@@ -50,6 +50,7 @@ class NoticeView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
         setupViewStyles()
         setupGestureRecognizers()
+        configureAccessibilityIfNeeded()
 
         layoutIfNeeded()
     }
@@ -72,6 +73,15 @@ class NoticeView: UIView {
         noticeButton.titleLabel?.font = UIFont.preferredFont(for: .subheadline, weight: .semibold)
         noticeButton.titleLabel?.adjustsFontForContentSizeCategory = true
 
+    }
+
+    private func configureAccessibilityIfNeeded() {
+        switch traitCollection.preferredContentSizeCategory {
+        case .accessibilityLarge, .accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge:
+            stackView.axis = .vertical
+        default:
+            return
+        }
     }
 
     // MARK: Action

--- a/Simplenote/NoticeView.xib
+++ b/Simplenote/NoticeView.xib
@@ -22,7 +22,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="SfY-hE-pTa">
                     <rect key="frame" x="0.0" y="0.0" width="275" height="94"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="999" verticalCompressionResistancePriority="751" insetsLayoutMarginsFromSafeArea="NO" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VzW-UO-SDt">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="751" insetsLayoutMarginsFromSafeArea="NO" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VzW-UO-SDt">
                             <rect key="frame" x="28" y="60" width="102" height="18"/>
                             <directionalEdgeInsets key="directionalLayoutMargins" top="0.0" leading="0.0" bottom="0.0" trailing="8"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>

--- a/Simplenote/NoticeView.xib
+++ b/Simplenote/NoticeView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,18 +19,18 @@
                     <rect key="frame" x="0.0" y="0.0" width="275" height="94"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="SfY-hE-pTa">
+                <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="SfY-hE-pTa">
                     <rect key="frame" x="0.0" y="0.0" width="275" height="94"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" insetsLayoutMarginsFromSafeArea="NO" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VzW-UO-SDt">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="999" verticalCompressionResistancePriority="751" insetsLayoutMarginsFromSafeArea="NO" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VzW-UO-SDt">
                             <rect key="frame" x="28" y="60" width="102" height="18"/>
                             <directionalEdgeInsets key="directionalLayoutMargins" top="0.0" leading="0.0" bottom="0.0" trailing="8"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="752" verticalCompressionResistancePriority="752" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PEr-q4-fDe">
-                            <rect key="frame" x="202" y="60" width="46" height="18"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="752" insetsLayoutMarginsFromSafeArea="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PEr-q4-fDe">
+                            <rect key="frame" x="146" y="60" width="102" height="18"/>
                             <directionalEdgeInsets key="directionalLayoutMargins" top="16" leading="8" bottom="16" trailing="0.0"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <inset key="contentEdgeInsets" minX="0.0" minY="-6" maxX="0.0" maxY="-6"/>


### PR DESCRIPTION
###Fix
Fixes issue #1270 

Currently there is an issue with the in app notifications where they do not size correctly when there is an action button visible.
<img src="https://camo.githubusercontent.com/0bc441cdd549ff32dc44b31e941b2ca67d8347da7d257069910e9fc2a2c532e4/68747470733a2f2f63646e2d7374642e64726f706c722e6e65742f66696c65732f6163635f3539333835392f68726576564d" /> 

This problem came up while trying to fix an issue with how the notices render when on the largest of accessibility sizes.  Per a conversation about how best to approach this (internal ref p2XJRt-2Za ) the idea was to first fix how the sizing works for the normal size, and then to change the layout of the stack view for the largest of accessibility sizes.  This PR makes both changes.

(in order from left to right: Normal size, Accessibility Medium, Accessibility Large, Accessibility extra extra extra large)

<img src="https://cdn-std.droplr.net/files/acc_593859/ylzRs3" />

### Test
1. Trigger a notice that has a button (trashed note, publish successful, unpublish successful) make sure that the layout sizes correctly
2. Using Publish Successful (the largest notice currently) on a few different accessibility sizes.
3. Make sure to check sizes below Accessibility Medium (the last size that will keep the label and button horizontal)
4. Check accessibility sizes that are Accessibility Large or bigger (all sizes over Accessibility large will change the axis of the stack view to vertical)

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
