### PR TITLE
Add `previous-application-identifier` to Intents' Release entitlements

### DIFF
--- a/SimplenoteIntents/Supporting Files/SimplenoteIntents-Release.entitlements
+++ b/SimplenoteIntents/Supporting Files/SimplenoteIntents-Release.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>group.com.codality.NotationalFlow</string>
 	</array>
+	<key>previous-application-identifiers</key>
+	<array>
+		<string>4ESDVWK654.com.codality.NotationalFlow</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
@jleandroperez mentioned an entitlements & provisioning profiles warning in Xcode 13 in a private conversation.

I tried on my end and, while I didn't get the exact same warning he did, I got the following:

![image](https://user-images.githubusercontent.com/1218433/135025534-b4a038d0-71b6-4671-8b9a-038bfacc616d.png)

This PR address the issue by adding the value to the `.entitlements` file so Xcode is happy.

I couldn't find a way to update the profile on the Developer Portal to remove that entitlement, so adding it on the `.entitlements` file end seems like the only option to address the warning.

As far as I understand, the `previous-application-identifier` entitlement is useless for the widgets and intents extensions because they were created after the migration from NotationalFlow. Somehow, Xcode or the Developer Portal seem to disagree (but only in certain circumstances) and generate Provisioning Profiles with the entitlement embedded — I'm not sure how, since we use `match` for them and there is no option to specify that value 🤔 


### Test

Checkout this branch and try to archive the app, you shouldn't get any entitlements-related warnings.

### Review

Only one developer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
