### PR TITLE
Adds release notes for 4.38

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 4.38
 -----
 
+-   Fixed a bug in which the New Note button might not appear #1298
+-   New Biometry Lock Flow #1299
 
 4.37
 -----


### PR DESCRIPTION
The CI failure is a false negative and we should just ignore it. This is only a release file update. With BuildKite, I hope we'll set things up so that these PRs are not even built.