### PR TITLE
Use multiple elements to verify `PasscodeScreen` is loaded on screen

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -5638,7 +5638,7 @@
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.2.0;
 			};
 		};
 		3F762E8D2677F19C0088CD45 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
-          "version": "0.1.0"
+          "revision": "2d65beae47cdcaaf21703ce1b321f382fe0d0730",
+          "version": "0.2.0"
         }
       },
       {

--- a/SimplenoteScreenshots/PasscodeScreen.swift
+++ b/SimplenoteScreenshots/PasscodeScreen.swift
@@ -3,11 +3,14 @@ import XCTest
 
 class PasscodeScreen: ScreenObject {
 
-    // TODO: Add more digits verifications once `ScreenObject` support initializing with more than
-    // one expected element. The digits we had originally were 1, 4, 7, 0 (one per pad row).
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetter: { $0.staticTexts["1"].firstMatch },
+            expectedElementGetters: [
+                { $0.staticTexts["1"].firstMatch },
+                { $0.staticTexts["4"].firstMatch },
+                { $0.staticTexts["7"].firstMatch },
+                { $0.staticTexts["0"].firstMatch }
+            ],
             app: app
         )
     }

--- a/SimplenoteScreenshots/PasscodeScreen.swift
+++ b/SimplenoteScreenshots/PasscodeScreen.swift
@@ -3,25 +3,13 @@ import XCTest
 
 class PasscodeScreen: ScreenObject {
 
-    // We need to store this as `static` in order to reuse it between the `static` `isLoaded` and
-    // the value in the `init` implementation.
-    //
-    // We need a `static` `isLoaded` because the current `ScreenObject` version doesn't offer a
-    // way to check if a screen is loaded without creating it, but if you create the screen, the
-    // framework also verifies it exists via an XCTest assertion. As this use case shows, that's
-    // not the most versatile behavior, but we'll address that at a later moment.
-    private static let expectedElementGetter: (XCUIApplication) -> XCUIElement = {
-        // Note that `firstMatch` is required, otherwise some of the queries internal to
-        // `ScreenObject` will fail because there are multiple matches and it just so happen that
-        // the one they pick is not the desired one. See the `UIButton` vs `UILabel` comment in
-        // the `type(passcode:)` implementation.
-        $0.staticTexts["1"].firstMatch
-    }
-
     // TODO: Add more digits verifications once `ScreenObject` support initializing with more than
     // one expected element. The digits we had originally were 1, 4, 7, 0 (one per pad row).
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetter: Self.expectedElementGetter, app: app)
+        try super.init(
+            expectedElementGetter: { $0.staticTexts["1"].firstMatch },
+            app: app
+        )
     }
 
     func type(passcode: Int) {
@@ -38,6 +26,11 @@ class PasscodeScreen: ScreenObject {
     }
 
     static func isLoaded(in app: XCUIApplication = XCUIApplication()) -> Bool {
-        expectedElementGetter(app).exists
+        do {
+            let screen = try PasscodeScreen(app: app)
+            return screen.isLoaded
+        } catch {
+            return false
+        }
     }
 }


### PR DESCRIPTION
### Fix
This PR leverages and further verifies the changes from https://github.com/Automattic/ScreenObject/pull/9 to use more than one element to verify the passcode screen is loaded in the screenshot automation tests.

### Test
Checkout this branch, run the screenshot automation tests and verify they work.

If you want to have a test against false positives, try changing the `PasscodeScreen` init implementation adding an element that is not on screen and verify the tests fail.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.

---

I'll keep this PR a draft till https://github.com/Automattic/ScreenObject/pull/9 has been merged an a new version shipped. Still, I'd appreciate a quick review.
