### PR TITLE
Add background color to code block in dark mode preview

### DIFF
--- a/Simplenote/Resources/markdown-dark.css
+++ b/Simplenote/Resources/markdown-dark.css
@@ -20,11 +20,11 @@ html {
 }
 
 .note-detail-markdown pre {
-    background: #f6f7f8;
+    background: #002b36;
 }
 
 .note-detail-markdown pre code {
-    color: #616870;
+    color: #84878a;
 }
 
 .note-detail-markdown table tr:nth-child(2n) {


### PR DESCRIPTION
### Fix
This PR fixes [#1372](https://github.com/Automattic/simplenote-ios/issues/1372)

When using dark mode, the preview note option on the web app shows a dark color scheme for code blocks. The same does not happen when previewing the note from the iOS app. This fix adds a background color to dark mode that matches the same color as found on the web app (#002b36).

![Simplenote-web-app](https://user-images.githubusercontent.com/81433983/224428123-b5a23be4-1a70-4b5f-be66-7513da331b62.png)

### Test
1. Change the theme to Dark
2. Add code block to note
3. Choose to preview the note

![Simplenote-code-block](https://user-images.githubusercontent.com/81433983/224428448-f723493b-59a6-426d-9aa9-535eae1bbd5c.png)

### Review
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.

### Observation

This addresses the code block background color not matching the web app (#002b36).

To add a color scheme similar to that of the web app, it may be worth adding [syntax highlighting](https://www.markdownguide.org/extended-syntax/#syntax-highlighting) to the app's roadmap, if not already done so.
