### PR TITLE
Fixed a crash for ios 12 and 13 caused by widgets when app enters bg

### DIFF
--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -279,9 +279,7 @@ extension SPAppDelegate: SimperiumDelegate {
         CrashLoggingShim.cacheUser(user)
         CrashLoggingShim.cacheOptOutSetting(!analyticsEnabled)
 
-        if #available(iOS 14.0, *) {
-            syncWidgetDefaults()
-        }
+        syncWidgetDefaults()
 
         setupVerificationController()
     }
@@ -296,9 +294,7 @@ extension SPAppDelegate: SimperiumDelegate {
         // Shortcuts!
         ShortcutsHandler.shared.clearHomeScreenQuickActions()
 
-        if #available(iOS 14.0, *) {
-            syncWidgetDefaults()
-        }
+        syncWidgetDefaults()
 
         destroyVerificationController()
     }
@@ -497,10 +493,12 @@ extension SPAppDelegate {
 }
 
 // MARK: - Widgets
-@available(iOS 14.0, *)
 extension SPAppDelegate {
     @objc
     func resetWidgetTimelines() {
+        guard #available(iOS 14.0, *) else {
+            return
+        }
         WidgetController.resetWidgetTimelines()
     }
 

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -497,7 +497,6 @@ extension SPAppDelegate {
 }
 
 // MARK: - Widgets
-
 @available(iOS 14.0, *)
 extension SPAppDelegate {
     @objc

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -168,7 +168,9 @@
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
     [SPTracker trackApplicationOpened];
-    [self syncWidgetDefaults];
+    if (@available(iOS 14.0, *)) {
+        [self syncWidgetDefaults];
+    }
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
@@ -182,8 +184,11 @@
 
     [self showPasscodeLockIfNecessary];
     [self cleanupScrollPositionCache];
-    [self syncWidgetDefaults];
-    [self resetWidgetTimelines];
+
+    if (@available(iOS 14.0, *)) {
+        [self syncWidgetDefaults];
+        [self resetWidgetTimelines];
+    } 
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -168,9 +168,7 @@
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
     [SPTracker trackApplicationOpened];
-    if (@available(iOS 14.0, *)) {
-        [self syncWidgetDefaults];
-    }
+    [self syncWidgetDefaults];
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
@@ -184,11 +182,8 @@
 
     [self showPasscodeLockIfNecessary];
     [self cleanupScrollPositionCache];
-
-    if (@available(iOS 14.0, *)) {
-        [self syncWidgetDefaults];
-        [self resetWidgetTimelines];
-    } 
+    [self syncWidgetDefaults];
+    [self resetWidgetTimelines];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application


### PR DESCRIPTION
### Fix
Currently  SNiOS 4.45 on iOS 12 or 13, when the app enters the background it will crash.

This is caused by the app delegate trying to call libraries that are not available before iOS14. 

This PR fixes that issue

### Test
1. on a device or simulator running iOS 13 or iOS 12 open simplenote and login
2. enter the background.  The app should not crash


### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
