### PR TITLE
Fixed an issue where cell separators appeared on ipad

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -614,7 +614,7 @@ extension SPNoteListViewController: UITableViewDelegate {
 
         cell.separatorInset = insets
 
-        cell.shouldDisplayBottomSeparator = indexPath.row < notesListController.numberOfObjects - 1
+        cell.shouldDisplayBottomSeparator = indexPath.row < notesListController.numberOfObjects - 1 && !UIDevice.isPad
     }
 }
 


### PR DESCRIPTION
### Fix
This is a quick PR to fix an issue that was added with the inclusion of the edit mode.  On iPad the note list does not usually have cell separators.  To simplify the animations on iPhone with edit mode, I added a separator view, but didn't realize that the separators didn't appear on iPad.  

This change adds a check to check device for iPad and doesn't activate the separators if it is.

### Test
1. on an iPad load the note list.  You shouldn't see separators between the notes
2. On iPhone check the note list again, there should be separators in between the notes
3. on iPhone, check and make sure there is not a separator after the last cell.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
