### PR TITLE
Updated check for verification required body response

### DIFF
--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -82,7 +82,7 @@ extension SPAuthError {
         case .compromisedPassword:
             return NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.", comment: "error for compromised password")
         case .unverifiedEmail:
-            return NSLocalizedString("You must verify your email before being able to login.", comment: "Erro for un verified email")
+            return NSLocalizedString("You must verify your email before being able to login.", comment: "Error for un verified email")
         case .unknown:
             return NSLocalizedString("We're having problems. Please try again soon.", comment: "Generic error")
         }
@@ -91,5 +91,5 @@ extension SPAuthError {
 
 private struct Constants {
     static let compromisedPassword = "compromised password"
-    static let requiresVerification = "requires verification"
+    static let requiresVerification = "verification required"
 }


### PR DESCRIPTION
### Fix
This is a quick PR to update SPAuthError key for verification required.

Previously the expected response that had been added to the error was not correct.  It was `requires verification` which is not the correct key.  I have updated it to `verification required` 

(also fixed a type I found in one of the other error descriptions)

### Test
1. Setup some sort of proxy system like Charles to interrupt responses from the auth endpoint
2. modify the response to be a 403 error with a body of `verification required` 
3. You should see an alert with instructions for resending a verification

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
