### PR TITLE
iOS 12 crash hot fix

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -3332,7 +3332,6 @@
 				B56A696322F9D53400B90398 /* SPAuthViewController.swift in Sources */,
 				B50789FE1C1F5517009F097A /* SPInteractivePushPopAnimationController.m in Sources */,
 				B5D3FCD0201F96AC00A813B7 /* StatusChecker.m in Sources */,
-				BAB27BD626BA425C00AE4ACC /* Color+Simplenote.swift in Sources */,
 				B57DE27825013C6600B4D435 /* Simperium+Simplenote.swift in Sources */,
 				A6E4875025BEEC9F00D0CE3B /* SPSidebarViewController+Extensions.swift in Sources */,
 				A6F4881B25A8881B0050CFA8 /* TagListTextField.swift in Sources */,


### PR DESCRIPTION
### Fix
This PR is a potential fix for the current crash on launch issue for Simplenote on iOS 12.

### Test
With a physical device, install a testing build and make sure that the app launches without a crash

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in 44c8d9 with:
> 
> > Fixed an iOS 12 specific crash when app launched #1463
