### PR TITLE
Track XCUITestHelpers using version 0.1.0

### DIFF
--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,9 +32,9 @@
         "package": "XCUITestHelpers",
         "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
         "state": {
-          "branch": "trunk",
+          "branch": null,
           "revision": "47d688b0b2a6356361a16836c4d23f12d6643a73",
-          "version": null
+          "version": "0.1.0"
         }
       }
     ]


### PR DESCRIPTION
This should have been part of 39e10c34, but I somehow missed it.


### Test
If CI builds, we're good.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.