### PR TITLE
Fixing failing Search tests and `addBulletedLists` test (again)

### DIFF
--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -34,6 +34,16 @@ class NoteEditor {
             noteContentTextView.clearText()
             noteContentTextView.paste(text: enteredValue)
 
+            // Once the text is pasted, there might be an info bubble shown at the note top,
+            // saying "Simplenote pasted from Simplenote-UITestsRunner". Since it covers all
+            // navbar buttons, we have to wait for it to disappear:
+            let isHittablePredicate = NSPredicate { _, _ in
+                app.buttons[UID.Button.dismissKeyboard].isHittable == true
+            }
+
+            let expectation = XCTNSPredicateExpectation(predicate: isHittablePredicate, object: .none)
+            XCTWaiter().wait(for: [expectation], timeout: 0.5)
+
             // Swipe up fast to show tags input, which disappears if pasted text is large
             // enough to push tags input off screen
             noteContentTextView.swipeUp(velocity: .fast)
@@ -47,6 +57,7 @@ class NoteEditor {
     }
 
     class func setFocus() {
+        _ = app.textViews.firstMatch.waitForExistence(timeout: averageLoadTimeout)
         app.textViews.firstMatch.tap()
     }
 

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -36,7 +36,7 @@ class NoteEditor {
 
             // Once the text is pasted, there might be an info bubble shown at the note top,
             // saying "Simplenote pasted from Simplenote-UITestsRunner". Since it covers all
-            // navbar buttons, we have to wait for it to disappear:
+            // NavBar buttons, we have to wait for it to disappear:
             let isHittablePredicate = NSPredicate { _, _ in
                 app.buttons[UID.Button.dismissKeyboard].isHittable == true
             }

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -42,7 +42,8 @@ class NoteEditor {
             }
 
             let expectation = XCTNSPredicateExpectation(predicate: isHittablePredicate, object: .none)
-            XCTWaiter().wait(for: [expectation], timeout: 0.5)
+            XCTWaiter().wait(for: [expectation], timeout: averageLoadTimeout)
+            // end of wait
 
             // Swipe up fast to show tags input, which disappears if pasted text is large
             // enough to push tags input off screen
@@ -57,7 +58,15 @@ class NoteEditor {
     }
 
     class func setFocus() {
-        _ = app.textViews.firstMatch.waitForExistence(timeout: averageLoadTimeout)
+        // Waiting for the TextView to become hittable before using it:
+        let isHittablePredicate = NSPredicate { _, _ in
+            app.textViews.firstMatch.isHittable == true
+        }
+
+        let expectation = XCTNSPredicateExpectation(predicate: isHittablePredicate, object: .none)
+        XCTWaiter().wait(for: [expectation], timeout: averageLoadTimeout)
+        // end of wait
+
         app.textViews.firstMatch.tap()
     }
 

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -64,7 +64,6 @@ class NoteEditor {
 
         let expectation = XCTNSPredicateExpectation(predicate: isHittablePredicate, object: .none)
         XCTWaiter().wait(for: [expectation], timeout: averageLoadTimeout)
-        // end of wait
 
         app.textViews.firstMatch.tap()
     }

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -58,7 +58,7 @@ class NoteEditor {
     }
 
     class func setFocus() {
-        // Waiting for the TextView to become hittable before using it:
+        // Waiting for the TextView to become hittable before using it
         let isHittablePredicate = NSPredicate { _, _ in
             app.textViews.firstMatch.isHittable == true
         }

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -43,7 +43,6 @@ class NoteEditor {
 
             let expectation = XCTNSPredicateExpectation(predicate: isHittablePredicate, object: .none)
             XCTWaiter().wait(for: [expectation], timeout: averageLoadTimeout)
-            // end of wait
 
             // Swipe up fast to show tags input, which disappears if pasted text is large
             // enough to push tags input off screen

--- a/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
+++ b/SimplenoteUITests/SimplenoteUISmokeTestsSettings.swift
@@ -54,6 +54,4 @@ class SimplenoteUISmokeTestsSettings: XCTestCase {
         NoteListAssert.contentIsShown(for: note)
         NoteListAssert.note(note, hasHeight: cellHeightUsual)
     }
-
-
 }

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -264,7 +264,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
         NoteEditor.markdownEnable()
-        
+
         trackStep()
         NoteEditor.clearAndEnterText(enteredValue: noteTitle + noteContent)
         NoteEditor.leaveEditor()

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -263,7 +263,8 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         trackStep()
         NoteList.addNoteTap()
         NoteEditorAssert.editorShown()
-
+        NoteEditor.markdownEnable()
+        
         trackStep()
         NoteEditor.clearAndEnterText(enteredValue: noteTitle + noteContent)
         NoteEditor.leaveEditor()
@@ -276,7 +277,6 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         NoteEditorAssert.textViewWithExactLabelsShownOnce(labels: ["* Asterisk1", "* Asterisk2", "* Asterisk3"])
 
         trackStep()
-        NoteEditor.markdownEnable()
         NoteEditor.swipeToPreview()
         PreviewAssert.staticTextWithExactValuesShownOnce(values: ["• Minus1", "• Minus2", "• Minus3"])
         PreviewAssert.staticTextWithExactValuesShownOnce(values: ["• Plus1", "• Plus2", "• Plus3"])


### PR DESCRIPTION
### Fix
This PR hopefully fixes two issues:
1. `testBulletedLists` test still continues to fail on CI, and now it looks like the reason was in trying to enter the text into note editor before the text view actually appeared. Wait for text view to appear has been added.
**Edit:** besides this, moving the call to enable Markdown in the note to an earlier stage (as done for all other tests) seems to finally solve the issue. 🧙 

2. `setUp()` part of the Search tests started failing in the recent version, because of the text bubble (can be seen on picture) covering NavBar button after pasting text from clipboard:

<img width="291" alt="Screenshot 2021-07-13 at 23 39 37" src="https://user-images.githubusercontent.com/73365754/125525982-6d14e562-32be-4bbd-b292-40fc0cf18a36.png">

The fail occurred at the point of tapping the `Dismiss Keyboard` button - it was not tappable. In this case, I decided to wait for `Dimiss Keyboard` button to become hittable (which means the bubble is gone), instead of hiding the bubble with a swipe.

### Test
Seeing `Subset` and `Full` suits passing on CI should be enough, I believe. [Here](https://app.circleci.com/pipelines/github/Automattic/simplenote-ios?branch=UI-tests-fix-failing-search-tests) you can see that there are:
- 5 successful `Subset` runs since [this commit](https://github.com/Automattic/simplenote-ios/commit/ddb92552b6df87f34409186c72f5fe0378a57537). `testBulletedLists` is a part of this suite.
- One `Full` run, which contains Search tests (and all the other tests).

### Review
I've assigned two reviewers: @thehenrybyrd and @mokagio, but one is enough. _Thank you!_ 🙇 

### Release
These changes do not require release notes.
