### PR TITLE
Replaced automattic tracks cocoa pod with automattic track SPM

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -25,8 +25,6 @@ abstract_target 'Automattic' do
 
     # Automattic
     #
-    pod 'Automattic-Tracks-iOS', '~> 0.13'
-    #		pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'add/support-for-tracking-crashes'
     pod 'Simperium', '1.9.0'
     pod 'WordPress-Ratings-iOS', '0.0.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,14 +9,7 @@ PODS:
     - AppCenter/Core
   - AppCenter/Distribute (4.4.3):
     - AppCenter/Core
-  - Automattic-Tracks-iOS (0.13.0):
-    - Sentry (~> 7.25)
-    - Sodium (>= 0.9.1)
-    - UIDeviceIdentifier (~> 2.0)
   - Gridicons (0.19)
-  - Sentry (7.31.5):
-    - Sentry/Core (= 7.31.5)
-  - Sentry/Core (7.31.5)
   - Simperium (1.9.0):
     - Simperium/DiffMatchPach (= 1.9.0)
     - Simperium/JRSwizzle (= 1.9.0)
@@ -28,15 +21,12 @@ PODS:
   - Simperium/SocketTrust (1.9.0)
   - Simperium/SPReachability (1.9.0)
   - Simperium/SSKeychain (1.9.0)
-  - Sodium (0.9.1)
-  - UIDeviceIdentifier (2.3.0)
   - WordPress-Ratings-iOS (0.0.2)
   - ZIPFoundation (0.9.15)
 
 DEPENDENCIES:
   - AppCenter (~> 4.4.3)
   - AppCenter/Distribute (~> 4.4.3)
-  - Automattic-Tracks-iOS (~> 0.13)
   - Gridicons (~> 0.18)
   - Simperium (= 1.9.0)
   - WordPress-Ratings-iOS (= 0.0.2)
@@ -45,26 +35,18 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - AppCenter
-    - Automattic-Tracks-iOS
     - Gridicons
-    - Sentry
     - Simperium
-    - Sodium
-    - UIDeviceIdentifier
     - WordPress-Ratings-iOS
     - ZIPFoundation
 
 SPEC CHECKSUMS:
   AppCenter: 3fd04aa1b166e16fdb03ec81dabe488aece83fbd
-  Automattic-Tracks-iOS: 63e55654f500b3e8fb35087e64575e00d12eb2f5
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
-  Sentry: 4c9babff9034785067c896fd580b1f7de44da020
   Simperium: 45d828d68aad71f3449371346f270013943eff78
-  Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
-  UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: 063163dc828bf699c5be160eb4f58f676322d94f
 
-PODFILE CHECKSUM: 9cc274c6be26f2c5d638648574ddf65553445e98
+PODFILE CHECKSUM: 0663a4b2a1777f0957be7a40d3b2f7bf92a7fb64
 
 COCOAPODS: 1.14.1

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -436,6 +436,7 @@
 		BA12B06F26B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA12B06C26B0D0150026F31D /* SPManagedObject+Widget.swift */; };
 		BA12B07026B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA12B06C26B0D0150026F31D /* SPManagedObject+Widget.swift */; };
 		BA18532826488DBC00D9A347 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */; };
+		BA2015BB2B57384F005E59AA /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA2015BA2B57384F005E59AA /* AutomatticTracks */; };
 		BA2D82C6261522F100A1695B /* PublishNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */; };
 		BA3101A926C8C76A00C95F93 /* ListWidgetIntent.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		BA32A90F26B7469F00727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
@@ -1326,6 +1327,7 @@
 				46A3C9B417DFA81A002865AE /* libicucore.dylib in Frameworks */,
 				B5BAF9ED24E4D0D2000917C0 /* SimplenoteFoundation in Frameworks */,
 				46A3C9B517DFA81A002865AE /* CoreFoundation.framework in Frameworks */,
+				BA2015BB2B57384F005E59AA /* AutomatticTracks in Frameworks */,
 				B59CACFC2541E05400958330 /* SimplenoteInterlinks in Frameworks */,
 				46A3C9B617DFA81A002865AE /* SystemConfiguration.framework in Frameworks */,
 				46A3C9B717DFA81A002865AE /* CoreData.framework in Frameworks */,
@@ -2783,6 +2785,7 @@
 				B5BAF9EC24E4D0D2000917C0 /* SimplenoteFoundation */,
 				B50D2FB524E6DFAC00163FC3 /* SimplenoteSearch */,
 				B59CACFB2541E05400958330 /* SimplenoteInterlinks */,
+				BA2015BA2B57384F005E59AA /* AutomatticTracks */,
 			);
 			productName = Simplenote;
 			productReference = 46A3C9D717DFA81A002865AE /* Simplenote.app */;
@@ -3000,6 +3003,7 @@
 				B59CACFA2541E05400958330 /* XCRemoteSwiftPackageReference "SimplenoteInterlinks-Swift" */,
 				3F762E8D2677F19C0088CD45 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				3F4BA07C26CDF295000619B1 /* XCRemoteSwiftPackageReference "ScreenObject" */,
+				BA2015B92B573761005E59AA /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */,
 			);
 			productRefGroup = E29ADD3917848E8500E55842 /* Products */;
 			projectDirPath = "";
@@ -6053,6 +6057,14 @@
 				minimumVersion = 1.2.0;
 			};
 		};
+		BA2015B92B573761005E59AA /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.2.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -6095,6 +6107,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B5BAF9EB24E4D0D2000917C0 /* XCRemoteSwiftPackageReference "SimplenoteFoundation-Swift" */;
 			productName = SimplenoteFoundation;
+		};
+		BA2015BA2B57384F005E59AA /* AutomatticTracks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA2015B92B573761005E59AA /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
+			productName = AutomatticTracks;
 		};
 		BA8662A926B3B40800466746 /* SimplenoteFoundation */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "automattic-tracks-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
+      "state" : {
+        "revision" : "b6979ef69b4b094c8809ba83661222dcd0d7667e",
+        "version" : "3.2.0"
+      }
+    },
+    {
       "identity" : "screenobject",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/ScreenObject",
       "state" : {
         "revision" : "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
         "version" : "0.2.3"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "3b9a8e69ca296bd8cd0e317ad7a448e5daf4a342",
+        "version" : "8.18.0"
       }
     },
     {
@@ -34,6 +52,24 @@
       "state" : {
         "revision" : "499d2809d169fcbeb9ff75568d9f1f937f290ffc",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-sodium",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jedisct1/swift-sodium",
+      "state" : {
+        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "uideviceidentifier",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/squarefrog/UIDeviceIdentifier",
+      "state" : {
+        "revision" : "4699794b08bb79a4d77785edaba6ea739e298e4b",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Simplenote/Classes/SPAutomatticTracker.m
+++ b/Simplenote/Classes/SPAutomatticTracker.m
@@ -1,6 +1,6 @@
 #import "SPAutomatticTracker.h"
 #import "TracksService.h"
-#import "TracksContextManager.h"
+@import AutomatticTracksModelObjC;
 
 
 static NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksUserDefaultsAnonymousUserIDKey";

--- a/Simplenote/SPPrivacyViewController.swift
+++ b/Simplenote/SPPrivacyViewController.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 import Gridicons
-import AutomatticTracks
+//import AutomatticTracks
 
 /// Privacy: Lets our users Opt Out from any (and all) trackers.
 ///


### PR DESCRIPTION
### Fix
Simplenote iOS is currently using tracks version 0.13, which is a little old...  Tracks stopped supporting cocoa pods on version 2 as well. So it seemed like a good idea to update to using the SPM version of tracks and get onto the newest release.  In this PR I have done that.

Relies on #1545 
### Test
***(Required)*** List the steps to test the behavior.  For example:
1. pull the branch and run `rake dependencies` on the repo to update the pods
2. make sure the app can build
3. Trigger a trackable event (like opening the sidebar or making a note)
4. Go to tracks live, wait a while, and then confirm your event comes through.  Be aware that you can't filter SN events by user id, so you will have to find it manually

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.
