### PR TITLE
Added blur effect to notice view

### DIFF
--- a/Simplenote/NoticeView.swift
+++ b/Simplenote/NoticeView.swift
@@ -14,6 +14,7 @@ class NoticeView: UIView {
     @IBOutlet private weak var stackView: UIStackView!
     @IBOutlet private weak var noticeLabel: UILabel!
     @IBOutlet private weak var noticeButton: UIButton!
+    private let blurView = SPBlurEffectView(effect: .simplenoteBlurEffect)
 
     var message: String? {
         get {
@@ -63,8 +64,16 @@ class NoticeView: UIView {
     private func setupViewStyles() {
         backgroundColor = .clear
 
+        blurView.layer.cornerRadius = Constants.cornerRadius
+        blurView.clipsToBounds = true
+        blurView.tintColor = .simplenoteNoticeViewBackgroundColor
+        blurView.backgroundColor = .clear
+        addFillingSubview(blurView)
+        sendSubviewToBack(blurView)
+
         backgroundView.backgroundColor = .simplenoteNoticeViewBackgroundColor
         backgroundView.layer.cornerRadius = Constants.cornerRadius
+        backgroundView.alpha = 0.5
 
         noticeLabel.textColor = .simplenoteTextColor
         noticeButton.setTitleColor(.simplenoteTintColor, for: .normal)


### PR DESCRIPTION
### Fix
Under certain conditions, the in app notifications have the same background color as other elements, which makes them sort of disappear into their background
<img src="https://cdn-std.droplr.net/files/acc_593859/8gf9EG" />

This PR adds a blur effect to the notices so that they are more visible.

<img src="https://cdn-std.droplr.net/files/acc_593859/m6inac" />

### Test
This problem is easiest to notice when in dark mode and in large accessibility sizes, but this fix should work for all sizes and visual modes.

1. go to the options menu while in dark mode
2. change the publish state of a notice
3. make sure that it can be seen against the background colors of the cells in the table

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
