### PR TITLE
Adds missing PROJECT_ROOT_FOLDER to fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,7 @@ USER_ENV_FILE_PATH = File.join(Dir.home, '.simplenoteios-env.default')
 PROJECT_ENV_FILE_PATH = File.join(
   Dir.home, '.configure', 'simplenote-ios', 'secrets', 'project.env'
 )
+PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 $used_test_account_index = nil
 
 before_all do


### PR DESCRIPTION
It turns out we don't have the `PROJECT_ROOT_FOLDER` set, so when I applied [this suggestion](https://github.com/Automattic/simplenote-ios/pull/1321#pullrequestreview-683078231) [here](https://github.com/Automattic/simplenote-ios/pull/1322/files), I broke the code freeze lane 🤦 

I've copied the `PROJECT_ROOT_FOLDER` definition from [WPiOS one](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/fastlane/Fastfile#L11).