### PR TITLE
Add higher CI priority to release builds 

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -13,7 +13,7 @@ common_params:
         repo: "automattic/simplenote-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14.0.1
+    IMAGE_ID: xcode-14.2
 
 steps:
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ common_params:
         repo: "automattic/simplenote-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14.0.1
+    IMAGE_ID: xcode-14.2
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/release-build.yml
+++ b/.buildkite/release-build.yml
@@ -10,12 +10,13 @@ common_params:
         repo: "automattic/simplenote-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-14.0.1
+    IMAGE_ID: xcode-14.2
 
 steps:
 
   - label: ":testflight: Simplenote iOS Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build.sh"
+    priority: 1
     env: *common_env
     plugins: *common_plugins
     notify:


### PR DESCRIPTION
### Summary of changes:

This PR increases the priority of release builds on Buildkite. This will be useful so that release builds won't get delayed if the CI queue gets backed up. The default priority of a build is 0, so increasing the release builds to 1 will put them before other builds: https://buildkite.com/docs/pipelines/managing-priorities

I also increased the CI image to Xcode 14.2 while I was changing these files. 