### PR TITLE
[Tooling] Fix hotfix lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -184,7 +184,7 @@ end
   #####################################################################################
   # new_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane updates the release branch for a new hotix release.
+  # This lane creates the release branch for a new hotfix release.
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<version>]
@@ -193,7 +193,7 @@ end
   # bundle exec fastlane new_hotfix_release version:10.6.1
   # bundle exec fastlane new_hotfix_release skip_confirm:true version:10.6.1
   #####################################################################################
-  desc "Creates a new hotfix branch from the given tag"
+  desc 'Creates a new hotfix branch for the given version:x.y.z. The branch will be cut from the tag x.y of the previous release'
   lane :new_hotfix_release do | options |
     prev_ver = ios_hotfix_prechecks(options)
     ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
@@ -210,10 +210,10 @@ end
   # Example:
   # bundle exec fastlane finalize_hotfix_release skip_confirm:true
   #####################################################################################
-  desc "Creates a new hotfix branch from the given tag"
-  lane :finalize_hotfix_release do | options |
+  desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
+  lane :finalize_hotfix_release do |options|
     ios_finalize_prechecks(options)
-    version = ios_get_app_version()
+    version = ios_get_app_version
     trigger_release_build(branch_to_build: "release/#{version}")
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -231,26 +231,27 @@ end
   # bundle exec fastlane finalize_release skip_confirm:true
   #####################################################################################
   desc 'Trigger the final release build on CI'
-  lane :finalize_release do | options |
+  lane :finalize_release do |options|
+    UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
+
     ios_finalize_prechecks(options)
-    unless ios_current_branch_is_hotfix
-      UI.message('Checking app strings translation status...')
-      check_translation_progress(
-        glotpress_url: 'https://translate.wordpress.com/projects/simplenote/ios/',
-        abort_on_violations: false
-      )
+    
+    UI.message('Checking app strings translation status...')
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.com/projects/simplenote/ios/',
+      abort_on_violations: false
+    )
 
-      UI.message("Checking release notes strings translation status...")
-      check_translation_progress(
-        glotpress_url: 'https://translate.wordpress.com/projects/simplenote/ios/release-notes/',
-        abort_on_violations: false
-      )
+    UI.message("Checking release notes strings translation status...")
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.com/projects/simplenote/ios/release-notes/',
+      abort_on_violations: false
+    )
 
-      ios_update_metadata(options)
-      sanitize_appstore_keywords()
-      ios_lint_localizations(input_dir: 'Simplenote', allow_retry: true)
-      ios_bump_version_beta() unless ios_current_branch_is_hotfix
-    end
+    ios_update_metadata(options)
+    sanitize_appstore_keywords()
+    ios_lint_localizations(input_dir: 'Simplenote', allow_retry: true)
+    ios_bump_version_beta()
 
     # Wrap up
     version = ios_get_app_version()


### PR DESCRIPTION
Part of the paaHJt-1WQ-p2 project.

_Note: In the case of SNiOS, not much has been changed on the hotfix lanes as part of this PR (except the lane's description to make them more descriptive), but as part of this project, it's still worth going through the test scenario below to ensure that hotfix were already working as expected (and didn't break in the past but got unnoticed)_

## To test

 - Checkout this branch, run `bundle install`
 - Run `bundle exec fastlane new_hotfix_release version:4.40.1`
 - Verify that it cut a `release/4.40.1` branch from the `4.40` tag
 - Verify that it bumped the version in `Version.public.xcconfig` and `fastlane/Deliverfile` (*)
 - cherry-pick all the commits from this PR on top of the `release/4.40.1` branch. This is because we are gonna test the updated finalize lanes, and need to be on the hotfix release branch to test them. (You might get conflicts during the cherry-pick)
 - [Open the CircleCI page for SNiOS](https://app.circleci.com/pipelines/github/Automattic/simplenote-ios) in advance, to be ready to cancel the release build
 - Run `bundle exec fastlane finalize_release`. You should get an error telling you that you should use `finalize_hotfix_release` for hotfix branches instead
 - Run `bundle exec fastlane finalize_hotfix_release` and verify that it triggered a release build, and that is is building it from the release/4.40.1 hotfix branch. Cancel the CI build immediately.
 - Delete the `release/4.40.1` branch (from both local and remote)

## A note on Deliverfile bump

@mokagio is working on removing the `Deliverfile` – see https://github.com/wordpress-mobile/release-toolkit/pull/287 – in our repos, to run `deliver` as part of a lane to which we'll explicitly pass the right parameters, including the version, hence the bump not needing to change the app version in `Deliverfile` anymore in the future.

This means that once @mokagio's work lands, the hotfix lanes will need to be amended again, to specify that the `Deliverfile` should not be updated as part of any version bump… including hotfix ones. This work will be done separately to the hotfix alignment work from this PR, to avoid postponing things too much and blocking the project.