### PR TITLE
H5/H6 remove force capitalized in markdown preview

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		B5EB1EFF1C205A800080A1B3 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */; };
 		B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F3000123F4502C007A7C59 /* SPSortBar.xib */; };
 		B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */; };
+		BA113E4D269E860500F3E3B4 /* markdown-light.css in Resources */ = {isa = PBXBuildFile; fileRef = BA113E4C269E860500F3E3B4 /* markdown-light.css */; };
 		BA18532826488DBC00D9A347 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */; };
 		BA2D82C6261522F100A1695B /* PublishNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */; };
 		BA3FB8CF25FEA0C500EA9A1B /* NoticeControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA3FB8CE25FEA0C500EA9A1B /* NoticeControllerTests.swift */; };
@@ -937,6 +938,7 @@
 		B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = ../Icons.xcassets; sourceTree = "<group>"; };
 		B5F3000123F4502C007A7C59 /* SPSortBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSortBar.xib; path = Classes/SPSortBar.xib; sourceTree = "<group>"; };
 		B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortBar.swift; path = Classes/SPSortBar.swift; sourceTree = "<group>"; };
+		BA113E4C269E860500F3E3B4 /* markdown-light.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-light.css"; sourceTree = "<group>"; };
 		BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
 		BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishNoticePresenter.swift; sourceTree = "<group>"; };
 		BA3FB8CE25FEA0C500EA9A1B /* NoticeControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeControllerTests.swift; sourceTree = "<group>"; };
@@ -1122,6 +1124,7 @@
 				17BC3D461BC46BA800535DF3 /* markdown-dark.css */,
 				BA83478225F59F8B0059B797 /* markdown-default-contrast.css */,
 				BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */,
+				BA113E4C269E860500F3E3B4 /* markdown-light.css */,
 			);
 			name = CSS;
 			sourceTree = "<group>";
@@ -2492,6 +2495,7 @@
 				A61471A925D6BC700065D849 /* NoteEditorTagSuggestionsViewController.xib in Resources */,
 				A69F861D25408085005140F2 /* NoteInformationViewController.xib in Resources */,
 				BA4499AA25ED8821000C563E /* NoticeView.xib in Resources */,
+				BA113E4D269E860500F3E3B4 /* markdown-light.css in Resources */,
 				B513F2B62319A8F40021CFA4 /* SPNoteTableViewCell.xib in Resources */,
 				B5078A001C1F5595009F097A /* markdown-dark.css in Resources */,
 				B502311325129525002C3CDA /* SPDiagnosticsViewController.xib in Resources */,

--- a/Simplenote/Classes/SPMarkdownParser.m
+++ b/Simplenote/Classes/SPMarkdownParser.m
@@ -50,7 +50,19 @@
             "<style media=\"screen\" type=\"text/css\">\n";
     NSString *headerEnd = @"</style></head><body><div class=\"note-detail-markdown\">";
 
+    NSString *css = [self cssForMarkdown];
+
+    return [[headerStart stringByAppendingString:css] stringByAppendingString:headerEnd];
+}
+
++ (NSString *)cssForMarkdown
+{
     NSString *css = [self loadCSSAtPath:self.cssPath];
+
+    // Load CSS colors
+    //
+    NSString *colors = [self loadCSSAtPath:self.cssColorPath];
+    css = [css stringByAppendingString:colors];
 
     // Check if increase contrast is enabled.  If enabled amend CSS to include high contrast colors
     //
@@ -60,8 +72,8 @@
             css = [css stringByAppendingString:contrast];
         }
     }
-    
-    return [[headerStart stringByAppendingString:css] stringByAppendingString:headerEnd];
+
+    return css;
 }
 
 + (NSString *)loadCSSAtPath:(NSString *)path
@@ -72,11 +84,15 @@
 
 + (NSString *)cssPath
 {
+    return @"markdown-default.css";
+}
+
++ (NSString *)cssColorPath
+{
     if (SPUserInterface.isDark) {
         return @"markdown-dark.css";
     }
-
-    return @"markdown-default.css";
+    return @"markdown-light.css";
 }
 
 + (NSString *)contrastCssPath

--- a/Simplenote/Resources/markdown-default.css
+++ b/Simplenote/Resources/markdown-default.css
@@ -74,7 +74,6 @@ html {
 
 .note-detail-markdown h5, .note-detail-markdown h6 {
     font-size: 1em;
-    text-transform: uppercase;
 }
 
 .note-detail-markdown #title {

--- a/Simplenote/Resources/markdown-default.css
+++ b/Simplenote/Resources/markdown-default.css
@@ -19,8 +19,6 @@ img {
 html {
     margin: 0;
     padding: 0;
-    background: #FFFFFF;
-    color: #111111;
     text-rendering: optimizeLegibility;
 }
 
@@ -34,7 +32,6 @@ html {
 
 ::-webkit-scrollbar-thumb {
     border-radius: 6px;
-    background: #84878a;
 }
 
 /* Same styles as app.simplenote.com/publish */
@@ -103,14 +100,9 @@ html {
     height: auto;
 }
 
-.note-detail-markdown a {
-    color: #3361cc;
-}
-
 .note-detail-markdown hr {
     border: 0;
     margin: 3.4em 0;
-    color: #4895d9;
     height: 1em;
 }
 
@@ -132,19 +124,13 @@ html {
     padding-left: 1.7em;
 }
 
-.note-detail-markdown code {
-    color: #899199;
-}
-
 .note-detail-markdown pre {
     padding: 1em;
     border-radius: 3px;
-    background: #f6f7f8;
 }
 
 .note-detail-markdown pre code {
     font-size: 85%;
-    color: #616870;
     background: transparent;
     width: 100%;
     overflow-x: auto;
@@ -159,12 +145,8 @@ html {
     width: 100%;
 }
 
-.note-detail-markdown table tr:nth-child(2n) {
-    background-color: #f6f7f8;
-}
-
 .note-detail-markdown table th, .note-detail-markdown table td {
-    border: 1px solid #c0c4c8;
+    border: 1px solid;
     padding: 6px 13px;
 }
 

--- a/Simplenote/Resources/markdown-light.css
+++ b/Simplenote/Resources/markdown-light.css
@@ -1,6 +1,7 @@
+
 html {
-    background: 1f2123;
-    color: #DDDDDD;
+    background: #FFFFFF;
+    color: #111111;
 }
 
 ::-webkit-scrollbar-thumb {
@@ -8,7 +9,7 @@ html {
 }
 
 .note-detail-markdown a {
-    color: #618df2;
+    color: #3361cc;
 }
 
 .note-detail-markdown hr {
@@ -16,7 +17,7 @@ html {
 }
 
 .note-detail-markdown code {
-    color: #84878a;
+    color: #899199;
 }
 
 .note-detail-markdown pre {
@@ -28,9 +29,9 @@ html {
 }
 
 .note-detail-markdown table tr:nth-child(2n) {
-    background-color: #383d41;
+    background-color: #f6f7f8;
 }
 
 .note-detail-markdown table th, .note-detail-markdown table td {
-    border-color: #575e65;
+    border-color: #c0c4c8;
 }


### PR DESCRIPTION
### Fix
With this PR I have made two changes, first fixes #1304  where all H5 and H6 text in markdown preview were set to uppercase.  That will not happen now.

The other change in this PR changes the organization of the CSS and how it is loaded.  Previously all the CSS was in two separate files, default and dark.  Depending on if the device was in dark mode or not it would load one file or another.  But that also meant that we needed to maintain two files to update the CSS correctly.

What I have done is removed the color CSS from the default file and made two files for the colors.  So now the main CSS is loaded and then depending on the dark mode setting the correct color css is loaded and appended to the main css.  This change isn't visible in the app,  just an convenience for maintaining the markdown css

### Test
1. create a note that has mixed case H5 and H6 text in it
2. activate markdown on that note
3. go to the preview and check to make sure the heading text case is unchanged
4. Check dark mode and light mode

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
