### PR TITLE
Sustainer: Purchase Restoration

### DIFF
--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -46,6 +46,24 @@ extension SPSettingsViewController {
         let sustainerAlertController = UIAlertController.buildSustainerAlert()
         present(sustainerAlertController, animated: true)
     }
+
+    @objc
+    func restorePurchases() {
+        guard #available(iOS 15.0, *) else {
+            presentPurchasesRestored(alert: .unsupported)
+            return
+        }
+
+        StoreManager.shared.restorePurchases { isActiveSubscriber in
+            self.presentPurchasesRestored(alert: isActiveSubscriber ? .sustainer : .notFound)
+        }
+    }
+
+    private func presentPurchasesRestored(alert: RestorationAlert) {
+        let alertController = UIAlertController(title: alert.title, message: alert.message, preferredStyle: .alert)
+        alertController.addDefaultActionWithTitle(alert.action)
+        present(alertController, animated: true)
+    }
 }
 
 
@@ -220,5 +238,41 @@ private struct AccountDeletion {
 
     static func successMessage(email: String) -> String {
         String(format: successAlertMessage, email)
+    }
+}
+
+
+// MARK: - RestorationAlert
+//
+struct RestorationAlert {
+    let title: String
+    let message: String
+    let action: String
+}
+
+extension RestorationAlert {
+
+    static var notFound: RestorationAlert {
+        let title = NSLocalizedString("No purchases found", comment: "No purchases Found Title")
+        let message = NSLocalizedString("No previous valid purchases found, for the current period", comment: "No purchases Found Message")
+        let action = NSLocalizedString("Dismiss", comment: "Dismiss Alert")
+
+        return RestorationAlert(title: title, message: message, action: action)
+    }
+
+    static var sustainer: RestorationAlert {
+        let title = NSLocalizedString("Thank You!", comment: "Restoration Successful Title")
+        let message = NSLocalizedString("Sustainer subscription restored. Thank you for supporting Simplenote!", comment: "Restoration Successful Message")
+        let action = NSLocalizedString("Dismiss", comment: "Dismiss Alert")
+
+        return RestorationAlert(title: title, message: message, action: action)
+    }
+
+    static var unsupported: RestorationAlert {
+        let title = NSLocalizedString("Unsupported", comment: "Upgrade Alert Title")
+        let message = NSLocalizedString("Please upgrade to the latest iOS release to restore purchases", comment: "Upgrade Alert Message")
+        let action = NSLocalizedString("Dismiss", comment: "Dismiss Alert")
+
+        return RestorationAlert(title: title, message: message, action: action)
     }
 }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -54,8 +54,13 @@ extension SPSettingsViewController {
             return
         }
 
+        if StoreManager.shared.isActiveSubscriber {
+            presentPurchasesRestored(alert: .alreadySustainer)
+            return
+        }
+
         StoreManager.shared.restorePurchases { isActiveSubscriber in
-            self.presentPurchasesRestored(alert: isActiveSubscriber ? .sustainer : .notFound)
+            self.presentPurchasesRestored(alert: isActiveSubscriber ? .becameSustainer : .notFound)
         }
     }
 
@@ -260,9 +265,17 @@ extension RestorationAlert {
         return RestorationAlert(title: title, message: message, action: action)
     }
 
-    static var sustainer: RestorationAlert {
+    static var becameSustainer: RestorationAlert {
         let title = NSLocalizedString("Thank You!", comment: "Restoration Successful Title")
         let message = NSLocalizedString("Sustainer subscription restored. Thank you for supporting Simplenote!", comment: "Restoration Successful Message")
+        let action = NSLocalizedString("Dismiss", comment: "Dismiss Alert")
+
+        return RestorationAlert(title: title, message: message, action: action)
+    }
+
+    static var alreadySustainer: RestorationAlert {
+        let title = NSLocalizedString("Simplenote Sustainer", comment: "Restoration Successful Title")
+        let message = NSLocalizedString("You're already a Sustainer. Thank you for supporting Simplenote!", comment: "Restoration Successful Message")
         let action = NSLocalizedString("Dismiss", comment: "Dismiss Alert")
 
         return RestorationAlert(title: title, message: message, action: action)

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -36,12 +36,18 @@ typedef NS_ENUM(NSInteger, SPOptionsViewSections) {
     SPOptionsViewSectionsTags           = 1,
     SPOptionsViewSectionsAppearance     = 2,
     SPOptionsViewSectionsSecurity       = 3,
-    SPOptionsViewSectionsAccount        = 4,
-    SPOptionsViewSectionsDelete         = 5,
-    SPOptionsViewSectionsAbout          = 6,
-    SPOptionsViewSectionsHelp           = 7,
-    SPOptionsViewSectionsDebug          = 8,
-    SPOptionsViewSectionsCount          = 9,
+    SPOptionsViewSectionsSustainer      = 4,
+    SPOptionsViewSectionsAccount        = 5,
+    SPOptionsViewSectionsDelete         = 6,
+    SPOptionsViewSectionsAbout          = 7,
+    SPOptionsViewSectionsHelp           = 8,
+    SPOptionsViewSectionsDebug          = 9,
+    SPOptionsViewSectionsCount          = 10,
+};
+
+typedef NS_ENUM(NSInteger, SPOptionsSustainerRow) {
+    SPOptionsSustainerRowRestore        = 0,
+    SPOptionsSustainerRowCount          = 1
 };
 
 typedef NS_ENUM(NSInteger, SPOptionsAccountRow) {
@@ -245,7 +251,11 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             int disabledPinLockRows = [self isBiometryAvailable] ? 2 : 1;
             return [self isPinLockEnabled] ? SPOptionsSecurityRowRowCount - rowsToRemove : disabledPinLockRows;
         }
-            
+
+        case SPOptionsViewSectionsSustainer: {
+            return SPOptionsSustainerRowCount;
+        }
+
         case SPOptionsViewSectionsAccount: {
             return SPOptionsAccountRowCount;
         }
@@ -284,9 +294,12 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             
         case SPOptionsViewSectionsAppearance:
             return NSLocalizedString(@"Appearance", nil);
-            
+
         case SPOptionsViewSectionsSecurity:
             return NSLocalizedString(@"Security", nil);
+
+        case SPOptionsViewSectionsSustainer:
+            return NSLocalizedString(@"Sustainer", nil);
 
         case SPOptionsViewSectionsAccount:
             return NSLocalizedString(@"Account", nil);
@@ -431,6 +444,21 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             }
             
             break;
+
+        } case SPOptionsViewSectionsSustainer: {
+
+            switch (indexPath.row) {
+                case SPOptionsSustainerRowRestore: {
+                    cell.textLabel.text = NSLocalizedString(@"Restore Purchases", @"Manually Restores IAP Purchases");
+                    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            break;
+
         } case SPOptionsViewSectionsAccount:{
             
             switch (indexPath.row) {
@@ -564,6 +592,12 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             }
             
             break;
+
+        } case SPOptionsViewSectionsSustainer: {
+
+            [self restorePurchases];
+            break;
+
         } case SPOptionsViewSectionsAccount: {
             
             switch (indexPath.row) {
@@ -582,6 +616,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             }
             
             break;
+
         } case SPOptionsViewSectionsDelete: {
             switch (indexPath.row) {
                 case SPOptionsDeleteRowTitle: {

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -111,6 +111,19 @@ class StoreManager {
 
         return product.displayPrice
     }
+
+    /// Restores Purchases. Shouldn't be required, but review guideliens dictate we provide an explicit action!
+    ///
+    func restorePurchases(completion: @escaping (Bool) -> Void) {
+        Task {
+            await refreshPurchasedProducts()
+            await refreshSubscriptionGroupStatus()
+
+            Task { @MainActor in
+                completion(isActiveSubscriber)
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
### Details
In this PR we're implementing manual purchase restoration. Not really needed, but required by guidelines.

#1491

### Test: Not Found
1. Fresh install Simplenote
2. Log into your account
3. Open `Settings > Restore Purchases`

- [ ] Verify you get an alert indicating that no previous purchases were found

### Test: Restored
1. Fresh install Simplenote
2. Log into your account
5. Open the sidebar and click on the Sustainer UI
6. Follow thru the IAP flow. Once you get the final alert (`You're all set`) **DO NOT click OK**
7. Stop execution
8. Comment [L82](https://github.com/Automattic/simplenote-ios/blob/trunk/Simplenote/StoreManager.swift#L82) and [L83](https://github.com/Automattic/simplenote-ios/blob/trunk/Simplenote/StoreManager.swift#L83) from StoreManager
9. Relaunch Simplenote
10. Open `Settings` and press over `Restore purchases`

- [ ] Verify you get your Sustainer status restored

### Test: Already Sustainer
1. Fresh install Simplenote
2. Log into your account
3. Become a Sustainer
4. Open `Settings` and tap over `Restore Purchases`

- [ ] Verify that you get an alert indicating that you're already a sustainer

### Release
These changes do not require release notes.
