### PR TITLE
Fixed a bug where non http/https urls crashed when opened from markdown

### DIFF
--- a/Simplenote/Classes/SPMarkdownPreviewViewController.m
+++ b/Simplenote/Classes/SPMarkdownPreviewViewController.m
@@ -130,8 +130,13 @@
         return;
     }
 
-    SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:targetURL];
-    [self presentViewController:sfvc animated:YES completion:nil];
+
+    if ([WKWebView handlesURLScheme:targetURL.scheme]) {
+        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:targetURL];
+        [self presentViewController:sfvc animated:YES completion:nil];
+    } else {
+        [UIApplication.sharedApplication openURL:targetURL options:@{} completionHandler:nil];
+    }
 
     decisionHandler(WKNavigationActionPolicyCancel);
 }


### PR DESCRIPTION
### Fix
This PR fixes #725 

Currently if you try to open an a URL scheme that is note simplenote:// http:// or https:// from markdown preview the app will crash because the urls can not be natively opened from web kit.

This change checks to see if the webkit can open a url and if it can't then it passes it along to safari to avoid the crash.

### Test
1. in a note with markdown enabled add this text `[shortcuts](shortcuts://)
2. open markdown mode
3. tap on the link.  You should be taken to the shortcuts app and simplenote should not crash

### Review
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
