### PR TITLE
Update Fastlane code signing automation to include Intents extension

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -4764,7 +4764,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -4803,7 +4803,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
@@ -4820,6 +4820,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codality.NotationalFlow.Intents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.codality.NotationalFlow.Intents";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4837,7 +4838,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Automattic, Inc.";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 99KV9Z6BKV;
@@ -4854,6 +4855,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codality.NotationalFlow.Internal.Intents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.codality.NotationalFlow.Internal.Intents";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4871,7 +4873,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Automattic, Inc.";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 99KV9Z6BKV;
@@ -4888,6 +4890,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codality.NotationalFlow.Alpha.Intents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.codality.NotationalFlow.Alpha.Intents";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4905,7 +4908,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "Apple Distribution: Automattic, Inc. (PZYM8XX95Q)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution: Automattic, Inc. (PZYM8XX95Q)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
@@ -4922,6 +4925,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codality.NotationalFlow.Intents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.codality.NotationalFlow.Intents";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -4784,6 +4784,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codality.NotationalFlow.Development.Intents;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Simplenote Development Intents";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -350,7 +350,8 @@ end
         method: "enterprise",
         provisioningProfiles: {
           "com.codality.NotationalFlow.Internal" => "match InHouse com.codality.NotationalFlow.Internal",
-          "com.codality.NotationalFlow.Internal.Share" => "match InHouse com.codality.NotationalFlow.Internal.Share"
+          "com.codality.NotationalFlow.Internal.Share" => "match InHouse com.codality.NotationalFlow.Internal.Share",
+          "#{APP_STORE_BUNDLE_IDENTIFIER}.Internal.Intents" => "match InHouse #{APP_STORE_BUNDLE_IDENTIFIER}.Internal.Intents"
       }})
 
     sh("mv ../build/Simplenote.ipa \"../build/Simplenote Internal.ipa\"")
@@ -400,7 +401,8 @@ end
         export_team_id: ENV["EXT_EXPORT_TEAM_ID"],
         provisioningProfiles: {
           "com.codality.NotationalFlow" => "match AppStore com.codality.NotationalFlow",
-          "com.codality.NotationalFlow.Share" => "match AppStore com.codality.NotationalFlow.Share"
+          "com.codality.NotationalFlow.Share" => "match AppStore com.codality.NotationalFlow.Share",
+          "#{APP_STORE_BUNDLE_IDENTIFIER}.Intents" => "match InHouse #{APP_STORE_BUNDLE_IDENTIFIER}.Intents"
         }
       }
     )
@@ -515,7 +517,8 @@ end
         method: "enterprise",
         provisioningProfiles: {
           "com.codality.NotationalFlow.Alpha" => "match InHouse com.codality.NotationalFlow.Alpha",
-          "com.codality.NotationalFlow.Alpha.Share" => "match InHouse com.codality.NotationalFlow.Alpha.Share"
+          "com.codality.NotationalFlow.Alpha.Share" => "match InHouse com.codality.NotationalFlow.Alpha.Share",
+          "#{APP_STORE_BUNDLE_IDENTIFIER}.Alpha.Intents" => "match InHouse #{APP_STORE_BUNDLE_IDENTIFIER}.Alpha.Intents"
       }})
 
     sh("mv ../build/Simplenote.ipa \"../build/Simplenote Alpha.ipa\"")
@@ -833,7 +836,8 @@ end
     [
       root_bundle_id,
       "#{root_bundle_id}.Share",
-      "#{root_bundle_id}.Widgets"
+      "#{root_bundle_id}.Widgets",
+      "#{root_bundle_id}.Intents"
     ]
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -824,7 +824,7 @@ end
       type: "appstore",
       team_id: get_required_env("EXT_EXPORT_TEAM_ID"),
       readonly: options[:readonly] || is_ci,
-      app_identifier: simplenote_app_identifiers(root_bundle_id: APP_STORE_BUNDLE_IDENTIFIER),
+      app_identifier: simplenote_app_identifiers,
       template_name: "NotationalFlow Keychain Access (Distribution)",
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -833,12 +833,11 @@ end
   end
 
   def simplenote_app_identifiers(root_bundle_id:)
-    [
-      root_bundle_id,
-      "#{root_bundle_id}.Share",
-      "#{root_bundle_id}.Widgets",
-      "#{root_bundle_id}.Intents"
-    ]
+    extension_bundle_ids =
+      %w[Share Widgets Intents]
+      .map { |suffix| "#{root_bundle_id}.#{suffix}" }
+
+    [root_bundle_id, *extension_bundle_ids]
   end
 
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -844,15 +844,14 @@ end
   # profiles to be used in the `export_options > provisioningProfiles`
   # parameter for the `build_app`/`gym` action.
   def simplenote_provisioning_profiles(root_bundle_id: APP_STORE_BUNDLE_IDENTIFIER, match_type: 'AppStore')
-    # FIXME: replace the array below with the following once established the
-    # impact of adding the mapping for the Widgets extension, which is
+    # FIXME: replace the array below with the following call once established
+    # the impact of adding the mapping for the Widgets extension, which is
     # something we haven't had up to this point.
     #
-    # bundle_ids = simplenote_app_identifiers(root_bundle_id: root_bundle_id)
-    bundle_ids = [
-      root_bundle_id, "#{root_bundle_id}.Share", "#{root_bundle_id}.Intents"
-    ]
-    bundle_ids.map { |key| [key, "match #{match_type} #{key}"] }.to_h
+    # simplenote_app_identifiers(root_bundle_id: root_bundle_id)
+    [root_bundle_id, "#{root_bundle_id}.Share", "#{root_bundle_id}.Intents"]
+      .map { |key| [key, "match #{match_type} #{key}"] }
+      .to_h
   end
 
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -798,16 +798,15 @@ end
 ########################################################################
 # Fastlane match code signing
 ########################################################################
+
+  APP_STORE_BUNDLE_IDENTIFIER = 'com.codality.NotationalFlow'.freeze
+
   private_lane :alpha_code_signing do |options|
     match(
       type: "enterprise",
       team_id: get_required_env("INT_EXPORT_TEAM_ID"),
       readonly: options[:readonly] || is_ci,
-      app_identifier: [
-        "com.codality.NotationalFlow.Alpha",
-        "com.codality.NotationalFlow.Alpha.Share",
-        "com.codality.NotationalFlow.Alpha.Widgets",
-      ]
+      app_identifier: simplenote_app_identifiers(root_bundle_id: "#{APP_STORE_BUNDLE_IDENTIFIER}.Alpha")
     )
   end
 
@@ -816,11 +815,7 @@ end
       type: "enterprise",
       team_id: get_required_env("INT_EXPORT_TEAM_ID"),
       readonly: options[:readonly] || is_ci,
-      app_identifier: [
-        "com.codality.NotationalFlow.Internal",
-        "com.codality.NotationalFlow.Internal.Share",
-        "com.codality.NotationalFlow.Internal.Widgets",
-      ]
+      app_identifier: simplenote_app_identifiers(root_bundle_id: "#{APP_STORE_BUNDLE_IDENTIFIER}.Internal")
     )
   end
 
@@ -829,13 +824,17 @@ end
       type: "appstore",
       team_id: get_required_env("EXT_EXPORT_TEAM_ID"),
       readonly: options[:readonly] || is_ci,
-      app_identifier: [
-        "com.codality.NotationalFlow",
-        "com.codality.NotationalFlow.Share",
-        "com.codality.NotationalFlow.Widgets",
-      ],
+      app_identifier: simplenote_app_identifiers(root_bundle_id: APP_STORE_BUNDLE_IDENTIFIER),
       template_name: "NotationalFlow Keychain Access (Distribution)",
     )
+  end
+
+  def simplenote_app_identifiers(root_bundle_id:)
+    [
+      root_bundle_id,
+      "#{root_bundle_id}.Share",
+      "#{root_bundle_id}.Widgets"
+    ]
   end
 
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -348,11 +348,12 @@ end
       export_team_id: ENV["INT_EXPORT_TEAM_ID"],
       export_options: {
         method: "enterprise",
-        provisioningProfiles: {
-          "com.codality.NotationalFlow.Internal" => "match InHouse com.codality.NotationalFlow.Internal",
-          "com.codality.NotationalFlow.Internal.Share" => "match InHouse com.codality.NotationalFlow.Internal.Share",
-          "#{APP_STORE_BUNDLE_IDENTIFIER}.Internal.Intents" => "match InHouse #{APP_STORE_BUNDLE_IDENTIFIER}.Internal.Intents"
-      }})
+        provisioningProfiles: simplenote_provisioning_profiles(
+          root_bundle_id: "#{APP_STORE_BUNDLE_IDENTIFIER}.Internal",
+          match_type: 'InHouse'
+        )
+      }
+    )
 
     sh("mv ../build/Simplenote.ipa \"../build/Simplenote Internal.ipa\"")
 
@@ -399,11 +400,7 @@ end
       export_options: {
         method: "app-store",
         export_team_id: ENV["EXT_EXPORT_TEAM_ID"],
-        provisioningProfiles: {
-          "com.codality.NotationalFlow" => "match AppStore com.codality.NotationalFlow",
-          "com.codality.NotationalFlow.Share" => "match AppStore com.codality.NotationalFlow.Share",
-          "#{APP_STORE_BUNDLE_IDENTIFIER}.Intents" => "match InHouse #{APP_STORE_BUNDLE_IDENTIFIER}.Intents"
-        }
+        provisioningProfiles: simplenote_provisioning_profiles
       }
     )
 
@@ -515,11 +512,12 @@ end
       export_team_id: ENV["INT_EXPORT_TEAM_ID"],
       export_options: {
         method: "enterprise",
-        provisioningProfiles: {
-          "com.codality.NotationalFlow.Alpha" => "match InHouse com.codality.NotationalFlow.Alpha",
-          "com.codality.NotationalFlow.Alpha.Share" => "match InHouse com.codality.NotationalFlow.Alpha.Share",
-          "#{APP_STORE_BUNDLE_IDENTIFIER}.Alpha.Intents" => "match InHouse #{APP_STORE_BUNDLE_IDENTIFIER}.Alpha.Intents"
-      }})
+        provisioningProfiles: simplenote_provisioning_profiles(
+          root_bundle_id: "#{APP_STORE_BUNDLE_IDENTIFIER}.Alpha",
+          match_type: 'InHouse'
+        )
+      }
+    )
 
     sh("mv ../build/Simplenote.ipa \"../build/Simplenote Alpha.ipa\"")
 
@@ -832,12 +830,30 @@ end
     )
   end
 
-  def simplenote_app_identifiers(root_bundle_id:)
+  # Compiles the array of bundle identifiers for the different targets that
+  # make up the Simplenote app, to be used as the `app_identifier` parameter
+  # for the `match` action.
+  def simplenote_app_identifiers(root_bundle_id: APP_STORE_BUNDLE_IDENTIFIER)
     extension_bundle_ids =
       %w[Share Widgets Intents]
       .map { |suffix| "#{root_bundle_id}.#{suffix}" }
 
     [root_bundle_id, *extension_bundle_ids]
+  end
+
+  # Compiles the dictionary mapping of the bundle identifiers and provisioning
+  # profiles to be used in the `export_options > provisioningProfiles`
+  # parameter for the `build_app`/`gym` action.
+  def simplenote_provisioning_profiles(root_bundle_id: APP_STORE_BUNDLE_IDENTIFIER, match_type: 'AppStore')
+    # FIXME: replace the array below with the following once established the
+    # impact of adding the mapping for the Widgets extension, which is
+    # something we haven't had up to this point.
+    #
+    # bundle_ids = simplenote_app_identifiers(root_bundle_id: root_bundle_id)
+    bundle_ids = [
+      root_bundle_id, "#{root_bundle_id}.Share", "#{root_bundle_id}.Intents"
+    ]
+    bundle_ids.map { |key| [key, "match #{match_type} #{key}"] }.to_h
   end
 
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,6 +45,7 @@ ENV['APP_STORE_STRINGS_FILE_NAME']='AppStoreStrings.pot'
 ENV["PUBLIC_CONFIG_FILE"]="./config/Version.Public.xcconfig"
 ENV["DOWNLOAD_METADATA"]="./fastlane/download_metadata.swift"
 REPOSITORY_NAME="simplenote-ios"
+APP_STORE_BUNDLE_IDENTIFIER = 'com.codality.NotationalFlow'.freeze
 
 # Use this instead of getting values from ENV directly
 # It will throw an error if the requested value is missing
@@ -799,8 +800,6 @@ end
 ########################################################################
 # Fastlane match code signing
 ########################################################################
-
-  APP_STORE_BUNDLE_IDENTIFIER = 'com.codality.NotationalFlow'.freeze
 
   private_lane :alpha_code_signing do |options|
     match(


### PR DESCRIPTION
Builds on top of #1336 to ensure the app can build with the new intents extension.

### Test
This is time consuming to test manually because of the multiple targets and because we want to ensure code signing work.

Here's what I did:

- Try to archive the app with the "Simplenote"
- Modify the "Simplenote" scheme to use "Distribution Alpha" and try to archive
- Repeat with "Distribution Internal"
- Notice how I launched an Installable Build and it [succeeded](https://app.circleci.com/pipelines/github/Automattic/simplenote-ios/3988/workflows/b35025e1-82ba-47d6-a494-7d7b0c8f9ab1/jobs/4450), this exercises the Alpha build configuration in CI
- Comment the ASC and App Center upload in `Fastfile` (see aac0063) and run `bundle exec fastlane build_and_upload_beta_release skip_confirm:true create_gh_release:false`
- Run `bundle exec fastlane build_and_upload_beta_release skip_confirm:true create_gh_release:false`

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

@charilescheer: could you please try this out and let me know if it work for you? Thanks!