### PR TITLE
Undo via snackbar and copy internal link tests

### DIFF
--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -55,7 +55,7 @@ class NoteEditor {
     class func enterTitle(enteredValue: String) {
         let noteContentTextView = app.textViews.element
 
-        noteContentTextView.clearAndEnterText(text: enteredValue)
+        noteContentTextView.clearAndEnterText(text: enteredValue + "\n")
     }
 
     class func pasteNoteContent() {

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -52,6 +52,17 @@ class NoteEditor {
         }
     }
 
+    class func enterTitle(enteredValue: String) {
+        let noteContentTextView = app.textViews.element
+
+        noteContentTextView.clearAndEnterText(text: enteredValue)
+    }
+
+    class func pasteNoteContent() {
+        app.press(forDuration: 1.2)
+        app.menuItems["Paste"].tap()
+    }
+
     class func getEditorText() -> String {
         return app.textViews.element.value as! String
     }

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -60,7 +60,7 @@ class NoteEditor {
 
     class func pasteNoteContent() {
         app.press(forDuration: 1.2)
-        app.menuItems["Paste"].tap()
+        app.menuItems[UID.ContextMenuItem.paste].tap()
     }
 
     class func getEditorText() -> String {

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -140,6 +140,18 @@ class NoteList {
         selectButton.tap()
     }
 
+    class func deleteNoteFromContextMenu() {
+        let deleteNoteButton = app.buttons[UID.Button.deleteNote]
+        guard deleteNoteButton.exists else { return }
+        deleteNoteButton.tap()
+    }
+
+    class func copyInternalLinkFromContextMenu() {
+        let copyInternalLinkButton = app.buttons[UID.Button.copyInternalLink]
+        guard copyInternalLinkButton.exists else { return }
+        copyInternalLinkButton.tap()
+    }
+
     class func selectAll() {
         let selectAllButton = app.buttons[UID.Button.selectAll]
         guard selectAllButton.exists else { return }
@@ -150,6 +162,12 @@ class NoteList {
         let trashNotesButton = app.buttons[UID.Button.trashNotes]
         guard trashNotesButton.exists else { return }
         trashNotesButton.tap()
+    }
+
+    class func tapUndoOnSnackbar() {
+        let undoButton = app.buttons[UID.Button.undoTrashButton]
+        guard undoButton.exists else { return }
+        undoButton.tap()
     }
 }
 

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -331,30 +331,27 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         NoteListAssert.noteExists(noteName: noteName + "-1")
     }
 
-    func testCopyAndPasteInterlink() throws {
+    func testCopyAndPasteInternalLink() throws {
         trackTest()
-        let toCopyNoteTitle = "Copy Internal Link Title"
-        let toPasteNoteTitle = "Paste Internal Link Title\n"
-        let note = NoteData(
-            name: "Paste Internal Link Title",
-            content: "[Copy Internal Link Title-1](simplenote://note/"
-        )
+        let originalNoteTitle = "Original Note Title"
+        let referringNoteTitle = "Referring Note Title"
+        let referringNoteData = NoteData(
+                name: referringNoteTitle,
+                content: "[\(originalNoteTitle)](simplenote://note/"
+            )
 
         trackStep()
-        populateNoteList(title: toCopyNoteTitle, numberToCreate: 1)
-
-        trackStep()
-        NoteList.longPressNote(title: toCopyNoteTitle + "-1")
+        NoteList.createNoteAndLeaveEditor(noteName: originalNoteTitle)
+        NoteList.longPressNote(title: originalNoteTitle)
         NoteList.copyInternalLinkFromContextMenu()
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
 
         trackStep()
         NoteList.addNoteTap()
-        NoteEditor.enterTitle(enteredValue: toPasteNoteTitle)
+        NoteEditor.enterTitle(enteredValue: referringNoteTitle)
         NoteEditor.pasteNoteContent()
         NoteEditor.leaveEditor()
-
-        trackStep()
         NoteListAssert.notesNumber(expectedNotesNumber: 2)
-        NoteListAssert.contentIsShown(for: note)
+        NoteListAssert.contentIsShown(for: referringNoteData)
     }
 }

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -295,8 +295,6 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
         trackStep()
         populateNoteList(title: noteTitle, numberToCreate: 2)
-
-        trackStep()
         NoteList.longPressNote(title: noteTitle + "-1")
         NoteList.selectNoteFromContextMenu()
         NoteList.selectAll()

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -318,17 +318,15 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let noteName = "Note Title"
 
         trackStep()
-        populateNoteList(title: noteName, numberToCreate: 1)
-
-        trackStep()
-        NoteList.longPressNote(title: noteName + "-1")
+        NoteList.createNoteAndLeaveEditor(noteName: noteName)
+        NoteList.longPressNote(title: noteName)
         NoteList.deleteNoteFromContextMenu()
         NoteListAssert.notesNumber(expectedNotesNumber: 0)
 
         trackStep()
         NoteList.tapUndoOnSnackbar()
         NoteListAssert.notesNumber(expectedNotesNumber: 1)
-        NoteListAssert.noteExists(noteName: noteName + "-1")
+        NoteListAssert.noteExists(noteName: noteName)
     }
 
     func testCopyAndPasteInternalLink() throws {

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -312,4 +312,44 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         TrashAssert.noteExists(noteName: noteTitle + "-1")
         TrashAssert.noteExists(noteName: noteTitle + "-2")
     }
+
+    func testUndoTrashFromSnackbar() throws {
+        trackTest()
+        let noteName = "Note Title"
+
+        trackStep()
+        populateNoteList(noteName: noteName, numberToCreate: 1)
+
+        trackStep()
+        NoteList.longPressNote(noteName: noteName + "-1")
+        NoteList.deleteNoteFromContextMenu()
+        NoteListAssert.notesNumber(expectedNotesNumber: 0)
+
+        trackStep()
+        NoteList.tapUndoOnSnackbar()
+        NoteListAssert.notesNumber(expectedNotesNumber: 1)
+        NoteListAssert.noteExists(noteName: noteName + "-1")
+    }
+
+    func testCopyAndPasteInterlink() throws {
+        trackTest()
+        let toCopyNoteTitle = "Test Copy Internal Link Note Title"
+        let toPasteNoteTitle = "Test Paste Internal Link Note Title\n"
+
+        trackStep()
+        populateNoteList(noteName: toCopyNoteTitle, numberToCreate: 1)
+
+        trackStep()
+        NoteList.longPressNote(noteName: toCopyNoteTitle + "-1")
+        NoteList.copyInternalLinkFromContextMenu()
+
+        trackStep()
+        NoteList.addNoteTap()
+        NoteEditor.enterTitle(enteredValue: toPasteNoteTitle)
+        NoteEditor.pasteNoteContent()
+        NoteEditor.leaveEditor()
+        
+        trackStep()
+        // todo: add validation here
+    }
 }

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -333,8 +333,12 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
 
     func testCopyAndPasteInterlink() throws {
         trackTest()
-        let toCopyNoteTitle = "Test Copy Internal Link Note Title"
-        let toPasteNoteTitle = "Test Paste Internal Link Note Title\n"
+        let toCopyNoteTitle = "Copy Internal Link Title"
+        let toPasteNoteTitle = "Paste Internal Link Title\n"
+        let note = NoteData(
+            name: "Paste Internal Link Title",
+            content: "[Copy Internal Link Title-1](simplenote://note/"
+        )
 
         trackStep()
         populateNoteList(title: toCopyNoteTitle, numberToCreate: 1)
@@ -350,6 +354,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         NoteEditor.leaveEditor()
 
         trackStep()
-        // todo: add validation here
+        NoteListAssert.notesNumber(expectedNotesNumber: 2)
+        NoteListAssert.contentIsShown(for: note)
     }
 }

--- a/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
+++ b/SimplenoteUITests/SimplenoteUITestsNoteEditor.swift
@@ -318,10 +318,10 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let noteName = "Note Title"
 
         trackStep()
-        populateNoteList(noteName: noteName, numberToCreate: 1)
+        populateNoteList(title: noteName, numberToCreate: 1)
 
         trackStep()
-        NoteList.longPressNote(noteName: noteName + "-1")
+        NoteList.longPressNote(title: noteName + "-1")
         NoteList.deleteNoteFromContextMenu()
         NoteListAssert.notesNumber(expectedNotesNumber: 0)
 
@@ -337,10 +337,10 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         let toPasteNoteTitle = "Test Paste Internal Link Note Title\n"
 
         trackStep()
-        populateNoteList(noteName: toCopyNoteTitle, numberToCreate: 1)
+        populateNoteList(title: toCopyNoteTitle, numberToCreate: 1)
 
         trackStep()
-        NoteList.longPressNote(noteName: toCopyNoteTitle + "-1")
+        NoteList.longPressNote(title: toCopyNoteTitle + "-1")
         NoteList.copyInternalLinkFromContextMenu()
 
         trackStep()
@@ -348,7 +348,7 @@ class SimplenoteUISmokeTestsNoteEditor: XCTestCase {
         NoteEditor.enterTitle(enteredValue: toPasteNoteTitle)
         NoteEditor.pasteNoteContent()
         NoteEditor.leaveEditor()
-        
+
         trackStep()
         // todo: add validation here
     }

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -58,6 +58,8 @@ enum UID {
         static let deselectAll = "Deselect All"
         static let trashNotes = "Trash Notes"
         static let crossIcon = "icon cross"
+        static let undoTrashButton = "Undo"
+        static let copyInternalLink = "Copy Internal Link"
     }
 
     enum Text {

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -79,6 +79,10 @@ enum UID {
     enum SearchField {
         static let search = "Search notes or tags"
     }
+
+    enum ContextMenuItem {
+        static let paste = "Paste"
+    }
 }
 
 enum Text {


### PR DESCRIPTION
### Fix
Adding two new tests to the test suite:
1. Undo trash via snackbar on note list
2. Copy internal link via context menu and pasting to another note

### Test
Test flow:
1. Login > Create 1 note > Trash note > Validate note list is empty > Undo trash > Validate note list not empty
2. Login > Create 1 note > Copy internal link via context menu > Create another note > Paste link into new note > Validate on note list that the new note has the correct title and internal link as content

### Review
@pachlava 

### Release
These changes do not require release notes.
