### PR TITLE
Sanitize app store keywords after updating metadata

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -124,7 +124,7 @@ end
   # This lane lacks documentation because it ought to be part of the localized
   # metadata download script instead!
   desc "Updates the files with the localized keywords values for App Store Connect to match the 100 characters requirement"
-  lane :sanitize_appstore_keywords do | options |
+  lane :sanitize_appstore_keywords do
     Dir["./metadata/**"].each do |locale_dir|
       keywords_path = File.join(locale_dir, 'keywords.txt')
 
@@ -175,7 +175,7 @@ end
   lane :new_beta_release do | options |
     ios_betabuild_prechecks(options)
     ios_update_metadata(options)
-    sanitize_appstore_keywords(options)
+    sanitize_appstore_keywords()
     ios_lint_localizations(input_dir: 'Simplenote', allow_retry: true)
     ios_bump_version_beta()
     ios_tag_build()
@@ -247,7 +247,7 @@ end
       )
 
       ios_update_metadata(options)
-      sanitize_appstore_keywords(options)
+      sanitize_appstore_keywords()
       ios_lint_localizations(input_dir: 'Simplenote', allow_retry: true)
       ios_bump_version_beta() unless ios_current_branch_is_hotfix
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -175,6 +175,7 @@ end
   lane :new_beta_release do | options |
     ios_betabuild_prechecks(options)
     ios_update_metadata(options)
+    sanitize_appstore_keywords(options)
     ios_lint_localizations(input_dir: 'Simplenote', allow_retry: true)
     ios_bump_version_beta()
     ios_tag_build()
@@ -246,6 +247,7 @@ end
       )
 
       ios_update_metadata(options)
+      sanitize_appstore_keywords(options)
       ios_lint_localizations(input_dir: 'Simplenote', allow_retry: true)
       ios_bump_version_beta() unless ios_current_branch_is_hotfix
     end


### PR DESCRIPTION
During `4.40` release, we had quite a few languages go over the 100 character limit for `keywords`. I've manually shortened them in 1d38adb8f02366cffe6a3f35d141f10b224d088a & 10e87a360a3dab31902290eb7f1be82e518344d4.

I pinged Sylvester in the platform9 request for updating keywords with this information and he re-ordered the `keywords` ([updated here](https://github.com/Automattic/simplenote-ios/pull/1367#discussion_r677205683)) and asked us to cut the keywords down for any locales that go above the 100 character limit.

When I started working on this request, I realized we already have this implemented in our `sanitize_appstore_keywords`, we just had to call it manually. With this new request, I think it makes sense to do this after every `ios_update_metadata` call, so I've made the change in this PR.

I am wondering if it'd make sense to do this in release-toolkit instead and make it available to every app. It should probably be a deliberate decision per app, but we can make it optional and default to `false`. Then, each app can maybe decide whether to sanitize the keywords.

Regardless of whether we implement this in the toolkit, I think we should merge this PR in for now. (assuming this is the correct way to handle this issue)