### PR TITLE
Add bulk trash test

### DIFF
--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -47,18 +47,17 @@ func toggleSwitchIfNeeded(_ switchElement: XCUIElement, _ value: String) {
     switchElement.tap()
 }
 
-func dismissVerifyEmailIfNeeded(using app: XCUIApplication) {
-    guard app.staticTexts["Review Your Account"].waitForExistence(timeout: 15) else { return }
-    app.buttons["icon cross"].tap()
+func dismissVerifyEmailIfNeeded() {
+    guard app.staticTexts[Text.alertReviewAccount].waitForExistence(timeout: 15) else { return }
+    app.buttons[UID.Button.crossIcon].tap()
 }
 
 func populateNoteList(title: String, numberToCreate: Int) {
     for i in 1...numberToCreate {
-        let noteTitle = title + String(i)
+        let noteTitle = title + "-" + String(i)
         let noteContent = "\n\nSome content here for note " + String(i)
 
         NoteList.addNoteTap()
-        NoteEditorAssert.editorShown()
         NoteEditor.clearAndEnterText(enteredValue: noteTitle + noteContent)
         NoteEditor.leaveEditor()
     }

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -47,6 +47,18 @@ func toggleSwitchIfNeeded(_ switchElement: XCUIElement, _ value: String) {
     switchElement.tap()
 }
 
+func populateNotesList(title: String, numberToCreate: Int) {
+    for i in 1...numberToCreate {
+        let noteTitle = title + String(i)
+        let noteContent = "\n\nSome content here for note " + String(i)
+
+        NoteList.addNoteTap()
+        NoteEditorAssert.editorShown()
+        NoteEditor.clearAndEnterText(enteredValue: noteTitle + noteContent)
+        NoteEditor.leaveEditor()
+    }
+}
+
 class Table {
 
     class func getAllCells() -> XCUIElementQuery {

--- a/SimplenoteUITests/Generic.swift
+++ b/SimplenoteUITests/Generic.swift
@@ -47,7 +47,12 @@ func toggleSwitchIfNeeded(_ switchElement: XCUIElement, _ value: String) {
     switchElement.tap()
 }
 
-func populateNotesList(title: String, numberToCreate: Int) {
+func dismissVerifyEmailIfNeeded(using app: XCUIApplication) {
+    guard app.staticTexts["Review Your Account"].waitForExistence(timeout: 15) else { return }
+    app.buttons["icon cross"].tap()
+}
+
+func populateNoteList(title: String, numberToCreate: Int) {
     for i in 1...numberToCreate {
         let noteTitle = title + String(i)
         let noteContent = "\n\nSome content here for note " + String(i)

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -129,6 +129,28 @@ class NoteList {
         guard searchCancelButton.exists else { return }
         searchCancelButton.tap()
     }
+
+    class func longPressNote(title: String) {
+        app.tables.cells[title].press(forDuration: 3)
+    }
+
+    class func selectNote() {
+        let selectButton = app.buttons[UID.Button.select]
+        guard selectButton.exists else { return }
+        selectButton.tap()
+    }
+
+    class func selectAll() {
+        let selectAllButton = app.buttons[UID.Button.selectAll]
+        guard selectAllButton.exists else { return }
+        selectAllButton.tap()
+    }
+
+    class func tapTrashButton() {
+        let trashIcon = app.buttons[UID.Button.trashIcon]
+        guard trashIcon.exists else { return }
+        trashIcon.tap()
+    }
 }
 
 class NoteListAssert {
@@ -273,5 +295,9 @@ class NoteListAssert {
 
         print(">>> Actual search string is '\(actualSearchString)'")
         XCTAssertEqual(actualSearchString, searchString)
+    }
+
+    class func isDeselectAllButtonDisplayed() {
+        XCTAssertTrue(app.buttons[UID.Button.deselectAll].waitForExistence(timeout: maxLoadTimeout))
     }
 }

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -134,7 +134,7 @@ class NoteList {
         app.tables.cells[title].press(forDuration: 3)
     }
 
-    class func selectNote() {
+    class func selectNoteFromContextMenu() {
         let selectButton = app.buttons[UID.Button.select]
         guard selectButton.exists else { return }
         selectButton.tap()
@@ -146,10 +146,10 @@ class NoteList {
         selectAllButton.tap()
     }
 
-    class func tapTrashButton() {
-        let trashIcon = app.buttons[UID.Button.trashIcon]
-        guard trashIcon.exists else { return }
-        trashIcon.tap()
+    class func tapTrashNotesButton() {
+        let trashNotesButton = app.buttons[UID.Button.trashNotes]
+        guard trashNotesButton.exists else { return }
+        trashNotesButton.tap()
     }
 }
 
@@ -297,7 +297,7 @@ class NoteListAssert {
         XCTAssertEqual(actualSearchString, searchString)
     }
 
-    class func isDeselectAllButtonDisplayed() {
+    class func deselectAllButtonDisplayed() {
         XCTAssertTrue(app.buttons[UID.Button.deselectAll].waitForExistence(timeout: maxLoadTimeout))
     }
 }

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -16,6 +16,12 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let _ = attemptLogOut()
         EmailLogin.open()
         EmailLogin.logIn()
+
+        // Extra check for certain emails
+        if testDataEmail.contains("trial") {
+            dismissVerifyEmailIfNeeded(using: app)
+        }
+
         NoteList.waitForLoad()
     }
 
@@ -288,7 +294,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let noteTitle = "Note Title "
 
         trackStep()
-        populateNotesList(title: noteTitle, numberToCreate: 2)
+        populateNoteList(title: noteTitle, numberToCreate: 2)
 
         trackStep()
         NoteList.longPressNote(title: noteTitle + "1")

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -308,6 +308,8 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         trackStep()
         Trash.open()
-        NoteListAssert.notesNumber(expectedNotesNumber: 2)
+        TrashAssert.notesNumber(expectedNotesNumber: 2)
+        TrashAssert.noteExists(noteName: noteTitle + "-1")
+        TrashAssert.noteExists(noteName: noteTitle + "-2")
     }
 }

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -282,4 +282,22 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         PreviewAssert.staticTextWithExactValuesShownOnce(values: ["• Plus1", "• Plus2", "• Plus3"])
         PreviewAssert.staticTextWithExactValuesShownOnce(values: ["• Asterisk1", "• Asterisk2", "• Asterisk3"])
     }
+
+    func testSelectAllAndTrashNotes() throws {
+        trackTest()
+        let noteTitle = "Note Title "
+
+        trackStep()
+        populateNotesList(title: noteTitle, numberToCreate: 2)
+
+        trackStep()
+        NoteList.longPressNote(title: noteTitle + "1")
+        NoteList.selectNote()
+        NoteList.selectAll()
+        NoteListAssert.isDeselectAllButtonDisplayed()
+
+        trackStep()
+        NoteList.tapTrashButton()
+        NoteListAssert.notesNumber(expectedNotesNumber: 0)
+    }
 }

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -19,7 +19,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         // Extra check for certain emails
         if testDataEmail.contains("trial") {
-            dismissVerifyEmailIfNeeded(using: app)
+            dismissVerifyEmailIfNeeded()
         }
 
         NoteList.waitForLoad()
@@ -291,19 +291,23 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
     func testSelectAllAndTrashNotes() throws {
         trackTest()
-        let noteTitle = "Note Title "
+        let noteTitle = "Note Title"
 
         trackStep()
         populateNoteList(title: noteTitle, numberToCreate: 2)
 
         trackStep()
-        NoteList.longPressNote(title: noteTitle + "1")
-        NoteList.selectNote()
+        NoteList.longPressNote(title: noteTitle + "-1")
+        NoteList.selectNoteFromContextMenu()
         NoteList.selectAll()
-        NoteListAssert.isDeselectAllButtonDisplayed()
+        NoteListAssert.deselectAllButtonDisplayed()
 
         trackStep()
-        NoteList.tapTrashButton()
+        NoteList.tapTrashNotesButton()
         NoteListAssert.notesNumber(expectedNotesNumber: 0)
+
+        trackStep()
+        Trash.open()
+        NoteListAssert.notesNumber(expectedNotesNumber: 2)
     }
 }

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -56,7 +56,8 @@ enum UID {
         static let select = "Select"
         static let selectAll = "Select All"
         static let deselectAll = "Deselect All"
-        static let trashIcon = "Trash Notes"
+        static let trashNotes = "Trash Notes"
+        static let crossIcon = "icon cross"
     }
 
     enum Text {
@@ -83,6 +84,7 @@ enum Text {
     static let appTagline = "The simplest way to keep notes."
     static let alertHeadingSorry = "Sorry!"
     static let alertContentLoginFailed = "Could not login with the provided email address and password."
+    static let alertReviewAccount = "Review Your Account"
     static let loginEmailInvalid = "Your email address is not valid"
     static let loginPasswordShort = "Password must contain at least 4 characters"
 }

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -38,7 +38,7 @@ enum UID {
         static let trashNote = "Move to Trash"
         static let restoreNote = "Restore Note"
         static let deleteNote = "Delete Note"
-      
+
         // "Empty Trash" button label is generated
         // differently by Xcode 12.4 and 12.5 (runs iOS 14.5+)
         static private(set) var trashEmptyTrash: String = {
@@ -53,6 +53,10 @@ enum UID {
         static let cancel = "Cancel"
         static let dismissKeyboard = "Dismiss keyboard"
         static let deleteTagConfirmation = "Delete Tag"
+        static let select = "Select"
+        static let selectAll = "Select All"
+        static let deselectAll = "Deselect All"
+        static let trashIcon = "Trash Notes"
     }
 
     enum Text {


### PR DESCRIPTION
### Fix
This PR doesn't fix anything but rather adds an additional UI test. There is also an additional function that is used to dismiss alerts seen on certain accounts.

### Test
Test flow: Login -> Add multiple notes -> Select one note by long press -> Select all notes -> Tap trash icon on note list screen

### Review
@pachlava 

### Release
These changes do not require release notes.
