### PR TITLE
[UI Tests] Always run only full set of UI tests on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,13 +37,6 @@ steps:
   #################
   # UI Tests
   #################
-  - label: "🔬 UI Test (Subset)"
-    command: ".buildkite/commands/build-and-ui-test.sh SimplenoteUITests_Subset 'iPhone SE (3rd generation)'"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/*"
-
   - label: "🔬 UI Test (Full)"
     command: ".buildkite/commands/build-and-ui-test.sh SimplenoteUITests 'iPhone SE (3rd generation)'"
     env: *common_env


### PR DESCRIPTION
### Fix
When CircleCI was used, we followed these rules:

- Run a subset of UI tests on every commit. It took ~10 minutes.
- Run a full set of UI tests only after approval. It takes ~33 minutes.

This was done to save up waiting time in the period of active Simplenote development. The UI provided by CircleCI for jobs requiring an approval was quite accessible - it was visible in the PR itself that there's a job that can be approved.

After migrating to Buildkite, the closest alternative to approval that I found is [Block step](https://buildkite.com/docs/pipelines/block-step), but it has a downside of not showing up in the PR page (example PR #1509). It's only visible when a dedicated Buidkite build page is opened, making it very probable that it will never be used (example):

<img width="1150" alt="Screenshot 2022-11-25 at 13 10 27" src="https://user-images.githubusercontent.com/73365754/203973233-492ec91b-ee27-4cd8-a8c0-5ff5e8b39263.png">


Given the low visibility, and also the low number of commits in this repo nowadays, I opted for running a full set of UI tests every time. This can be reverted fairly easily if needed, since the `SimplenotUITests_Subset` scheme still remains untouched in Xcode project.

### Test
1. Make sure that only the full set of UI tests is [executed on CI](https://buildkite.com/automattic/simplenote-ios/builds/189#0184a991-0087-4206-9b0c-2343db87cf99).
2. Make sure that subset of UI tests is not executed on CI.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

