### PR TITLE
Sustainer IAP

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 4.48
 -----
-
+-   Simplenote Users now have the ability to become sustainers #1493
 
 4.47
 -----

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		B5476BBD23D8A71D000E7723 /* UIFont+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BBC23D8A71D000E7723 /* UIFont+Simplenote.swift */; };
 		B5476BBF23D8B686000E7723 /* NotesListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BBE23D8B686000E7723 /* NotesListSection.swift */; };
 		B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */; };
+		B549E249290B3BDB0072C3E8 /* Preferences+IAP.swift in Sources */ = {isa = PBXBuildFile; fileRef = B549E248290B3BDB0072C3E8 /* Preferences+IAP.swift */; };
 		B54B04D82407169500401FBB /* SPAppDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */; };
 		B54D9C572909BA2600D0E0EC /* StoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D9C562909BA2600D0E0EC /* StoreManager.swift */; };
 		B54D9C592909CC4400D0E0EC /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D9C582909CC4400D0E0EC /* StoreProduct.swift */; };
@@ -957,6 +958,7 @@
 		B5476BBC23D8A71D000E7723 /* UIFont+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIFont+Simplenote.swift"; path = "Classes/UIFont+Simplenote.swift"; sourceTree = "<group>"; };
 		B5476BBE23D8B686000E7723 /* NotesListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotesListSection.swift; path = Classes/NotesListSection.swift; sourceTree = "<group>"; };
 		B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "String+Simplenote.swift"; path = "Classes/String+Simplenote.swift"; sourceTree = "<group>"; };
+		B549E248290B3BDB0072C3E8 /* Preferences+IAP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Preferences+IAP.swift"; sourceTree = "<group>"; };
 		B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPAppDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		B54D9C542909B21700D0E0EC /* Simplenote 6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 6.xcdatamodel"; sourceTree = "<group>"; };
 		B54D9C562909BA2600D0E0EC /* StoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreManager.swift; sourceTree = "<group>"; };
@@ -1483,6 +1485,7 @@
 				A64DE6E8255D1C9F001D0526 /* ContentSlice.swift */,
 				BA4499BB25ED95D0000C563E /* Notice.swift */,
 				BA4499C425ED95E5000C563E /* NoticeAction.swift */,
+				B549E248290B3BDB0072C3E8 /* Preferences+IAP.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -3520,6 +3523,7 @@
 				A6E4875825BEF3C700D0CE3B /* UIResponder+Simplenote.swift in Sources */,
 				46A3C99C17DFA81A002865AE /* NSString+Bullets.m in Sources */,
 				B58BF1FB23D78ADF00515B50 /* UIContextualAction+Simplenote.swift in Sources */,
+				B549E249290B3BDB0072C3E8 /* Preferences+IAP.swift in Sources */,
 				BA02A5DC26C0B4B1005FF36E /* URL+Simplenote.swift in Sources */,
 				BABFFF2226CF9094003A4C25 /* WidgetDefaults.swift in Sources */,
 				B54D9C572909BA2600D0E0EC /* StoreManager.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1047,6 +1047,7 @@
 		B5BA5B072551FB3C002AAD43 /* UIDevice+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIDevice+Simplenote.swift"; path = "Classes/UIDevice+Simplenote.swift"; sourceTree = "<group>"; };
 		B5BA5B1B25520ECF002AAD43 /* UIKeyboardAppearance+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIKeyboardAppearance+Simplenote.swift"; path = "Classes/UIKeyboardAppearance+Simplenote.swift"; sourceTree = "<group>"; };
 		B5BA5B2925520F79002AAD43 /* NSMutableParagraphStyle+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSMutableParagraphStyle+Simplenote.swift"; path = "Classes/NSMutableParagraphStyle+Simplenote.swift"; sourceTree = "<group>"; };
+		B5BADB7C2909D78B00275B29 /* TestConfiguration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestConfiguration.storekit; sourceTree = "<group>"; };
 		B5BDD8721BEA6B01006EB940 /* Simplenote-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Simplenote-Bridging-Header.h"; sourceTree = "<group>"; };
 		B5BE05431AB7522F002417BF /* JSONKit+Simplenote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "JSONKit+Simplenote.h"; path = "Classes/JSONKit+Simplenote.h"; sourceTree = "<group>"; };
 		B5BE05441AB7522F002417BF /* JSONKit+Simplenote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "JSONKit+Simplenote.m"; path = "Classes/JSONKit+Simplenote.m"; sourceTree = "<group>"; };
@@ -1872,6 +1873,7 @@
 			children = (
 				B54D9C562909BA2600D0E0EC /* StoreManager.swift */,
 				B54D9C582909CC4400D0E0EC /* StoreProduct.swift */,
+				B5BADB7C2909D78B00275B29 /* TestConfiguration.storekit */,
 			);
 			name = Store;
 			sourceTree = "<group>";

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -294,6 +294,8 @@
 		B5476BBF23D8B686000E7723 /* NotesListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BBE23D8B686000E7723 /* NotesListSection.swift */; };
 		B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */; };
 		B54B04D82407169500401FBB /* SPAppDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */; };
+		B54D9C572909BA2600D0E0EC /* StoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D9C562909BA2600D0E0EC /* StoreManager.swift */; };
+		B54D9C592909CC4400D0E0EC /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D9C582909CC4400D0E0EC /* StoreProduct.swift */; };
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B550F93122BA65CD00091939 /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93022BA65CD00091939 /* ActivityType.swift */; };
 		B550F93322BA6A3300091939 /* ShortcutsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93222BA6A3300091939 /* ShortcutsHandler.swift */; };
@@ -957,6 +959,8 @@
 		B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "String+Simplenote.swift"; path = "Classes/String+Simplenote.swift"; sourceTree = "<group>"; };
 		B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPAppDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		B54D9C542909B21700D0E0EC /* Simplenote 6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 6.xcdatamodel"; sourceTree = "<group>"; };
+		B54D9C562909BA2600D0E0EC /* StoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreManager.swift; sourceTree = "<group>"; };
+		B54D9C582909CC4400D0E0EC /* StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProduct.swift; sourceTree = "<group>"; };
 		B55051811A4328B9002A1093 /* LocalAuthentication.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LocalAuthentication.framework; path = System/Library/Frameworks/LocalAuthentication.framework; sourceTree = SDKROOT; };
 		B550F93022BA65CD00091939 /* ActivityType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ActivityType.swift; path = Classes/ActivityType.swift; sourceTree = "<group>"; };
 		B550F93222BA6A3300091939 /* ShortcutsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShortcutsHandler.swift; path = Classes/ShortcutsHandler.swift; sourceTree = "<group>"; };
@@ -1863,6 +1867,15 @@
 			name = Headers;
 			sourceTree = "<group>";
 		};
+		B54D9C552909BA0A00D0E0EC /* Store */ = {
+			isa = PBXGroup;
+			children = (
+				B54D9C562909BA2600D0E0EC /* StoreManager.swift */,
+				B54D9C582909CC4400D0E0EC /* StoreProduct.swift */,
+			);
+			name = Store;
+			sourceTree = "<group>";
+		};
 		B550F92F22BA643800091939 /* Siri */ = {
 			isa = PBXGroup;
 			children = (
@@ -2559,6 +2572,7 @@
 				B5B8AE7B1AB9ECF80082775D /* Ratings */,
 				B512AF981C20B1A200FE76D8 /* Settings */,
 				B550F92F22BA643800091939 /* Siri */,
+				B54D9C552909BA0A00D0E0EC /* Store */,
 				B5C57A3F22E78EDF009166EA /* Themes */,
 				B5BE053E1AB751FD002417BF /* Tools */,
 				B521A19B1BC8452800E1CF2A /* Trackers */,
@@ -3374,6 +3388,7 @@
 				B5DF734222A565DA00602CE7 /* Options.swift in Sources */,
 				B5BA5B2A25520F79002AAD43 /* NSMutableParagraphStyle+Simplenote.swift in Sources */,
 				A6FDF75825435CA500415C87 /* SubtitleTableViewCell.swift in Sources */,
+				B54D9C592909CC4400D0E0EC /* StoreProduct.swift in Sources */,
 				A6C0589924AD47CB006BC572 /* SPSnappingSlider.swift in Sources */,
 				B550F93122BA65CD00091939 /* ActivityType.swift in Sources */,
 				BA3101A926C8C76A00C95F93 /* ListWidgetIntent.intentdefinition in Sources */,
@@ -3505,6 +3520,7 @@
 				B58BF1FB23D78ADF00515B50 /* UIContextualAction+Simplenote.swift in Sources */,
 				BA02A5DC26C0B4B1005FF36E /* URL+Simplenote.swift in Sources */,
 				BABFFF2226CF9094003A4C25 /* WidgetDefaults.swift in Sources */,
+				B54D9C572909BA2600D0E0EC /* StoreManager.swift in Sources */,
 				E215C79A180B130B00AD36B5 /* SPTableViewController.m in Sources */,
 				BA4499BC25ED95D0000C563E /* Notice.swift in Sources */,
 				BA5C1C0725BF9D6C006E3820 /* SPDragBar.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -294,6 +294,7 @@
 		B5476BBF23D8B686000E7723 /* NotesListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BBE23D8B686000E7723 /* NotesListSection.swift */; };
 		B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */; };
 		B549E249290B3BDB0072C3E8 /* Preferences+IAP.swift in Sources */ = {isa = PBXBuildFile; fileRef = B549E248290B3BDB0072C3E8 /* Preferences+IAP.swift */; };
+		B549E24B290B3DD70072C3E8 /* StoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B549E24A290B3DD70072C3E8 /* StoreConstants.swift */; };
 		B54B04D82407169500401FBB /* SPAppDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */; };
 		B54D9C572909BA2600D0E0EC /* StoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D9C562909BA2600D0E0EC /* StoreManager.swift */; };
 		B54D9C592909CC4400D0E0EC /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D9C582909CC4400D0E0EC /* StoreProduct.swift */; };
@@ -959,6 +960,7 @@
 		B5476BBE23D8B686000E7723 /* NotesListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NotesListSection.swift; path = Classes/NotesListSection.swift; sourceTree = "<group>"; };
 		B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "String+Simplenote.swift"; path = "Classes/String+Simplenote.swift"; sourceTree = "<group>"; };
 		B549E248290B3BDB0072C3E8 /* Preferences+IAP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Preferences+IAP.swift"; sourceTree = "<group>"; };
+		B549E24A290B3DD70072C3E8 /* StoreConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreConstants.swift; sourceTree = "<group>"; };
 		B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPAppDelegate+Extensions.swift"; sourceTree = "<group>"; };
 		B54D9C542909B21700D0E0EC /* Simplenote 6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 6.xcdatamodel"; sourceTree = "<group>"; };
 		B54D9C562909BA2600D0E0EC /* StoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreManager.swift; sourceTree = "<group>"; };
@@ -1875,6 +1877,7 @@
 			isa = PBXGroup;
 			children = (
 				B54D9C562909BA2600D0E0EC /* StoreManager.swift */,
+				B549E24A290B3DD70072C3E8 /* StoreConstants.swift */,
 				B54D9C582909CC4400D0E0EC /* StoreProduct.swift */,
 				B5BADB7C2909D78B00275B29 /* TestConfiguration.storekit */,
 			);
@@ -3551,6 +3554,7 @@
 				B550F93322BA6A3300091939 /* ShortcutsHandler.swift in Sources */,
 				A6C0589424AD2B8F006BC572 /* SPNoteHistoryViewController.swift in Sources */,
 				F52A2FD11DE8B1FB002DEB0E /* CSSearchable+Helpers.swift in Sources */,
+				B549E24B290B3DD70072C3E8 /* StoreConstants.swift in Sources */,
 				37FD30491FC4CFA2008D0B78 /* KeychainPasswordItem.swift in Sources */,
 				A664845325B6C31900BFEF27 /* SPTracker+Extensions.swift in Sources */,
 				B52F35D122F3254800724793 /* Theme.swift in Sources */,

--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/Simplenote.xcscheme
@@ -79,6 +79,9 @@
             ReferencedContainer = "container:Simplenote.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../Simplenote/TestConfiguration.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Simplenote/Classes/SPNotifications.h
+++ b/Simplenote/Classes/SPNotifications.h
@@ -16,3 +16,5 @@ extern NSString *const SPAlphabeticalTagSortPreferenceChangedNotification;
 extern NSString *const SPCondensedNoteListPreferenceChangedNotification;
 extern NSString *const SPNotesListSortModeChangedNotification;
 extern NSString *const SPSimplenoteThemeChangedNotification;
+extern NSString *const SPSubscriptionStatusDidChangeNotification;
+

--- a/Simplenote/Classes/SPNotifications.m
+++ b/Simplenote/Classes/SPNotifications.m
@@ -16,3 +16,4 @@ NSString *const SPAlphabeticalTagSortPreferenceChangedNotification  = @"SPAlphab
 NSString *const SPCondensedNoteListPreferenceChangedNotification    = @"SPCondensedNoteListPreferenceChangedNotification";
 NSString *const SPNotesListSortModeChangedNotification              = @"SPNotesListSortModeChangedNotification";
 NSString *const SPSimplenoteThemeChangedNotification                = @"SPSimplenoteThemeChangedNotification";
+NSString *const SPSubscriptionStatusDidChangeNotification           = @"SPSubscriptionStatusDidChangeNotification";

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -1,9 +1,13 @@
 import UIKit
 
 
-// MARK: - Interface Helpers
+// MARK: - Subscriber UI
 //
 extension SPSettingsViewController {
+
+    private var isActiveSustainer: Bool {
+        SPAppDelegate.shared().simperium.preferencesObject().isActiveSubscriber
+    }
 
     @objc
     func setupTableHeaderView() {
@@ -21,11 +25,12 @@ extension SPSettingsViewController {
     }
 
     @objc
-    func refreshTableHeaderSize() {
+    func refreshTableHeaderView() {
         guard let headerView = tableView.tableHeaderView as? SustainerView else {
             return
         }
 
+        headerView.isActiveSustainer = isActiveSustainer
         headerView.preferredWidth = tableView.frame.width
         headerView.adjustSizeForCompressedLayout()
 

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -18,7 +18,7 @@ extension SPSettingsViewController {
         let sustainerView: SustainerView = SustainerView.instantiateFromNib()
         sustainerView.appliesTopInset = true
         sustainerView.onPress = {
-            StoreManager.shared.purchase(storeProduct: .sustainer)
+            StoreManager.shared.purchase(storeProduct: .sustainerYearly)
         }
 
         tableView.tableHeaderView = sustainerView

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -6,6 +6,21 @@ import UIKit
 extension SPSettingsViewController {
 
     @objc
+    func setupTableHeaderView() {
+        guard #available(iOS 15.0, *) else {
+            return
+        }
+
+        let sustainerView: SustainerView = SustainerView.instantiateFromNib()
+        sustainerView.appliesTopInset = true
+        sustainerView.onPress = {
+            StoreManager.shared.purchase(storeProduct: .sustainer)
+        }
+
+        tableView.tableHeaderView = sustainerView
+    }
+
+    @objc
     func refreshTableHeaderSize() {
         guard let headerView = tableView.tableHeaderView as? SustainerView else {
             return

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -175,7 +175,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(refreshTableHeaderView)
+                                             selector:@selector(subscriptionStatusDidChange)
                                                  name:SPSubscriptionStatusDidChangeNotification
                                                object:nil];
 
@@ -201,6 +201,16 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 - (void)doneAction:(id)sender
 {
     [self.navigationController dismissViewControllerAnimated:YES completion:nil];
+}
+
+
+#pragma mark - Notifications
+
+- (void)subscriptionStatusDidChange
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self refreshTableHeaderView];
+    });
 }
 
 

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -168,10 +168,15 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     self.pinTimeoutTextField.inputAccessoryView = self.doneToolbar;
     [self.view addSubview:self.pinTimeoutTextField];
     
-    // Listen to Theme Notifications
+    // Listen to Notifications
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(themeDidChange)
                                                  name:SPSimplenoteThemeChangedNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(refreshTableHeaderView)
+                                                 name:SPSubscriptionStatusDidChangeNotification
                                                object:nil];
 
     [self refreshThemeStyles];
@@ -180,7 +185,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [self refreshTableHeaderSize];
+    [self refreshTableHeaderView];
     [self.tableView reloadData];
 }
 
@@ -189,7 +194,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        [self refreshTableHeaderSize];
+        [self refreshTableHeaderView];
     } completion:nil];
 }
 

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -128,11 +128,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                                                                            action:@selector(doneAction:)];
     
     // Header View
-    if (@available(iOS 15.0, *)) {
-        SustainerView *sustainerView = [SustainerView loadFromNib];
-        sustainerView.appliesTopInset = YES;
-        self.tableView.tableHeaderView = sustainerView;
-    }
+    [self setupTableHeaderView];
 
     // Setup the Switches
     self.alphabeticalTagSortSwitch = [UISwitch new];

--- a/Simplenote/Classes/Simperium+Simplenote.h
+++ b/Simplenote/Classes/Simperium+Simplenote.h
@@ -5,6 +5,6 @@
 
 @interface Simperium (Simplenote)
 
-- (Preferences *)preferencesObject;
+- (nonnull Preferences *)preferencesObject;
 
 @end

--- a/Simplenote/Classes/UITableView+Simplenote.swift
+++ b/Simplenote/Classes/UITableView+Simplenote.swift
@@ -135,7 +135,7 @@ extension UITableView {
         }
     }
 
-    open func selectAllRows(inSection section: Int, animated: Bool) {
+    func selectAllRows(inSection section: Int, animated: Bool) {
         forEachIndexPath(in: section) { indexPath in
             selectRow(at: indexPath, animated: animated, scrollPosition: .none)
         }

--- a/Simplenote/CrashLogging.swift
+++ b/Simplenote/CrashLogging.swift
@@ -55,7 +55,7 @@ private class SNCrashLoggingDataProvider: CrashLoggingDataProvider {
 
     var userHasOptedOut: Bool {
 
-        if let analyticsEnabledSetting = simperium.preferencesObject()?.analytics_enabled {
+        if let analyticsEnabledSetting = simperium.preferencesObject().analytics_enabled {
             return !analyticsEnabledSetting.boolValue
         }
 

--- a/Simplenote/Preferences+IAP.swift
+++ b/Simplenote/Preferences+IAP.swift
@@ -1,0 +1,20 @@
+//
+//  Preferences+IAP.swift
+//  Simplenote
+//
+//  Created by Jorge Leandro Perez on 10/27/22.
+//  Copyright © 2022 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - Preferences Extensions
+//
+extension Preferences {
+
+    @objc
+    var isActiveSubscriber: Bool {
+        subscription_level == StoreSettings.activeSubscriptionLevel
+    }
+}

--- a/Simplenote/Preferences+IAP.swift
+++ b/Simplenote/Preferences+IAP.swift
@@ -15,6 +15,6 @@ extension Preferences {
 
     @objc
     var isActiveSubscriber: Bool {
-        subscription_level == StoreSettings.activeSubscriptionLevel
+        subscription_level == StoreConstants.activeSubscriptionLevel
     }
 }

--- a/Simplenote/Preferences.m
+++ b/Simplenote/Preferences.m
@@ -19,8 +19,14 @@
 
 - (void) didChangeValueForKey:(NSString *)key
 {
-    if ([key isEqualToString:@"analytics_enabled"]) {
+    NSString *analyticsKey = NSStringFromSelector(@selector((analytics_enabled)));
+    if ([key isEqualToString:analyticsKey]) {
         [CrashLogging cacheOptOutSetting: !self.analytics_enabled.boolValue];
+    }
+
+    NSString *subscriptionKey = NSStringFromSelector(@selector((subscription_level)));
+    if ([key isEqualToString:subscriptionKey]) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:SPSubscriptionStatusDidChangeNotification object:nil];
     }
 
     [super didChangeValueForKey:key];

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -36,6 +36,16 @@ extension SPAppDelegate {
 
         authenticator.providerString = "simplenote.com"
     }
+
+    @objc
+    func setupStoreManager() {
+        guard #available(iOS 15, *) else {
+            NSLog("[StoreManager] Unavailable")
+            return
+        }
+
+        StoreManager.shared.initialize()
+    }
 }
 
 // MARK: - Internal Methods

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -285,7 +285,7 @@ extension SPAppDelegate: SimperiumDelegate {
         ShortcutsHandler.shared.updateHomeScreenQuickActionsIfNeeded()
 
         // Now that the user info is present, cache it for use by the crash logging system.
-        let analyticsEnabled = simperium.preferencesObject()?.analytics_enabled?.boolValue ?? true
+        let analyticsEnabled = simperium.preferencesObject().analytics_enabled?.boolValue ?? true
         CrashLoggingShim.shared.cacheUser(user)
         CrashLoggingShim.cacheOptOutSetting(!analyticsEnabled)
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -130,14 +130,17 @@
     [self configureAccountDeletionController];
     [self setupDefaultWindow];
     [self configureStateRestoration];
-    
+
     return YES;
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-	// Once the UI is wired, Auth Simperium
-	[self authenticateSimperium];
+    // Once the UI is wired, Auth Simperium
+    [self authenticateSimperium];
+
+    // Start the StoreKit Manager
+    [self setupStoreManager];
 
     // Handle Simplenote Migrations: We *need* to initialize the Ratings framework after this step, for reasons be.
     [[MigrationsHandler new] ensureUpdateIsHandled];
@@ -147,7 +150,7 @@
 
     // Initialize UI
     [self loadSelectedTheme];
-    
+
     // Check to see if first time user
     if ([self isFirstLaunch]) {
         _noteListViewController.firstLaunch = YES;

--- a/Simplenote/SPPrivacyViewController.swift
+++ b/Simplenote/SPPrivacyViewController.swift
@@ -27,11 +27,9 @@ class SPPrivacyViewController: SPTableViewController {
     ///
     private var isAnalyticsEnabled: Bool {
         let simperium = SPAppDelegate.shared().simperium
-        guard let preferences = simperium.preferencesObject() else {
-            return true
-        }
+        let preferences = simperium.preferencesObject()
 
-        return preferences.analytics_enabled?.boolValue ==  true
+        return preferences.analytics_enabled?.boolValue == true
     }
 
 
@@ -97,11 +95,9 @@ extension SPPrivacyViewController {
     ///
     @objc func switchDidChange(sender: UISwitch) {
         let simperium = SPAppDelegate.shared().simperium
-        guard let preferences = simperium.preferencesObject() else {
-            return
-        }
-
+        let preferences = simperium.preferencesObject()
         preferences.analytics_enabled = NSNumber(booleanLiteral: sender.isOn)
+
         simperium.save()
     }
 

--- a/Simplenote/SPPrivacyViewController.swift
+++ b/Simplenote/SPPrivacyViewController.swift
@@ -27,9 +27,11 @@ class SPPrivacyViewController: SPTableViewController {
     ///
     private var isAnalyticsEnabled: Bool {
         let simperium = SPAppDelegate.shared().simperium
-        let preferences = simperium.preferencesObject()
+        guard let isAnalyticsEnabled = simperium.preferencesObject().analytics_enabled else {
+            return true
+        }
 
-        return preferences.analytics_enabled?.boolValue == true
+        return isAnalyticsEnabled.boolValue
     }
 
 
@@ -96,8 +98,8 @@ extension SPPrivacyViewController {
     @objc func switchDidChange(sender: UISwitch) {
         let simperium = SPAppDelegate.shared().simperium
         let preferences = simperium.preferencesObject()
-        preferences.analytics_enabled = NSNumber(booleanLiteral: sender.isOn)
 
+        preferences.analytics_enabled = NSNumber(booleanLiteral: sender.isOn)
         simperium.save()
     }
 

--- a/Simplenote/StoreConstants.swift
+++ b/Simplenote/StoreConstants.swift
@@ -1,0 +1,17 @@
+//
+//  StoreConstants.swift
+//  Simplenote
+//
+//  Created by Jorge Leandro Perez on 10/27/22.
+//  Copyright © 2022 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - Settings
+//
+enum StoreConstants {
+    static let platform = "iOS"
+    static let activeSubscriptionLevel = "sustainer"
+}

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -153,7 +153,8 @@ private extension StoreManager {
     @MainActor
     func refreshSubscriptionGroupStatus() async {
         do {
-            subscriptionGroupStatus = try await storeProductMap.values.first?.subscription?.status.first
+            let newStatus = try await storeProductMap.values.first?.subscription?.status.first
+            subscriptionGroupStatus = newStatus
         } catch {
             NSLog("[StoreKit] Failed to refresh the Subscription Group Status: \(error)")
         }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -251,7 +251,6 @@ private extension StoreManager {
         }
 
         simperium.save()
-        NotificationCenter.default.post(name: .SPSubscriptionStatusDidChange, object: nil)
     }
 
     func mustUpdatePreferences(preferences: Preferences) -> Bool {

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -63,8 +63,8 @@ class StoreManager {
     ///
     ///     1.  Listen for Pending Transactions
     ///     2.  Request the Known Products
-    ///     3.  Refresh the Purchased Products (and update Core Data)
-    ///     4.  Refresh the SubscriptionGroup Status
+    ///     3.  Refresh the Purchased Products
+    ///     4.  Refresh the SubscriptionGroup Status (and update Core Data / refresh UI all over!)
     ///
     /// This API should be invoked shortly after the Launch Sequence is complete.
     ///

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -34,6 +34,7 @@ class StoreManager {
 
     // MARK: - Private Properties
 
+    private var updateListenerTask: Task<Void, Error>?
     private(set) var storeProductMap: [StoreProduct: Product] = [:]
     private(set) var purchasedProducts: [Product] = []
     private(set) var subscriptionGroupStatus: SubscriptionStatus? {
@@ -43,17 +44,7 @@ class StoreManager {
     }
 
 
-    // MARK: - Calculated Properties
-
-    private var allProducts: [Product] {
-        Array(storeProductMap.values)
-    }
-
-
-    // MARK: - Public Properties
-
-    private var updateListenerTask: Task<Void, Error>?
-
+    // MARK: - Deinit
 
     deinit {
         updateListenerTask?.cancel()
@@ -145,7 +136,7 @@ private extension StoreManager {
         for await result in Transaction.currentEntitlements {
             do {
                 let transaction = try checkVerified(result)
-                if let subscription = allProducts.first(where: { $0.id == transaction.productID }) {
+                if let subscription = storeProductMap.values.first(where: { $0.id == transaction.productID }) {
                     newPurchasedProducts.append(subscription)
                 }
 
@@ -162,7 +153,7 @@ private extension StoreManager {
     @MainActor
     func refreshSubscriptionGroupStatus() async {
         do {
-            subscriptionGroupStatus = try await allProducts.first?.subscription?.status.first
+            subscriptionGroupStatus = try await storeProductMap.values.first?.subscription?.status.first
         } catch {
             NSLog("[StoreKit] Failed to refresh the Subscription Group Status: \(error)")
         }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -151,7 +151,11 @@ private extension StoreManager {
 
         /// - Important!
         ///     Simplenote has a single Subscription Group. `product.subscription.status` represents the entire subscription group status
-        subscriptionGroupStatus = try? await subscriptions.values.first?.subscription?.status.first?.state
+        do {
+            subscriptionGroupStatus = try await subscriptions.values.first?.subscription?.status.first?.state
+        } catch {
+            NSLog("[StoreKit] Failed to refresh the Subscription Group Status: \(error)")
+        }
     }
 
     @discardableResult

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -278,7 +278,7 @@ private extension StoreManager {
         if let status {
             preferences.subscription_date = subscriptionDate(from: status)
             preferences.subscription_level = subscriptionLevel(from: status)
-            preferences.subscription_platform = Settings.platform
+            preferences.subscription_platform = StoreSettings.platform
         } else {
             preferences.subscription_date = nil
             preferences.subscription_level = nil
@@ -294,7 +294,7 @@ private extension StoreManager {
             return true
         }
 
-        return platform.isEmpty || platform == Settings.platform
+        return platform.isEmpty || platform == StoreSettings.platform
     }
 
     func subscriptionDate(from status: SubscriptionStatus) -> Date? {
@@ -311,14 +311,14 @@ private extension StoreManager {
             return nil
         }
 
-        return Settings.activeSubscriptionLevel
+        return StoreSettings.activeSubscriptionLevel
     }
 }
 
 
 // MARK: - Settings
 //
-private enum Settings {
+enum StoreSettings {
     static let platform = "iOS"
     static let activeSubscriptionLevel = "sustainer"
 }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -286,6 +286,7 @@ private extension StoreManager {
         }
 
         simperium.save()
+        NotificationCenter.default.post(name: .SPSubscriptionStatusDidChange, object: nil)
     }
 
     func mustUpdatePreferences(preferences: Preferences) -> Bool {

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -1,0 +1,188 @@
+//
+//  StoreManager.swift
+//  Simplenote
+//
+//  Created by Jorge Leandro Perez on 10/26/22.
+//  Copyright © 2022 Automattic. All rights reserved.
+//
+
+import Foundation
+import StoreKit
+
+
+// MARK: - StoreError
+//
+enum StoreError: Error {
+    case failedVerification
+}
+
+
+// MARK: - StoreManager
+//
+@available(iOS 15, *)
+class StoreManager {
+
+    // MARK: - Static
+    //
+    static let shared = StoreManager()
+
+
+    // MARK: - Aliases
+    //
+    typealias RenewalState = Product.SubscriptionInfo.RenewalState
+
+
+    // MARK: - Private Properties
+
+    private(set) var subscriptions: [Product] = []
+    private(set) var purchasedSubscriptions: [Product] = []
+    private(set) var subscriptionGroupStatus: RenewalState?
+
+
+    // MARK: - Public Properties
+
+    private var updateListenerTask: Task<Void, Error>?
+
+
+    // MARK: - Public API(s)
+
+    /// Initialization:
+    /// - Starts listening for Pending Transactions
+    /// - Requests the Available Products
+    ///
+    func initialize() {
+        NSLog("[StoreManager] Initializing...")
+
+        updateListenerTask = listenForTransactions()
+        refreshSubscriptionProducts()
+    }
+
+
+    ///
+    ///
+    func purchase(_ product: Product) async throws -> Transaction? {
+        let result = try await product.purchase()
+
+        switch result {
+        case .success(let verification):
+            //Check whether the transaction is verified. If it isn't,
+            //this function rethrows the verification error.
+            let transaction = try checkVerified(verification)
+
+            await refreshSubscriptionStatus()
+
+            await transaction.finish()
+
+            return transaction
+        case .userCancelled, .pending:
+            return nil
+        default:
+            return nil
+        }
+    }
+}
+
+
+// MARK: - Private API(s)
+//
+@available(iOS 15, *)
+private extension StoreManager {
+
+    func listenForTransactions() -> Task<Void, Error> {
+        return Task.detached {
+            for await result in Transaction.updates {
+                do {
+                    let transaction = try self.checkVerified(result)
+
+                    await self.refreshSubscriptionStatus()
+
+                    await transaction.finish()
+                } catch {
+                    NSLog("[StoreKit] Transaction failed verification. Error \(error)")
+                }
+            }
+        }
+    }
+
+    func refreshSubscriptionProducts() {
+        Task { @MainActor in
+            do {
+                let storeProducts = try await Product.products(for: StoreProduct.allIdentifiers)
+                subscriptions = filter(products: storeProducts, ofType: .autoRenewable)
+            } catch {
+                NSLog("Failed product request from the App Store server: \(error)")
+            }
+        }
+    }
+
+    @MainActor
+    func refreshSubscriptionStatus() async {
+        var newPurchasedSubscriptions: [Product] = []
+
+        for await result in Transaction.currentEntitlements {
+            do {
+                let transaction = try checkVerified(result)
+
+                switch transaction.productType {
+                case .autoRenewable:
+                    if let subscription = subscriptions.first(where: { $0.id == transaction.productID }) {
+                        newPurchasedSubscriptions.append(subscription)
+                    }
+                default:
+                    break
+                }
+            } catch {
+                print()
+            }
+        }
+
+        purchasedSubscriptions = newPurchasedSubscriptions
+
+        // Check the `subscriptionGroupStatus` to learn the auto-renewable subscription state to determine whether the customer
+        // is new (never subscribed), active, or inactive (expired subscription). This app has only one subscription
+        // group, so products in the subscriptions array all belong to the same group. The statuses that
+        // `product.subscription.status` returns apply to the entire subscription group.
+        subscriptionGroupStatus = try? await subscriptions.first?.subscription?.status.first?.state
+    }
+}
+
+
+
+// MARK: - Private Helpers
+//
+@available(iOS 15, *)
+private extension StoreManager {
+
+    func filter(products: [Product], ofType type: Product.ProductType) -> [Product] {
+        var newSubscriptions: [Product] = []
+
+        for product in products {
+            switch product.type {
+            case .autoRenewable:
+                newSubscriptions.append(product)
+            default:
+                NSLog("[StoreManager] Unknown product: \(product)")
+            }
+        }
+
+        return newSubscriptions
+    }
+
+    func isPurchased(_ product: Product) async throws -> Bool {
+        switch product.type {
+        case .autoRenewable:
+            return purchasedSubscriptions.contains(product)
+        default:
+            return false
+        }
+    }
+
+    func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .unverified:
+            throw StoreError.failedVerification
+        case .verified(let safe):
+            return safe
+        }
+    }
+}

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -263,8 +263,14 @@ private extension StoreManager {
 
     func refreshSimperiumPreferences(status: SubscriptionStatus?) {
         let simperium = SPAppDelegate.shared().simperium
-        let preferences = simperium.preferencesObject()
 
+        simperium.managedObjectContext().perform {
+            self.refreshSimperiumPreferences(simperium: simperium, status: status)
+        }
+    }
+
+    func refreshSimperiumPreferences(simperium: Simperium, status: SubscriptionStatus?) {
+        let preferences = simperium.preferencesObject()
         guard mustUpdatePreferences(preferences: preferences) else {
             return
         }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -84,16 +84,16 @@ class StoreManager {
     }
 
 
-    /// Purchases the specified Product
+    /// Purchases the specified Product (as long as we don't own it already?)
     ///
-    func purchase(product: StoreProduct) {
-        guard let subcription = subscriptions[product] else {
+    func purchase(storeProduct: StoreProduct) {
+        guard let product = subscriptions[storeProduct], isPurchased(product) == false else {
             return
         }
 
         Task {
             do {
-                try await purchase(product: subcription)
+                try await purchase(product: product)
             } catch {
                 NSLog("[StoreManager] Purchase Failed \(error)")
             }
@@ -199,7 +199,6 @@ private extension StoreManager {
 }
 
 
-
 // MARK: - Private Helpers
 //
 @available(iOS 15, *)
@@ -237,7 +236,7 @@ private extension StoreManager {
         }
     }
 
-    func isPurchased(_ product: Product) async throws -> Bool {
+    func isPurchased(_ product: Product) -> Bool {
         switch product.type {
         case .autoRenewable:
             return purchasedSubscriptions.contains(product)

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -145,10 +145,13 @@ private extension StoreManager {
             }
         }
 
+        /// This structure helps us determine if a given `Product` instance has been purchased, or not
+        ///
+        purchasedSubscriptions = newPurchasedSubscriptions
+
         /// - Important!
         ///     Simplenote has a single Subscription Group. `product.subscription.status` represents the entire subscription group status
         subscriptionGroupStatus = try? await subscriptions.values.first?.subscription?.status.first?.state
-        purchasedSubscriptions = newPurchasedSubscriptions
     }
 
     @discardableResult

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -145,13 +145,10 @@ private extension StoreManager {
             }
         }
 
-        purchasedSubscriptions = newPurchasedSubscriptions
-
-        // Check the `subscriptionGroupStatus` to learn the auto-renewable subscription state to determine whether the customer
-        // is new (never subscribed), active, or inactive (expired subscription). This app has only one subscription
-        // group, so products in the subscriptions array all belong to the same group. The statuses that
-        // `product.subscription.status` returns apply to the entire subscription group.
+        /// - Important!
+        ///     Simplenote has a single Subscription Group. `product.subscription.status` represents the entire subscription group status
         subscriptionGroupStatus = try? await subscriptions.values.first?.subscription?.status.first?.state
+        purchasedSubscriptions = newPurchasedSubscriptions
     }
 
     @discardableResult

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -122,6 +122,9 @@ private extension StoreManager {
         do {
             let storeProducts = try await Product.products(for: StoreProduct.allIdentifiers)
             subscriptions = filter(products: storeProducts, ofType: .autoRenewable)
+
+            NSLog("[StoreKit] Retrieved \(subscriptions.count) Subscription Products")
+
         } catch {
             NSLog("[StoreKit] Failed product request from the App Store server: \(error)")
         }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -278,7 +278,7 @@ private extension StoreManager {
         if let status {
             preferences.subscription_date = subscriptionDate(from: status)
             preferences.subscription_level = subscriptionLevel(from: status)
-            preferences.subscription_platform = StoreSettings.platform
+            preferences.subscription_platform = StoreConstants.platform
         } else {
             preferences.subscription_date = nil
             preferences.subscription_level = nil
@@ -294,7 +294,7 @@ private extension StoreManager {
             return true
         }
 
-        return platform.isEmpty || platform == StoreSettings.platform
+        return platform.isEmpty || platform == StoreConstants.platform
     }
 
     func subscriptionDate(from status: SubscriptionStatus) -> Date? {
@@ -311,14 +311,6 @@ private extension StoreManager {
             return nil
         }
 
-        return StoreSettings.activeSubscriptionLevel
+        return StoreConstants.activeSubscriptionLevel
     }
-}
-
-
-// MARK: - Settings
-//
-enum StoreSettings {
-    static let platform = "iOS"
-    static let activeSubscriptionLevel = "sustainer"
 }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -43,6 +43,12 @@ class StoreManager {
         }
     }
 
+    // MARK: - Public Properties
+
+    var isActiveSubscriber: Bool {
+        subscriptionGroupStatus != nil
+    }
+
 
     // MARK: - Deinit
 
@@ -78,7 +84,7 @@ class StoreManager {
     /// Purchases the specified Product (as long as we don't own it already?)
     ///
     func purchase(storeProduct: StoreProduct) {
-        guard let product = storeProductMap[storeProduct], isPurchased(product) == false else {
+        guard let product = storeProductMap[storeProduct], isActiveSubscriber == false else {
             return
         }
 

--- a/Simplenote/StoreProduct.swift
+++ b/Simplenote/StoreProduct.swift
@@ -16,10 +16,10 @@ enum StoreProduct: String, CaseIterable {
 
     var identifier: String {
         guard let prefix = Bundle.main.rootBundleIdentifier else {
-            return "com.codality.NotationalFlow.sustainer"
+            return "com.codality.NotationalFlow.sustainer200"
         }
 
-        return prefix + ".sustainer"
+        return prefix + ".sustainer200"
     }
 
     static var allIdentifiers: [String] {

--- a/Simplenote/StoreProduct.swift
+++ b/Simplenote/StoreProduct.swift
@@ -1,0 +1,30 @@
+//
+//  StoreProduct.swift
+//  Simplenote
+//
+//  Created by Jorge Leandro Perez on 10/26/22.
+//  Copyright © 2022 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - StoreProduct
+//
+enum StoreProduct: String, CaseIterable {
+    case sustainer
+
+    var identifier: String {
+        guard let prefix = Bundle.main.rootBundleIdentifier else {
+            return "com.codality.NotationalFlow.sustainer"
+        }
+
+        return prefix + ".sustainer"
+    }
+
+    static var allIdentifiers: [String] {
+        StoreProduct.allCases.map { product in
+            product.identifier
+        }
+    }
+}

--- a/Simplenote/StoreProduct.swift
+++ b/Simplenote/StoreProduct.swift
@@ -12,14 +12,16 @@ import Foundation
 // MARK: - StoreProduct
 //
 enum StoreProduct: String, CaseIterable {
-    case sustainer
+    case sustainerMonthly
+    case sustainerYearly
 
     var identifier: String {
-        guard let prefix = Bundle.main.rootBundleIdentifier else {
+        switch self {
+        case .sustainerYearly:
             return "com.codality.NotationalFlow.sustainer200"
+        case .sustainerMonthly:
+            return "com.codality.NotationalFlow.sustainer20"
         }
-
-        return prefix + ".sustainer200"
     }
 }
 

--- a/Simplenote/StoreProduct.swift
+++ b/Simplenote/StoreProduct.swift
@@ -21,10 +21,18 @@ enum StoreProduct: String, CaseIterable {
 
         return prefix + ".sustainer200"
     }
+}
 
+extension StoreProduct {
     static var allIdentifiers: [String] {
         StoreProduct.allCases.map { product in
             product.identifier
+        }
+    }
+
+    static func findStoreProduct(identifier: String) -> StoreProduct? {
+        StoreProduct.allCases.first { storeProduct in
+            storeProduct.identifier == identifier
         }
     }
 }

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -100,7 +100,7 @@ private extension TagListViewController {
 
         let sustainerView: SustainerView = SustainerView.instantiateFromNib()
         sustainerView.onPress = {
-            StoreManager.shared.purchase(storeProduct: .sustainer)
+            StoreManager.shared.purchase(storeProduct: .sustainerYearly)
         }
 
         tableView.tableHeaderView = sustainerView

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -173,7 +173,9 @@ private extension TagListViewController {
 
     @objc
     func subscriptionStatusDidChange() {
-        refreshTableHeaderView()
+        DispatchQueue.main.async {
+            self.refreshTableHeaderView()
+        }
     }
 }
 

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -78,6 +78,7 @@ final class TagListViewController: UIViewController {
 // MARK: - Configuration
 //
 private extension TagListViewController {
+
     func configureView() {
         view.backgroundColor = .simplenoteBackgroundColor
     }

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -94,10 +94,8 @@ private extension TagListViewController {
         }
 
         let sustainerView: SustainerView = SustainerView.instantiateFromNib()
-        sustainerView.onPress = { [weak sustainerView, weak self] in
-            // TODO: Remove. For demo purposes only.
-            sustainerView?.isActiveSustainer.toggle()
-            self?.refreshTableHeaderSize()
+        sustainerView.onPress = {
+            StoreManager.shared.purchase(product: .sustainer)
         }
 
         tableView.tableHeaderView = sustainerView

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -95,7 +95,7 @@ private extension TagListViewController {
 
         let sustainerView: SustainerView = SustainerView.instantiateFromNib()
         sustainerView.onPress = {
-            StoreManager.shared.purchase(product: .sustainer)
+            StoreManager.shared.purchase(storeProduct: .sustainer)
         }
 
         tableView.tableHeaderView = sustainerView

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -18,6 +18,10 @@ final class TagListViewController: UIViewController {
 
     private var renameTag: Tag?
 
+    private var isActiveSustainer: Bool {
+        SPAppDelegate.shared().simperium.preferencesObject().isActiveSubscriber
+    }
+
     override var shouldAutorotate: Bool {
         return false
     }
@@ -44,7 +48,7 @@ final class TagListViewController: UIViewController {
         super.viewWillAppear(animated)
         startListeningToKeyboardNotifications()
 
-        refreshTableHeaderSize()
+        refreshTableHeaderView()
         reloadTableView()
         startListeningForChanges()
         becomeFirstResponder()
@@ -62,14 +66,14 @@ final class TagListViewController: UIViewController {
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
-        refreshTableHeaderSize()
+        refreshTableHeaderView()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate { _ in
-            self.refreshTableHeaderSize()
+            self.refreshTableHeaderView()
         }
     }
 }
@@ -133,6 +137,7 @@ private extension TagListViewController {
         nc.addObserver(self, selector: #selector(menuDidChangeVisibility), name: UIMenuController.didHideMenuNotification, object: nil)
         nc.addObserver(self, selector: #selector(tagsSortOrderWasUpdated), name: NSNotification.Name.SPAlphabeticalTagSortPreferenceChanged, object: nil)
         nc.addObserver(self, selector: #selector(themeDidChange), name: NSNotification.Name.SPSimplenoteThemeChanged, object: nil)
+        nc.addObserver(self, selector: #selector(subscriptionStatusDidChange), name: .SPSubscriptionStatusDidChange, object: nil)
     }
 
     func startListeningToKeyboardNotifications() {
@@ -164,6 +169,11 @@ private extension TagListViewController {
     @objc
     func tagsSortOrderWasUpdated() {
         refreshSortDescriptorsAndPerformFetch()
+    }
+
+    @objc
+    func subscriptionStatusDidChange() {
+        refreshTableHeaderView()
     }
 }
 
@@ -545,6 +555,7 @@ extension TagListViewController: TagListViewCellDelegate {
 // MARK: - Helper Methods
 //
 private extension TagListViewController {
+
     func setEditing(_ editing: Bool) {
         // Note: Neither super.setEditing nor tableView.setEditing will resign the first responder.
         if !editing {
@@ -562,11 +573,12 @@ private extension TagListViewController {
         tagsHeaderView.actionButton.setTitle(title, for: .normal)
     }
 
-    func refreshTableHeaderSize() {
+    func refreshTableHeaderView() {
         guard let headerView = tableView.tableHeaderView as? SustainerView else {
             return
         }
 
+        headerView.isActiveSustainer = isActiveSustainer
         headerView.preferredWidth = tableView.frame.width - view.safeAreaInsets.left
         headerView.adjustSizeForCompressedLayout()
 

--- a/Simplenote/TestConfiguration.storekit
+++ b/Simplenote/TestConfiguration.storekit
@@ -36,9 +36,34 @@
               "locale" : "en_US"
             }
           ],
-          "productID" : "com.codality.NotationalFlow.Development.sustainer200",
+          "productID" : "com.codality.NotationalFlow.sustainer200",
           "recurringSubscriptionPeriod" : "P1Y",
-          "referenceName" : "Simplenote Sustainer",
+          "referenceName" : "Sustainer Yearly",
+          "subscriptionGroupID" : "6ED580C5",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "19.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "51054854",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.codality.NotationalFlow.sustainer20",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Sustainer Monthly",
           "subscriptionGroupID" : "6ED580C5",
           "type" : "RecurringSubscription"
         }

--- a/Simplenote/TestConfiguration.storekit
+++ b/Simplenote/TestConfiguration.storekit
@@ -24,7 +24,7 @@
           "codeOffers" : [
 
           ],
-          "displayPrice" : "200",
+          "displayPrice" : "199.99",
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "6BF391A1",

--- a/Simplenote/TestConfiguration.storekit
+++ b/Simplenote/TestConfiguration.storekit
@@ -1,0 +1,52 @@
+{
+  "identifier" : "A7468C4F",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+
+  ],
+  "settings" : {
+
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "6ED580C5",
+      "localizations" : [
+
+      ],
+      "name" : "sustainer",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "200",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "6BF391A1",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.codality.NotationalFlow.Development.sustainer200",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "Simplenote Sustainer",
+          "subscriptionGroupID" : "6ED580C5",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 2,
+    "minor" : 0
+  }
+}


### PR DESCRIPTION
### Details
In this PR we're setting up the Sustainer IAP Infrastructure. The core of this PR revolves around the `StoreManager` class, which encapsulates all the things IAP for us.

Ref. #1491

### Important!
The following pendings will be addressed in a follow up PR:

- Price Alert: Users will be able to pick between Yearly / Monthly subscription
- Tracks

I'm opting to keep this PR as leaner as possible, since I'm already exceeding the 500LOC ballpark.
**Thank you!!**

### Test
1. Edit the scheme and open `Options`
2. Make sure the `TestConfiguration.storekit` **StoreKit configuration** is selected
3. Launch Simplenote and log into your account
4. Open the Sidebar
5. Tap on the sustainer banner

- [ ] Verify that if you go thru the IAP flow, the Banner switches to `Sustainer`
- [ ] Verify that signing on in a different device gets you the same banner
- [ ] Verify that if you delete the subscription (Xcode / Store Debugging) and relaunch, the banner reverts


### Release
`RELEASE-NOTES.txt` was updated in f0e7aa6f with:
 
> Simplenote Users now have the ability to become sustainers #1493
