### PR TITLE
Fixed an issue where loading notes from widgets use different animations

### DIFF
--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -99,7 +99,7 @@ extension SPAppDelegate {
             return false
         }
         popToNoteList()
-        presentNote(note)
+        noteListViewController.open(note, ignoringSearchQuery: true, animated: false)
 
         return true
     }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -99,7 +99,7 @@ extension SPAppDelegate {
             return false
         }
         popToNoteList()
-        noteListViewController.open(note, ignoringSearchQuery: true, animated: true)
+        presentNote(note)
 
         return true
     }


### PR DESCRIPTION
### Fix
There are several different ways to use the Simplenote home screen widgets to get direct to where you want to be in the app.  Currently there is an inconsistency in the animations when you load notes from the widgets as compared to creating new notes or going to the note list.

This PR changes the animation that is used when a note is loaded to a fade effect, making all of the animations the same.

https://d.pr/i/1NuCPW

internal ref:  p5T066-2GH-p2#comment-10122

### Test
1. add all three of Simplenote iOS' widgets
2. test opening a note from the note widget, opening a note from the list widget, creating a new note from the list widget, creating a new note from the new note widget.
3. Confirm that in all cases Simplenote uses a fade animation to load the new content

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
