### PR TITLE
Update git s3 cache plugin to the latest version

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -8,7 +8,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/a8c-ci-toolkit#2.15.0
-    - automattic/git-s3-cache#v1.1.3:
+    - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/simplenote-ios/"
   # Common environment values to use with the `env` key.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/a8c-ci-toolkit#2.15.0
-    - automattic/git-s3-cache#v1.1.3:
+    - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/simplenote-ios/"
   # Common environment values to use with the `env` key.

--- a/.buildkite/release-build.yml
+++ b/.buildkite/release-build.yml
@@ -5,7 +5,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/a8c-ci-toolkit#2.15.0
-    - automattic/git-s3-cache#v1.1.3:
+    - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/simplenote-ios/"
   # Common environment values to use with the `env` key.


### PR DESCRIPTION
What says in the title. This change is good to go as long as CI passes.