### PR TITLE
Make sure that updating the subscriptions doesnt remove sustainer status

### DIFF
--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -17,7 +17,6 @@ enum StoreError: Error {
 
 // MARK: - StoreManager
 //
-@available(iOS 15, *)
 class StoreManager {
 
     // MARK: - Static
@@ -122,7 +121,6 @@ class StoreManager {
 
 // MARK: - Private API(s)
 //
-@available(iOS 15, *)
 private extension StoreManager {
 
     func listenForTransactions() -> Task<Void, Error> {
@@ -211,7 +209,6 @@ private extension StoreManager {
 
 // MARK: - Private Helpers
 //
-@available(iOS 15, *)
 private extension StoreManager {
 
     func buildStoreProductMap(products: [Product]) -> [StoreProduct: Product] {
@@ -242,7 +239,6 @@ private extension StoreManager {
 
 // MARK: - Simperium Kung Fu
 //
-@available(iOS 15, *)
 private extension StoreManager {
 
     func refreshSimperiumPreferences(status: SubscriptionStatus?) {
@@ -263,10 +259,6 @@ private extension StoreManager {
             preferences.subscription_level = subscriptionLevel(from: status)
             preferences.subscription_date = subscriptionDate(from: status)
             preferences.subscription_platform = StoreConstants.platform
-        } else {
-            preferences.subscription_date = nil
-            preferences.subscription_level = nil
-            preferences.subscription_platform = nil
         }
 
         simperium.save()
@@ -300,7 +292,6 @@ private extension StoreManager {
 
 // MARK: - SubscriptionStatus Helpers
 //
-@available(iOS 15, *)
 private extension Product.SubscriptionInfo.Status {
 
     var isActive: Bool {


### PR DESCRIPTION
### Fix
Currently if the subscription status of a users account changes in store kit then we will update and sync those values through Simperium.  As we drop the sustainer plan, we don't want to remove these values so we can still identify the previous sustainers.

So in this PR I have made it so that we only update the Simperium values if the subscription status is active.  Since the UI has been removed from the rest of the app this won't effect how the existing sustainers see the app and no new sustainers will be able to sign up.  This should make the subscription level values sticky for all users accounts.


### Test
Nothing really to test here, just verify the code makes sense

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
