### PR TITLE
Changed in app notification dark mode background color

### DIFF
--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -261,7 +261,7 @@ extension UIColor {
 
     @objc
     static var simplenoteNoticeViewBackgroundColor: UIColor {
-        UIColor(lightColor: .spGray3, darkColor: .darkGray2)
+        UIColor(lightColor: .spGray3, darkColor: .darkGray3)
     }
 
     @objc


### PR DESCRIPTION
### Fix
Under certain conditions, the in app notifications have the same background color as other elements, which makes them sort of disappear into their background
<img src="https://cdn-std.droplr.net/files/acc_593859/8gf9EG" />

This PR changes the color for the notifications in dark mode so that they do not blend into the background.

<img src="https://cdn-std.droplr.net/files/acc_593859/rBnGSU" />

### Test
This problem is easiest to notice when in dark mode and in large accessibility sizes, but this fix should work for all sizes and visual modes.

1. go to the options menu while in dark mode
2. change the publish state of a notice
3. make sure that it can be seen against the background colors of the cells in the table

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
