### PR TITLE
Update logic to sanitize keywords via Fastlane – Take 3

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -144,16 +144,8 @@ end
       UI.message "#{keywords_path} has more than #{app_store_connect_keywords_length_limit} characters. Trimming it..."
 
       english_comma = ','
-      case File.basename(locale_dir)
-      when 'ar-SA'
-        # Replace Arabic comma with English one as per App Store
-        # Connect requirement
-        separator = '،'
-        keywords = keywords.split(separator).join(english_comma)
-      else
-        # Nothing do do here, but we might have more languages
-        # with different commas in the future
-      end
+      arabic_comma = '،'
+      keywords = keywords.gsub(arabic_comma, english_comma) if File.basename(locale_dir) == 'ar-SA'
 
       until keywords.length <= app_store_connect_keywords_length_limit
         keywords = keywords.split(english_comma)[0...-1].join(english_comma)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -155,9 +155,7 @@ end
         # with different commas in the future
       end
 
-      until keywords.length <=
-          app_store_connect_keywords_length_limit do
-      UI.error(keywords)
+      until keywords.length <= app_store_connect_keywords_length_limit do
         keywords = keywords.split(english_comma)[0...-1].join(english_comma)
       end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -155,7 +155,7 @@ end
         # with different commas in the future
       end
 
-      until keywords.length <= app_store_connect_keywords_length_limit do
+      until keywords.length <= app_store_connect_keywords_length_limit
         keywords = keywords.split(english_comma)[0...-1].join(english_comma)
       end
 


### PR DESCRIPTION
### Fix
Alternative to #1330 to bring the changes that went into `trunk` with #1317 without affecting the Git history with extra commits from `trunk` but also by keeping the same commit hashes

### Test
Nothing to test as the Fastlane code was already tested in #1317 and this only brings that in.

### Review
Only one required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.