### PR TITLE
Update get_prs_list helper lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -832,9 +832,13 @@ end
 ########################################################################
 # Helper Lanes
 ########################################################################
-desc "Get a list of pull request from `start_tag` to the current state"
+desc "Get a list of pull request from `milestone` to the current state"
 lane :get_pullrequests_list do | options |
-  get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/simplenoteios_prs_list.txt")
+  get_prs_list(
+    repository:GHHELPER_REPO,
+    milestone: options[:milestone],
+    report_path: File.join(Dir.home, 'simplenoteios_prs_list.txt')
+  )
 end
 
 def fastlane_directory()


### PR DESCRIPTION
I touched this to get the missing release notes for 4.37 to make it easier to do the code freeze, otherwise it would have found empty release notes which is always confusing.

It felt like a change that deserved its own PR, to avoid noise elsewhere.

### Test
Nothing to test, really. You can run the helper lane and verify the output is coherent. E.g.:

```
bundle exec fastlane get_pullrequests_list milestone:4.37 && cat ~/simplenoteios_prs_list.txt

[...]

#1279: Integrates Simperium Mk 1.8.0 @jleandroperez https://github.com/Automattic/simplenote-ios/pull/1279
#1281: Fix xcode compiler warnings @charliescheer https://github.com/Automattic/simplenote-ios/pull/1281
#1284: Move secrets out of the repository – Part 1 @mokagio https://github.com/Automattic/simplenote-ios/pull/1284
#1288: Changed in app notification dark mode background color @charliescheer https://github.com/Automattic/simplenote-ios/pull/
1288
#1290: Experimental Scheme @jleandroperez https://github.com/Automattic/simplenote-ios/pull/1290
```

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.