### PR TITLE
Fix xcode compiler warnings

### DIFF
--- a/Simplenote/Classes/KeyboardObservable.swift
+++ b/Simplenote/Classes/KeyboardObservable.swift
@@ -5,7 +5,7 @@ import UIKit
 /// Adopters of this protocol will recieve interactive keyboard-based notifications
 /// by implmenting the provided functions within.
 ///
-public protocol KeyboardObservable: class {
+public protocol KeyboardObservable: AnyObject {
 
     /// Called during a Keyboard Repositioning Notification.
     ///

--- a/Simplenote/Classes/OptionsViewController.swift
+++ b/Simplenote/Classes/OptionsViewController.swift
@@ -5,7 +5,7 @@ import SimplenoteFoundation
 
 // MARK: - OptionsControllerDelegate
 //
-protocol OptionsControllerDelegate: class {
+protocol OptionsControllerDelegate: AnyObject {
     func optionsControllerDidPressHistory(_ sender: OptionsViewController)
     func optionsControllerDidPressShare(_ sender: OptionsViewController)
     func optionsControllerDidPressTrash(_ sender: OptionsViewController)

--- a/Simplenote/Classes/PinLock/PinLockController.swift
+++ b/Simplenote/Classes/PinLock/PinLockController.swift
@@ -13,7 +13,7 @@ struct PinLockControllerConfiguration: Equatable {
 
 // MARK: - PinLockController
 //
-protocol PinLockController: class {
+protocol PinLockController: AnyObject {
     /// Observer for configuration changes. Provides updated configuration and optional animation
     ///
     var configurationObserver: ((PinLockControllerConfiguration, UIView.ReloadAnimation?) -> Void)? { get set }

--- a/Simplenote/Classes/PinLock/PinLockRemoveController.swift
+++ b/Simplenote/Classes/PinLock/PinLockRemoveController.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - PinLockRemoveControllerDelegate
 //
-protocol PinLockRemoveControllerDelegate: class {
+protocol PinLockRemoveControllerDelegate: AnyObject {
     func pinLockRemoveControllerDidComplete(_ controller: PinLockRemoveController)
     func pinLockRemoveControllerDidCancel(_ controller: PinLockRemoveController)
 }

--- a/Simplenote/Classes/PinLock/PinLockSetupController.swift
+++ b/Simplenote/Classes/PinLock/PinLockSetupController.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - PinLockSetupControllerDelegate
 //
-protocol PinLockSetupControllerDelegate: class {
+protocol PinLockSetupControllerDelegate: AnyObject {
     func pinLockSetupControllerDidComplete(_ controller: PinLockSetupController)
     func pinLockSetupControllerDidCancel(_ controller: PinLockSetupController)
 }

--- a/Simplenote/Classes/PinLock/PinLockVerifyController.swift
+++ b/Simplenote/Classes/PinLock/PinLockVerifyController.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - PinLockVerifyControllerDelegate
 //
-protocol PinLockVerifyControllerDelegate: class {
+protocol PinLockVerifyControllerDelegate: AnyObject {
     func pinLockVerifyControllerDidComplete(_ controller: PinLockVerifyController)
 }
 

--- a/Simplenote/Classes/SPEntryListViewController.m
+++ b/Simplenote/Classes/SPEntryListViewController.m
@@ -213,7 +213,7 @@ static CGFloat const EntryListCellHeight = 44;
         
         finalCell = cell;;
     }
-    finalCell.selectionStyle = UITableViewCellAccessoryNone;
+    finalCell.selectionStyle = UITableViewCellSelectionStyleNone;
     
     return finalCell;
 }

--- a/Simplenote/Classes/SPRatingsPromptView.swift
+++ b/Simplenote/Classes/SPRatingsPromptView.swift
@@ -5,7 +5,7 @@ import UIKit
 // MARK: - SPRatingsPromptDelegate
 //
 @objc
-protocol SPRatingsPromptDelegate: class {
+protocol SPRatingsPromptDelegate: AnyObject {
     func simplenoteWasLiked()
     func simplenoteWasDisliked()
     func displayReviewUI()

--- a/Simplenote/Classes/TagView.swift
+++ b/Simplenote/Classes/TagView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 // MARK: - TagViewDelegate
 //
-protocol TagViewDelegate: class {
+protocol TagViewDelegate: AnyObject {
     func tagView(_ tagView: TagView, wantsToCreateTagWithName name: String)
     func tagView(_ tagView: TagView, wantsToRemoveTagWithName name: String)
 

--- a/Simplenote/NoticeView.swift
+++ b/Simplenote/NoticeView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol NoticeInteractionDelegate: class {
+protocol NoticeInteractionDelegate: AnyObject {
     func noticePressBegan()
     func noticePressEnded()
     func actionWasTapped()

--- a/Simplenote/SPCardPresentationController.swift
+++ b/Simplenote/SPCardPresentationController.swift
@@ -15,7 +15,7 @@ enum SPCardDismissalReason {
 
 // MARK: - SPCardPresentationControllerDelegate
 //
-protocol SPCardPresentationControllerDelegate: class {
+protocol SPCardPresentationControllerDelegate: AnyObject {
     func cardDidDismiss(_ viewController: UIViewController, reason: SPCardDismissalReason)
 }
 

--- a/Simplenote/SPNoteHistoryControllerDelegate.swift
+++ b/Simplenote/SPNoteHistoryControllerDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - SPNoteHistoryControllerDelegate
 //
-protocol SPNoteHistoryControllerDelegate: class {
+protocol SPNoteHistoryControllerDelegate: AnyObject {
 
     /// Cancel
     ///

--- a/Simplenote/TagListViewCell.swift
+++ b/Simplenote/TagListViewCell.swift
@@ -9,7 +9,7 @@ enum TagListViewCellDeletionSource {
 
 // MARK: - TagListViewCellDelegate
 //
-protocol TagListViewCellDelegate: class {
+protocol TagListViewCellDelegate: AnyObject {
     func tagListViewCellShouldDeleteTag(_ cell: TagListViewCell, source: TagListViewCellDeletionSource)
     func tagListViewCellShouldRenameTag(_ cell: TagListViewCell)
 }

--- a/Simplenote/Tags/NoteEditorTagListViewController.swift
+++ b/Simplenote/Tags/NoteEditorTagListViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 // MARK: - NoteEditorTagListViewControllerDelegate
 //
-protocol NoteEditorTagListViewControllerDelegate: class {
+protocol NoteEditorTagListViewControllerDelegate: AnyObject {
     func tagListDidUpdate(_ tagList: NoteEditorTagListViewController)
     func tagListIsEditing(_ tagList: NoteEditorTagListViewController)
 }


### PR DESCRIPTION
### Fix
With a recent update to Xcode, there were a few changes that were causing the complier to throw up some warnings.  This PR make the changes to remove those warnings.

Two things needed to be changed:
1.For delegates the class keyword was depreciated, suggestion was to replace those with AnyClass
2. in SPEntryListViewController we were setting the selectionStyle for the cell using an enum that required an implicit conversion.  Changing that from "UITableViewCellAccessoryNone" to "UITableViewCellSelectionStyleNone" silenced the warning.

### Test
1. build the project and confirm there are no warnings

Nothing should have changed about how the app operates, but do a quick smoke test to confirm

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
