### PR TITLE
Use XCUITestsHelper to query user interface style (dark mode)

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -4628,8 +4628,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				branch = "add-is-dark-mode";
+				kind = branch;
 			};
 		};
 		B50D2FB424E6DFAC00163FC3 /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */ = {

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -4624,8 +4624,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
 			requirement = {
-				branch = "add-is-dark-mode";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
 			};
 		};
 		B50D2FB424E6DFAC00163FC3 /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */ = {

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -54,7 +54,6 @@
 		37FD30491FC4CFA2008D0B78 /* KeychainPasswordItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD30471FC4CFA2008D0B78 /* KeychainPasswordItem.swift */; };
 		3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */; };
 		3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */; };
-		3F5EDD0C2435A3AE00959576 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */; };
 		3F762E8F2677F19C0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E8E2677F19C0088CD45 /* XCUITestHelpers */; };
 		3F762E912677F1AA0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E902677F1AA0088CD45 /* XCUITestHelpers */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
@@ -577,7 +576,6 @@
 		3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotsCredentials.swift; sourceTree = "<group>"; };
 		3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		3F3CA94826255FA800F6316F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
 		3F6CECDC2FEA90B9E5C920F5 /* Pods-SimplenoteTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.release.xcconfig"; sourceTree = "<group>"; };
 		3FA17B5526240FF000C11C46 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
 		3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplenoteScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1177,7 +1175,6 @@
 				3FA6013D242C5AAE0068FC52 /* Info.plist */,
 				3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */,
 				3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */,
-				3F5EDD0B2435A3AE00959576 /* XCTest+Extensions.swift */,
 			);
 			path = SimplenoteScreenshots;
 			sourceTree = "<group>";
@@ -2725,7 +2722,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F5EDD0C2435A3AE00959576 /* XCTest+Extensions.swift in Sources */,
 				3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */,
 				3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */,
 				3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */,

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,9 +32,9 @@
         "package": "XCUITestHelpers",
         "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
         "state": {
-          "branch": "add-is-dark-mode",
-          "revision": "4c4bb89a44417e98dfcda276eaff18d71e8fdb0e",
-          "version": null
+          "branch": null,
+          "revision": "2cf059427b0f0362ddd8c14109493141cf710cc8",
+          "version": "0.2.0"
         }
       }
     ]

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,9 +32,9 @@
         "package": "XCUITestHelpers",
         "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
         "state": {
-          "branch": null,
-          "revision": "47d688b0b2a6356361a16836c4d23f12d6643a73",
-          "version": "0.1.0"
+          "branch": "add-is-dark-mode",
+          "revision": "4c4bb89a44417e98dfcda276eaff18d71e8fdb0e",
+          "version": null
         }
       }
     ]

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -249,9 +249,8 @@ class SimplenoteScreenshots: XCTestCase {
         text.forEach { app.keyboards.firstMatch.keys[String($0)].tap() }
     }
 
-    // See https://github.com/woocommerce/woocommerce-ios/blob/mokagio-gems-update-test/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift#L66-L79
     func takeScreenshot(_ title: String) {
-        let mode = isDarkMode ? "dark" : "light"
+        let mode = XCUIDevice.inDarkMode ? "dark" : "light"
 
         snapshot("\(title)-\(mode)")
     }

--- a/SimplenoteScreenshots/XCTest+Extensions.swift
+++ b/SimplenoteScreenshots/XCTest+Extensions.swift
@@ -1,9 +1,0 @@
-// See https://github.com/woocommerce/woocommerce-ios/blob/ed0d71d7dd4a40802a0d38d82cf2eb0e8cc45cd4/WooCommerce/WooCommerceUITests/Utils/XCTest%2BExtensions.swift
-import XCTest
-
-extension XCTest {
-
-    var isDarkMode: Bool {
-        UIViewController().traitCollection.userInterfaceStyle == .dark
-    }
-}


### PR DESCRIPTION
Companion to https://github.com/Automattic/XCUITestHelpers/pull/1.

### Test

1. Checkout this branch
2. Run `bundle install`
3. Run `bundle exec fastlane take_screenshots_from_app mode:dark devices:'iPhone 11 Pro Max' languages:en-US`

It should work and open your browser and show screenshots in dark mode:

<img width="1277" alt="Screen Shot 2021-08-10 at 1 02 14 pm" src="https://user-images.githubusercontent.com/1218433/128803002-67b4eebf-5ee6-4a9e-be0b-db913c59acda.png">

If you can verify that light mode is detected correctly, too, either by passing `mode:light` to the command above, or by running `bundle exec fastlane take_screenshots devices:'iPhone 11 Pro Max' languages:en-US` to take both screenshots (and spend twice as much time).

Worth pointing out that the logic is already tested in isolation in the library 😉.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.