### PR TITLE
Updated rake file to fix bundle install --path depreciation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'English'
 XCODE_WORKSPACE = 'Simplenote.xcworkspace'
 XCODE_SCHEME = 'Simplenote'
 XCODE_CONFIGURATION = 'Debug'
+LOCAL_PATH = "vendor/bundle"
 
 require 'fileutils'
 require 'tmpdir'
@@ -36,7 +37,8 @@ namespace :dependencies do
 
   namespace :bundle do
     task :check do
-      sh 'bundle check --path=${BUNDLE_PATH:-vendor/bundle} > /dev/null', verbose: false do |ok, _res|
+      sh "bundle config set --local path #{LOCAL_PATH} > /dev/null", verbose: false
+      sh 'bundle check > /dev/null', verbose: false do |ok, _res|
         next if ok
 
         # bundle check exits with a non zero code if install is needed
@@ -47,7 +49,7 @@ namespace :dependencies do
 
     task :install do
       fold('install.bundler') do
-        sh 'bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}'
+        sh 'bundle install --jobs=3 --retry=3'
       end
     end
     CLOBBER << 'vendor/bundle'

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'English'
 XCODE_WORKSPACE = 'Simplenote.xcworkspace'
 XCODE_SCHEME = 'Simplenote'
 XCODE_CONFIGURATION = 'Debug'
-LOCAL_PATH = "vendor/bundle"
+LOCAL_PATH = 'vendor/bundle'
 
 require 'fileutils'
 require 'tmpdir'


### PR DESCRIPTION
### Fix
While working on SNiOS I noticed that bundle has depreciated using `--path` when invoking commands and suggests setting a config path value instead.

```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using this flag
```

In this PR I have updated the rake file to fix this depreciation

### Test
1.  The bundle commands only run and show anything if it has to do work, so in terminal go to the SNiOS folder and type `bundle exec gem uninstall nokogiri 1.15.4`. Hit yes a couple of times to remove this gem
2. type `rake dependencies`
3. confirm that bundler runs without any depreciation notices

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
