### PR TITLE
Fixes a bug where the select all button state might be off

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 4.44
 -----
-
+-   Fixed an issue with the select all button when only one note is in the list #1417
 
 4.43
 -----

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -850,6 +850,7 @@ private extension SPNoteListViewController {
             self?.tableView.scrollToNearestSelectedRow(at: .none, animated: false)
             self?.refreshListViewTitle()
             self?.refreshTrashButton()
+            self?.refreshSelectAllLabels()
         }
         if isSearchActive {
             select.attributes = .disabled


### PR DESCRIPTION
### Fix
This PR fixes #1377 

Currently if you start the edit mode on the note list, and only one note is in the list currently the Select all button will continue to be set as Select all even though all of the notes in the list are selected.  

This PR adds a refresh to the start of select mode to update the state of the select all button after the cell has been selected.

### Test
1. Select a tag that only has one note in it
2. long press on the note to see the contextual menu and then tap on Select
3. The edit mode should appear, check the select all/deselect all button in the top left.  It should say "Deselect All"
4. try the button to make sure it behaves as expected

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in f17001 with:
> 
> > - Fixed an issue with the select all button when only one note is in the list #1417
