### PR TITLE
Merge release/4.43 into develop - AppStore keywords update

### DIFF
--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -68,7 +68,7 @@ msgstr ""
 #. translators: Keywords used in the App Store search engine to find the app.
 #. Delimit with an English comma between each keyword. Limit to 100 characters including spaces and commas.
 msgctxt "app_store_keywords"
-msgid "notes,text,planner,journal,diary,sync,to-do,cloud,notebook,simple,notepad,tag,todo,writing,memo"
+msgid "notes,note,markdown,journal,sync,to-do,list,cloud,notebook,simple,notepad,tag,todo,writing,memo"
 msgstr ""
 
 msgctxt "v4.43-whats-new"

--- a/fastlane/appstoreres/metadata/source/keywords.txt
+++ b/fastlane/appstoreres/metadata/source/keywords.txt
@@ -1,1 +1,1 @@
-notes,text,planner,journal,diary,sync,to-do,cloud,notebook,simple,notepad,tag,todo,writing,memo
+notes,note,markdown,journal,sync,to-do,list,cloud,notebook,simple,notepad,tag,todo,writing,memo


### PR DESCRIPTION
See request in pd8BQf-9O-p2

We need this to land in `develop` ASAP so it gets picked and imported by GlotPress soon after, such that translators start translating the new keywords and get the translations in before the 4.43 release.