### PR TITLE
UIAlertController+Sustainer: Switching to Alert

### DIFF
--- a/Simplenote/UIAlertController+Sustainer.swift
+++ b/Simplenote/UIAlertController+Sustainer.swift
@@ -19,7 +19,8 @@ extension UIAlertController {
         let monthlyActionTitle = Localization.monthlyActionTitle(price: manager.displayPrice(for: .sustainerMonthly))
         let yearlyActionTitle = Localization.yearlyActionTitle(price: manager.displayPrice(for: .sustainerYearly))
 
-        let alert = UIAlertController(title: Localization.title, message: Localization.message, preferredStyle: .alert)
+        let style: UIAlertController.Style = UIDevice.isPad ? .alert : .actionSheet
+        let alert = UIAlertController(title: Localization.title, message: Localization.message, preferredStyle: style)
         alert.addActionWithTitle(monthlyActionTitle, style: .default) { _ in
             SPTracker.trackSustainerMonthlyButtonTapped()
             manager.purchase(storeProduct: .sustainerMonthly)

--- a/Simplenote/UIAlertController+Sustainer.swift
+++ b/Simplenote/UIAlertController+Sustainer.swift
@@ -19,7 +19,7 @@ extension UIAlertController {
         let monthlyActionTitle = Localization.monthlyActionTitle(price: manager.displayPrice(for: .sustainerMonthly))
         let yearlyActionTitle = Localization.yearlyActionTitle(price: manager.displayPrice(for: .sustainerYearly))
 
-        let alert = UIAlertController(title: Localization.title, message: Localization.message, preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: Localization.title, message: Localization.message, preferredStyle: .alert)
         alert.addActionWithTitle(monthlyActionTitle, style: .default) { _ in
             SPTracker.trackSustainerMonthlyButtonTapped()
             manager.purchase(storeProduct: .sustainerMonthly)


### PR DESCRIPTION
### Fix
In this PR we're fixing an iPad crasher, triggered after pressing the Sustainer banner.

Closes #1499

### Test
1. Launch Simplenote on an iPad device
2. Open the Sidebar
3. Tap the Sustainer button

- [x] Verify the app doesn't crash

### Release
These changes do not require release notes.
