### PR TITLE
Update keywords for 4.40

### DIFF
--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -63,7 +63,8 @@ msgstr ""
 #. translators: Keywords used in the App Store search engine to find the app.
 #. Delimit with an English comma between each keyword. Limit to 100 characters including spaces and commas.
 msgctxt "app_store_keywords"
-msgid "simplenote,note,taking,taker,notes,sync,share,simple,markdown,tag,to-do,list,lock,cloud,writing"
+msgid "notes,cloud,simple,notebook,text,to-do,todo,planner,journal,diary,sync,notepad,tag,writing,memo
+"
 msgstr ""
 
 msgctxt "v4.40-whats-new"

--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -63,8 +63,7 @@ msgstr ""
 #. translators: Keywords used in the App Store search engine to find the app.
 #. Delimit with an English comma between each keyword. Limit to 100 characters including spaces and commas.
 msgctxt "app_store_keywords"
-msgid "notes,cloud,simple,notebook,text,to-do,todo,planner,journal,diary,sync,notepad,tag,writing,memo
-"
+msgid "notes,cloud,simple,notebook,text,to-do,todo,planner,journal,diary,sync,notepad,tag,writing,memo"
 msgstr ""
 
 msgctxt "v4.40-whats-new"
@@ -72,4 +71,3 @@ msgid ""
 "-   Some bug fixes #1345, #1347, #1348\n"
 "\n"
 msgstr ""
-

--- a/fastlane/appstoreres/metadata/source/keywords.txt
+++ b/fastlane/appstoreres/metadata/source/keywords.txt
@@ -1,1 +1,1 @@
-simplenote,note,taking,taker,notes,sync,share,simple,markdown,tag,to-do,list,lock,cloud,writing
+notes,cloud,simple,notebook,text,to-do,todo,planner,journal,diary,sync,notepad,tag,writing,memo


### PR DESCRIPTION
This PR updates the keywords as requested in platform9p2. This is my first time updating keywords, so I am not sure what the correct process is. Looking at [update_appstore_strings lane](https://github.com/Automattic/simplenote-ios/blob/develop/fastlane/Fastfile#L107-L122), I think we are supposed to update the `fastlane/appstoreres/metadata/source/keywords.txt` and call that lane as such `bundle exec fastlane update_appstore_strings version:4.40`, so that's what I did.

I am hoping someone who has more experience in the area can correct me if I am mistaken. cc @AliSoftware @mokagio 