### PR TITLE
Sustainer: Product Alert

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		B513F2B62319A8F40021CFA4 /* SPNoteTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B513F2B52319A8F40021CFA4 /* SPNoteTableViewCell.xib */; };
 		B513F2B82319A9A40021CFA4 /* UITableViewCell+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513F2B72319A9A40021CFA4 /* UITableViewCell+Simplenote.swift */; };
 		B513FB2422EF6A4B00B178AC /* SPUserInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = B513FB2322EF6A4B00B178AC /* SPUserInterface.swift */; };
+		B514678D291AC7790062736E /* UIAlertController+Sustainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B514678C291AC7790062736E /* UIAlertController+Sustainer.swift */; };
 		B5185CFB23427F2F0060145A /* SearchDisplayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5185CFA23427F2F0060145A /* SearchDisplayController.swift */; };
 		B518899E1E0D5EF800E71B83 /* SPContactsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */; };
 		B51889A01E0D5F2200E71B83 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B518899F1E0D5F2200E71B83 /* Contacts.framework */; };
@@ -905,6 +906,7 @@
 		B513F2B52319A8F40021CFA4 /* SPNoteTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = SPNoteTableViewCell.xib; path = Classes/SPNoteTableViewCell.xib; sourceTree = "<group>"; };
 		B513F2B72319A9A40021CFA4 /* UITableViewCell+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UITableViewCell+Simplenote.swift"; path = "Classes/UITableViewCell+Simplenote.swift"; sourceTree = "<group>"; };
 		B513FB2322EF6A4B00B178AC /* SPUserInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SPUserInterface.swift; path = Classes/SPUserInterface.swift; sourceTree = "<group>"; };
+		B514678C291AC7790062736E /* UIAlertController+Sustainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Sustainer.swift"; sourceTree = "<group>"; };
 		B5185CFA23427F2F0060145A /* SearchDisplayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchDisplayController.swift; path = Classes/SearchDisplayController.swift; sourceTree = "<group>"; };
 		B518899D1E0D5EF800E71B83 /* SPContactsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SPContactsManager.swift; path = Classes/SPContactsManager.swift; sourceTree = "<group>"; };
 		B518899F1E0D5F2200E71B83 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
@@ -1879,6 +1881,7 @@
 				B54D9C562909BA2600D0E0EC /* StoreManager.swift */,
 				B549E24A290B3DD70072C3E8 /* StoreConstants.swift */,
 				B54D9C582909CC4400D0E0EC /* StoreProduct.swift */,
+				B514678C291AC7790062736E /* UIAlertController+Sustainer.swift */,
 				B5BADB7C2909D78B00275B29 /* TestConfiguration.storekit */,
 			);
 			name = Store;
@@ -3419,6 +3422,7 @@
 				A66E41E1256D0F44000C6FCB /* RoundedButton.swift in Sources */,
 				F920265B2294661C0061B1DE /* BuildConfiguration.swift in Sources */,
 				B59188C0240059950069EF96 /* NSRegularExpression+Simplenote.swift in Sources */,
+				B514678D291AC7790062736E /* UIAlertController+Sustainer.swift in Sources */,
 				A68ABCA824ABFB5300715EBD /* SPShadowView.swift in Sources */,
 				B56E763622BD565700C5AA47 /* UIView+Simplenote.swift in Sources */,
 				B5E4082D235DE41A00D4E1DF /* UIColor+Studio.swift in Sources */,

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -17,8 +17,13 @@ extension SPSettingsViewController {
 
         let sustainerView: SustainerView = SustainerView.instantiateFromNib()
         sustainerView.appliesTopInset = true
-        sustainerView.onPress = {
-            StoreManager.shared.purchase(storeProduct: .sustainerYearly)
+        sustainerView.onPress = { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let sustainerAlertController = UIAlertController.buildSustainerAlert()
+            self.present(sustainerAlertController, animated: true)
         }
 
         tableView.tableHeaderView = sustainerView

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -18,12 +18,7 @@ extension SPSettingsViewController {
         let sustainerView: SustainerView = SustainerView.instantiateFromNib()
         sustainerView.appliesTopInset = true
         sustainerView.onPress = { [weak self] in
-            guard let self else {
-                return
-            }
-
-            let sustainerAlertController = UIAlertController.buildSustainerAlert()
-            self.present(sustainerAlertController, animated: true)
+            self?.presentSubscriptionAlertIfNeeded()
         }
 
         tableView.tableHeaderView = sustainerView
@@ -40,6 +35,16 @@ extension SPSettingsViewController {
         headerView.adjustSizeForCompressedLayout()
 
         tableView.tableHeaderView = headerView
+    }
+
+    @available(iOS 15.0, *)
+    func presentSubscriptionAlertIfNeeded() {
+        if isActiveSustainer {
+            return
+        }
+
+        let sustainerAlertController = UIAlertController.buildSustainerAlert()
+        present(sustainerAlertController, animated: true)
     }
 }
 

--- a/Simplenote/SPTracker+Extensions.swift
+++ b/Simplenote/SPTracker+Extensions.swift
@@ -91,9 +91,34 @@ extension SPTracker {
     }
 }
 
+
 // MARK: Account Deletion
+//
 extension SPTracker {
     static func trackDeleteAccountButttonTapped() {
         trackAutomatticEvent(withName: "spios_delete_account_button_clicked", properties: nil)
+    }
+}
+
+// MARK: - IAP
+//
+extension SPTracker {
+
+    static func trackSustainerMonthlyButtonTapped() {
+        trackAutomatticEvent(withName: "iap_monthly_button_tapped", properties: nil)
+    }
+
+    static func trackSustainerYearlyButtonTapped() {
+        trackAutomatticEvent(withName: "iap_yearly_button_tapped", properties: nil)
+    }
+
+    static func trackSustainerDismissButtonTapped() {
+        trackAutomatticEvent(withName: "iap_dismiss_button_tapped", properties: nil)
+    }
+
+    static func trackSustainerPurchaseCompleted(product: StoreProduct) {
+        trackAutomatticEvent(withName: "iap_purchase_completed", properties: [
+            "product": product.identifier
+        ])
     }
 }

--- a/Simplenote/SPTracker+Extensions.swift
+++ b/Simplenote/SPTracker+Extensions.swift
@@ -116,6 +116,7 @@ extension SPTracker {
         trackAutomatticEvent(withName: "iap_dismiss_button_tapped", properties: nil)
     }
 
+    @MainActor
     static func trackSustainerPurchaseCompleted(storeProduct: StoreProduct) {
         trackAutomatticEvent(withName: "iap_purchase_completed", properties: [
             "product": storeProduct.identifier

--- a/Simplenote/SPTracker+Extensions.swift
+++ b/Simplenote/SPTracker+Extensions.swift
@@ -116,9 +116,9 @@ extension SPTracker {
         trackAutomatticEvent(withName: "iap_dismiss_button_tapped", properties: nil)
     }
 
-    static func trackSustainerPurchaseCompleted(product: StoreProduct) {
+    static func trackSustainerPurchaseCompleted(storeProduct: StoreProduct) {
         trackAutomatticEvent(withName: "iap_purchase_completed", properties: [
-            "product": product.identifier
+            "product": storeProduct.identifier
         ])
     }
 }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -46,7 +46,11 @@ class StoreManager {
     // MARK: - Public Properties
 
     var isActiveSubscriber: Bool {
-        subscriptionGroupStatus != nil
+        guard let subscriptionGroupStatus else {
+            return false
+        }
+
+        return subscriptionGroupStatus.isActive
     }
 
 
@@ -255,9 +259,9 @@ private extension StoreManager {
             return
         }
 
-        if let status {
-            preferences.subscription_date = subscriptionDate(from: status)
+        if let status, status.isActive {
             preferences.subscription_level = subscriptionLevel(from: status)
+            preferences.subscription_date = subscriptionDate(from: status)
             preferences.subscription_platform = StoreConstants.platform
         } else {
             preferences.subscription_date = nil
@@ -286,10 +290,21 @@ private extension StoreManager {
     }
 
     func subscriptionLevel(from status: SubscriptionStatus) -> String? {
-        guard status.state == .subscribed || status.state == .inGracePeriod else {
+        guard status.isActive else {
             return nil
         }
 
         return StoreConstants.activeSubscriptionLevel
+    }
+}
+
+
+// MARK: - SubscriptionStatus Helpers
+//
+@available(iOS 15, *)
+private extension Product.SubscriptionInfo.Status {
+
+    var isActive: Bool {
+        state == .subscribed || state == .inGracePeriod
     }
 }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -96,6 +96,16 @@ class StoreManager {
             }
         }
     }
+
+    /// Returns the Display Price for a given Product
+    ///
+    func displayPrice(for storeProduct: StoreProduct) -> String? {
+        guard let product = storeProductMap[storeProduct] else {
+            return nil
+        }
+
+        return product.displayPrice
+    }
 }
 
 

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -91,6 +91,7 @@ class StoreManager {
         Task {
             do {
                 try await purchase(product: product)
+                SPTracker.trackSustainerPurchaseCompleted(product: storeProduct)
             } catch {
                 NSLog("[StoreManager] Purchase Failed \(error)")
             }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -95,11 +95,7 @@ class StoreManager {
         Task {
             do {
                 try await purchase(product: product)
-
-                Task { @MainActor in
-                    /// Note: This must be invoked in the main thread, otherwise, warnings get triggered!
-                    SPTracker.trackSustainerPurchaseCompleted(storeProduct: storeProduct)
-                }
+                await SPTracker.trackSustainerPurchaseCompleted(storeProduct: storeProduct)
             } catch {
                 NSLog("[StoreManager] Purchase Failed \(error)")
             }

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -91,7 +91,11 @@ class StoreManager {
         Task {
             do {
                 try await purchase(product: product)
-                SPTracker.trackSustainerPurchaseCompleted(product: storeProduct)
+
+                Task { @MainActor in
+                    /// Note: This must be invoked in the main thread, otherwise, warnings get triggered!
+                    SPTracker.trackSustainerPurchaseCompleted(storeProduct: storeProduct)
+                }
             } catch {
                 NSLog("[StoreManager] Purchase Failed \(error)")
             }

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -99,8 +99,13 @@ private extension TagListViewController {
         }
 
         let sustainerView: SustainerView = SustainerView.instantiateFromNib()
-        sustainerView.onPress = {
-            StoreManager.shared.purchase(storeProduct: .sustainerYearly)
+        sustainerView.onPress = { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let sustainerAlertController = UIAlertController.buildSustainerAlert()
+            self.present(sustainerAlertController, animated: true)
         }
 
         tableView.tableHeaderView = sustainerView

--- a/Simplenote/UIAlertController+Sustainer.swift
+++ b/Simplenote/UIAlertController+Sustainer.swift
@@ -21,14 +21,19 @@ extension UIAlertController {
 
         let alert = UIAlertController(title: Localization.title, message: Localization.message, preferredStyle: .actionSheet)
         alert.addActionWithTitle(monthlyActionTitle, style: .default) { _ in
+            SPTracker.trackSustainerMonthlyButtonTapped()
             manager.purchase(storeProduct: .sustainerMonthly)
         }
 
         alert.addActionWithTitle(yearlyActionTitle, style: .default) { _ in
+            SPTracker.trackSustainerYearlyButtonTapped()
             manager.purchase(storeProduct: .sustainerYearly)
         }
 
-        alert.addCancelActionWithTitle(Localization.dismissActionTitle)
+        alert.addCancelActionWithTitle(Localization.dismissActionTitle) { _ in
+            SPTracker.trackSustainerDismissButtonTapped()
+        }
+
         return alert
     }
 }

--- a/Simplenote/UIAlertController+Sustainer.swift
+++ b/Simplenote/UIAlertController+Sustainer.swift
@@ -1,0 +1,61 @@
+//
+//  UIAlertController+Sustainer.swift
+//  Simplenote
+//
+//  Created by Jorge Leandro Perez on 11/8/22.
+//  Copyright © 2022 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - UIAlertController+Sustainer
+//
+@available(iOS 15, *)
+extension UIAlertController {
+
+    static func buildSustainerAlert() -> UIAlertController {
+        let manager = StoreManager.shared
+        let monthlyActionTitle = Localization.monthlyActionTitle(price: manager.displayPrice(for: .sustainerMonthly))
+        let yearlyActionTitle = Localization.yearlyActionTitle(price: manager.displayPrice(for: .sustainerYearly))
+
+        let alert = UIAlertController(title: Localization.title, message: Localization.message, preferredStyle: .actionSheet)
+        alert.addActionWithTitle(monthlyActionTitle, style: .default) { _ in
+            manager.purchase(storeProduct: .sustainerMonthly)
+        }
+
+        alert.addActionWithTitle(yearlyActionTitle, style: .default) { _ in
+            manager.purchase(storeProduct: .sustainerYearly)
+        }
+
+        alert.addCancelActionWithTitle(Localization.dismissActionTitle)
+        return alert
+    }
+}
+
+
+// MARK: - Localization
+//
+private enum Localization {
+    static let title = NSLocalizedString("Simplenote Sustainer", comment: "Sustainer Alert's Title")
+    static let message = NSLocalizedString("Choose a plan and help unlock future features", comment: "Sustainer Alert's Message")
+    static let dismissActionTitle = NSLocalizedString("Cancel", comment: "Dismisses the alert")
+
+    static func monthlyActionTitle(price: String?) -> String {
+        guard let price else {
+            return NSLocalizedString("Monthly", comment: "Monthly Subscription Option (Used when / if the price fails to load)")
+        }
+
+        let text = NSLocalizedString("%@ per Month", comment: "Monthly Subscription Option. Please preserve the special marker!")
+        return String(format: text, price)
+    }
+
+    static func yearlyActionTitle(price: String?) -> String {
+        guard let price else {
+            return NSLocalizedString("Yearly", comment: "Yearly Subscription Option (Used when / if the price fails to load)")
+        }
+
+        let text = NSLocalizedString("%@ per Year", comment: "Yearly Subscription Option. Please preserve the special marker!")
+        return String(format: text, price)
+    }
+}


### PR DESCRIPTION
### Details
In this PR we're:

1. Implementing a Product Tier Alert, presented whenever the Sustainer Header is pressed
2. Hiding the Sidebar Sustainer Header, whenever the user is an active subscriber
3. Fixing a glitch processing refunds
4. Wiring **Tracks Events** for all the things Sustainer!

Ref. #1491

### Test: Sidebar
1. Edit the scheme and open Options
2. Make sure the **TestConfiguration.storekit** StoreKit configuration is selected
3. Launch Simplenote and log into your account
5. Open the Sidebar
6. Tap on the **Sustainer** banner

 - [ ] Verify an Alert shows up, offering the different price tiers
 - [ ] Verify that if you go ahead and purchase something, the Sidebar's Header gets hidden
 - [ ] Verify that the "Sustainer" Header does get presented in the Settings UI
 - [ ] Verify that pressing over the **Sustainer** Header (Settings UI) doesn't do anything (no alerts should show up)

### Test: Settings
1. Repeat steps 1-4 from the previous scenario
2. Press over **Settings**
3. Press over the **Sustainer** banner

- [ ] Verify the IAP flow works as expected

### Test: Refunds
1. Edit the scheme and open Options
5. Make sure the TestConfiguration.storekit StoreKit configuration is selected
7. Launch Simplenote and log into your account
8. Open the Sidebar
9. Tap on the **Sustainer** banner
10. Proceed subscribing
11. Open the **StoreKit Manager** and refund your subscription

- [ ] Verify that the **Become a Subscriber** Headers show up again
- [ ] Verify that you can become a subscriber again


### Release
These changes do not require release notes.
