### PR TITLE
Simplenote Sustainer UI

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -406,6 +406,8 @@
 		B5EB1EF61C204EBD0080A1B3 /* SimplenoteShare.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B5EB1EEC1C204EBD0080A1B3 /* SimplenoteShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B5EB1EFE1C205A800080A1B3 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */; };
 		B5EB1EFF1C205A800080A1B3 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */; };
+		B5F232B629084336006D8570 /* SustainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F232B529084336006D8570 /* SustainerView.swift */; };
+		B5F232BA29084526006D8570 /* SustainerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F232B929084526006D8570 /* SustainerView.xib */; };
 		B5F3000223F4502C007A7C59 /* SPSortBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F3000123F4502C007A7C59 /* SPSortBar.xib */; };
 		B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */; };
 		BA02A59226C0AE92005FF36E /* NoteListTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA02A59126C0AE92005FF36E /* NoteListTable.swift */; };
@@ -492,7 +494,6 @@
 		BAB01792260AAE93007A9CC3 /* NoticeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB01791260AAE93007A9CC3 /* NoticeFactory.swift */; };
 		BAB0179B260AD591007A9CC3 /* PublishControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB0179A260AD591007A9CC3 /* PublishControllerTests.swift */; };
 		BAB017AB260ADDEB007A9CC3 /* MockTimerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB017AA260ADDEB007A9CC3 /* MockTimerFactory.swift */; };
-		BAB27BD626BA425C00AE4ACC /* Color+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB27BD526BA425C00AE4ACC /* Color+Simplenote.swift */; };
 		BAB27BD726BA425C00AE4ACC /* Color+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB27BD526BA425C00AE4ACC /* Color+Simplenote.swift */; };
 		BAB32C63269E4190005C72B2 /* RemoteResult+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB32C62269E4190005C72B2 /* RemoteResult+TestHelpers.swift */; };
 		BAB5762426703C8100B0C56F /* Intents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BAB5762326703C8100B0C56F /* Intents.framework */; };
@@ -1094,6 +1095,8 @@
 		B5EB1EF11C204EBD0080A1B3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		B5EB1EF31C204EBD0080A1B3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B5EB1EFD1C205A800080A1B3 /* Icons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = ../Icons.xcassets; sourceTree = "<group>"; };
+		B5F232B529084336006D8570 /* SustainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SustainerView.swift; sourceTree = "<group>"; };
+		B5F232B929084526006D8570 /* SustainerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SustainerView.xib; sourceTree = "<group>"; };
 		B5F3000123F4502C007A7C59 /* SPSortBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPSortBar.xib; path = Classes/SPSortBar.xib; sourceTree = "<group>"; };
 		B5F3FFFE23F44679007A7C59 /* SPSortBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPSortBar.swift; path = Classes/SPSortBar.swift; sourceTree = "<group>"; };
 		BA02A59126C0AE92005FF36E /* NoteListTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListTable.swift; sourceTree = "<group>"; };
@@ -2220,6 +2223,15 @@
 			path = SimplenoteShare;
 			sourceTree = "<group>";
 		};
+		B5F232B429084317006D8570 /* Sustainer */ = {
+			isa = PBXGroup;
+			children = (
+				B5F232B529084336006D8570 /* SustainerView.swift */,
+				B5F232B929084526006D8570 /* SustainerView.xib */,
+			);
+			name = Sustainer;
+			sourceTree = "<group>";
+		};
 		B5F3000023F446FC007A7C59 /* SortBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -2410,6 +2422,7 @@
 				B52E2B13253747F20074509A /* Editor */,
 				B5476BB523D89AE2000E7723 /* Headers */,
 				B5F3000023F446FC007A7C59 /* SortBar */,
+				B5F232B429084317006D8570 /* Sustainer */,
 				B546BE9A234E758E00A126DA /* TableViewCells */,
 				E2922AB3180C7322003AF914 /* Tag View */,
 				B5C2EDEF255AFB6C00C09B32 /* PassthruView.swift */,
@@ -3022,6 +3035,7 @@
 				A69F861D25408085005140F2 /* NoteInformationViewController.xib in Resources */,
 				BA4499AA25ED8821000C563E /* NoticeView.xib in Resources */,
 				BA113E4D269E860500F3E3B4 /* markdown-light.css in Resources */,
+				B5F232BA29084526006D8570 /* SustainerView.xib in Resources */,
 				B513F2B62319A8F40021CFA4 /* SPNoteTableViewCell.xib in Resources */,
 				B5078A001C1F5595009F097A /* markdown-dark.css in Resources */,
 				B502311325129525002C3CDA /* SPDiagnosticsViewController.xib in Resources */,
@@ -3289,6 +3303,7 @@
 				B5B9AB4522EE8AF0001CB0AD /* UIImageName.swift in Sources */,
 				BA2D82C6261522F100A1695B /* PublishNoticePresenter.swift in Sources */,
 				A64DE6E9255D1C9F001D0526 /* ContentSlice.swift in Sources */,
+				B5F232B629084336006D8570 /* SustainerView.swift in Sources */,
 				B5A6846D23CE84D400398BBC /* NotesListController.swift in Sources */,
 				B52BB74822CFBD540042C162 /* UIActivityViewController+Simplenote.swift in Sources */,
 				B5BA5B1C25520ECF002AAD43 /* UIKeyboardAppearance+Simplenote.swift in Sources */,

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -14,7 +14,6 @@ extension SPSettingsViewController {
         headerView.preferredWidth = tableView.frame.width
         headerView.adjustSizeForCompressedLayout()
 
-        NSLog("# RESET")
         tableView.tableHeaderView = headerView
     }
 }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -1,5 +1,25 @@
 import UIKit
 
+
+// MARK: - Interface Helpers
+//
+extension SPSettingsViewController {
+
+    @objc
+    func refreshTableHeaderSize() {
+        guard let headerView = tableView.tableHeaderView as? SustainerView else {
+            return
+        }
+
+        headerView.preferredWidth = tableView.frame.width
+        headerView.adjustSizeForCompressedLayout()
+
+        NSLog("# RESET")
+        tableView.tableHeaderView = headerView
+    }
+}
+
+
 // MARK: - Pin
 //
 extension SPSettingsViewController {

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -127,6 +127,11 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                                                                            target:self
                                                                                            action:@selector(doneAction:)];
     
+    // Header View
+    SustainerView *sustainerView = [SustainerView loadFromNib];
+    sustainerView.appliesTopInset = YES;
+    self.tableView.tableHeaderView = sustainerView;
+    
     // Setup the Switches
     self.alphabeticalTagSortSwitch = [UISwitch new];
     [self.alphabeticalTagSortSwitch addTarget:self
@@ -177,7 +182,17 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+    [self refreshTableHeaderSize];
     [self.tableView reloadData];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        [self refreshTableHeaderSize];
+    } completion:nil];
 }
 
 - (void)doneAction:(id)sender

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -128,10 +128,12 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                                                                            action:@selector(doneAction:)];
     
     // Header View
-    SustainerView *sustainerView = [SustainerView loadFromNib];
-    sustainerView.appliesTopInset = YES;
-    self.tableView.tableHeaderView = sustainerView;
-    
+    if (@available(iOS 15.0, *)) {
+        SustainerView *sustainerView = [SustainerView loadFromNib];
+        sustainerView.appliesTopInset = YES;
+        self.tableView.tableHeaderView = sustainerView;
+    }
+
     // Setup the Switches
     self.alphabeticalTagSortSwitch = [UISwitch new];
     [self.alphabeticalTagSortSwitch addTarget:self

--- a/Simplenote/Classes/SPSidebarContainerViewController.m
+++ b/Simplenote/Classes/SPSidebarContainerViewController.m
@@ -89,6 +89,15 @@ static const CGFloat SPSidebarAnimationCompletionFactorZero = 0.0;
     [self.mainViewController endAppearanceTransition];
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        [self ensureSideTableViewInsetsMatchMainViewInsets];
+    } completion:nil];
+}
+
 
 #pragma mark - Dynamic Properties
 

--- a/Simplenote/Classes/UIColor+Studio.swift
+++ b/Simplenote/Classes/UIColor+Studio.swift
@@ -264,6 +264,11 @@ extension UIColor {
     }
 
     @objc
+    static var simplenoteSustainerViewBackgroundColor: UIColor {
+        UIColor(lightColor: .gray50, darkColor: .darkGray2)
+    }
+
+    @objc
     static var simplenoteTableViewCellBackgroundColor: UIColor {
         UIColor(lightColor: .white, darkColor: .darkGray2)
     }

--- a/Simplenote/SustainerView.swift
+++ b/Simplenote/SustainerView.swift
@@ -30,6 +30,12 @@ class SustainerView: UIView {
 
     var onPress: (() -> Void)?
 
+    var isActiveSustainer = false {
+        didSet {
+            refreshInterface()
+        }
+    }
+
     var preferredWidth: CGFloat? {
         didSet {
             guard let preferredWidth else {
@@ -44,18 +50,11 @@ class SustainerView: UIView {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundView.layer.cornerRadius = 8
-        backgroundView.backgroundColor = .simplenoteBlue50Color
-
-        titleLabel.text = NSLocalizedString("Become a Simplenote Sustainer", comment: "Sustainer Title")
-        detailsLabel.text = NSLocalizedString("Support your favorite notes app to help unlock future features", comment: "Sustainer Legend")
-
-        titleLabel.textColor = .white
-        detailsLabel.textColor = .white
+        refreshInterface()
     }
 
 
-    // MARK: - Tap Events
+    // MARK: - Actions
 
     @IBAction
     func sustainerWasPresssed() {
@@ -64,8 +63,53 @@ class SustainerView: UIView {
 }
 
 
+// MARK: - Private API(s)
+//
+private extension SustainerView {
+
+    func refreshInterface() {
+        let style = isActiveSustainer ? Style.sustainer : Style.notSubscriber
+
+        titleLabel.text = style.title
+        detailsLabel.text = style.details
+        titleLabel.textColor = style.textColor
+        detailsLabel.textColor = style.textColor
+        backgroundView.backgroundColor = style.backgroundColor
+        backgroundView.layer.cornerRadius = Metrics.defaultCornerRadius
+    }
+}
+
+
+// MARK: - Style
+//
+private struct Style {
+    let title: String
+    let details: String
+    let textColor: UIColor
+    let backgroundColor: UIColor
+}
+
+
+private extension Style {
+    static var sustainer: Style {
+        Style(title: NSLocalizedString("You are a Simplenote Sustainer", comment: "Current Sustainer Title"),
+              details: NSLocalizedString("Thank you for your continued support", comment: "Current Sustainer Details"),
+              textColor: .white,
+              backgroundColor: .simplenoteSustainerViewBackgroundColor)
+    }
+
+    static var notSubscriber: Style {
+        Style(title: NSLocalizedString("Become a Simplenote Sustainer", comment: "Become a Sustainer Title"),
+              details: NSLocalizedString("Support your favorite notes app to help unlock future features", comment: "Become a Sustainer Details"),
+              textColor: .white,
+              backgroundColor: .simplenoteBlue50Color)
+    }
+}
+
+
 // MARK: - Metrics
 //
 private enum Metrics {
     static let defaultTopInset: CGFloat = 19
+    static let defaultCornerRadius: CGFloat = 8
 }

--- a/Simplenote/SustainerView.swift
+++ b/Simplenote/SustainerView.swift
@@ -1,0 +1,30 @@
+import Foundation
+import UIKit
+
+
+// MARK: - SustainerView
+//
+class SustainerView: UIView {
+
+    @IBOutlet
+    private var backgroundView: UIView!
+
+    @IBOutlet
+    private var titleLabel: UILabel!
+
+    @IBOutlet
+    private var detailsLabel: UILabel!
+
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        backgroundView.layer.cornerRadius = 8
+        backgroundView.backgroundColor = .simplenoteBlue50Color
+
+        titleLabel.text = NSLocalizedString("Become a Simplenote Sustainer", comment: "Sustainer Title")
+        detailsLabel.text = NSLocalizedString("Support your favorite notes app to help unlock future features", comment: "Sustainer Legend")
+
+        titleLabel.textColor = .white
+        detailsLabel.textColor = .white
+    }
+}

--- a/Simplenote/SustainerView.swift
+++ b/Simplenote/SustainerView.swift
@@ -15,6 +15,19 @@ class SustainerView: UIView {
     @IBOutlet
     private var detailsLabel: UILabel!
 
+    @IBOutlet
+    private var widthConstraint: NSLayoutConstraint!
+
+    public var preferredWidth: CGFloat? {
+        didSet {
+            guard let preferredWidth else {
+                return
+            }
+
+            widthConstraint.constant = preferredWidth
+        }
+    }
+
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/Simplenote/SustainerView.swift
+++ b/Simplenote/SustainerView.swift
@@ -16,9 +16,19 @@ class SustainerView: UIView {
     private var detailsLabel: UILabel!
 
     @IBOutlet
+    private var topConstraint: NSLayoutConstraint!
+
+    @IBOutlet
     private var widthConstraint: NSLayoutConstraint!
 
-    public var preferredWidth: CGFloat? {
+    @objc
+    public var appliesTopInset: Bool = false {
+        didSet {
+            topConstraint.constant = appliesTopInset ? Metrics.defaultTopInset : .zero
+        }
+    }
+
+    var preferredWidth: CGFloat? {
         didSet {
             guard let preferredWidth else {
                 return
@@ -28,7 +38,8 @@ class SustainerView: UIView {
         }
     }
 
-
+    // MARK: - Overridden Methods
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         backgroundView.layer.cornerRadius = 8
@@ -40,4 +51,11 @@ class SustainerView: UIView {
         titleLabel.textColor = .white
         detailsLabel.textColor = .white
     }
+}
+
+
+// MARK: - Metrics
+//
+private enum Metrics {
+    static let defaultTopInset: CGFloat = 19
 }

--- a/Simplenote/SustainerView.swift
+++ b/Simplenote/SustainerView.swift
@@ -22,11 +22,13 @@ class SustainerView: UIView {
     private var widthConstraint: NSLayoutConstraint!
 
     @objc
-    public var appliesTopInset: Bool = false {
+    var appliesTopInset: Bool = false {
         didSet {
             topConstraint.constant = appliesTopInset ? Metrics.defaultTopInset : .zero
         }
     }
+
+    var onPress: (() -> Void)?
 
     var preferredWidth: CGFloat? {
         didSet {
@@ -39,7 +41,7 @@ class SustainerView: UIView {
     }
 
     // MARK: - Overridden Methods
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
         backgroundView.layer.cornerRadius = 8
@@ -50,6 +52,14 @@ class SustainerView: UIView {
 
         titleLabel.textColor = .white
         detailsLabel.textColor = .white
+    }
+
+
+    // MARK: - Tap Events
+
+    @IBAction
+    func sustainerWasPresssed() {
+        onPress?()
     }
 }
 

--- a/Simplenote/SustainerView.xib
+++ b/Simplenote/SustainerView.xib
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" id="H3q-Rz-XVn" customClass="SustainerView" customModule="Simplenote" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="390" height="63"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sc5-2f-Alr">
+                    <rect key="frame" x="12" y="0.0" width="366" height="44"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="IH4-GE-Uvn">
+                            <rect key="frame" x="16" y="0.0" width="334" height="44"/>
+                            <subviews>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="simplenote-logo" translatesAutoresizingMaskIntoConstraints="NO" id="qwE-CN-MTc" userLabel="Logo">
+                                    <rect key="frame" x="0.0" y="0.0" width="27" height="44"/>
+                                    <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="27" id="hG0-9J-Fdt"/>
+                                    </constraints>
+                                </imageView>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="jzQ-ge-KHY">
+                                    <rect key="frame" x="42" y="7.6666666666666679" width="292" height="29.000000000000004"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xLW-HX-XmH" userLabel="Title">
+                                            <rect key="frame" x="0.0" y="0.0" width="34.333333333333336" height="15.666666666666666"/>
+                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="13"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c5O-bV-2OC" userLabel="Description">
+                                            <rect key="frame" x="0.0" y="15.666666666666664" width="42" height="13.333333333333336"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="IH4-GE-Uvn" secondAttribute="trailing" constant="16" id="0P2-hx-Rw3"/>
+                        <constraint firstItem="IH4-GE-Uvn" firstAttribute="leading" secondItem="sc5-2f-Alr" secondAttribute="leading" constant="16" id="b1v-8q-GJ9"/>
+                        <constraint firstAttribute="bottom" secondItem="IH4-GE-Uvn" secondAttribute="bottom" id="dzV-sc-DBu"/>
+                        <constraint firstItem="IH4-GE-Uvn" firstAttribute="top" secondItem="sc5-2f-Alr" secondAttribute="top" id="gRb-D5-fIO"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="FBi-kX-fTh"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="sc5-2f-Alr" secondAttribute="bottom" constant="19" id="95y-YN-4mQ"/>
+                <constraint firstItem="sc5-2f-Alr" firstAttribute="leading" secondItem="FBi-kX-fTh" secondAttribute="leading" constant="12" id="RsN-Tc-quu"/>
+                <constraint firstAttribute="trailing" secondItem="sc5-2f-Alr" secondAttribute="trailing" constant="12" id="x1m-lk-tgr"/>
+                <constraint firstItem="sc5-2f-Alr" firstAttribute="top" secondItem="H3q-Rz-XVn" secondAttribute="top" id="zYV-v0-Hdi"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="backgroundView" destination="sc5-2f-Alr" id="hfq-9u-tWz"/>
+                <outlet property="detailsLabel" destination="c5O-bV-2OC" id="Yzb-l5-bwj"/>
+                <outlet property="titleLabel" destination="xLW-HX-XmH" id="G19-ww-50A"/>
+            </connections>
+            <point key="canvasLocation" x="87.692307692307693" y="-258.05687203791467"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="simplenote-logo" width="64" height="64"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Simplenote/SustainerView.xib
+++ b/Simplenote/SustainerView.xib
@@ -82,6 +82,7 @@
                 <outlet property="backgroundView" destination="sc5-2f-Alr" id="hfq-9u-tWz"/>
                 <outlet property="detailsLabel" destination="c5O-bV-2OC" id="Yzb-l5-bwj"/>
                 <outlet property="titleLabel" destination="xLW-HX-XmH" id="G19-ww-50A"/>
+                <outlet property="topConstraint" destination="SUn-BD-pzh" id="e9F-8I-nc7"/>
                 <outlet property="widthConstraint" destination="kYU-Lx-Xbh" id="yEN-6g-UV9"/>
             </connections>
             <point key="canvasLocation" x="87.692307692307693" y="-258.05687203791467"/>

--- a/Simplenote/SustainerView.xib
+++ b/Simplenote/SustainerView.xib
@@ -68,6 +68,7 @@
             </subviews>
             <viewLayoutGuide key="safeArea" id="FBi-kX-fTh"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <gestureRecognizers/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="RSL-o1-Qz1" secondAttribute="trailing" id="5A2-TL-w9u"/>
                 <constraint firstItem="sc5-2f-Alr" firstAttribute="leading" secondItem="FBi-kX-fTh" secondAttribute="leading" constant="12" id="CJ4-gH-CaM"/>
@@ -84,9 +85,15 @@
                 <outlet property="titleLabel" destination="xLW-HX-XmH" id="G19-ww-50A"/>
                 <outlet property="topConstraint" destination="SUn-BD-pzh" id="e9F-8I-nc7"/>
                 <outlet property="widthConstraint" destination="kYU-Lx-Xbh" id="yEN-6g-UV9"/>
+                <outletCollection property="gestureRecognizers" destination="4op-51-Dvd" appends="YES" id="gpV-aI-zul"/>
             </connections>
             <point key="canvasLocation" x="87.692307692307693" y="-258.05687203791467"/>
         </view>
+        <tapGestureRecognizer id="4op-51-Dvd">
+            <connections>
+                <action selector="sustainerWasPresssed" destination="H3q-Rz-XVn" id="usw-j5-ej9"/>
+            </connections>
+        </tapGestureRecognizer>
     </objects>
     <resources>
         <image name="simplenote-logo" width="64" height="64"/>

--- a/Simplenote/SustainerView.xib
+++ b/Simplenote/SustainerView.xib
@@ -12,33 +12,42 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" id="H3q-Rz-XVn" customClass="SustainerView" customModule="Simplenote" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="390" height="63"/>
+            <rect key="frame" x="0.0" y="0.0" width="390" height="72"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RSL-o1-Qz1" userLabel="Sizing View">
+                    <rect key="frame" x="12" y="71" width="378" height="1"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="eOJ-hI-5vD"/>
+                        <constraint firstAttribute="width" priority="999" constant="378" id="kYU-Lx-Xbh"/>
+                    </constraints>
+                </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sc5-2f-Alr">
-                    <rect key="frame" x="12" y="0.0" width="366" height="44"/>
+                    <rect key="frame" x="12" y="0.0" width="366" height="53"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="IH4-GE-Uvn">
-                            <rect key="frame" x="16" y="0.0" width="334" height="44"/>
+                            <rect key="frame" x="16" y="12" width="334" height="29"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="simplenote-logo" translatesAutoresizingMaskIntoConstraints="NO" id="qwE-CN-MTc" userLabel="Logo">
-                                    <rect key="frame" x="0.0" y="0.0" width="27" height="44"/>
+                                    <rect key="frame" x="0.0" y="1" width="27" height="27"/>
                                     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
+                                        <constraint firstAttribute="height" constant="27" id="0Cw-8J-qDY"/>
                                         <constraint firstAttribute="width" constant="27" id="hG0-9J-Fdt"/>
                                     </constraints>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="jzQ-ge-KHY">
-                                    <rect key="frame" x="42" y="7.6666666666666679" width="292" height="29.000000000000004"/>
+                                    <rect key="frame" x="42" y="0.0" width="292" height="29"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xLW-HX-XmH" userLabel="Title">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xLW-HX-XmH" userLabel="Title">
                                             <rect key="frame" x="0.0" y="0.0" width="34.333333333333336" height="15.666666666666666"/>
                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="13"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c5O-bV-2OC" userLabel="Description">
-                                            <rect key="frame" x="0.0" y="15.666666666666664" width="42" height="13.333333333333336"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Details?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c5O-bV-2OC" userLabel="Description">
+                                            <rect key="frame" x="0.0" y="15.666666666666668" width="42" height="13.333333333333332"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -52,24 +61,28 @@
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="IH4-GE-Uvn" secondAttribute="trailing" constant="16" id="0P2-hx-Rw3"/>
                         <constraint firstItem="IH4-GE-Uvn" firstAttribute="leading" secondItem="sc5-2f-Alr" secondAttribute="leading" constant="16" id="b1v-8q-GJ9"/>
-                        <constraint firstAttribute="bottom" secondItem="IH4-GE-Uvn" secondAttribute="bottom" id="dzV-sc-DBu"/>
-                        <constraint firstItem="IH4-GE-Uvn" firstAttribute="top" secondItem="sc5-2f-Alr" secondAttribute="top" id="gRb-D5-fIO"/>
+                        <constraint firstAttribute="bottom" secondItem="IH4-GE-Uvn" secondAttribute="bottom" constant="12" id="dzV-sc-DBu"/>
+                        <constraint firstItem="IH4-GE-Uvn" firstAttribute="top" secondItem="sc5-2f-Alr" secondAttribute="top" constant="12" id="gRb-D5-fIO"/>
                     </constraints>
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="FBi-kX-fTh"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="sc5-2f-Alr" secondAttribute="bottom" constant="19" id="95y-YN-4mQ"/>
-                <constraint firstItem="sc5-2f-Alr" firstAttribute="leading" secondItem="FBi-kX-fTh" secondAttribute="leading" constant="12" id="RsN-Tc-quu"/>
-                <constraint firstAttribute="trailing" secondItem="sc5-2f-Alr" secondAttribute="trailing" constant="12" id="x1m-lk-tgr"/>
-                <constraint firstItem="sc5-2f-Alr" firstAttribute="top" secondItem="H3q-Rz-XVn" secondAttribute="top" id="zYV-v0-Hdi"/>
+                <constraint firstAttribute="trailing" secondItem="RSL-o1-Qz1" secondAttribute="trailing" id="5A2-TL-w9u"/>
+                <constraint firstItem="sc5-2f-Alr" firstAttribute="leading" secondItem="FBi-kX-fTh" secondAttribute="leading" constant="12" id="CJ4-gH-CaM"/>
+                <constraint firstItem="RSL-o1-Qz1" firstAttribute="leading" secondItem="FBi-kX-fTh" secondAttribute="leading" constant="12" id="LXq-Xi-2b0"/>
+                <constraint firstItem="sc5-2f-Alr" firstAttribute="top" secondItem="H3q-Rz-XVn" secondAttribute="top" id="SUn-BD-pzh"/>
+                <constraint firstItem="FBi-kX-fTh" firstAttribute="bottom" secondItem="sc5-2f-Alr" secondAttribute="bottom" constant="19" id="Yee-qR-skq"/>
+                <constraint firstItem="FBi-kX-fTh" firstAttribute="trailing" secondItem="sc5-2f-Alr" secondAttribute="trailing" constant="12" id="Yrr-YJ-WXn"/>
+                <constraint firstAttribute="bottom" secondItem="RSL-o1-Qz1" secondAttribute="bottom" id="oJY-XJ-HEo"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="backgroundView" destination="sc5-2f-Alr" id="hfq-9u-tWz"/>
                 <outlet property="detailsLabel" destination="c5O-bV-2OC" id="Yzb-l5-bwj"/>
                 <outlet property="titleLabel" destination="xLW-HX-XmH" id="G19-ww-50A"/>
+                <outlet property="widthConstraint" destination="kYU-Lx-Xbh" id="yEN-6g-UV9"/>
             </connections>
             <point key="canvasLocation" x="87.692307692307693" y="-258.05687203791467"/>
         </view>

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -58,7 +58,18 @@ final class TagListViewController: UIViewController {
 
         resignFirstResponder()
     }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        refreshTableHeaderSize()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        refreshTableHeaderSize()
+    }
 }
+
 
 // MARK: - Configuration
 //
@@ -68,6 +79,9 @@ private extension TagListViewController {
     }
 
     func configureTableView() {
+        let sustainerView: SustainerView = SustainerView.instantiateFromNib()
+
+        tableView.tableHeaderView = sustainerView
         tableView.register(TagListViewCell.loadNib(), forCellReuseIdentifier: TagListViewCell.reuseIdentifier)
         tableView.register(Value1TableViewCell.self, forCellReuseIdentifier: Value1TableViewCell.reuseIdentifier)
 
@@ -533,6 +547,17 @@ private extension TagListViewController {
     func refreshEditTagsButton(isEditing: Bool) {
         let title = isEditing ? Localization.done : Localization.edit
         tagsHeaderView.actionButton.setTitle(title, for: .normal)
+    }
+
+    func refreshTableHeaderSize() {
+        guard let headerView = tableView.tableHeaderView as? SustainerView else {
+            return
+        }
+
+        headerView.preferredWidth = tableView.frame.width - view.safeAreaInsets.left
+        headerView.adjustSizeForCompressedLayout()
+
+        tableView.tableHeaderView = headerView
     }
 
     func openNoteListForTagName(_ tagName: String?, isTraversing: Bool) {

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -89,10 +89,18 @@ private extension TagListViewController {
         tableView.separatorInsetReference = .fromAutomaticInsets
         tableView.automaticallyAdjustsScrollIndicatorInsets = false
 
-        if #available(iOS 15.0, *) {
-            let sustainerView: SustainerView = SustainerView.instantiateFromNib()
-            tableView.tableHeaderView = sustainerView
+        guard #available(iOS 15.0, *) else {
+            return
         }
+
+        let sustainerView: SustainerView = SustainerView.instantiateFromNib()
+        sustainerView.onPress = { [weak sustainerView, weak self] in
+            // TODO: Remove. For demo purposes only.
+            sustainerView?.isActiveSustainer.toggle()
+            self?.refreshTableHeaderSize()
+        }
+
+        tableView.tableHeaderView = sustainerView
     }
 
     func configureTableHeaderView() {

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -83,14 +83,16 @@ private extension TagListViewController {
     }
 
     func configureTableView() {
-        let sustainerView: SustainerView = SustainerView.instantiateFromNib()
-
-        tableView.tableHeaderView = sustainerView
         tableView.register(TagListViewCell.loadNib(), forCellReuseIdentifier: TagListViewCell.reuseIdentifier)
         tableView.register(Value1TableViewCell.self, forCellReuseIdentifier: Value1TableViewCell.reuseIdentifier)
 
         tableView.separatorInsetReference = .fromAutomaticInsets
         tableView.automaticallyAdjustsScrollIndicatorInsets = false
+
+        if #available(iOS 15.0, *) {
+            let sustainerView: SustainerView = SustainerView.instantiateFromNib()
+            tableView.tableHeaderView = sustainerView
+        }
     }
 
     func configureTableHeaderView() {

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -60,6 +60,11 @@ final class TagListViewController: UIViewController {
         resignFirstResponder()
     }
 
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        refreshTableHeaderSize()
+    }
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -44,6 +44,7 @@ final class TagListViewController: UIViewController {
         super.viewWillAppear(animated)
         startListeningToKeyboardNotifications()
 
+        refreshTableHeaderSize()
         reloadTableView()
         startListeningForChanges()
         becomeFirstResponder()
@@ -59,14 +60,12 @@ final class TagListViewController: UIViewController {
         resignFirstResponder()
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        refreshTableHeaderSize()
-    }
-
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        refreshTableHeaderSize()
+
+        coordinator.animate { _ in
+            self.refreshTableHeaderSize()
+        }
     }
 }
 


### PR DESCRIPTION
### Fix
In this PR we're implementing the Simplenote Sustainer UI.

@frosty Can I bug you with this one?
Thank yooouuuu!!

Ref. #1491

### Test: iOS +15
1. Launch Simplenote iOS on a device running iOS 15 or 16
2. Open the Sidebar

- [x] Verify the **Become  a Subscriber** UI shows up at the top of the table
- [x] Verify that pressing over such Header causes the UI to toggle between `Become a Subscriber` / `Active Subscriber` modes
- [x] Verify this UI looks great in Light / Dark Mode


### Test: iOS 14
1. Launch Simplenote iOS on a device running iOS 14
2. Open the Sidebar

- [x] Verify the Subscriber UI doesn't show up
- [x] Verify the Subscriber UI isn't visible, either, at the top of the Settings UI

### Release
These changes do not require release notes.

### Screenshots

Become Subscriber | Active Subscriber
-|-
<img width="300" src="https://user-images.githubusercontent.com/1195260/198293883-4ffc7c51-5051-4374-8255-bbc3f3f0eee9.png"> | <img width="300" src="https://user-images.githubusercontent.com/1195260/198293895-e878733b-f1c1-4d62-9767-3b48c3cdf53d.png">

Become Subscriber | Active Subscriber
-|-
<img width="300" src="https://user-images.githubusercontent.com/1195260/198294314-aef5afaa-8d03-4f39-8847-5ffa7ea954b2.png"> | <img width="300" src="https://user-images.githubusercontent.com/1195260/198294331-e7691ac8-c2f5-4d08-a253-07da11bb0e9d.png">

