### PR TITLE
Updated text for Compromised password alert

### DIFF
--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -80,7 +80,7 @@ extension SPAuthError {
         case .network:
             return NSLocalizedString("The network could not be reached.", comment: "Error when the network is inaccessible")
         case .compromisedPassword:
-            return NSLocalizedString("It is recommended that you change your password immediately. To protect your data, you'll need to update your password before being able to log in again.", comment: "error for compromised password")
+            return NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. To protect your data, you'll need to update your password before being able to log in again.", comment: "error for compromised password")
         case .unverifiedEmail:
             return NSLocalizedString("You must verify your email before being able to login.", comment: "Error for un verified email")
         case .unknown:

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -80,7 +80,7 @@ extension SPAuthError {
         case .network:
             return NSLocalizedString("The network could not be reached.", comment: "Error when the network is inaccessible")
         case .compromisedPassword:
-            return NSLocalizedString("This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.", comment: "error for compromised password")
+            return NSLocalizedString("It is recommended that you change your password immediately. To protect your data, you'll need to update your password before being able to log in again.", comment: "error for compromised password")
         case .unverifiedEmail:
             return NSLocalizedString("You must verify your email before being able to login.", comment: "Error for un verified email")
         case .unknown:

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -694,7 +694,7 @@ private enum AuthenticationStrings {
     static let acceptActionText             = NSLocalizedString("Accept", comment: "Accept Action")
     static let cancelActionText             = NSLocalizedString("Cancel", comment: "Cancel Action")
     static let loginActionText              = NSLocalizedString("Log In", comment: "Log In Action")
-    static let compromisedAlertCancel       = NSLocalizedString("Not Yet", comment: "Cancel action for password alert")
+    static let compromisedAlertCancel       = NSLocalizedString("Dismiss", comment: "Cancel action for password alert")
     static let compromisedAlertReset        = NSLocalizedString("Change Password", comment: "Change password action")
     static let unverifiedCancelText         = NSLocalizedString("Ok", comment: "Email unverified alert dismiss")
     static let unverifiedActionText         = NSLocalizedString("Resend Verification Email", comment: "Send email verificaiton action")

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -694,7 +694,7 @@ private enum AuthenticationStrings {
     static let acceptActionText             = NSLocalizedString("Accept", comment: "Accept Action")
     static let cancelActionText             = NSLocalizedString("Cancel", comment: "Cancel Action")
     static let loginActionText              = NSLocalizedString("Log In", comment: "Log In Action")
-    static let compromisedAlertCancel       = NSLocalizedString("Dismiss", comment: "Cancel action for password alert")
+    static let compromisedAlertCancel       = NSLocalizedString("Cancel", comment: "Cancel action for password alert")
     static let compromisedAlertReset        = NSLocalizedString("Change Password", comment: "Change password action")
     static let unverifiedCancelText         = NSLocalizedString("Ok", comment: "Email unverified alert dismiss")
     static let unverifiedActionText         = NSLocalizedString("Resend Verification Email", comment: "Send email verificaiton action")


### PR DESCRIPTION
### Fix
This is a quick PR to clarify the text that appears when a user's password has been found to be compromised.  This text should be clearer and imply more urgency around changing that password

internal ref: p1632202617005500-slack-C01KRRK0MLJ

<img height=400 src="https://cdn-std.droplr.net/files/acc_593859/GxfiBJ" />

### Test
1. setup a tool like charles proxy to interrupt web auth traffic and set a breakpoint on the auth endpoint
2. attempt to log into the app with a bad username/password combe
2. edit the response from the auth endpoint to 401 with a body of "compromised password"
3. the warning will appear

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
