### PR TITLE
Run `Trash` UI tests on every commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,9 +185,6 @@ workflows:
       - UI Tests:
           name: UI Tests (iPhone 12)
           device: "iPhone 12"
-          filters:
-            branches:
-              only: /.*UI-tests.*/
   Installable Build:
     when:
        and:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,6 @@ end
 USER_ENV_FILE_PATH = File.join(Dir.home, '.simplenoteios-env.default')
 PROJECT_ENV_FILE_PATH = File.expand_path(File.join(Dir.pwd, '../.configure-files/project.env'))
 UI_TESTS_SCHEME = "SimplenoteUITests"
-UI_TESTS_ACCOUNTS_URL = "https://api.keyvalue.xyz/82649691/simplenoteuitest-ios"
 $used_test_account_index = nil
 
 before_all do
@@ -736,9 +735,13 @@ end
   #####################################################################################
   desc "Occupy a free test account and run UI tests with it"
   lane :pick_test_account_and_run_ui_tests do | options |
-    occupy_test_account
-    run_ui_tests(options.merge({ test_account: "simplenoteuitest-ios-#{$used_test_account_index}@a8c.com" }))
-    deoccupy_test_account
+    if is_ci
+      occupy_test_account
+      run_ui_tests(options.merge({ test_account: get_required_env("UI_TESTS_ACCOUNT_EMAIL").sub("X", $used_test_account_index.to_s)}))
+      deoccupy_test_account
+    else
+      UI.message("This lane runs only on CI")
+    end
   end
 end
 
@@ -895,7 +898,7 @@ end
 #   get_test_accounts_state
 #     => "TFFFF"
 def get_test_accounts_state
-  uri = URI.parse(UI_TESTS_ACCOUNTS_URL)
+  uri = URI.parse(get_required_env("UI_TESTS_ACCOUNTS_URL")
   response = Net::HTTP.get_response(uri)
   accounts_state = response.body.chomp
   UI.message("State of test accounts: #{accounts_state}")
@@ -921,8 +924,9 @@ def change_test_account_availability(availability)
   accounts_state = get_test_accounts_state
   accounts_state[$used_test_account_index] = availability
   UI.message("Writing new account state: #{accounts_state}")
-  uri = URI.parse(UI_TESTS_ACCOUNTS_URL + "/" + accounts_state)
+  uri = URI.parse(get_required_env("UI_TESTS_ACCOUNTS_URL")
   request = Net::HTTP::Post.new(uri)
+  request.body = accounts_state
 
   req_options = {
     use_ssl: uri.scheme == "https",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -898,7 +898,7 @@ end
 #   get_test_accounts_state
 #     => "TFFFF"
 def get_test_accounts_state
-  uri = URI.parse(get_required_env("UI_TESTS_ACCOUNTS_URL")
+  uri = URI.parse(get_required_env("UI_TESTS_ACCOUNTS_URL"))
   response = Net::HTTP.get_response(uri)
   accounts_state = response.body.chomp
   UI.message("State of test accounts: #{accounts_state}")
@@ -924,7 +924,7 @@ def change_test_account_availability(availability)
   accounts_state = get_test_accounts_state
   accounts_state[$used_test_account_index] = availability
   UI.message("Writing new account state: #{accounts_state}")
-  uri = URI.parse(get_required_env("UI_TESTS_ACCOUNTS_URL")
+  uri = URI.parse(get_required_env("UI_TESTS_ACCOUNTS_URL"))
   request = Net::HTTP::Post.new(uri)
   request.body = accounts_state
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -740,7 +740,7 @@ end
       run_ui_tests(options.merge({ test_account: get_required_env("UI_TESTS_ACCOUNT_EMAIL").sub("X", $used_test_account_index.to_s)}))
       deoccupy_test_account
     else
-      UI.user_error!("This lane runs only on CI")
+      UI.user_error!("This lane should be run only from CI")
     end
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -740,7 +740,7 @@ end
       run_ui_tests(options.merge({ test_account: get_required_env("UI_TESTS_ACCOUNT_EMAIL").sub("X", $used_test_account_index.to_s)}))
       deoccupy_test_account
     else
-      UI.message("This lane runs only on CI")
+      UI.important("This lane runs only on CI")
     end
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -740,7 +740,7 @@ end
       run_ui_tests(options.merge({ test_account: get_required_env("UI_TESTS_ACCOUNT_EMAIL").sub("X", $used_test_account_index.to_s)}))
       deoccupy_test_account
     else
-      UI.important("This lane runs only on CI")
+      UI.user_error!("This lane runs only on CI")
     end
   end
 end


### PR DESCRIPTION
This is an unexpected PR prior to the one introducing a subset of tests to be executed on every commit.

### Fix
- Since the previously used third party key-value service went down, I switched to another one, which looks more reliable
- The sensitive information, such as the URL of the key, and the test account login was moved to CircleCI environment variables `UI_TESTS_ACCOUNTS_URL` and `UI_TESTS_ACCOUNT_EMAIL`
- `pick_test_account_and_run_ui_tests` lane now runs only on CI
- Previously existing selection of tests (`Trash`) runs now on every commit. The tests selection is temporary until next PR with a new scheme.

As for the upcoming subset of tests: it looks like test plans will not really fit the purpose here, because they are more about running tests under different configurations, rather than having different selections of tests. It looks like having additional scheme(s) is still the easiest way to accomplish this.

### Test
1. Running `bundle exec fastlane pick_test_account_and_run_ui_tests` is no longer possible locally and results in `This lane runs only on CI` message 
2. Rerunning `UI Tests` job here is successful, Fastlane informs about accounts state before and after running the tests.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
