### PR TITLE
Previously viewed tag loaded on app launch

### DIFF
--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -133,7 +133,7 @@
     [self configurePublishController];
     [self setupDefaultWindow];
     [self configureStateRestoration];
-    NSLog(@"selected tag: %@", self.selectedTag);
+    
     return YES;
 }
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -79,12 +79,6 @@
     self.window.backgroundColor = [UIColor simplenoteWindowBackgroundColor];
     self.window.tintColor = [UIColor simplenoteTintColor];
 
-    // check to see if the app terminated with a previously selected tag
-    NSString *selectedTag = [[NSUserDefaults standardUserDefaults] objectForKey:kSelectedTagKey];
-    if (selectedTag != nil) {
-		_selectedTag = selectedTag;
-	}
-
     self.tagListViewController = [TagListViewController new];
     self.noteListViewController = [SPNoteListViewController new];
 
@@ -139,7 +133,7 @@
     [self configurePublishController];
     [self setupDefaultWindow];
     [self configureStateRestoration];
-
+    NSLog(@"selected tag: %@", self.selectedTag);
     return YES;
 }
 
@@ -218,11 +212,6 @@
 
 - (void)applicationWillTerminate:(UIApplication *)application
 {
-    // Save the current note and tag
-    if (_selectedTag) {
-        [[NSUserDefaults standardUserDefaults] setObject:_selectedTag forKey:kSelectedTagKey];
-    }
-
     // Save any pending changes
     [self.noteEditorViewController save];
 }

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -364,10 +364,6 @@
             self.selectedTag = nil;
             [self.noteListViewController update];
 			
-			NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-			[defaults removeObjectForKey:kSelectedTagKey];
-			[defaults synchronize];
-			
             [[CSSearchableIndex defaultSearchableIndex] deleteAllSearchableItemsWithCompletionHandler:nil];
             
             // Nuke all of the User Preferences

--- a/Simplenote/SPConstants.m
+++ b/Simplenote/SPConstants.m
@@ -31,7 +31,6 @@ NSString *const kShareExtensionGroupName            = @"group.com.codality.Notat
 NSString *const kShareExtensionGroupName            = @"group.com.codality.NotationalFlow.Development";
 #endif
 
-NSString *const kSelectedTagKey                     = @"SPSelectedTag";
 NSString *const kSimplenoteTrashKey                 = @"__##__trash__##__";
 NSString *const kSimplenoteUntaggedKey              = @"__##__untagged__##__";
 NSString *const kSimplenoteWPServiceName            = @"simplenote-wpcom";


### PR DESCRIPTION
### Fix
This PR fixes #1218 

Currently when Simplenote terminates the previously viewed tag is restored so the app launches into a specific tag, even if that tag has been removed.  This includes going into the trash.  What is expected is the app would launch into All Notes instead.

This PR removes the logic that was saving the last selected tag (there was something odd going on with user defaults and clearing this value) so the app will launch into All Notes

### Test
1. Open the app and select a tag
2. Use the app switcher to close out of Simplenote completely
3. Launch Simplenote
4. You should be taken to All notes when the app loads.

### Review
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
