### PR TITLE
Added error case at login if user email is not verified

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.43
 -----
 -   [Internal] added login alert for compromised password #1394
+- [Intenrnal] added error response case on login for unverified emails #1398
 
 4.42
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 4.43
 -----
 -   [Internal] added login alert for compromised password #1394
-- [Intenrnal] added error response case on login for unverified emails #1398
+-   [Internal] added error response case on login for unverified emails #1398
 
 4.42
 -----

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -25,7 +25,9 @@ extension SPAuthError {
         case 401:
             self = response == Constants.compromisedPassword ? .compromisedPassword : .loginBadCredentials
         case 403:
-            self = .unverifiedEmail
+            self = response == Constants.requiresVerification ?
+                .unverifiedEmail :
+                .unknown(statusCode: loginErrorCode, response: response, error: error)
         default:
             self = .unknown(statusCode: loginErrorCode, response: response, error: error)
         }
@@ -89,4 +91,5 @@ extension SPAuthError {
 
 private struct Constants {
     static let compromisedPassword = "compromised password"
+    static let requiresVerification = "requires verification"
 }

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -22,12 +22,12 @@ extension SPAuthError {
     ///
     init(loginErrorCode: Int, response: String?, error: Error?) {
         switch loginErrorCode {
+        case 401 where response == Constants.compromisedPassword:
+            self = .compromisedPassword
         case 401:
-            self = response == Constants.compromisedPassword ? .compromisedPassword : .loginBadCredentials
-        case 403:
-            self = response == Constants.requiresVerification ?
-                .unverifiedEmail :
-                .unknown(statusCode: loginErrorCode, response: response, error: error)
+            self = .loginBadCredentials
+        case 403 where response == Constants.requiresVerification:
+            self = .unverifiedEmail
         default:
             self = .unknown(statusCode: loginErrorCode, response: response, error: error)
         }

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -9,6 +9,7 @@ enum SPAuthError: Error {
     case signupUserAlreadyExists
     case network
     case compromisedPassword
+    case unverifiedEmail
     case unknown(statusCode: Int, response: String?, error: Error?)
 }
 
@@ -23,6 +24,8 @@ extension SPAuthError {
         switch loginErrorCode {
         case 401:
             self = response == Constants.compromisedPassword ? .compromisedPassword : .loginBadCredentials
+        case 403:
+            self = .unverifiedEmail
         default:
             self = .unknown(statusCode: loginErrorCode, response: response, error: error)
         }
@@ -55,6 +58,8 @@ extension SPAuthError {
             return NSLocalizedString("Email in use", comment: "Email Taken Alert Title")
         case .compromisedPassword:
             return NSLocalizedString("Compromised Password", comment: "Compromised password alert title")
+        case .unverifiedEmail:
+            return NSLocalizedString("Account Verification Required", comment: "Email verification required alert title")
         default:
             return NSLocalizedString("Sorry!", comment: "Authentication Error Alert Title")
         }
@@ -74,6 +79,8 @@ extension SPAuthError {
             return NSLocalizedString("The network could not be reached.", comment: "Error when the network is inaccessible")
         case .compromisedPassword:
             return NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.", comment: "error for compromised password")
+        case .unverifiedEmail:
+            return NSLocalizedString("You must verify your email before being able to login.", comment: "Erro for un verified email")
         case .unknown:
             return NSLocalizedString("We're having problems. Please try again soon.", comment: "Generic error")
         }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -415,6 +415,8 @@ private extension SPAuthViewController {
             presentUserAlreadyExistsError(error: error)
         case .compromisedPassword:
             presentPasswordCompromisedError(error: error)
+        case .unverifiedEmail:
+            presentUserUnverifiedError(error: error)
         case .unknown(let statusCode, let response, let error) where debugEnabled:
             let details = NSAttributedString.stringFromNetworkError(statusCode: statusCode, response: response, error: error)
             presentDebugDetails(details: details)
@@ -439,6 +441,16 @@ private extension SPAuthViewController {
             self.presentPasswordReset()
         }
         alertController.addCancelActionWithTitle(AuthenticationStrings.compromisedAlertCancel)
+
+        present(alertController, animated: true, completion: nil)
+    }
+
+    func presentUserUnverifiedError(error: SPAuthError) {
+        let alertController = UIAlertController(title: error.title, message: error.message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(AuthenticationStrings.unverifiedCancelText)
+        alertController.addDefaultActionWithTitle(AuthenticationStrings.unverifiedActionText) { _ in
+            AccountRemote().verify(email: self.email) { _ in }
+        }
 
         present(alertController, animated: true, completion: nil)
     }
@@ -670,6 +682,8 @@ private enum AuthenticationStrings {
     static let loginActionText              = NSLocalizedString("Log In", comment: "Log In Action")
     static let compromisedAlertCancel       = NSLocalizedString("Not Yet", comment: "Cancel action for password alert")
     static let compromisedAlertReset        = NSLocalizedString("Change Password", comment: "Change password action")
+    static let unverifiedCancelText         = NSLocalizedString("Okay", comment: "Email unverified alert dismiss")
+    static let unverifiedActionText         = NSLocalizedString("Resend Verification Email", comment: "Send email verificaiton action")
 }
 
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -700,7 +700,7 @@ private enum AuthenticationStrings {
     static let unverifiedCancelText         = NSLocalizedString("Okay", comment: "Email unverified alert dismiss")
     static let unverifiedActionText         = NSLocalizedString("Resend Verification Email", comment: "Send email verificaiton action")
     static let unverifriedErrorTitle        = NSLocalizedString("Request Error", comment: "Request error alert title")
-    static let unverifiedErrorMessage       = NSLocalizedString("There was an error processing your login, please try again later", comment: "Request error alert message")
+    static let unverifiedErrorMessage       = NSLocalizedString("There was an preparing your verification email, please try again later", comment: "Request error alert message")
     static let verificationSentTitle        = NSLocalizedString("Check your Email", comment: "Vefification sent alert title")
     static let verificationSentTemplate     = NSLocalizedString("We’ve sent a verification email to %1$@. Please check your inbox and follow the instructions.", comment: "Confirmation that an email has been sent")
 }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -458,10 +458,10 @@ private extension SPAuthViewController {
                 switch result {
                 case .success:
                     alert = UIAlertController.dismissableAlert(title: AuthenticationStrings.verificationSentTitle,
-                                                                   message: String(format: AuthenticationStrings.verificationSentTemplate, email))
+                                                               message: String(format: AuthenticationStrings.verificationSentTemplate, email))
                 case .failure:
-                    alert = UIAlertController.dismissableAlert(title: AuthenticationStrings.unverifriedErrorTitle,
-                                                                   message: AuthenticationStrings.unverifiedErrorMessage)
+                    alert = UIAlertController.dismissableAlert(title: AuthenticationStrings.unverifiedErrorTitle,
+                                                               message: AuthenticationStrings.unverifiedErrorMessage)
                 }
                 self?.present(alert, animated: true, completion: nil)
             }
@@ -697,9 +697,9 @@ private enum AuthenticationStrings {
     static let loginActionText              = NSLocalizedString("Log In", comment: "Log In Action")
     static let compromisedAlertCancel       = NSLocalizedString("Not Yet", comment: "Cancel action for password alert")
     static let compromisedAlertReset        = NSLocalizedString("Change Password", comment: "Change password action")
-    static let unverifiedCancelText         = NSLocalizedString("Okay", comment: "Email unverified alert dismiss")
+    static let unverifiedCancelText         = NSLocalizedString("Ok", comment: "Email unverified alert dismiss")
     static let unverifiedActionText         = NSLocalizedString("Resend Verification Email", comment: "Send email verificaiton action")
-    static let unverifriedErrorTitle        = NSLocalizedString("Request Error", comment: "Request error alert title")
+    static let unverifiedErrorTitle         = NSLocalizedString("Request Error", comment: "Request error alert title")
     static let unverifiedErrorMessage       = NSLocalizedString("There was an preparing your verification email, please try again later", comment: "Request error alert message")
     static let verificationSentTitle        = NSLocalizedString("Check your Email", comment: "Vefification sent alert title")
     static let verificationSentTemplate     = NSLocalizedString("We’ve sent a verification email to %1$@. Please check your inbox and follow the instructions.", comment: "Confirmation that an email has been sent")

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -416,7 +416,7 @@ private extension SPAuthViewController {
         case .compromisedPassword:
             presentPasswordCompromisedError(error: error)
         case .unverifiedEmail:
-            presentUserUnverifiedError(error: error)
+            presentUserUnverifiedError(error: error, email: email)
         case .unknown(let statusCode, let response, let error) where debugEnabled:
             let details = NSAttributedString.stringFromNetworkError(statusCode: statusCode, response: response, error: error)
             presentDebugDetails(details: details)
@@ -445,11 +445,26 @@ private extension SPAuthViewController {
         present(alertController, animated: true, completion: nil)
     }
 
-    func presentUserUnverifiedError(error: SPAuthError) {
+    func presentUserUnverifiedError(error: SPAuthError, email: String) {
         let alertController = UIAlertController(title: error.title, message: error.message, preferredStyle: .alert)
         alertController.addCancelActionWithTitle(AuthenticationStrings.unverifiedCancelText)
-        alertController.addDefaultActionWithTitle(AuthenticationStrings.unverifiedActionText) { _ in
-            AccountRemote().verify(email: self.email) { _ in }
+        alertController.addDefaultActionWithTitle(AuthenticationStrings.unverifiedActionText) { [weak self] _ in
+            let spinnerVC = SpinnerViewController()
+            self?.present(spinnerVC, animated: false, completion: nil)
+
+            AccountRemote().verify(email: email) { result in
+                spinnerVC.dismiss(animated: false, completion: nil)
+                var alert: UIAlertController
+                switch result {
+                case .success:
+                    alert = UIAlertController.dismissableAlert(title: AuthenticationStrings.verificationSentTitle,
+                                                                   message: String(format: AuthenticationStrings.verificationSentTemplate, email))
+                case .failure:
+                    alert = UIAlertController.dismissableAlert(title: AuthenticationStrings.unverifriedErrorTitle,
+                                                                   message: AuthenticationStrings.unverifiedErrorMessage)
+                }
+                self?.present(alert, animated: true, completion: nil)
+            }
         }
 
         present(alertController, animated: true, completion: nil)
@@ -684,6 +699,10 @@ private enum AuthenticationStrings {
     static let compromisedAlertReset        = NSLocalizedString("Change Password", comment: "Change password action")
     static let unverifiedCancelText         = NSLocalizedString("Okay", comment: "Email unverified alert dismiss")
     static let unverifiedActionText         = NSLocalizedString("Resend Verification Email", comment: "Send email verificaiton action")
+    static let unverifriedErrorTitle        = NSLocalizedString("Request Error", comment: "Request error alert title")
+    static let unverifiedErrorMessage       = NSLocalizedString("There was an error processing your login, please try again later", comment: "Request error alert message")
+    static let verificationSentTitle        = NSLocalizedString("Check your Email", comment: "Vefification sent alert title")
+    static let verificationSentTemplate     = NSLocalizedString("We’ve sent a verification email to %1$@. Please check your inbox and follow the instructions.", comment: "Confirmation that an email has been sent")
 }
 
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -628,27 +628,27 @@ extension AuthenticationMode {
     /// Login Operation Mode: Contains all of the strings + delegate wirings, so that the AuthUI handles authentication scenarios.
     ///
     static var login: AuthenticationMode {
-        return .init(title:                         AuthenticationStrings.loginTitle,
-                     validationStyle:               .legacy,
-                     primaryActionSelector:         #selector(SPAuthViewController.performLogIn),
-                     primaryActionText:             AuthenticationStrings.loginPrimaryAction,
-                     secondaryActionSelector:       #selector(SPAuthViewController.presentPasswordReset),
-                     secondaryActionText:           AuthenticationStrings.loginSecondaryAction,
+        return .init(title: AuthenticationStrings.loginTitle,
+                     validationStyle: .legacy,
+                     primaryActionSelector: #selector(SPAuthViewController.performLogIn),
+                     primaryActionText: AuthenticationStrings.loginPrimaryAction,
+                     secondaryActionSelector: #selector(SPAuthViewController.presentPasswordReset),
+                     secondaryActionText: AuthenticationStrings.loginSecondaryAction,
                      secondaryActionAttributedText: nil,
-                     isPasswordHidden:              false)
+                     isPasswordHidden: false)
     }
 
     /// Signup Operation Mode: Contains all of the strings + delegate wirings, so that the AuthUI handles user account creation scenarios.
     ///
     static var signup: AuthenticationMode {
-        return .init(title:                         AuthenticationStrings.signupTitle,
-                     validationStyle:               .strong,
-                     primaryActionSelector:         #selector(SPAuthViewController.performSignUp),
-                     primaryActionText:             AuthenticationStrings.signupPrimaryAction,
-                     secondaryActionSelector:       #selector(SPAuthViewController.presentTermsOfService),
-                     secondaryActionText:           nil,
+        return .init(title: AuthenticationStrings.signupTitle,
+                     validationStyle: .strong,
+                     primaryActionSelector: #selector(SPAuthViewController.performSignUp),
+                     primaryActionText: AuthenticationStrings.signupPrimaryAction,
+                     secondaryActionSelector: #selector(SPAuthViewController.presentTermsOfService),
+                     secondaryActionText: nil,
                      secondaryActionAttributedText: AuthenticationStrings.signupSecondaryAttributedAction,
-                     isPasswordHidden:              true)
+                     isPasswordHidden: true)
     }
 }
 

--- a/Simplenote/Classes/UIAlertController+Helpers.swift
+++ b/Simplenote/Classes/UIAlertController+Helpers.swift
@@ -26,4 +26,12 @@ extension UIAlertController {
 
         return action
     }
+
+    static func dismissableAlert(title: String,
+                                        message: String,
+                                        style: UIAlertController.Style = .alert) -> UIAlertController {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: style)
+        alert.addCancelActionWithTitle("Okay")
+        return alert
+    }
 }

--- a/Simplenote/Classes/UIAlertController+Helpers.swift
+++ b/Simplenote/Classes/UIAlertController+Helpers.swift
@@ -31,7 +31,7 @@ extension UIAlertController {
                                         message: String,
                                         style: UIAlertController.Style = .alert) -> UIAlertController {
         let alert = UIAlertController(title: title, message: message, preferredStyle: style)
-        alert.addCancelActionWithTitle("Okay")
+        alert.addCancelActionWithTitle(NSLocalizedString("Ok", comment: "Alert dismiss action"))
         return alert
     }
 }


### PR DESCRIPTION
### Fix
This PR adds a new error case while logging in where a user's email address has not been verified they will receive an error alerting them to the fact that they can not login till their email is verified and then supplies them with a button to resend the verification email.

<img src="https://cdn-std.droplr.net/files/acc_593859/KbU6i3" />

### Test
1. setup a tool like Charles proxy to get in the way of the login request response.
2. When the response returns, change the response value to 403
3. You should see an alert with two options, verify and okay.

Note this will require more testing when the backend changes are made to return the 403 response to an unverified email, currently that has not been added in, so it can not be fully tested.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> `RELEASE-NOTES.txt` was updated in 5ac0b1f5 with:
> 
> >- [Intenrnal] added error response case on login for unverified emails #1398
