### PR TITLE
Updated copy for account deletion alert message to include user email

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 4.44
 -----
 
+-   Fixed an issue with the select all button when only one note is in the list #1417
+-   Updated the account deletion flow for clarity #1423
 
 4.43
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,6 @@
 4.44
 -----
 
--   Fixed an issue with the select all button when only one note is in the list #1417
--   Updated the account deletion flow for clarity #1423
-
 4.43
 -----
 -   Fixed a bug where non http/https urls crashed when opened from markdown #1397
@@ -11,6 +8,7 @@
 -   Tags are now removed from deleted Notes #1391
 -   [Internal] added login alert for compromised password #1394
 -   [Internal] added error response case on login for unverified emails #1398
+-   Updated the account deletion flow for clarity #1423
 
 4.42
 -----

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -101,7 +101,7 @@ extension SPSettingsViewController {
         SPTracker.trackDeleteAccountButttonTapped()
         let spinnerViewController = SpinnerViewController()
 
-        presentAccountDeletionConfirmation { (_) in
+        presentAccountDeletionConfirmation(forEmail: user.email) { (_) in
             self.present(spinnerViewController, animated: false, completion: nil)
             deletionController.requestAccountDeletion(user) { [weak self] (result) in
                 spinnerViewController.dismiss(animated: false, completion: nil)
@@ -119,9 +119,9 @@ extension SPSettingsViewController {
         }
     }
 
-    private func presentAccountDeletionConfirmation(onConfirm: @escaping ((UIAlertAction) -> Void)) {
+    private func presentAccountDeletionConfirmation(forEmail email: String, onConfirm: @escaping ((UIAlertAction) -> Void)) {
         let alert = UIAlertController(title: AccountDeletion.deleteAccount,
-                                      message: AccountDeletion.confirmAlertMessage,
+                                      message: AccountDeletion.confirmAlertMessage(with: email),
                                       preferredStyle: .alert)
         let deleteAccountButton = UIAlertAction(title: AccountDeletion.deleteAccountButton, style: .destructive, handler: onConfirm)
 
@@ -154,8 +154,11 @@ extension SPSettingsViewController {
 }
 
 private struct AccountDeletion {
+    static func confirmAlertMessage(with email: String) -> String {
+        String(format: confirmAlertTemplate, email)
+    }
     static let deleteAccount = NSLocalizedString("Delete Account", comment: "Delete account title and action")
-    static let confirmAlertMessage = NSLocalizedString("By deleting your account, all notes created with this account will be permanently deleted. This action is not reversible", comment: "Delete account confirmation alert message")
+    static let confirmAlertTemplate = NSLocalizedString("By deleting the account for %@, all notes created with this account will be permanently deleted. This action is not reversible", comment: "Delete account confirmation alert message")
     static let deleteAccountButton = NSLocalizedString("Request Account Deletion", comment: "Title for account deletion confirm button")
     static let cancel = NSLocalizedString("Cancel", comment: "Cancel button title")
 


### PR DESCRIPTION
### Fix
Currently the alert message that appears when a user tries to delete their account does not include any details that identify their account.  This update adds their email address to the alert message for clarity

<img src="https://cdn-std.droplr.net/files/acc_593859/Pji1a5" />

### Test
1. go to the slide out menu -> Delete Account
2. an alert will appear that should include the email address for the account being deleted

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in 4a2da07 with:
> 
> > - Updated the account deletion flow for clarity #1423
