### PR TITLE
Fixed an issue where tags aren't removed from notes when deleted

### DIFF
--- a/Simplenote/Classes/SPObjectManager+Simplenote.swift
+++ b/Simplenote/Classes/SPObjectManager+Simplenote.swift
@@ -31,10 +31,14 @@ extension SPObjectManager {
         }
 
         let request = NSFetchRequest<Note>(entityName: Note.entityName)
-        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            .predicateForNotes(tag: tagName),
-            .predicateForNotes(deleted: includeDeleted)
-        ])
+
+        var predicates: [NSPredicate] = []
+        predicates.append(.predicateForNotes(tag: tagName))
+        if includeDeleted == false {
+            predicates.append(.predicateForNotes(deleted: includeDeleted))
+        }
+        
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
 
         return (try? managedObjectContext.fetch(request)) ?? []
     }

--- a/Simplenote/Classes/SPObjectManager+Simplenote.swift
+++ b/Simplenote/Classes/SPObjectManager+Simplenote.swift
@@ -37,7 +37,7 @@ extension SPObjectManager {
         if includeDeleted == false {
             predicates.append(.predicateForNotes(deleted: includeDeleted))
         }
-        
+
         request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
 
         return (try? managedObjectContext.fetch(request)) ?? []


### PR DESCRIPTION
### Fix
This issue fixes #1352 

Currently there is an issue where tags are not removed from notes when they are deleted from the tag list in Simplenote iOS.

This PR fixes that issue so that if a tag is deleted in the list it is also removed from all notes (including deleted notes)

### Test
1. Create a few tags on a few different notes
2. delete one of those notes
3. go to the tags list and delete a tag
4. check the notes that had that tag and confirm they have been deleted
5. restore the deleted note and check the tag was removed from that note too

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
