### PR TITLE
Alert users that biometric lock requires setting up a pin code

### DIFF
--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -668,18 +668,19 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 
 - (UIAlertController*)pinLockRequiredAlert
 {
-    NSString* alertTitle = NSLocalizedString(([NSString stringWithFormat:@"To enable %@, you must have a passcode setup first.", self.biometryTitle]),
-                                             @"Prompt to setup passcode before biomtery lock");
-    UIAlertController* alert = [UIAlertController alertControllerWithTitle:self.biometryTitle
+    NSString *alertTitleTemplate = NSLocalizedString(@"To enable %1$@, you must have a passcode setup first.",
+                                                     @"Prompt to setup passcode before biomtery lock. Parameters: %1$@ - biometry type (Face ID or Touch ID");
+    NSString *alertTitle = [NSString stringWithFormat:alertTitleTemplate, self.biometryTitle];
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:self.biometryTitle
                                                                    message:alertTitle
                                                             preferredStyle:UIAlertControllerStyleAlert];
 
-    NSString* setupTitle = NSLocalizedString(@"Set up Passcode", @"Setup a passcode action button");
+    NSString *setupTitle = NSLocalizedString(@"Set up Passcode", @"Setup a passcode action button");
     [alert addActionWithTitle:setupTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         [self showPinLockViewController];
     }];
 
-    NSString* cancelTitle = NSLocalizedString(@"Cancel", @"Cancel action button");
+    NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel action button");
     [alert addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * action) {
         [self.biometrySwitch setOn:NO];
     }];

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -660,9 +660,31 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 {
     SPPinLockManager.shared.shouldUseBiometry = sender.on;
 
-    if (![self isPinLockEnabled]) {
-        [self showPinLockViewController];
+    if (![self isPinLockEnabled] && [self.biometrySwitch isOn]) {
+        UIAlertController* alert = [self pinLockRequiredAlert];
+        [self presentViewController:alert animated:YES completion:nil];
     }
+}
+
+- (UIAlertController*)pinLockRequiredAlert
+{
+    NSString* alertTitle = NSLocalizedString(([NSString stringWithFormat:@"To enable %@, you must have a passcode setup first.", self.biometryTitle]),
+                                             @"Prompt to setup passcode before biomtery lock");
+    UIAlertController* alert = [UIAlertController alertControllerWithTitle:self.biometryTitle
+                                                                   message:alertTitle
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+
+    NSString* setupTitle = NSLocalizedString(@"Set up Passcode", @"Setup a passcode action button");
+    [alert addActionWithTitle:setupTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [self showPinLockViewController];
+    }];
+
+    NSString* cancelTitle = NSLocalizedString(@"Cancel", @"Cancel action button");
+    [alert addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * action) {
+        [self.biometrySwitch setOn:NO];
+    }];
+
+    return alert;
 }
 
 


### PR DESCRIPTION
### Fix
This PR fixes #1256 

To be able to use the biometric locks on iOS (face ID or touch ID) a user needs to also setup a pin lock code.  Currently when you try to set it up without having a pin code setup, the pin code setup appears without any notification.  

In this PR I have added an alert that pops up informing the user that they need a pin code to use the biometrics and giving them a chance to concur or to dismiss the setup.

Note that in the original issue the request was just for this alert to setup face ID, but touch id has the same need of setting up a pin code, so I extended the change to deal with touch ID as well. cc: @SylvesterWilmott 

Face ID:
<img height="500px" src="https://cdn-std.droplr.net/files/acc_593859/dFv1RN" />

Touch ID:
<img height="500px" src="https://cdn-std.droplr.net/files/acc_593859/aHu5Z5" />

### Test
1. on a device with face id go to simplenote > sidebar > Settings
2. once there disable the pin lock if it is currently enabled
3. tap on the biometric switch. An alert asking you to setup the pin code will appear
4. test canceling the setup (the switch should switch to off) and test setting up a pin code
5. Repeat steps with a touch id device if possible  (make sure the touch id/face id titles show up correctly based on the device used)

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
