### PR TITLE
Update some localized string definitions to correct the English rendering

### DIFF
--- a/Simplenote/Classes/NotesListFilter.swift
+++ b/Simplenote/Classes/NotesListFilter.swift
@@ -44,7 +44,7 @@ extension NotesListFilter {
         case .everything:
             return NSLocalizedString("All Notes", comment: "Title: No filters applied")
         case .deleted:
-            return NSLocalizedString("Trash-noun", comment: "Title: Trash Tag is selected")
+            return NSLocalizedString("Trash", comment: "Title: Trash Tag is selected")
         case .untagged:
             return NSLocalizedString("Untagged", comment: "Title: Untagged Notes are onscreen")
         case .tag(let name):

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.m
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.m
@@ -145,7 +145,11 @@
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if ([tableView isEqual:primaryTableView]) {
-        return self.dataSource.count > 0 ? nil : NSLocalizedString(@"collaborators-description", nil);
+        if (self.dataSource.count > 0) {
+            return nil;
+        } else {
+            return NSLocalizedString(@"Add an email address to share this note with someone. Then you can both make changes to it.", @"Description text for the screen that allows users to share notes with other users");
+        }
     }
 
     return [super tableView:tableView titleForFooterInSection:section];

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -830,7 +830,7 @@ CGFloat const SPSelectedAreaPadding = 20;
 
 - (void)didDeleteCurrentNote {
 
-    NSString *title = NSLocalizedString(@"deleted-note-warning", @"Warning message shown when current note is deleted on another device");
+    NSString *title = NSLocalizedString(@"This note was deleted on another device", @"Warning message shown when current note is deleted on another device");
     NSString *cancelTitle = NSLocalizedString(@"Accept", @"Label of accept button on alert dialog");
 
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleAlert];

--- a/Simplenote/Classes/SPTagEntryField.m
+++ b/Simplenote/Classes/SPTagEntryField.m
@@ -29,7 +29,7 @@ CGFloat const TagEntryFieldPadding = 40;
 
 
         self.accessibilityLabel = NSLocalizedString(@"Add tag", @"Label on button to add a new tag to a note");
-        self.accessibilityHint = NSLocalizedString(@"tag-add-accessibility-hint", @"Accessibility hint for adding a tag to a note");
+        self.accessibilityHint = NSLocalizedString(@"Add a tag to the current note", @"Accessibility hint for adding a tag to a note");
 
         [self sizeField];
 

--- a/Simplenote/Classes/SPTagEntryField.m
+++ b/Simplenote/Classes/SPTagEntryField.m
@@ -22,12 +22,11 @@ CGFloat const TagEntryFieldPadding = 40;
         self.textColor = [UIColor simplenoteTagViewTextColor];
         self.placeholdTextColor = [UIColor simplenoteTagViewPlaceholderColor];
         self.textAlignment = NSTextAlignmentNatural;
-        self.placeholder = NSLocalizedString(@"Add a tag...", nil);
+        self.placeholder = NSLocalizedString(@"Tag...", @"Placeholder text in textfield when adding a new tag to a note");
         self.returnKeyType = UIReturnKeyNext;
         self.autocorrectionType = UITextAutocorrectionTypeNo;
         self.autocapitalizationType = UITextAutocapitalizationTypeNone;
 
-        [self setPlaceholder:NSLocalizedString(@"Add a tag...", @"Placeholder test in textfield when adding a new tag to a note")];
 
         self.accessibilityLabel = NSLocalizedString(@"Add tag", @"Label on button to add a new tag to a note");
         self.accessibilityHint = NSLocalizedString(@"tag-add-accessibility-hint", @"Accessibility hint for adding a tag to a note");
@@ -43,10 +42,10 @@ CGFloat const TagEntryFieldPadding = 40;
 - (void)setText:(NSString *)text
 {
     [super setText:text];
-    
+
     // size field appropriately
     [self sizeField];
-    
+
     if ([self.tagDelegate respondsToSelector:@selector(tagEntryFieldDidChange:)]) {
         [self.tagDelegate tagEntryFieldDidChange:self];
     }
@@ -55,12 +54,12 @@ CGFloat const TagEntryFieldPadding = 40;
 - (void)sizeField
 {
     [self sizeToFit];
-    
+
     CGRect frame = self.frame;
-    
+
     frame.size.width += 2 * TagEntryFieldPadding;
     frame.size.height = self.frame.size.height;
-    
+
     self.frame = frame;
 }
 

--- a/Simplenote/Classes/TagViewCell.swift
+++ b/Simplenote/Classes/TagViewCell.swift
@@ -176,5 +176,5 @@ private struct Constants {
 // MARK: - Localization
 //
 private struct Localization {
-    static let removeTagHint = NSLocalizedString("tag-delete-accessibility-hint", comment: "Remove a tag from the current note")
+    static let removeTagHint = NSLocalizedString("Remove tag from the current note", comment: "Accessibility hint for removing a tag from the current note")
 }

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -860,7 +860,7 @@ private struct Localization {
     static let done = NSLocalizedString("Done", comment: "Done editing tags")
 
     static let allNotes = NSLocalizedString("All Notes", comment: "All Notes filter button")
-    static let trash = NSLocalizedString("Trash-noun", comment: "Trash filter button")
+    static let trash = NSLocalizedString("Trash", comment: "Trash filter button")
     static let settings = NSLocalizedString("Settings", comment: "Settings button")
 
     static let tags = NSLocalizedString("Tags", comment: "Tags List Header")

--- a/Simplenote/en.lproj/Localizable.strings
+++ b/Simplenote/en.lproj/Localizable.strings
@@ -74,8 +74,11 @@
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Add a new collaborator..." = "Add a new collaborator...";
 
-/* Placeholder test in textfield when adding a new tag to a note */
-"Add a tag..." = "Add a tag...";
+/* Accessibility hint for adding a tag to a note */
+"Add a tag to the current note" = "Add a tag to the current note";
+
+/* Description text for the screen that allows users to share notes with other users */
+"Add an email address to share this note with someone. Then you can both make changes to it." = "Add an email address to share this note with someone. Then you can both make changes to it.";
 
 /* Label on button to add a new tag to a note */
 "Add tag" = "Add tag";
@@ -169,9 +172,6 @@
 
 /* Noun - collaborators are other Simplenote users who you chose to share a note with */
 "Collaborators" = "Collaborators";
-
-/* No comment provided by engineer. */
-"collaborators-description" = "collaborators-description";
 
 /* Compromised password alert title */
 "Compromised Password" = "Compromised Password";
@@ -271,9 +271,6 @@
 
 /* Confirmation button of deletion confirmation message for a tag. */
 "Delete Tag" = "Delete Tag";
-
-/* Warning message shown when current note is deleted on another device */
-"deleted-note-warning" = "deleted-note-warning";
 
 /* Deselect all Button Label */
 "Deselect All" = "Deselect All";
@@ -628,6 +625,9 @@
 /* No comment provided by engineer. */
 "Remove all notes from trash" = "Remove all notes from trash";
 
+/* Accessibility hint for removing a tag from the current note */
+"Remove tag from the current note" = "Remove tag from the current note";
+
 /* Rename a tag */
 "Rename" = "Rename";
 
@@ -759,11 +759,8 @@
 /* Widget warning if tag is deleted */
 "Tag no longer available" = "Tag no longer available";
 
-/* Accessibility hint for adding a tag to a note */
-"tag-add-accessibility-hint" = "tag-add-accessibility-hint";
-
-/* Remove a tag from the current note */
-"tag-delete-accessibility-hint" = "tag-delete-accessibility-hint";
+/* Placeholder text in textfield when adding a new tag to a note */
+"Tag..." = "Tag...";
 
 /* Search Operator for tags. Please preserve the semicolons when translating! */
 "tag:" = "tag:";
@@ -798,6 +795,9 @@
 /* Request error alert message */
 "There was an preparing your verification email, please try again later" = "There was an preparing your verification email, please try again later";
 
+/* Warning message shown when current note is deleted on another device */
+"This note was deleted on another device" = "This note was deleted on another device";
+
 /* error for compromised password */
 "This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately." = "This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.";
 
@@ -819,12 +819,12 @@
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";
 
-/* Move selected notes to trash */
-"Trash Notes" = "Trash Notes";
-
 /* Title: Trash Tag is selected
    Trash filter button */
-"Trash-noun" = "Trash-noun";
+"Trash" = "Trash";
+
+/* Move selected notes to trash */
+"Trash Notes" = "Trash Notes";
 
 /* Prompt when disabling passcode */
 "Turn off Passcode" = "Turn off Passcode";


### PR DESCRIPTION
After the localization tooling improvement from #1437, I noticed a few localized values changed in a way that would have resulted in an incorrect representation for the English locale. E.g.:

<img width="426" alt="Screen Shot 2021-09-22 at 11 13 58 am" src="https://user-images.githubusercontent.com/1218433/134275508-89902a58-5bea-44e8-8af1-259ccab7cf21.png">


I believe this is an issue we always had, but that was revealed by the change in how `genstrings` run.

I updated the strings definition in the source to the best of my understanding. The resulting `en.lproj/Localizable.strings` might not be perfect from a copy writing point of view, but at least has human-readable English words and sentences. 😅

I think we should merge this initial version I'm proposing to unblock the 4.45 code freeze, and proceed with copy writing updates where needed against `develop` to ship with the next version.

### Test
Nothing to test, just take a look at the `.strings` diff.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.