### PR TITLE
Updated release notes for 4.42

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 4.42
 -----
-
+-   Added In app account deletion #1354
 
 4.41
 -----
@@ -9,7 +9,6 @@
 
 4.40
 -----
--   Added In app account deletion #1354
 -   Some bug fixes #1345, #1347, #1348
 
 4.39


### PR DESCRIPTION
### Fix
Previously added release notes for #1354  had been added in the wrong place on the release notes.

This PR puts them under the correct release

