### PR TITLE
Fixed a bug where the account deletion token was  created incorrectly

### DIFF
--- a/Simplenote/AccountRemote.swift
+++ b/Simplenote/AccountRemote.swift
@@ -8,7 +8,7 @@ class AccountRemote: Remote {
     /// Send verification request for specified email address
     ///
     func verify(email: String, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        let request = verificationURLRequest(with: email)!
+        let request = verificationURLRequest(with: email)
 
         performDataTask(with: request, completion: completion)
     }
@@ -16,17 +16,14 @@ class AccountRemote: Remote {
     /// Send account deletion request for user
     ///
     func requestDelete(_ user: SPUser, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        let request = deleteRequest(with: user)!
-
+        let request = deleteRequest(with: user)
         performDataTask(with: request, completion: completion)
     }
 
     // MARK: URL Requests
 
-    private func verificationURLRequest(with email: String) -> URLRequest? {
-        guard let base64EncodedEmail = email.data(using: .utf8)?.base64EncodedString() else {
-            return nil
-        }
+    private func verificationURLRequest(with email: String) -> URLRequest {
+        let base64EncodedEmail = email.data(using: .utf8)!.base64EncodedString()
         let verificationURL = URL(string: SimplenoteConstants.verificationURL)!
 
         var request = URLRequest(url: verificationURL.appendingPathComponent(base64EncodedEmail),
@@ -37,7 +34,7 @@ class AccountRemote: Remote {
         return request
     }
 
-    private func deleteRequest(with user: SPUser) -> URLRequest? {
+    private func deleteRequest(with user: SPUser) -> URLRequest {
         let url = URL(string: SimplenoteConstants.accountDeletionURL)!
 
         var request = URLRequest(url: url,

--- a/Simplenote/AccountRemote.swift
+++ b/Simplenote/AccountRemote.swift
@@ -8,10 +8,7 @@ class AccountRemote: Remote {
     /// Send verification request for specified email address
     ///
     func verify(email: String, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        guard let request = verificationURLRequest(with: email) else {
-            completion(.failure(RemoteError.urlRequestError))
-            return
-        }
+        let request = verificationURLRequest(with: email)!
 
         performDataTask(with: request, completion: completion)
     }
@@ -19,10 +16,7 @@ class AccountRemote: Remote {
     /// Send account deletion request for user
     ///
     func requestDelete(_ user: SPUser, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        guard let request = deleteRequest(with: user) else {
-            completion(.failure(RemoteError.urlRequestError))
-            return
-        }
+        let request = deleteRequest(with: user)!
 
         performDataTask(with: request, completion: completion)
     }
@@ -30,10 +24,10 @@ class AccountRemote: Remote {
     // MARK: URL Requests
 
     private func verificationURLRequest(with email: String) -> URLRequest? {
-        guard let base64EncodedEmail = email.data(using: .utf8)?.base64EncodedString(),
-              let verificationURL = URL(string: SimplenoteConstants.verificationURL) else {
+        guard let base64EncodedEmail = email.data(using: .utf8)?.base64EncodedString() else {
             return nil
         }
+        let verificationURL = URL(string: SimplenoteConstants.verificationURL)!
 
         var request = URLRequest(url: verificationURL.appendingPathComponent(base64EncodedEmail),
                                  cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
@@ -44,9 +38,7 @@ class AccountRemote: Remote {
     }
 
     private func deleteRequest(with user: SPUser) -> URLRequest? {
-        guard let url = URL(string: SimplenoteConstants.accountDeletionURL) else {
-            return nil
-        }
+        let url = URL(string: SimplenoteConstants.accountDeletionURL)!
 
         var request = URLRequest(url: url,
                                  cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -8,7 +8,6 @@ enum SPAuthError: Error {
     case signupBadCredentials
     case signupUserAlreadyExists
     case network
-    case urlRequestError
     case unknown(statusCode: Int, response: String?, error: Error?)
 }
 
@@ -70,8 +69,6 @@ extension SPAuthError {
             return NSLocalizedString("The email you've entered is already associated with a Simplenote account.", comment: "Error when address is in use")
         case .network:
             return NSLocalizedString("The network could not be reached.", comment: "Error when the network is inaccessible")
-        case .urlRequestError:
-            return NSLocalizedString("Could not prepare URL request.", comment: "Error when url request can't be made")
         case .unknown:
             return NSLocalizedString("We're having problems. Please try again soon.", comment: "Generic error")
         }

--- a/Simplenote/Classes/SPAuthHandler.swift
+++ b/Simplenote/Classes/SPAuthHandler.swift
@@ -82,8 +82,6 @@ class SPAuthHandler {
         switch remoteError {
         case .network:
             return SPAuthError.network
-        case .urlRequestError:
-            return SPAuthError.urlRequestError
         case .requestError(let statusCode, let error):
             return SPAuthError(signupErrorCode: statusCode, response: error?.localizedDescription, error: error)
         }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -135,7 +135,7 @@ extension SPSettingsViewController {
         switch error {
         case .network:
             NoticeController.shared.present(NoticeFactory.networkError())
-        case .requestError, .urlRequestError:
+        case .requestError:
             presentRequestErrorAlert()
         }
     }

--- a/Simplenote/Classes/SignupRemote.swift
+++ b/Simplenote/Classes/SignupRemote.swift
@@ -4,15 +4,13 @@ import Foundation
 //
 class SignupRemote: Remote {
     func signup(with email: String, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        let urlRequest = request(with: email)!
+        let urlRequest = request(with: email)
 
         performDataTask(with: urlRequest, completion: completion)
     }
 
-    private func request(with email: String) -> URLRequest? {
-        guard let url = URL(string: SimplenoteConstants.signupURL) else {
-            return nil
-        }
+    private func request(with email: String) -> URLRequest {
+        let url = URL(string: SimplenoteConstants.signupURL)!
 
         var request = URLRequest(url: url,
                                  cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,

--- a/Simplenote/Classes/SignupRemote.swift
+++ b/Simplenote/Classes/SignupRemote.swift
@@ -4,12 +4,9 @@ import Foundation
 //
 class SignupRemote: Remote {
     func signup(with email: String, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        guard let request = request(with: email) else {
-            completion(.failure(RemoteError.urlRequestError))
-            return
-        }
+        let urlRequest = request(with: email)!
 
-        performDataTask(with: request, completion: completion)
+        performDataTask(with: urlRequest, completion: completion)
     }
 
     private func request(with email: String) -> URLRequest? {

--- a/Simplenote/Controllers/AccountDeletionController.swift
+++ b/Simplenote/Controllers/AccountDeletionController.swift
@@ -14,7 +14,6 @@ class AccountDeletionController: NSObject {
     }
 
     func requestAccountDeletion(_ user: SPUser, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        accountDeletionRequestDate = Date()
         AccountRemote().requestDelete(user) { [weak self] (result) in
             if case .success = result {
                 self?.accountDeletionRequestDate = Date()

--- a/Simplenote/Controllers/AccountDeletionController.swift
+++ b/Simplenote/Controllers/AccountDeletionController.swift
@@ -5,8 +5,7 @@ class AccountDeletionController: NSObject {
     private var accountDeletionRequestDate: Date?
 
     var deletionTokenHasExpired: Bool {
-        guard let requestDate = accountDeletionRequestDate,
-              let expirationDate = requestDate.increased(byDays: 1) else {
+        guard let expirationDate = accountDeletionRequestDate?.increased(byDays: 1) else {
             return true
         }
 

--- a/Simplenote/RemoteError.swift
+++ b/Simplenote/RemoteError.swift
@@ -2,7 +2,6 @@ import Foundation
 
 enum RemoteError: Error {
     case network
-    case urlRequestError
     case requestError(Int, Error?)
 }
 
@@ -10,8 +9,6 @@ extension RemoteError: Equatable {
     static func == (lhs: RemoteError, rhs: RemoteError) -> Bool {
         switch (lhs, rhs) {
         case (.network, .network):
-            return true
-        case (.urlRequestError, .urlRequestError):
             return true
         case (.requestError(let lhsStatus, let lhsError), .requestError(let rhsStatus, let rhsError)):
             return lhsStatus == rhsStatus && lhsError?.localizedDescription == rhsError?.localizedDescription

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -414,7 +414,6 @@ extension SPAppDelegate {
         }
 
         if deletionController.deletionTokenHasExpired {
-            self.accountDeletionController = nil
             return
         }
 

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -79,6 +79,11 @@ extension SPAppDelegate {
             PublishNoticePresenter.presentNotice(for: note)
         }
     }
+
+    @objc
+    func configureAccountDeletionController() {
+        accountDeletionController = AccountDeletionController()
+    }
 }
 
 // MARK: - URL Handlers and Deep Linking

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -127,6 +127,7 @@
     [self setupCrashLogging];
     [self configureVersionsController];
     [self configurePublishController];
+    [self configureAccountDeletionController];
     [self setupDefaultWindow];
     [self configureStateRestoration];
     
@@ -576,18 +577,6 @@
 + (SPAppDelegate *)sharedDelegate
 {
     return (SPAppDelegate *)[[UIApplication sharedApplication] delegate];
-}
-
-#pragma mark ================================================================================
-#pragma mark Deletion Controller
-#pragma mark ================================================================================
-
-- (AccountDeletionController *)accountDeletionController {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        _accountDeletionController = [AccountDeletionController new];
-    });
-    return _accountDeletionController;
 }
 
 @end


### PR DESCRIPTION
### Fix
This PR is in response to feedback from  @eshurakov after the account deletion was merged.
I have:
1. fixed a bug where the account deletion token was created each time the app came from the background
2. removed guards for url request and url creations in the remotes

### Test
1. Attempt to do an account signup to confirm the remotes still work correctly
2. attempt to request deletion for that account
3. after requesting deletion, send the app into the background
4. complete the deletion
5. bring the app out of the background and confirm that the login screen appears

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
