### PR TITLE
Fixed an issue where note tableview cells highlighted before selection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 4.51
 -----
-
+- Fixed issue where note cell appearance changes on press down instead of when the cell is selected
 
 4.50
 -----

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -345,6 +345,15 @@ extension SPNoteTableViewCell {
 
         return max(result.rounded(.up), Constants.minCellHeight)
     }
+
+    // Ref: https://github.com/Automattic/simplenote-ios/issues/1307
+    // setHighlighted gets called on press down and on setSelected.  This causes the highlighting to change on press down but selection is on press up
+    // By only updating the highlighting if the cell is the cell is selected fixes this issue
+    override func setHighlighted(_ highlighted: Bool, animated: Bool) {
+        if isSelected {
+            super.setHighlighted(highlighted, animated: animated)
+        }
+    }
 }
 
 // MARK: - Cell Styles


### PR DESCRIPTION
### Fix
So... right now if you are in multiselect on the notes list and you tap on a note, the highlighting for the cell changes on press down events, but the selection changes on press up.  Because you can scroll after pressing down this can create a weird experience where it seems like you selected a cell (but you haven't) then you start swiping and the selection disappears (but it wasn't ever selected) This experience is a little bizarre.

In this PR I have updated the note list cells to only change their highlighting if the cell is selected.  `setHighlighting` is called on press down and on `setSelected` so we can piggy back off both of those calls to only update the high lighting if the cell is selected.

### Test
1. Open up Simplenote and long press on a note.  Choose select to enter multi select
2. on a cell that is not selected, press down on it but don't lift your finger.  Confirm that the cell appearance doesn't change. 
3. Lift your finger and confirm that the appearance changes to being selected.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in c46161 with:
> 
> > Fixed issue where note cell appearance changes on press down instead of when the cell is selected

