### PR TITLE
[UI Tests] Handle "Save Password" prompt from iOS.

### DIFF
--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/XCUITestHelpers",
       "state" : {
-        "revision" : "2cf059427b0f0362ddd8c14109493141cf710cc8",
-        "version" : "0.2.0"
+        "revision" : "5179cb69d58b90761cc713bdee7740c4889d3295",
+        "version" : "0.4.0"
       }
     }
   ],

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -12,6 +12,7 @@ class EmailLogin {
         guard backButton.isHittable else { return }
 
         backButton.tap()
+        handleSavePasswordPrompt()
     }
 
     class func logIn() {
@@ -33,6 +34,7 @@ class EmailLogin {
         enterEmail(enteredValue: email)
         enterPassword(enteredValue: password)
         app.buttons[UID.Button.logIn].tap()
+        handleSavePasswordPrompt()
     }
 
     class func enterEmail(enteredValue: String) {
@@ -45,5 +47,14 @@ class EmailLogin {
         let field = app.secureTextFields[UID.TextField.password]
         field.tap()
         field.typeText(enteredValue)
+    }
+
+    class func handleSavePasswordPrompt() {
+        // As of Xcode 14.3, the Simulator might ask to save the password which, of course, we don't want to do.
+        if app.buttons["Save Password"].waitForExistence(timeout: 5) {
+            // There should be no need to wait for this button to exist since it's part of the same
+            // alert where "Save Password" is.
+            app.buttons["Not Now"].tap()
+        }
     }
 }

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -3,7 +3,10 @@ import XCTest
 class EmailLogin {
 
     class func open() {
+        app.buttons[UID.Button.logIn].waitForIsHittable()
         app.buttons[UID.Button.logIn].tap()
+        
+        app.buttons[UID.Button.logInWithEmail].waitForIsHittable()
         app.buttons[UID.Button.logInWithEmail].tap()
     }
 


### PR DESCRIPTION
### Fix
The UI tests weren't executed for a really long time, during which the `Save password` prompt was introduced in iOS:

<img width="268" alt="Screenshot 2023-11-02 at 23 07 24" src="https://github.com/Automattic/simplenote-ios/assets/73365754/f2d4580f-2015-4b9b-a633-67aeefa31e84">

The prompt blocked nearly all the tests. This PR adds handling of this prompt (always tapping `No`).

### Test
- CI is 🟢 and [all UI tests are passing](https://buildkite.com/automattic/simplenote-ios/builds/601#018b9190-b0c4-44a2-9ea1-a5a3ee69f5fd/445-1400).