### PR TITLE
[UI Tests] Examine / address flakiness in `History` tests.

### DIFF
--- a/.buildkite/commands/build-and-ui-test.sh
+++ b/.buildkite/commands/build-and-ui-test.sh
@@ -22,11 +22,11 @@ if [[ $TESTS_EXIT_STATUS -ne 0 ]]; then
 fi
 
 echo "--- 📦 Zipping test results"
-cd build/results/ && zip -rq Simplenote.xcresult.zip Simplenote.xcresult && cd -
+cd build/results/ && zip -rq SimplenoteUITests.xcresult.zip SimplenoteUITests.xcresult && cd -
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then
-  echo "Unit Tests seems to have passed (exit code 0). All good 👍"
+  echo "UI Tests seems to have passed (exit code 0). All good 👍"
 else
   echo "The UI Tests, ran during the '🛠️ Build and Test' step above, have failed."
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🛠️ Build and Test' section and the \`.xcresult\` and test reports in Buildkite artifacts."

--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/SimplenoteUITests.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/SimplenoteUITests.xcscheme
@@ -21,11 +21,6 @@
                BlueprintName = "SimplenoteUITests"
                ReferencedContainer = "container:Simplenote.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "SimplenoteUISmokeTestsHistory">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Simplenote.xcodeproj/xcshareddata/xcschemes/SimplenoteUITests.xcscheme
+++ b/Simplenote.xcodeproj/xcshareddata/xcschemes/SimplenoteUITests.xcscheme
@@ -21,6 +21,11 @@
                BlueprintName = "SimplenoteUITests"
                ReferencedContainer = "container:Simplenote.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "SimplenoteUISmokeTestsHistory">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -5,7 +5,6 @@ class EmailLogin {
     class func open() {
         app.buttons[UID.Button.logIn].waitForIsHittable()
         app.buttons[UID.Button.logIn].tap()
-        
         app.buttons[UID.Button.logInWithEmail].waitForIsHittable()
         app.buttons[UID.Button.logInWithEmail].tap()
     }
@@ -38,6 +37,7 @@ class EmailLogin {
         enterPassword(enteredValue: password)
         app.buttons[UID.Button.logIn].tap()
         handleSavePasswordPrompt()
+        waitForSpinnerToDisappear()
     }
 
     class func enterEmail(enteredValue: String) {
@@ -59,5 +59,11 @@ class EmailLogin {
             // alert where "Save Password" is.
             app.buttons["Not Now"].tap()
         }
+    }
+
+    class func waitForSpinnerToDisappear() {
+        let predicate   = NSPredicate(format: "exists == false && isHittable == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: app.staticTexts["In progress"])
+        XCTWaiter().wait(for: [ expectation ], timeout: 10)
     }
 }

--- a/SimplenoteUITests/SimplenoteUITestsHistory.swift
+++ b/SimplenoteUITests/SimplenoteUITestsHistory.swift
@@ -5,6 +5,7 @@ class SimplenoteUISmokeTestsHistory: XCTestCase {
 
     override class func setUp() {
         app.launch()
+        EmailLogin.handleSavePasswordPrompt()
         getToAllNotes()
         let _ = attemptLogOut()
         EmailLogin.open()


### PR DESCRIPTION
### Fix
`History` tests demonstrated flakiness. E.g. [here](https://buildkite.com/automattic/simplenote-ios/builds/675#018d193d-0c10-4820-ae34-deae8afdca9a) and [here](https://buildkite.com/automattic/simplenote-ios/builds/690#018d31b7-c8a8-4ffa-aa1b-ea0716f382ae). This was not reproducible locally. The fix consists of two parts:

1. 50279cb9eca76c2bb47c41c90a8c2be5b8c04802: Fix the name of the `xcresult` log file, so that it's actually copied as BK artifact. Without the log, it was not clear what was going wrong on CI.
2. b7f407d87f22a89c821b174e628e90e6186d9c0f: adds handling of "Save Password" to one more place. After finally seeing the video / screenshots from the copied log, it was clear that the tests were blocked because of the "Save Password" prompt which was shown at the test start. Even though this prompt is [handled](https://github.com/Automattic/simplenote-ios/blob/trunk/SimplenoteUITests/EmailLogin.swift#L40) during the login process, in these cases of fails it looks like the Simulator was already launched in logged in state, with this alert being shown, and the tests could not handle it because it wasn't the part of login process. Why was it shown is a mystery to me, theoretically this should not happen because the Sim is [reset](https://github.com/Automattic/simplenote-ios/blob/trunk/fastlane/Fastfile#L844) before each run.

<img width="246" alt="Screenshot 2024-01-23 at 14 23 15" src="https://github.com/Automattic/simplenote-ios/assets/73365754/dc885dda-3f90-4c9d-b81a-71dbd9472f43">


Six subsequent green executions is not a hard proof of the fix success, but this deserves a chance to be tested in action, IMO.

### Test

- For the executed "UI Test" jobs, the "Artifacts" tab now contains the `xcresult` file.
- 6 last executions in this PR are 🟢.

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.
