### PR TITLE
Password verification alert

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 4.43
 -----
-
+-   [Internal] added login alert for compromised password #1394
 
 4.42
 -----

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -8,6 +8,7 @@ enum SPAuthError: Error {
     case signupBadCredentials
     case signupUserAlreadyExists
     case network
+    case compromisedPassword
     case unknown(statusCode: Int, response: String?, error: Error?)
 }
 
@@ -21,7 +22,7 @@ extension SPAuthError {
     init(loginErrorCode: Int, response: String?, error: Error?) {
         switch loginErrorCode {
         case 401:
-            self = .loginBadCredentials
+            self = response == "compromised password" ? .compromisedPassword : .loginBadCredentials
         default:
             self = .unknown(statusCode: loginErrorCode, response: response, error: error)
         }
@@ -52,6 +53,8 @@ extension SPAuthError {
         switch self {
         case .signupUserAlreadyExists:
             return NSLocalizedString("Email in use", comment: "Email Taken Alert Title")
+        case .compromisedPassword:
+            return NSLocalizedString("Compromised Password", comment: "Compromised password alert title")
         default:
             return NSLocalizedString("Sorry!", comment: "Authentication Error Alert Title")
         }
@@ -69,6 +72,8 @@ extension SPAuthError {
             return NSLocalizedString("The email you've entered is already associated with a Simplenote account.", comment: "Error when address is in use")
         case .network:
             return NSLocalizedString("The network could not be reached.", comment: "Error when the network is inaccessible")
+        case .compromisedPassword:
+            return NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.", comment: "error for compromised password")
         case .unknown:
             return NSLocalizedString("We're having problems. Please try again soon.", comment: "Generic error")
         }

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -22,7 +22,7 @@ extension SPAuthError {
     init(loginErrorCode: Int, response: String?, error: Error?) {
         switch loginErrorCode {
         case 401:
-            self = response == "compromised password" ? .compromisedPassword : .loginBadCredentials
+            self = response == Constants.compromisedPassword ? .compromisedPassword : .loginBadCredentials
         default:
             self = .unknown(statusCode: loginErrorCode, response: response, error: error)
         }
@@ -78,4 +78,8 @@ extension SPAuthError {
             return NSLocalizedString("We're having problems. Please try again soon.", comment: "Generic error")
         }
     }
+}
+
+private struct Constants {
+    static let compromisedPassword = "compromised password"
 }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -413,6 +413,8 @@ private extension SPAuthViewController {
         switch error {
         case .signupUserAlreadyExists:
             presentUserAlreadyExistsError(error: error)
+        case .compromisedPassword:
+            presentPasswordCompromisedError(error: error)
         case .unknown(let statusCode, let response, let error) where debugEnabled:
             let details = NSAttributedString.stringFromNetworkError(statusCode: statusCode, response: response, error: error)
             presentDebugDetails(details: details)
@@ -427,6 +429,16 @@ private extension SPAuthViewController {
         alertController.addDefaultActionWithTitle(AuthenticationStrings.loginActionText) { _ in
             self.attemptLoginWithCurrentCredentials()
         }
+
+        present(alertController, animated: true, completion: nil)
+    }
+
+    func presentPasswordCompromisedError(error: SPAuthError) {
+        let alertController = UIAlertController(title: error.title, message: error.message, preferredStyle: .alert)
+        alertController.addDefaultActionWithTitle(AuthenticationStrings.compromisedAlertReset) { _ in
+            self.presentPasswordReset()
+        }
+        alertController.addCancelActionWithTitle(AuthenticationStrings.compromisedAlertCancel)
 
         present(alertController, animated: true, completion: nil)
     }
@@ -656,6 +668,8 @@ private enum AuthenticationStrings {
     static let acceptActionText             = NSLocalizedString("Accept", comment: "Accept Action")
     static let cancelActionText             = NSLocalizedString("Cancel", comment: "Cancel Action")
     static let loginActionText              = NSLocalizedString("Log In", comment: "Log In Action")
+    static let compromisedAlertCancel       = NSLocalizedString("Not Yet", comment: "Cancel action for password alert")
+    static let compromisedAlertReset        = NSLocalizedString("Change Password", comment: "Change password action")
 }
 
 


### PR DESCRIPTION
### Fix
This pr adds a case to SPAuthError that can see if a user's password has been found in a compromised password database.  If it has, the user is prompted to change their password before they can log into their account.

<img src="https://cdn-std.droplr.net/files/acc_593859/rDYAOL" />

### Test
Internal reference for testing steps. 
p1628654849033800-slack-C01KRRK0MLJ

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in a39c48 with:
> 
> > - [Internal] added login alert for compromised password

