### PR TITLE
GHA Workflow for validating issues

### DIFF
--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -1,0 +1,18 @@
+name: 📝 Validate Issues
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+
+jobs:
+  check-labels-on-issues:
+    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@iangmaia/gha-labels-on-issues-check
+    with:
+      label-format-list: '[
+        "^\[.+\]",
+        "^[[:alnum:]]"
+      ]'
+      label-error-message: '🚫 Please add a type label (e.g. **[Type] Enhancement**) and a feature label (e.g. **Stats**) to this issue.'
+      label-success-message: 'Thanks for reporting! 👍'
+    secrets:
+      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}

--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-labels-on-issues:
-    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@trunk
+    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1.0.0
     with:
       label-format-list: '[
         "^\[.+\]",

--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-labels-on-issues:
-    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@iangmaia/gha-labels-on-issues-check
+    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@trunk
     with:
       label-format-list: '[
         "^\[.+\]",


### PR DESCRIPTION
This PR reimplements our [current Issues check done in Peril](https://github.com/Automattic/peril-settings/blob/master/org/issue/label.ts) with a GHA workflow. It uses the reusable workflow implemented on https://github.com/Automattic/dangermattic/pull/31.

## How to test
This is a bit hard to test as GHA Issue events are only triggered for workflows already on the main branch, and a complete test can be done only once this PR is merged.

I've tested it with a fork on my account. Feel free to create issues and play around with the labels on my forked project: https://github.com/iangmaia/woocommerce-android/