### PR TITLE
Persist was sustainer value in preferences

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -6192,7 +6192,7 @@
 				467D9C5D1788A4FB00785EF3 /* Simplenote 2.xcdatamodel */,
 				467D9C5E1788A4FB00785EF3 /* Simplenote.xcdatamodel */,
 			);
-			currentVersion = B54D9C542909B21700D0E0EC /* Simplenote 6.xcdatamodel */;
+			currentVersion = BA16C6A82BC4968400C9079F /* Simplenote 7.xcdatamodel */;
 			name = Simplenote.xcdatamodeld;
 			path = ../Simplenote.xcdatamodeld;
 			sourceTree = "<group>";

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -1121,6 +1121,7 @@
 		BA122DC5265EF90C003D3BC5 /* NewNoteWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteWidgetView.swift; sourceTree = "<group>"; };
 		BA122DC9265F2E2D003D3BC5 /* UIColorSimplenoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorSimplenoteTests.swift; sourceTree = "<group>"; };
 		BA12B06C26B0D0150026F31D /* SPManagedObject+Widget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SPManagedObject+Widget.swift"; sourceTree = "<group>"; };
+		BA16C6A82BC4968400C9079F /* Simplenote 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 7.xcdatamodel"; sourceTree = "<group>"; };
 		BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
 		BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishNoticePresenter.swift; sourceTree = "<group>"; };
 		BA32A90E26B7469F00727247 /* WidgetError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetError.swift; sourceTree = "<group>"; };
@@ -6183,6 +6184,7 @@
 		467D9C5C1788A4FB00785EF3 /* Simplenote.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				BA16C6A82BC4968400C9079F /* Simplenote 7.xcdatamodel */,
 				B54D9C542909B21700D0E0EC /* Simplenote 6.xcdatamodel */,
 				B5526335238881EE009AB3B2 /* Simplenote 5.xcdatamodel */,
 				B594E60C21508170001577EE /* Simplenote 4.xcdatamodel */,

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -45,6 +45,11 @@ extension SPSettingsViewController {
     }
 
     @objc
+    var wasSustainer: Bool {
+        SPAppDelegate.shared().simperium.preferencesObject().was_sustainer == true
+    }
+
+    @objc
     func sustainerSwitchDidChangeValue(sender: UISwitch) {
         let isOn = sender.isOn
 

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -40,13 +40,9 @@ fileprivate extension SPSettingsViewController {
 
 extension SPSettingsViewController {
     @objc
-    var isActiveSustainer: Bool {
-        SPAppDelegate.shared().simperium.preferencesObject().isActiveSubscriber
-    }
-
-    @objc
-    var wasSustainer: Bool {
-        SPAppDelegate.shared().simperium.preferencesObject().was_sustainer == true
+    var showSustainerSwitch: Bool {
+        let preferences = SPAppDelegate.shared().simperium.preferencesObject()
+        return preferences.isActiveSubscriber || preferences.wasSustainer
     }
 
     @objc

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -219,8 +219,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
         }
             
         case SPOptionsViewSectionsAppearance: {
-            BOOL showSustainerSwitch = self.isActiveSustainer || self.wasSustainer;
-            return showSustainerSwitch ? SPOptionsAppearanceRowCount : SPOptionsAppearanceRowCount - 1;
+            return self.showSustainerSwitch ? SPOptionsAppearanceRowCount : SPOptionsAppearanceRowCount - 1;
         }
 
         case SPOptionsViewSectionsSecurity: {

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -219,7 +219,8 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
         }
             
         case SPOptionsViewSectionsAppearance: {
-            return [self isActiveSustainer] ? SPOptionsAppearanceRowCount : SPOptionsAppearanceRowCount - 1;
+            BOOL showSustainerSwitch = self.isActiveSustainer || self.wasSustainer;
+            return showSustainerSwitch ? SPOptionsAppearanceRowCount : SPOptionsAppearanceRowCount - 1;
         }
 
         case SPOptionsViewSectionsSecurity: {

--- a/Simplenote/Classes/Simperium+Simplenote.swift
+++ b/Simplenote/Classes/Simperium+Simplenote.swift
@@ -61,4 +61,5 @@ extension Simperium {
 //
 extension Simperium {
     static let accountBucketName = "Account"
+    static let preferencesLastChangedSignatureKey = "lastChangeSignature-Preferences"
 }

--- a/Simplenote/Classes/UserDefaults+Simplenote.swift
+++ b/Simplenote/Classes/UserDefaults+Simplenote.swift
@@ -16,6 +16,7 @@ extension UserDefaults {
         case useBiometryInsteadOfPin = "SimplenoteUseTouchID"
         case accountIsLoggedIn
         case useSustainerIcon
+        case hasMigratedSustainerPreferences
     }
 }
 

--- a/Simplenote/Preferences+IAP.swift
+++ b/Simplenote/Preferences+IAP.swift
@@ -16,4 +16,9 @@ extension Preferences {
     var isActiveSubscriber: Bool {
         subscription_level == StoreConstants.activeSubscriptionLevel
     }
+
+    @objc
+    var wasSustainer: Bool {
+        was_sustainer == true
+    }
 }

--- a/Simplenote/Preferences.h
+++ b/Simplenote/Preferences.h
@@ -10,4 +10,6 @@
 @property (nullable, nonatomic,   copy) NSString            *subscription_level;
 @property (nullable, nonatomic,   copy) NSString            *subscription_platform;
 
+@property (nullable, nonatomic,   copy) NSNumber            *was_sustainer;
+
 @end

--- a/Simplenote/Preferences.m
+++ b/Simplenote/Preferences.m
@@ -16,6 +16,8 @@
 @dynamic subscription_level;
 @dynamic subscription_platform;
 
+@dynamic was_sustainer;
+
 
 - (void) didChangeValueForKey:(NSString *)key
 {

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -507,13 +507,13 @@ extension SPAppDelegate {
 
 // MARK: - Sustainer migration
 extension SPAppDelegate {
-    @objc 
+    @objc
     func migrateSimperiumPreferencesIfNeeded() {
         guard UserDefaults.standard.bool(forKey: .hasMigratedSustainerPreferences) == false else {
             return
         }
 
-        guard Options.shared.firstLaunch == false else {
+        guard isFirstLaunch() == false else {
             UserDefaults.standard.set(true, forKey: .hasMigratedSustainerPreferences)
             return
         }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -513,7 +513,7 @@ extension SPAppDelegate {
             return
         }
 
-        guard UserDefaults.standard.bool(forKey: .firstLaunch) == false else {
+        guard Options.shared.firstLaunch == false else {
             UserDefaults.standard.set(true, forKey: .hasMigratedSustainerPreferences)
             return
         }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -518,6 +518,7 @@ extension SPAppDelegate {
             return
         }
 
+        NSLog("Migrating Simperium Preferences object to include was_sustainer value")
         UserDefaults.standard.removeObject(forKey: Simperium.preferencesLastChangedSignatureKey)
         let prefs = simperium.preferencesObject()
         prefs.ghostData = ""

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -509,8 +509,12 @@ extension SPAppDelegate {
 extension SPAppDelegate {
     @objc 
     func migrateSimperiumPreferencesIfNeeded() {
-        guard UserDefaults.standard.bool(forKey: .firstLaunch) == false,
-              UserDefaults.standard.bool(forKey: .hasMigratedSustainerPreferences) == false else {
+        guard UserDefaults.standard.bool(forKey: .hasMigratedSustainerPreferences) == false else {
+            return
+        }
+
+        guard UserDefaults.standard.bool(forKey: .firstLaunch) == false else {
+            UserDefaults.standard.set(true, forKey: .hasMigratedSustainerPreferences)
             return
         }
 

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -504,3 +504,21 @@ extension SPAppDelegate {
         WidgetController.syncWidgetDefaults(authenticated: authenticated, sortMode: sortMode)
     }
 }
+
+// MARK: - Sustainer migration
+extension SPAppDelegate {
+    @objc 
+    func migrateSimperiumPreferencesIfNeeded() {
+        guard UserDefaults.standard.bool(forKey: .firstLaunch) == false,
+              UserDefaults.standard.bool(forKey: .hasMigratedSustainerPreferences) == false else {
+            return
+        }
+
+        UserDefaults.standard.removeObject(forKey: Simperium.preferencesLastChangedSignatureKey)
+        let prefs = simperium.preferencesObject()
+        prefs.ghostData = ""
+        simperium.saveWithoutSyncing()
+
+        UserDefaults.standard.set(true, forKey: .hasMigratedSustainerPreferences)
+    }
+}

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -45,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)save;
 - (void)logoutAndReset:(id)sender;
+- (BOOL)isFirstLaunch;
 
 + (SPAppDelegate *)sharedDelegate;
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -131,6 +131,8 @@
     [self setupDefaultWindow];
     [self configureStateRestoration];
 
+    [self migrateSimperiumPreferencesIfNeeded];
+    
     return YES;
 }
 

--- a/Simplenote/Simplenote.xcdatamodeld/.xccurrentversion
+++ b/Simplenote/Simplenote.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Simplenote 6.xcdatamodel</string>
+	<string>Simplenote 7.xcdatamodel</string>
 </dict>
 </plist>

--- a/Simplenote/Simplenote.xcdatamodeld/Simplenote 7.xcdatamodel/contents
+++ b/Simplenote/Simplenote.xcdatamodeld/Simplenote 7.xcdatamodel/contents
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23E214" minimumToolsVersion="Xcode 7.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+    <entity name="Note" representedClassName="Note" parentEntity="SPManagedObject" syncable="YES">
+        <attribute name="content" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="deleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastPosition" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES">
+            <userInfo>
+                <entry key="spDisableSync" value="value"/>
+            </userInfo>
+        </attribute>
+        <attribute name="modificationDate" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="noteSynced" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES">
+            <userInfo>
+                <entry key="spDisableSync" value="value"/>
+            </userInfo>
+        </attribute>
+        <attribute name="owner" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="pinned" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES">
+            <userInfo>
+                <entry key="spDisableSync" value="value"/>
+            </userInfo>
+        </attribute>
+        <attribute name="publishURL" attributeType="String" syncable="YES"/>
+        <attribute name="remoteId" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="spDisableSync" value="value"/>
+            </userInfo>
+        </attribute>
+        <attribute name="shareURL" attributeType="String" syncable="YES"/>
+        <attribute name="systemTags" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="spOverride" value="jsonlist"/>
+            </userInfo>
+        </attribute>
+        <attribute name="tags" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="spOverride" value="jsonlist"/>
+            </userInfo>
+        </attribute>
+    </entity>
+    <entity name="Preferences" representedClassName="Preferences" syncable="YES">
+        <attribute name="analytics_enabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="ghostData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="recent_searches" optional="YES" attributeType="Transformable" valueTransformerName="" syncable="YES"/>
+        <attribute name="simperiumKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subscription_date" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="subscription_level" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subscription_platform" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="was_sustainer" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+    </entity>
+    <entity name="Settings" representedClassName="Settings" syncable="YES">
+        <attribute name="decline_skip_versions" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dislike_skip_versions" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="ghostData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="like_skip_versions" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="minimum_events" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="minimum_interval_days" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="ratings_disabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="simperiumKey" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SPManagedObject" representedClassName="SPManagedObject" isAbstract="YES" syncable="YES">
+        <attribute name="ghostData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="simperiumKey" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Tag" representedClassName="Tag" parentEntity="SPManagedObject" syncable="YES">
+        <attribute name="index" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="share" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="spOverride" value="jsonlist"/>
+            </userInfo>
+        </attribute>
+    </entity>
+</model>

--- a/Simplenote/Simplenote.xcdatamodeld/Simplenote 7.xcdatamodel/contents
+++ b/Simplenote/Simplenote.xcdatamodeld/Simplenote 7.xcdatamodel/contents
@@ -40,14 +40,14 @@
         </attribute>
     </entity>
     <entity name="Preferences" representedClassName="Preferences" syncable="YES">
-        <attribute name="analytics_enabled" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="analytics_enabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="ghostData" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="recent_searches" optional="YES" attributeType="Transformable" valueTransformerName="" syncable="YES"/>
         <attribute name="simperiumKey" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="subscription_date" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="subscription_level" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="subscription_platform" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="was_sustainer" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="was_sustainer" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
     </entity>
     <entity name="Settings" representedClassName="Settings" syncable="YES">
         <attribute name="decline_skip_versions" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>


### PR DESCRIPTION
### Fix
We currently check to see if a user is an active sustainer if they have a subscription level that is set to sustainer.  Since we are going to drop that value, in the future we may want to be able to identify which users were once sustainers.  We have added a value for this in the user preferences, but need to be able to store and parse that information on the iOS client.

In this PR I have done that.  I have also created a migration so that existing clients will be able to pickup and store the value into their user preferences.

As a bonus I noticed that a fresh install of the app will override some existing in the preferences bucket with the app install defaults.  This isn't ideal as it clears the `was_sustainer` value and more importantly it clears `analytics_enabled`. I have removed the defaults for these values so when a new install happens and we fetch the preferences for the first time the local preferences are populated with the server values.

As a bonus I think this fixes #1442 will need to do some testing on that to confirm

### Test
1. on trunk, log into an account that has `was_sustainer` marked as true (contact me directly if you need steps to set that)
2. just to confirm, also go to Settings > Privacy and disable Share Analytics.
3. Stop running, checkout this branch.  In Xcode filter the logs for `Preferences`
4. run this branch.  After the app launches:

- [x] confirm you see `Migrating Simperium Preferences object to include was_sustainer value` in the logs
- [x] confirm you see simperium has pulled values for preferences, you are looking for something like

```
Simperium client ios-26bdebdd58cc46b79f002e1fe840a65a received change (Preferences) ios-26bdebdd58cc46b79f002e1fe840a65a [M] : {
    ccids =     (
        e59671b66ce24824aa8158e517b7de9b
    );
    clientid = "ios-26bdebdd58cc46b79f002e1fe840a65a";
    cv = 6615aa48d9b5bb0a654fb674;
    ev = 16;
    id = "preferences-key";
    o = M;
    sv = 15;
    v =     {
    "was_sustainer" : {
      "o" : "+",
      "v" : 1
    },
        "analytics_enabled" =         {
            o = r;
            v = 0;
        };
    };
}
```

- [x] Go to settings > Privacy and confirm that analytics are disabled


### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer if required to review these changes, but anyone can perform the review.
