### PR TITLE
Adopt ScreenObject package in screenshots tests: Proof of Concept

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -4660,8 +4660,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				branch = "always-compute-at-runtime";
+				kind = branch;
 			};
 		};
 		3F762E8D2677F19C0088CD45 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		37FD30491FC4CFA2008D0B78 /* KeychainPasswordItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD30471FC4CFA2008D0B78 /* KeychainPasswordItem.swift */; };
 		3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */; };
 		3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */; };
+		3F4BA07E26CDF295000619B1 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3F4BA07D26CDF295000619B1 /* ScreenObject */; };
 		3F762E8F2677F19C0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E8E2677F19C0088CD45 /* XCUITestHelpers */; };
 		3F762E912677F1AA0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E902677F1AA0088CD45 /* XCUITestHelpers */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
@@ -424,8 +425,8 @@
 		BA5E5B7D264A148C00D0EE19 /* URLRequest+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5E5B7C264A148C00D0EE19 /* URLRequest+Simplenote.swift */; };
 		BA83478325F59F8B0059B797 /* markdown-default-contrast.css in Resources */ = {isa = PBXBuildFile; fileRef = BA83478225F59F8B0059B797 /* markdown-default-contrast.css */; };
 		BA83478C25F59FE90059B797 /* markdown-dark-contrast.css in Resources */ = {isa = PBXBuildFile; fileRef = BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */; };
-		BA9B19F926A8EF3200692366 /* SpinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */; };
 		BA8FC2A5267AC7470082962E /* SharedStorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */; };
+		BA9B19F926A8EF3200692366 /* SpinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */; };
 		BA9B59022685549F00DAD1ED /* StorageSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B59012685549F00DAD1ED /* StorageSettings.swift */; };
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		BAA59E79269F9FE30068BD3D /* Date+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */; };
@@ -964,8 +965,8 @@
 		BA5E5B7C264A148C00D0EE19 /* URLRequest+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Simplenote.swift"; sourceTree = "<group>"; };
 		BA83478225F59F8B0059B797 /* markdown-default-contrast.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-default-contrast.css"; sourceTree = "<group>"; };
 		BA83478B25F59FE90059B797 /* markdown-dark-contrast.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-dark-contrast.css"; sourceTree = "<group>"; };
-		BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStorageMigrator.swift; sourceTree = "<group>"; };
+		BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		BA9B59012685549F00DAD1ED /* StorageSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSettings.swift; sourceTree = "<group>"; };
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Simplenote.swift"; sourceTree = "<group>"; };
@@ -1075,6 +1076,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F762E912677F1AA0088CD45 /* XCUITestHelpers in Frameworks */,
+				3F4BA07E26CDF295000619B1 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2281,6 +2283,7 @@
 			name = SimplenoteScreenshots;
 			packageProductDependencies = (
 				3F762E902677F1AA0088CD45 /* XCUITestHelpers */,
+				3F4BA07D26CDF295000619B1 /* ScreenObject */,
 			);
 			productName = SimplenoteScreenshots;
 			productReference = 3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */;
@@ -2474,6 +2477,7 @@
 				B50D2FB424E6DFAC00163FC3 /* XCRemoteSwiftPackageReference "SimplenoteSearch-Swift" */,
 				B59CACFA2541E05400958330 /* XCRemoteSwiftPackageReference "SimplenoteInterlinks-Swift" */,
 				3F762E8D2677F19C0088CD45 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
+				3F4BA07C26CDF295000619B1 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 			);
 			productRefGroup = E29ADD3917848E8500E55842 /* Products */;
 			projectDirPath = "";
@@ -4652,6 +4656,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		3F4BA07C26CDF295000619B1 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/ScreenObject";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
 		3F762E8D2677F19C0088CD45 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
@@ -4687,6 +4699,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3F4BA07D26CDF295000619B1 /* ScreenObject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F4BA07C26CDF295000619B1 /* XCRemoteSwiftPackageReference "ScreenObject" */;
+			productName = ScreenObject;
+		};
 		3F762E8E2677F19C0088CD45 /* XCUITestHelpers */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3F762E8D2677F19C0088CD45 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */; };
 		3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */; };
 		3F4BA07E26CDF295000619B1 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3F4BA07D26CDF295000619B1 /* ScreenObject */; };
+		3F4BA08026CE00A2000619B1 /* PasscodeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */; };
 		3F762E8F2677F19C0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E8E2677F19C0088CD45 /* XCUITestHelpers */; };
 		3F762E912677F1AA0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E902677F1AA0088CD45 /* XCUITestHelpers */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
@@ -583,6 +584,7 @@
 		3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotsCredentials.swift; sourceTree = "<group>"; };
 		3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		3F3CA94826255FA800F6316F /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeScreen.swift; sourceTree = "<group>"; };
 		3F6CECDC2FEA90B9E5C920F5 /* Pods-SimplenoteTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SimplenoteTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SimplenoteTests/Pods-SimplenoteTests.release.xcconfig"; sourceTree = "<group>"; };
 		3FA17B5526240FF000C11C46 /* NoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteData.swift; sourceTree = "<group>"; };
 		3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplenoteScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1189,6 +1191,7 @@
 				3FA6013D242C5AAE0068FC52 /* Info.plist */,
 				3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */,
 				3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */,
+				3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */,
 			);
 			path = SimplenoteScreenshots;
 			sourceTree = "<group>";
@@ -2753,6 +2756,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */,
+				3F4BA08026CE00A2000619B1 /* PasscodeScreen.swift in Sources */,
 				3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */,
 				3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */,
 			);

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": null,
-          "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
-          "version": "0.1.0"
+          "branch": "always-compute-at-runtime",
+          "revision": "d76744458980e38e25ac52f3445e45460003c3fb",
+          "version": null
         }
       },
       {

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "ScreenObject",
+        "repositoryURL": "https://github.com/Automattic/ScreenObject",
+        "state": {
+          "branch": null,
+          "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
+          "version": "0.1.0"
+        }
+      },
+      {
         "package": "SimplenoteFoundation",
         "repositoryURL": "git@github.com:Automattic/SimplenoteFoundation-Swift.git",
         "state": {

--- a/SimplenoteScreenshots/PasscodeScreen.swift
+++ b/SimplenoteScreenshots/PasscodeScreen.swift
@@ -1,0 +1,43 @@
+import ScreenObject
+import XCTest
+
+class PasscodeScreen: ScreenObject {
+
+    // We need to store this as `static` in order to reuse it between the `static` `isLoaded` and
+    // the value in the `init` implementation.
+    //
+    // We need a `static` `isLoaded` because the current `ScreenObject` version doesn't offer a
+    // way to check if a screen is loaded without creating it, but if you create the screen, the
+    // framework also verifies it exists via an XCTest assertion. As this use case shows, that's
+    // not the most versatile behavior, but we'll address that at a later moment.
+    private static let expectedElementGetter: (XCUIApplication) -> XCUIElement = {
+        // Note that `firstMatch` is required, otherwise some of the queries internal to
+        // `ScreenObject` will fail because there are multiple matches and it just so happen that
+        // the one they pick is not the desired one. See the `UIButton` vs `UILabel` comment in
+        // the `type(passcode:)` implementation.
+        $0.staticTexts["1"].firstMatch
+    }
+
+    // TODO: Add more digits verifications once `ScreenObject` support initializing with more than
+    // one expected element. The digits we had originally were 1, 4, 7, 0 (one per pad row).
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetter: Self.expectedElementGetter, app: app)
+    }
+
+    func type(passcode: Int) {
+        // This converts an Int into an [Int] of its digits
+        let digits = "\(passcode.magnitude)".compactMap(\.wholeNumberValue)
+
+        digits.forEach { digit in
+            let input = app.staticTexts["\(digit)"]
+            XCTAssertTrue(input.waitForExistence(timeout: 3))
+            // Both the custom UIButton and its UILabel match the "\(digit)" query. We need to pick
+            // one for the tap to work.
+            input.firstMatch.tap()
+        }
+    }
+
+    static func isLoaded(in app: XCUIApplication = XCUIApplication()) -> Bool {
+        expectedElementGetter(app).exists
+    }
+}

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -245,10 +245,6 @@ class SimplenoteScreenshots: XCTestCase {
         }
     }
 
-    func type(_ text: String, onFirstKeyboardOf app: XCUIApplication) {
-        text.forEach { app.keyboards.firstMatch.keys[String($0)].tap() }
-    }
-
     func takeScreenshot(_ title: String) {
         let mode = XCUIDevice.inDarkMode ? "dark" : "light"
 

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -235,7 +235,7 @@ extension XCUIElement {
 
     /// Workaround to type text into secure text fields due to the different behaviors across
     /// Simulators.
-    func typeSecureText(_ text: String, using app: XCUIApplication) -> Void {
+    func typeSecureText(_ text: String, using app: XCUIApplication) {
         tap()
 
         // At the time of writing, typing in a secure text field didn't work in some of the


### PR DESCRIPTION
I decided to link it only to the screenshots automation target because the work required to meaningfully integrate the framework in the UI tests target is more complex.

At this point in time, my goal is simply to get the framework setup and used in a leaf screen within the navigation tree (the passcode), just to serve as a proof of concept.

### Test

1. Checkout this branch
2. Either run the screenshot automation tests from Xcode, or via Fastlane with `bundle exec fastlane take_screenshots_from_app mode:dark devices:'iPhone 11 Pro Max' languages:en-US` and ensure they pass

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.