### PR TITLE
Add large note widget

### DIFF
--- a/SimplenoteWidgets/Widgets/NoteWidget.swift
+++ b/SimplenoteWidgets/Widgets/NoteWidget.swift
@@ -9,7 +9,7 @@ struct NoteWidget: Widget {
         }
         .configurationDisplayName(Constants.displayName)
         .description(Constants.description)
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 
     private func prepareWidgetView(fromEntry entry: NoteWidgetEntry) -> some View {


### PR DESCRIPTION
### Fix #1521 

Adds Large NoteWidget. I concur with the requester that the widget would be a useful option, especially for iPad and iPhones with larger screens.

### Test

1. Long press the empty screen area to bring up the "Add Widget" menu in the top right corner. Tap on the + sign.
2. Search for the Simplenote widget. Tap Simplenote.
3. Swipe to find the Large Note widget. Tap "Add Widget" to add the widget to the screen.

![Add Simplenote Widget Flow](https://user-images.githubusercontent.com/81433983/227839248-b3c5c791-0994-4445-b3e7-2836169b2e44.png)

Tested (in left-to-right order):
- iPod Touch 7th Gen
- iPhone SE 2nd Gen
- iPhone 14 Plus

![iPod touch 7th Gen - SE 2nd Gen - 14 Plus](https://user-images.githubusercontent.com/81433983/227839655-50cd30dc-24f8-48c9-88e9-3933d385519a.png)


Tested on iPad 9th Gen:

![iPad (9th generation)](https://user-images.githubusercontent.com/81433983/227839847-80feb629-b1e4-41b9-ba37-e69a011c82c1.png)

### Review

Reviewer requested.

### Release

`RELEASE-NOTES.txt` updated in [fad7599](https://github.com/Automattic/simplenote-ios/commit/fad7599448e05c765871a88ca217c877199645ae) with:

> - Adds Large NoteWidget support #1521
