### PR TITLE
Add UI tests foundation framework

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -60,6 +60,10 @@
 		3F762E912677F1AA0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E902677F1AA0088CD45 /* XCUITestHelpers */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
 		3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */; };
+		3FFBDBEE26FBF132008AD052 /* UITestsFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FFBDBED26FBF132008AD052 /* UITestsFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FFBDBF626FBF143008AD052 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FFBDBF526FBF143008AD052 /* XCUITestHelpers */; };
+		3FFBDBF826FBF148008AD052 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FFBDBF726FBF148008AD052 /* ScreenObject */; };
+		3FFBDBF926FBF161008AD052 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F3CA94826255FA800F6316F /* XCTest.framework */; platformFilter = ios; };
 		4352BA0867E0E416EB5FF6B9 /* Pods_Automattic_Simplenote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3318C36BBA08D53624E27EFC /* Pods_Automattic_Simplenote.framework */; };
 		46A3C96317DFA81A002865AE /* NSString+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 467D9C771788D0FF00785EF3 /* NSString+Metadata.m */; };
 		46A3C96617DFA81A002865AE /* SPAcitivitySafari.m in Sources */ = {isa = PBXBuildFile; fileRef = E283709917D7B46300AB562D /* SPAcitivitySafari.m */; };
@@ -477,7 +481,6 @@
 		BA8662C226B3B63F00466746 /* SimplenoteSearch in Frameworks */ = {isa = PBXBuildFile; productRef = BA8662C126B3B63F00466746 /* SimplenoteSearch */; };
 		BA88765126B79324001C9C9E /* DemoContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88765026B79324001C9C9E /* DemoContent.swift */; };
 		BA8FC2A5267AC7470082962E /* SharedStorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */; };
-		BA8FC2A5267AC7470082962E /* SharedStorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */; };
 		BA9B19F926A8EF3200692366 /* SpinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */; };
 		BA9B59022685549F00DAD1ED /* StorageSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B59012685549F00DAD1ED /* StorageSettings.swift */; };
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
@@ -720,6 +723,8 @@
 		3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplenoteScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteScreenshots.swift; sourceTree = "<group>"; };
 		3FA6013D242C5AAE0068FC52 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3FFBDBEB26FBF132008AD052 /* UITestsFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UITestsFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FFBDBED26FBF132008AD052 /* UITestsFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UITestsFoundation.h; sourceTree = "<group>"; };
 		467D9C5D1788A4FB00785EF3 /* Simplenote 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 2.xcdatamodel"; sourceTree = "<group>"; };
 		467D9C5E1788A4FB00785EF3 /* Simplenote.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Simplenote.xcdatamodel; sourceTree = "<group>"; };
 		467D9C611788A54900785EF3 /* Note.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Note.h; path = Classes/Note.h; sourceTree = "<group>"; };
@@ -1125,7 +1130,6 @@
 		BA86622226B3AE4A00466746 /* WidgetResultsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetResultsController.swift; sourceTree = "<group>"; };
 		BA88765026B79324001C9C9E /* DemoContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoContent.swift; sourceTree = "<group>"; };
 		BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStorageMigrator.swift; sourceTree = "<group>"; };
-		BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStorageMigrator.swift; sourceTree = "<group>"; };
 		BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		BA9B59012685549F00DAD1ED /* StorageSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSettings.swift; sourceTree = "<group>"; };
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
@@ -1265,6 +1269,16 @@
 			files = (
 				3F762E912677F1AA0088CD45 /* XCUITestHelpers in Frameworks */,
 				3F4BA07E26CDF295000619B1 /* ScreenObject in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FFBDBE826FBF132008AD052 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FFBDBF626FBF143008AD052 /* XCUITestHelpers in Frameworks */,
+				3FFBDBF926FBF161008AD052 /* XCTest.framework in Frameworks */,
+				3FFBDBF826FBF148008AD052 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1413,6 +1427,14 @@
 				3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */,
 			);
 			path = SimplenoteScreenshots;
+			sourceTree = "<group>";
+		};
+		3FFBDBEC26FBF132008AD052 /* UITestsFoundation */ = {
+			isa = PBXGroup;
+			children = (
+				3FFBDBED26FBF132008AD052 /* UITestsFoundation.h */,
+			);
+			path = UITestsFoundation;
 			sourceTree = "<group>";
 		};
 		467D9C601788A53700785EF3 /* Models */ = {
@@ -2437,6 +2459,7 @@
 				D864B15525CAE25000F9B73E /* SimplenoteUITests */,
 				BAFA93DD265DCFCA0009DCFB /* SimplenoteWidgets */,
 				BAB5762526703C8200B0C56F /* SimplenoteIntents */,
+				3FFBDBEC26FBF132008AD052 /* UITestsFoundation */,
 				E29ADD3A17848E8500E55842 /* Frameworks */,
 				E29ADD3917848E8500E55842 /* Products */,
 				564CAA42AA330D16FDBDD081 /* Pods */,
@@ -2454,6 +2477,7 @@
 				D864B15425CAE25000F9B73E /* SimplenoteUITests.xctest */,
 				BAFA93D8265DCFCA0009DCFB /* SimplenoteWidgetsExtension.appex */,
 				BAB5762226703C8100B0C56F /* SimplenoteIntents.appex */,
+				3FFBDBEB26FBF132008AD052 /* UITestsFoundation.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2622,6 +2646,17 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		3FFBDBE626FBF132008AD052 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3FFBDBEE26FBF132008AD052 /* UITestsFoundation.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		3FA60138242C5AAD0068FC52 /* SimplenoteScreenshots */ = {
 			isa = PBXNativeTarget;
@@ -2645,6 +2680,28 @@
 			productName = SimplenoteScreenshots;
 			productReference = 3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		3FFBDBEA26FBF132008AD052 /* UITestsFoundation */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3FFBDBF426FBF132008AD052 /* Build configuration list for PBXNativeTarget "UITestsFoundation" */;
+			buildPhases = (
+				3FFBDBE626FBF132008AD052 /* Headers */,
+				3FFBDBE726FBF132008AD052 /* Sources */,
+				3FFBDBE826FBF132008AD052 /* Frameworks */,
+				3FFBDBE926FBF132008AD052 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = UITestsFoundation;
+			packageProductDependencies = (
+				3FFBDBF526FBF143008AD052 /* XCUITestHelpers */,
+				3FFBDBF726FBF148008AD052 /* ScreenObject */,
+			);
+			productName = UITestsFoundation;
+			productReference = 3FFBDBEB26FBF132008AD052 /* UITestsFoundation.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		46A3C96017DFA81A002865AE /* Simplenote */ = {
 			isa = PBXNativeTarget;
@@ -2800,6 +2857,9 @@
 						ProvisioningStyle = Automatic;
 						TestTargetID = 46A3C96017DFA81A002865AE;
 					};
+					3FFBDBEA26FBF132008AD052 = {
+						CreatedOnToolsVersion = 13.0;
+					};
 					46A3C96017DFA81A002865AE = {
 						DevelopmentTeam = PZYM8XX95Q;
 						LastSwiftMigration = 1020;
@@ -2899,12 +2959,20 @@
 				D864B15325CAE25000F9B73E /* SimplenoteUITests */,
 				BAFA93D7265DCFCA0009DCFB /* SimplenoteWidgetsExtension */,
 				BAB5762126703C8100B0C56F /* SimplenoteIntents */,
+				3FFBDBEA26FBF132008AD052 /* UITestsFoundation */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3FA60137242C5AAD0068FC52 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FFBDBE926FBF132008AD052 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3179,6 +3247,13 @@
 				3F4BA08026CE00A2000619B1 /* PasscodeScreen.swift in Sources */,
 				3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */,
 				3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3FFBDBE726FBF132008AD052 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3975,6 +4050,216 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Simplenote;
+			};
+			name = "Distribution AppStore";
+		};
+		3FFBDBEF26FBF132008AD052 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Automattic. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simplenote.UITestsFoundation;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3FFBDBF026FBF132008AD052 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Automattic. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simplenote.UITestsFoundation;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3FFBDBF126FBF132008AD052 /* Distribution Internal */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Automattic. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simplenote.UITestsFoundation;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = "Distribution Internal";
+		};
+		3FFBDBF226FBF132008AD052 /* Distribution Alpha */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Automattic. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simplenote.UITestsFoundation;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = "Distribution Alpha";
+		};
+		3FFBDBF326FBF132008AD052 /* Distribution AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Automattic. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.simplenote.UITestsFoundation;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = "Distribution AppStore";
 		};
@@ -5534,6 +5819,18 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		3FFBDBF426FBF132008AD052 /* Build configuration list for PBXNativeTarget "UITestsFoundation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3FFBDBEF26FBF132008AD052 /* Debug */,
+				3FFBDBF026FBF132008AD052 /* Release */,
+				3FFBDBF126FBF132008AD052 /* Distribution Internal */,
+				3FFBDBF226FBF132008AD052 /* Distribution Alpha */,
+				3FFBDBF326FBF132008AD052 /* Distribution AppStore */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		46A3C9D417DFA81A002865AE /* Build configuration list for PBXNativeTarget "Simplenote" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -5690,6 +5987,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3F762E8D2677F19C0088CD45 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
 			productName = XCUITestHelpers;
+		};
+		3FFBDBF526FBF143008AD052 /* XCUITestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F762E8D2677F19C0088CD45 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
+			productName = XCUITestHelpers;
+		};
+		3FFBDBF726FBF148008AD052 /* ScreenObject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F4BA07C26CDF295000619B1 /* XCRemoteSwiftPackageReference "ScreenObject" */;
+			productName = ScreenObject;
 		};
 		B50D2FB524E6DFAC00163FC3 /* SimplenoteSearch */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -55,11 +55,11 @@
 		3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB49F242DB81E006D1A04 /* ScreenshotsCredentials.swift */; };
 		3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */; };
 		3F4BA07E26CDF295000619B1 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3F4BA07D26CDF295000619B1 /* ScreenObject */; };
-		3F4BA08026CE00A2000619B1 /* PasscodeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */; };
 		3F762E8F2677F19C0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E8E2677F19C0088CD45 /* XCUITestHelpers */; };
 		3F762E912677F1AA0088CD45 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3F762E902677F1AA0088CD45 /* XCUITestHelpers */; };
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
 		3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */; };
+		3FF314CE26FC20FD0012E68E /* PasscodeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */; };
 		3FFBDBEE26FBF132008AD052 /* UITestsFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FFBDBED26FBF132008AD052 /* UITestsFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3FFBDBF626FBF143008AD052 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FFBDBF526FBF143008AD052 /* XCUITestHelpers */; };
 		3FFBDBF826FBF148008AD052 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FFBDBF726FBF148008AD052 /* ScreenObject */; };
@@ -593,6 +593,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 46A3C96017DFA81A002865AE;
 			remoteInfo = Simplenote;
+		};
+		3FF314D026FC220B0012E68E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E29ADD3017848E8500E55842 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3FFBDBEA26FBF132008AD052;
+			remoteInfo = UITestsFoundation;
 		};
 		B582189C1FCC45170094ECA1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1424,7 +1431,6 @@
 				3FA6013D242C5AAE0068FC52 /* Info.plist */,
 				3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */,
 				3F1BB4A2242DC162006D1A04 /* SnapshotHelper.swift */,
-				3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */,
 			);
 			path = SimplenoteScreenshots;
 			sourceTree = "<group>";
@@ -1432,6 +1438,7 @@
 		3FFBDBEC26FBF132008AD052 /* UITestsFoundation */ = {
 			isa = PBXGroup;
 			children = (
+				3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */,
 				3FFBDBED26FBF132008AD052 /* UITestsFoundation.h */,
 			);
 			path = UITestsFoundation;
@@ -2669,6 +2676,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				3FF314D126FC220B0012E68E /* PBXTargetDependency */,
 				3F1BB4B724319A5B006D1A04 /* PBXTargetDependency */,
 				3FA6013F242C5AAE0068FC52 /* PBXTargetDependency */,
 			);
@@ -3244,7 +3252,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F1BB4A0242DB81E006D1A04 /* ScreenshotsCredentials.swift in Sources */,
-				3F4BA08026CE00A2000619B1 /* PasscodeScreen.swift in Sources */,
 				3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */,
 				3F1BB4A3242DC162006D1A04 /* SnapshotHelper.swift in Sources */,
 			);
@@ -3254,6 +3261,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FF314CE26FC20FD0012E68E /* PasscodeScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3775,6 +3783,11 @@
 			isa = PBXTargetDependency;
 			target = 46A3C96017DFA81A002865AE /* Simplenote */;
 			targetProxy = 3FA6013E242C5AAE0068FC52 /* PBXContainerItemProxy */;
+		};
+		3FF314D126FC220B0012E68E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3FFBDBEA26FBF132008AD052 /* UITestsFoundation */;
+			targetProxy = 3FF314D026FC220B0012E68E /* PBXContainerItemProxy */;
 		};
 		B582189D1FCC45170094ECA1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -602,6 +602,13 @@
 			remoteGlobalIDString = 3FFBDBEA26FBF132008AD052;
 			remoteInfo = UITestsFoundation;
 		};
+		3FF314D426FC47ED0012E68E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E29ADD3017848E8500E55842 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3FFBDBEA26FBF132008AD052;
+			remoteInfo = UITestsFoundation;
+		};
 		B582189C1FCC45170094ECA1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E29ADD3017848E8500E55842 /* Project object */;
@@ -2838,6 +2845,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				3FF314D526FC47ED0012E68E /* PBXTargetDependency */,
 				D864B15A25CAE25000F9B73E /* PBXTargetDependency */,
 			);
 			name = SimplenoteUITests;
@@ -3792,6 +3800,11 @@
 			isa = PBXTargetDependency;
 			target = 3FFBDBEA26FBF132008AD052 /* UITestsFoundation */;
 			targetProxy = 3FF314D026FC220B0012E68E /* PBXContainerItemProxy */;
+		};
+		3FF314D526FC47ED0012E68E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3FFBDBEA26FBF132008AD052 /* UITestsFoundation */;
+			targetProxy = 3FF314D426FC47ED0012E68E /* PBXContainerItemProxy */;
 		};
 		B582189D1FCC45170094ECA1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		3FA17B5626240FF000C11C46 /* NoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA17B5526240FF000C11C46 /* NoteData.swift */; };
 		3FA6013C242C5AAE0068FC52 /* SimplenoteScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */; };
 		3FF314CE26FC20FD0012E68E /* PasscodeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */; };
+		3FF314D326FC47720012E68E /* XCUIApplication+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF314D226FC47720012E68E /* XCUIApplication+Assertions.swift */; };
 		3FFBDBEE26FBF132008AD052 /* UITestsFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FFBDBED26FBF132008AD052 /* UITestsFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3FFBDBF626FBF143008AD052 /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FFBDBF526FBF143008AD052 /* XCUITestHelpers */; };
 		3FFBDBF826FBF148008AD052 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FFBDBF726FBF148008AD052 /* ScreenObject */; };
@@ -730,6 +731,7 @@
 		3FA60139242C5AAD0068FC52 /* SimplenoteScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SimplenoteScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FA6013B242C5AAE0068FC52 /* SimplenoteScreenshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteScreenshots.swift; sourceTree = "<group>"; };
 		3FA6013D242C5AAE0068FC52 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3FF314D226FC47720012E68E /* XCUIApplication+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+Assertions.swift"; sourceTree = "<group>"; };
 		3FFBDBEB26FBF132008AD052 /* UITestsFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UITestsFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FFBDBED26FBF132008AD052 /* UITestsFoundation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UITestsFoundation.h; sourceTree = "<group>"; };
 		467D9C5D1788A4FB00785EF3 /* Simplenote 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 2.xcdatamodel"; sourceTree = "<group>"; };
@@ -1440,6 +1442,7 @@
 			children = (
 				3F4BA07F26CE00A2000619B1 /* PasscodeScreen.swift */,
 				3FFBDBED26FBF132008AD052 /* UITestsFoundation.h */,
+				3FF314D226FC47720012E68E /* XCUIApplication+Assertions.swift */,
 			);
 			path = UITestsFoundation;
 			sourceTree = "<group>";
@@ -3261,6 +3264,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3FF314D326FC47720012E68E /* XCUIApplication+Assertions.swift in Sources */,
 				3FF314CE26FC20FD0012E68E /* PasscodeScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/UITestsFoundation.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/UITestsFoundation.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3FFBDBEA26FBF132008AD052"
+               BuildableName = "UITestsFoundation.framework"
+               BlueprintName = "UITestsFoundation"
+               ReferencedContainer = "container:Simplenote.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3FFBDBEA26FBF132008AD052"
+            BuildableName = "UITestsFoundation.framework"
+            BlueprintName = "UITestsFoundation"
+            ReferencedContainer = "container:Simplenote.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SimplenoteScreenshots/SimplenoteScreenshots.swift
+++ b/SimplenoteScreenshots/SimplenoteScreenshots.swift
@@ -1,3 +1,4 @@
+import UITestsFoundation
 import XCTest
 import XCUITestHelpers
 

--- a/SimplenoteUITests/SimplenoteUITestsLogin.swift
+++ b/SimplenoteUITests/SimplenoteUITestsLogin.swift
@@ -1,3 +1,4 @@
+import UITestsFoundation
 import XCTest
 
 class SimplenoteUISmokeTestsLogin: XCTestCase {
@@ -22,8 +23,8 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
         trackStep()
         EmailLogin.open()
         EmailLogin.logIn(email: "", password: "")
-        Assert.labelExists(labelText: Text.loginEmailInvalid)
-        Assert.labelExists(labelText: Text.loginPasswordShort)
+        app.assertLabelExists(withText: Text.loginEmailInvalid)
+        app.assertLabelExists(withText: Text.loginPasswordShort)
     }
 
     func testLogInWithNoEmail() throws {

--- a/UITestsFoundation/PasscodeScreen.swift
+++ b/UITestsFoundation/PasscodeScreen.swift
@@ -1,9 +1,9 @@
 import ScreenObject
 import XCTest
 
-class PasscodeScreen: ScreenObject {
+public class PasscodeScreen: ScreenObject {
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 { $0.staticTexts["1"].firstMatch },
@@ -15,7 +15,7 @@ class PasscodeScreen: ScreenObject {
         )
     }
 
-    func type(passcode: Int) {
+    public func type(passcode: Int) {
         // This converts an Int into an [Int] of its digits
         let digits = "\(passcode.magnitude)".compactMap(\.wholeNumberValue)
 
@@ -28,7 +28,7 @@ class PasscodeScreen: ScreenObject {
         }
     }
 
-    static func isLoaded(in app: XCUIApplication = XCUIApplication()) -> Bool {
+    public static func isLoaded(in app: XCUIApplication = XCUIApplication()) -> Bool {
         do {
             let screen = try PasscodeScreen(app: app)
             return screen.isLoaded

--- a/UITestsFoundation/UITestsFoundation.h
+++ b/UITestsFoundation/UITestsFoundation.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT double UITestsFoundationVersionNumber;
+FOUNDATION_EXPORT const unsigned char UITestsFoundationVersionString[];

--- a/UITestsFoundation/XCUIApplication+Assertions.swift
+++ b/UITestsFoundation/XCUIApplication+Assertions.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+extension XCUIApplication {
+
+    public func assertLabelExists(
+        withText text: String,
+        timetout: TimeInterval = 5.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            staticTexts[text].waitForExistence(timeout: timetout),
+            "\(text) label NOT found",
+            file: file,
+            line: line
+        )
+    }
+}

--- a/UITestsFoundation/XCUIApplication+Assertions.swift
+++ b/UITestsFoundation/XCUIApplication+Assertions.swift
@@ -10,7 +10,7 @@ extension XCUIApplication {
     ) {
         XCTAssertTrue(
             staticTexts[text].waitForExistence(timeout: timetout),
-            "\(text) label NOT found",
+            #"Label with text "\#(text)" NOT found"#,
             file: file,
             line: line
         )


### PR DESCRIPTION
### Fix

This adds a framework where to put all the "foundation" components and utilities for the UI tests, following the same principle as what [WordPress iOS does](https://github.com/wordpress-mobile/WordPress-iOS/pull/16662).

### Test

You can verify the tests run locally. I also run the full suite in CI.

### Review
Only one developer required to review these changes, but anyone can perform the review.

### Release

These changes do not require release notes.