### PR TITLE
Updates UI tests user(s) passwords to more secure ones

### DIFF
--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -98,4 +98,4 @@ enum Text {
 }
 
 let testDataEmail = "simplenoteuitest@mailinator.com"
-let testDataPassword = "qazxswedc"
+let testDataPassword = "yang8EEF3pall"


### PR DESCRIPTION
### Intro
Since the rollout of compromised password check on login, the UI test accounts credentials are not accepted any longer. Tests stopped working locally, and also were not working on the CI, because the other set of dedicated tests accounts (not exposed) also used non-secure passwords.

### Fix
The credentials for UI test accounts used on CI were changed, but it's not visible in the PR, since this is a change of CI masked environment variables.

The only visible change is the change of the single exposed test account password, which is used for local testing.


### Test
1. Seeing that tests were failing before the PR (see #1438)
2. Seeing that `UI Tests Subset` test now passes on CI in this PR
3. Seeing that `UI Tests Full` test now passes on CI in this PR

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review. Thanks!

### Release
These changes do not require release notes.

### PS
Hat tip to @mokagio for noticing this so early. I should add Slack notification for this...