### PR TITLE
Revert translateable app name

### DIFF
--- a/Simplenote/Resources/AppStoreStrings.pot
+++ b/Simplenote/Resources/AppStoreStrings.pot
@@ -13,11 +13,6 @@ msgstr ""
 "Last-Translator: \n"
 "Language-Team: \n"
 
-#. translators: App name to be displayed in the Apple App Store. Limit to 30 characters including spaces and commas!
-msgctxt "app_store_title"
-msgid "Simplenote"
-msgstr ""
-
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
 msgid "Simple notes, todos and memos"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,6 @@ end
 
     files = {
       whats_new: File.join(prj_folder,  "/Simplenote/Resources/release_notes.txt"),
-      app_store_title: File.join(source_metadata_folder, "name.txt"),
       app_store_subtitle: File.join(source_metadata_folder, "subtitle.txt"),
       app_store_desc: File.join(source_metadata_folder, "description.txt"),
       app_store_keywords: File.join(source_metadata_folder, "keywords.txt")

--- a/fastlane/download_metadata.swift
+++ b/fastlane/download_metadata.swift
@@ -108,7 +108,8 @@ func downloadTranslation(languageCode: String, folderName: String) {
         try? fileManager.createDirectory(atPath: languageFolder, withIntermediateDirectories: true, attributes: nil)
 
         do {
-            try title?.write(toFile: "\(languageFolder)/name.txt", atomically: true, encoding: .utf8)
+            // Disable downloading title from GlotPress since we don't want it to be translated anymore
+            // try title?.write(toFile: "\(languageFolder)/name.txt", atomically: true, encoding: .utf8)
             try subtitle?.write(toFile: "\(languageFolder)/subtitle.txt", atomically: true, encoding: .utf8)
             try whatsNew?.write(toFile: "\(languageFolder)/release_notes.txt", atomically: true, encoding: .utf8)
             try keywords?.write(toFile: "\(languageFolder)/keywords.txt", atomically: true, encoding: .utf8)

--- a/fastlane/metadata/id/name.txt
+++ b/fastlane/metadata/id/name.txt
@@ -1,1 +1,0 @@
-Simplenote - Catatan dan Tugas


### PR DESCRIPTION
This PR reverts the translateable app name changes from https://github.com/Automattic/simplenote-ios/pull/1411/ since we don't want the app name to be translated anymore as discussed in https://github.com/Automattic/simplenote-ios/pull/1459. It follows @AliSoftware's instructions outlined [here](https://github.com/Automattic/simplenote-ios/pull/1459#issuecomment-936866206).

@AliSoftware The only thing I did differently from your instructions is I removed the only `name.txt` file that was translated in GlotPress - instead of updating the value to "Simplenote" - since no other language had that file.

Hopefully I followed your other instructions correctly. 🤞 