### PR TITLE
Update AppStoreStrings to mention English comma keywords requirement

### DIFF
--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -61,7 +61,7 @@ msgid ""
 msgstr ""
 
 #. translators: Keywords used in the App Store search engine to find the app.
-#. Delimit with a comma between each keyword. Limit to 100 characters including spaces and commas.
+#. Delimit with an English comma between each keyword. Limit to 100 characters including spaces and commas.
 msgctxt "app_store_keywords"
 msgid "simplenote,note,taking,taker,notes,sync,share,simple,markdown,tag,to-do,list,lock,cloud,writing"
 msgstr ""


### PR DESCRIPTION
App Store Connect requires keywords to be separated by "English comma, Chinese comma, or a mix of both". For consistency and simplicity, I specify only English comma here.

### Test
Nothing to test, this change will be picked up as the new comment for translators in GlotPress.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.