### PR TITLE
Fixed:  Too Many Login Attempts alert header contains no Many word.

### DIFF
--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -68,7 +68,7 @@ extension SPAuthError {
         case .unverifiedEmail:
             return NSLocalizedString("Account Verification Required", comment: "Email verification required alert title")
         case .tooManyAttempts:
-            return NSLocalizedString("Too Login Attempts", comment: "Title for too many login attempts error")
+            return NSLocalizedString("Too Many Login Attempts", comment: "Title for too many login attempts error")
         default:
             return NSLocalizedString("Sorry!", comment: "Authentication Error Alert Title")
         }
@@ -91,7 +91,7 @@ extension SPAuthError {
         case .unverifiedEmail:
             return NSLocalizedString("You must verify your email before being able to login.", comment: "Error for un verified email")
         case .tooManyAttempts:
-            return NSLocalizedString("Too many log in attempts. Try again later.", comment: "Error message for too many login attempts")
+            return NSLocalizedString("Too many login attempts. Try again later.", comment: "Error message for too many login attempts")
         case .unknown:
             return NSLocalizedString("We're having problems. Please try again soon.", comment: "Generic error")
         }

--- a/Simplenote/ar.lproj/Localizable.strings
+++ b/Simplenote/ar.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "تبديل الشريط الجانبي للوسوم";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "محاولات تسجيل الدخول كثيرة";
+"Too Many Login Attempts" = "محاولات تسجيل الدخول كثيرة";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "محاولات تسجيل دخول كثيرة للغاية. حاول مرة أخرى لاحقًا.";
+"Too many login attempts. Try again later." = "محاولات تسجيل دخول كثيرة للغاية. حاول مرة أخرى لاحقًا.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "معرف اللمس";

--- a/Simplenote/cy.lproj/Localizable.strings
+++ b/Simplenote/cy.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Bar ochr toglo tagiau";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Too Login Attempts";
+"Too Many Login Attempts" = "Too Many Login Attempts";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Too many log in attempts. Try again later.";
+"Too many login attempts. Try again later." = "Too many login attempts. Try again later.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Enw Cyffwrdd";

--- a/Simplenote/de.lproj/Localizable.strings
+++ b/Simplenote/de.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Schlagwort-Seitenleiste umschalten";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Zu viele Anmeldeversuche";
+"Too Many Login Attempts" = "Zu viele Anmeldeversuche";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Zu viele Anmeldeversuche. Versuche es später erneut.";
+"Too many login attempts. Try again later." = "Zu viele Anmeldeversuche. Versuche es später erneut.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/el.lproj/Localizable.strings
+++ b/Simplenote/el.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Εμφάνιση στήλης";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Too Login Attempts";
+"Too Many Login Attempts" = "Too Many Login Attempts";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Too many log in attempts. Try again later.";
+"Too many login attempts. Try again later." = "Too many login attempts. Try again later.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/en.lproj/Localizable.strings
+++ b/Simplenote/en.lproj/Localizable.strings
@@ -815,10 +815,10 @@
 "Toggle tag sidebar" = "Toggle tag sidebar";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Too Login Attempts";
+"Too Many Login Attempts" = "Too Many Login Attempts";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Too many log in attempts. Try again later.";
+"Too many login attempts. Try again later." = "Too many login attempts. Try again later.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/es.lproj/Localizable.strings
+++ b/Simplenote/es.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Cambiar barra lateral de etiquetas";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Demasiados intentos de inicio de sesión";
+"Too Many Login Attempts" = "Demasiados intentos de inicio de sesión";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Demasiados intentos de inicio de sesión. Inténtalo de nuevo más tarde.";
+"Too many login attempts. Try again later." = "Demasiados intentos de inicio de sesión. Inténtalo de nuevo más tarde.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/fa.lproj/Localizable.strings
+++ b/Simplenote/fa.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Toggle tag sidebar";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Too Login Attempts";
+"Too Many Login Attempts" = "Too Many Login Attempts";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Too many log in attempts. Try again later.";
+"Too many login attempts. Try again later." = "Too many login attempts. Try again later.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/fr.lproj/Localizable.strings
+++ b/Simplenote/fr.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Activer\/désactiver la barre de tag";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Nombre excessif de tentatives de connexion";
+"Too Many Login Attempts" = "Nombre excessif de tentatives de connexion";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Nombre excessif de tentatives de connexion. Réessayez plus tard.";
+"Too many login attempts. Try again later." = "Nombre excessif de tentatives de connexion. Réessayez plus tard.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/he.lproj/Localizable.strings
+++ b/Simplenote/he.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "החלפת מצב סרגל צדדי";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "יותר מדי ניסיונות התחברות";
+"Too Many Login Attempts" = "יותר מדי ניסיונות התחברות";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "מספר ניסיונות התחברות גבוה מדי. יש לנסות שוב מאוחר יותר.";
+"Too many login attempts. Try again later." = "מספר ניסיונות התחברות גבוה מדי. יש לנסות שוב מאוחר יותר.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "מזהה מגע";

--- a/Simplenote/id.lproj/Localizable.strings
+++ b/Simplenote/id.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Panel sisi label pilihan";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Terlalu Banyak Upaya Login";
+"Too Many Login Attempts" = "Terlalu Banyak Upaya Login";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Terlalu banyak upaya login. Coba lagi nanti.";
+"Too many login attempts. Try again later." = "Terlalu banyak upaya login. Coba lagi nanti.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "ID Sentuhan";

--- a/Simplenote/it.lproj/Localizable.strings
+++ b/Simplenote/it.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Mostra barra laterale";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Troppi tentativi di accesso";
+"Too Many Login Attempts" = "Troppi tentativi di accesso";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Troppi tentativi di accesso. Riprova più tardi.";
+"Too many login attempts. Try again later." = "Troppi tentativi di accesso. Riprova più tardi.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/ja.lproj/Localizable.strings
+++ b/Simplenote/ja.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "タグサイドバーを切り替え";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "ログイン試行が多すぎる";
+"Too Many Login Attempts" = "ログイン試行が多すぎる";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "ログイン試行の回数が多すぎます。 後ほど、もう一度お試しください。";
+"Too many login attempts. Try again later." = "ログイン試行の回数が多すぎます。 後ほど、もう一度お試しください。";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/ko.lproj/Localizable.strings
+++ b/Simplenote/ko.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "태그 사이드바 토글";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "지나친 로그인 시도";
+"Too Many Login Attempts" = "지나친 로그인 시도";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "로그인을 너무 많이 시도했습니다. 나중에 다시 시도하세요.";
+"Too many login attempts. Try again later." = "로그인을 너무 많이 시도했습니다. 나중에 다시 시도하세요.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/nl.lproj/Localizable.strings
+++ b/Simplenote/nl.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Tag-sidebar tonen\/verbergen";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Te veel aanmeldpogingen";
+"Too Many Login Attempts" = "Te veel aanmeldpogingen";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Te veel aanmeldpogingen. Probeer het later nog eens.";
+"Too many login attempts. Try again later." = "Te veel aanmeldpogingen. Probeer het later nog eens.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/pt-BR.lproj/Localizable.strings
+++ b/Simplenote/pt-BR.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Exibir a barra lateral de tags";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Muitas tentativas de login";
+"Too Many Login Attempts" = "Muitas tentativas de login";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Muitas tentativas de login. Tente novamente mais tarde.";
+"Too many login attempts. Try again later." = "Muitas tentativas de login. Tente novamente mais tarde.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Identificação por toque";

--- a/Simplenote/ru.lproj/Localizable.strings
+++ b/Simplenote/ru.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Боковая панель переключения меток";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Слишком много попыток входа";
+"Too Many Login Attempts" = "Слишком много попыток входа";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Вы пробовали войти слишком много раз. Повторите попытку позже.";
+"Too many login attempts. Try again later." = "Вы пробовали войти слишком много раз. Повторите попытку позже.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Идентификатор прикосновения";

--- a/Simplenote/sv.lproj/Localizable.strings
+++ b/Simplenote/sv.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Slå på\/av etiketter i sidopanelen";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "För många inloggningsförsök";
+"Too Many Login Attempts" = "För många inloggningsförsök";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "För många inloggningsförsök. Försök igen senare.";
+"Too many login attempts. Try again later." = "För många inloggningsförsök. Försök igen senare.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/tr.lproj/Localizable.strings
+++ b/Simplenote/tr.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "Etiket kenar çubuğunu aç\/kapat";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "Çok Fazla Oturum Açma Denemesi";
+"Too Many Login Attempts" = "Çok Fazla Oturum Açma Denemesi";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "Çok fazla oturum açma denemesi. Daha sonra yeniden deneyin.";
+"Too many login attempts. Try again later." = "Çok fazla oturum açma denemesi. Daha sonra yeniden deneyin.";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";

--- a/Simplenote/zh-Hans-CN.lproj/Localizable.strings
+++ b/Simplenote/zh-Hans-CN.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "切换标签侧边栏";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "尝试登录次数过多";
+"Too Many Login Attempts" = "尝试登录次数过多";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "尝试登录次数过多。 请稍后重试。";
+"Too many login attempts. Try again later." = "尝试登录次数过多。 请稍后重试。";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "触摸 ID";

--- a/Simplenote/zh-Hant-TW.lproj/Localizable.strings
+++ b/Simplenote/zh-Hant-TW.lproj/Localizable.strings
@@ -817,10 +817,10 @@
 "Toggle tag sidebar" = "切換標籤側選單";
 
 /* Title for too many login attempts error */
-"Too Login Attempts" = "登入嘗試次數過多";
+"Too Many Login Attempts" = "登入嘗試次數過多";
 
 /* Error message for too many login attempts */
-"Too many log in attempts. Try again later." = "登入嘗試次數過多。 請稍後再試一次。";
+"Too many login attempts. Try again later." = "登入嘗試次數過多。 請稍後再試一次。";
 
 /* Offer to enable Touch ID support if available and passcode is on. */
 "Touch ID" = "Touch ID";


### PR DESCRIPTION
Fixed a minor grammatical error where the UI would show "Too Login Attempts", instead of "Too Many Login Attempts". #1462

### Fix
When too many login attempts were made by the user, the alert shown to the user had the title: "Too Login Attempts". It is not grammatically correct: "Too Many Login Attempts"

All instances of "Too Login Attempts" in the code were also corrected (this included all localization files).

### Test
***(Required)*** List the steps to test the behavior.  For example:
1. Go to the Login screen
2. Attempt to login with an incorrect password
3. Continue trying step 2 until you see the alert message, which will now be titled with "Too Many Login Attempts"

### Review
***(Required)*** Add instructions for reviewers. 
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** 

These changes do not require release notes.
