### PR TITLE
Fixed an issue where the new note button might not appear

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -246,10 +246,9 @@
         [self.navigationController setToolbarHidden:YES animated:YES];
         return;
     }
-    
-    [self configureNavigationToolbarButton];
 
     [self.navigationController setToolbarHidden:self.isSearchActive animated:YES];
+    [self configureNavigationToolbarButton];
 }
 
 - (void)updateNavigationBar {


### PR DESCRIPTION
### Fix
This is a quick PR to fix an issue I discovered while testing something else.  This problem came around in response to an issue where the new note button might be assigned to appear in the new note bar on iPad, but the navigation controller toolbar will never display.  The solve to that issue was to not set the new note button into the new note bar if the toolbar was hidden.

This caused a new issue on iOS where it was possible that at the time of that check, the toolbar was hidden, so the new note button got set to the wrong place, making the new note bar empty. 

This change rearranges the order of when the toolbar is set to hidden, so that this check will work correctly on iPad and iPhone.

<img src="https://cdn-std.droplr.net/files/acc_593859/h6VeKK" />

The new note button was missing when the app first opened.

### Test
1. load the app and make sure that the first time you open the app the new note button is there.
2. Navigate around a bit and make sure that the new note button is still there when ever the bar appears
3. Check multi select to make sure the button appears as the trash icon
4. Search for a note, select one of the notes that appears in the results to see that the nav bar appears as the search navigation bar.  Dismiss it to make sure the new note button returns.
5. Repeat all of these steps on iPad to make sure the new note button only appears in the top right.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
