### PR TITLE
Revert app name back to Simplenote and fix newline issue in AppStoreStrings.pot

### DIFF
--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -13,11 +13,6 @@ msgstr ""
 "Last-Translator: \n"
 "Language-Team: \n"
 
-#. translators: App name to be displayed in the Apple App Store. Limit to 30 characters including spaces and commas!
-msgctxt "app_store_title"
-msgid "Simplenote"
-msgstr ""
-
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
 msgid "Simple notes, todos and memos"

--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -15,7 +15,7 @@ msgstr ""
 
 #. translators: App name to be displayed in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_title"
-msgid "Simplenote – Notes and Todos
+msgid "Simplenote
 "
 msgstr ""
 

--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -15,14 +15,12 @@ msgstr ""
 
 #. translators: App name to be displayed in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_title"
-msgid "Simplenote
-"
+msgid "Simplenote"
 msgstr ""
 
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
-msgid "Simple notes, todos and memos
-"
+msgid "Simple notes, todos and memos"
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Apple App Store.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,6 @@ end
 
     files = {
       whats_new: File.join(prj_folder,  "/Simplenote/Resources/release_notes.txt"),
-      app_store_title: File.join(source_metadata_folder, "name.txt"),
       app_store_subtitle: File.join(source_metadata_folder, "subtitle.txt"),
       app_store_desc: File.join(source_metadata_folder, "description.txt"),
       app_store_keywords: File.join(source_metadata_folder, "keywords.txt")

--- a/fastlane/appstoreres/metadata/source/name.txt
+++ b/fastlane/appstoreres/metadata/source/name.txt
@@ -1,1 +1,1 @@
-Simplenote – Notes and Todos
+Simplenote

--- a/fastlane/download_metadata.swift
+++ b/fastlane/download_metadata.swift
@@ -108,7 +108,8 @@ func downloadTranslation(languageCode: String, folderName: String) {
         try? fileManager.createDirectory(atPath: languageFolder, withIntermediateDirectories: true, attributes: nil)
 
         do {
-            try title?.write(toFile: "\(languageFolder)/name.txt", atomically: true, encoding: .utf8)
+            // Disable downloading title from GlotPress since we don't want it to be translated anymore
+            // try title?.write(toFile: "\(languageFolder)/name.txt", atomically: true, encoding: .utf8)
             try subtitle?.write(toFile: "\(languageFolder)/subtitle.txt", atomically: true, encoding: .utf8)
             try whatsNew?.write(toFile: "\(languageFolder)/release_notes.txt", atomically: true, encoding: .utf8)
             try keywords?.write(toFile: "\(languageFolder)/keywords.txt", atomically: true, encoding: .utf8)

--- a/fastlane/metadata/id/name.txt
+++ b/fastlane/metadata/id/name.txt
@@ -1,1 +1,0 @@
-Simplenote - Catatan dan Tugas


### PR DESCRIPTION
We have a request from @SylvesterWilmott to revert the app name back to Simplenote, so I've updated `fastlane/appstoreres/metadata/source/name.txt` with that, regenerated the `AppStoreStrings.pot` file and manually fixed the newline issue.

@AliSoftware I assume this will still import the `Simplenote` app name to GlotPress and I was wondering if that's something we still want. I can imagine a case where someone would translate it even though we don't want it to be translated anymore. Do you think we should just stop uploading the app name to GlotPress? If so, could you help me make that change (or open a PR against the release branch)?
