### PR TITLE
Drop collaboration Step 1

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -518,6 +518,7 @@
 		BABFFF2226CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2326CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2426CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
+		BAC7264E2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC7264D2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift */; };
 		BAE08626261282D1009D40CD /* Note+Publish.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE08625261282D1009D40CD /* Note+Publish.swift */; };
 		BAE63CAF26E05312002BF81A /* NSString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */; };
 		BAE63CB026E05313002BF81A /* NSString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */; };
@@ -1181,6 +1182,7 @@
 		BAB576BD2670512C00B0C56F /* NoteWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWidget.swift; sourceTree = "<group>"; };
 		BAB6C04626BA4CAF007495C4 /* WidgetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetController.swift; sourceTree = "<group>"; };
 		BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDefaults.swift; sourceTree = "<group>"; };
+		BAC7264D2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPAddCollaboratorsViewController.swift; sourceTree = "<group>"; };
 		BAE08625261282D1009D40CD /* Note+Publish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Publish.swift"; sourceTree = "<group>"; };
 		BAF4A96E26DB085D00C51C1D /* NSURLComponents+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSURLComponents+Simplenote.swift"; sourceTree = "<group>"; };
 		BAF8D42226AE10F100CA9383 /* Tag+Widget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tag+Widget.swift"; sourceTree = "<group>"; };
@@ -2640,6 +2642,7 @@
 				E2F1497F179D8E1A00DC9690 /* Settings */,
 				E25C39CE17A41F3400B2591A /* SPAddCollaboratorsViewController.h */,
 				E25C39CF17A41F3400B2591A /* SPAddCollaboratorsViewController.m */,
+				BAC7264D2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift */,
 				E2EAE38117C2C2D400268682 /* SPEntryListViewController.h */,
 				E2EAE38217C2C2D400268682 /* SPEntryListViewController.m */,
 				E215C790180B115C00AD36B5 /* SPNavigationController.h */,
@@ -3394,6 +3397,7 @@
 				B531090823D0B685002B0998 /* SPSimpleTextPrintFormatter.swift in Sources */,
 				B5CDE61F2150834C00C3FED4 /* Simperium+Simplenote.m in Sources */,
 				A60A1A1E25655D840041701E /* ApplicationShortcutItemType.swift in Sources */,
+				BAC7264E2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift in Sources */,
 				B51F6DD12460C3EE0074DDD9 /* AuthenticationValidator.swift in Sources */,
 				B575736A232C567000443C2E /* UIImage+Dynamic.swift in Sources */,
 				A60DF31025A4524100FDADF3 /* PinLockBaseController.swift in Sources */,

--- a/Simplenote/BannerView.swift
+++ b/Simplenote/BannerView.swift
@@ -96,7 +96,7 @@ class BannerView: UIView {
         }
 
         static var collaborationRetirement: Style {
-            Style(title: NSLocalizedString("Collaboration Retirement", comment: "Title annoucning collaboration retirement"), details: NSLocalizedString("Collaboration is being retired and will be disabled for all users July 1st.  For more details tap here", comment: "Description for retiring collaboration feature"), textColor: .white, backgroundColor: .simplenoteBlue50Color)
+            Style(title: NSLocalizedString("Collaboration Retirement", comment: "Title annoucning collaboration retirement"), details: NSLocalizedString("Collaboration is retiring on July 1st.  For more details tap here.", comment: "Description for retiring collaboration feature"), textColor: .white, backgroundColor: .simplenoteBlue50Color)
         }
     }
 

--- a/Simplenote/BannerView.swift
+++ b/Simplenote/BannerView.swift
@@ -27,7 +27,11 @@ class BannerView: UIView {
         }
     }
 
-    var onPress: (() -> Void)?
+    var onPress: (() -> Void)? {
+        didSet {
+            setupTapRecognizer()
+        }
+    }
 
     var preferredWidth: CGFloat? {
         didSet {
@@ -48,17 +52,17 @@ class BannerView: UIView {
 
     // MARK: - Actions
 
-    @IBAction
-    func bannerWasPresssed() {
+    @objc
+    func bannerWasPressed() {
         onPress?()
     }
-}
 
-// MARK: - Private API(s)
-//
-private extension BannerView {
+    private func setupTapRecognizer() {
+        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(bannerWasPressed))
+        backgroundView.addGestureRecognizer(tapRecognizer)
+    }
 
-    func refreshInterface(with style: Style? = nil) {
+    func refreshInterface(with style: BannerStyle? = nil) {
         guard let style else {
             return
         }
@@ -74,27 +78,31 @@ private extension BannerView {
 
 // MARK: - Style
 //
-private struct Style {
+struct BannerStyle {
     let title: String
     let details: String
     let textColor: UIColor
     let backgroundColor: UIColor
 }
 
-private extension Style {
+extension BannerStyle {
     // Leaving these styles in cause we may want them back someday
-    static var sustainer: Style {
-        Style(title: NSLocalizedString("You are a Simplenote Sustainer", comment: "Current Sustainer Title"),
+    static var sustainer: BannerStyle {
+        BannerStyle(title: NSLocalizedString("You are a Simplenote Sustainer", comment: "Current Sustainer Title"),
               details: NSLocalizedString("Thank you for your continued support", comment: "Current Sustainer Details"),
               textColor: .white,
               backgroundColor: .simplenoteSustainerViewBackgroundColor)
     }
 
-    static var notSubscriber: Style {
-        Style(title: NSLocalizedString("Become a Simplenote Sustainer", comment: "Become a Sustainer Title"),
+    static var notSubscriber: BannerStyle {
+        BannerStyle(title: NSLocalizedString("Become a Simplenote Sustainer", comment: "Become a Sustainer Title"),
               details: NSLocalizedString("Support your favorite notes app to help unlock future features", comment: "Become a Sustainer Details"),
               textColor: .white,
               backgroundColor: .simplenoteBlue50Color)
+    }
+
+    static var collaborationRetirement: BannerStyle {
+        BannerStyle(title: NSLocalizedString("Collaboration Retirement", comment: "Title annoucning collaboration retirement"), details: NSLocalizedString("Collaboration is being retired and will be disabled for all users July 1st.  For more details tap here", comment: "Description for retiring collaboration feature"), textColor: .white, backgroundColor: .simplenoteBlue50Color)
     }
 }
 

--- a/Simplenote/BannerView.swift
+++ b/Simplenote/BannerView.swift
@@ -96,7 +96,7 @@ class BannerView: UIView {
         }
 
         static var collaborationRetirement: Style {
-            Style(title: NSLocalizedString("Collaboration Retirement", comment: "Title annoucning collaboration retirement"), details: NSLocalizedString("Collaboration is retiring on July 1st.  For more details tap here.", comment: "Description for retiring collaboration feature"), textColor: .white, backgroundColor: .simplenoteBlue50Color)
+            Style(title: NSLocalizedString("Collaboration Retirement", comment: "Title announcing collaboration retirement"), details: NSLocalizedString("Collaboration is retiring on July 1st, 2024. For more details, tap here.", comment: "Description for retiring collaboration feature"), textColor: .white, backgroundColor: .simplenoteBlue50Color)
         }
     }
 

--- a/Simplenote/BannerView.swift
+++ b/Simplenote/BannerView.swift
@@ -59,7 +59,7 @@ class BannerView: UIView {
         backgroundView.addGestureRecognizer(tapRecognizer)
     }
 
-    func refreshInterface(with style: BannerStyle? = nil) {
+    func refreshInterface(with style: BannerView.Style? = nil) {
         guard let style else {
             return
         }
@@ -71,36 +71,35 @@ class BannerView: UIView {
         backgroundView.backgroundColor = style.backgroundColor
         backgroundView.layer.cornerRadius = Metrics.defaultCornerRadius
     }
-}
 
-// MARK: - Style
-//
-struct BannerStyle {
-    let title: String
-    let details: String
-    let textColor: UIColor
-    let backgroundColor: UIColor
-}
+    // MARK: - Style
+    //
+    struct Style {
+        let title: String
+        let details: String
+        let textColor: UIColor
+        let backgroundColor: UIColor
 
-extension BannerStyle {
-    // Leaving these styles in cause we may want them back someday
-    static var sustainer: BannerStyle {
-        BannerStyle(title: NSLocalizedString("You are a Simplenote Sustainer", comment: "Current Sustainer Title"),
-              details: NSLocalizedString("Thank you for your continued support", comment: "Current Sustainer Details"),
-              textColor: .white,
-              backgroundColor: .simplenoteSustainerViewBackgroundColor)
+        // Leaving these styles in cause we may want them back someday
+        static var sustainer: Style {
+            Style(title: NSLocalizedString("You are a Simplenote Sustainer", comment: "Current Sustainer Title"),
+                  details: NSLocalizedString("Thank you for your continued support", comment: "Current Sustainer Details"),
+                  textColor: .white,
+                  backgroundColor: .simplenoteSustainerViewBackgroundColor)
+        }
+
+        static var notSubscriber: Style {
+            Style(title: NSLocalizedString("Become a Simplenote Sustainer", comment: "Become a Sustainer Title"),
+                  details: NSLocalizedString("Support your favorite notes app to help unlock future features", comment: "Become a Sustainer Details"),
+                  textColor: .white,
+                  backgroundColor: .simplenoteBlue50Color)
+        }
+
+        static var collaborationRetirement: Style {
+            Style(title: NSLocalizedString("Collaboration Retirement", comment: "Title annoucning collaboration retirement"), details: NSLocalizedString("Collaboration is being retired and will be disabled for all users July 1st.  For more details tap here", comment: "Description for retiring collaboration feature"), textColor: .white, backgroundColor: .simplenoteBlue50Color)
+        }
     }
 
-    static var notSubscriber: BannerStyle {
-        BannerStyle(title: NSLocalizedString("Become a Simplenote Sustainer", comment: "Become a Sustainer Title"),
-              details: NSLocalizedString("Support your favorite notes app to help unlock future features", comment: "Become a Sustainer Details"),
-              textColor: .white,
-              backgroundColor: .simplenoteBlue50Color)
-    }
-
-    static var collaborationRetirement: BannerStyle {
-        BannerStyle(title: NSLocalizedString("Collaboration Retirement", comment: "Title annoucning collaboration retirement"), details: NSLocalizedString("Collaboration is being retired and will be disabled for all users July 1st.  For more details tap here", comment: "Description for retiring collaboration feature"), textColor: .white, backgroundColor: .simplenoteBlue50Color)
-    }
 }
 
 // MARK: - Metrics

--- a/Simplenote/BannerView.swift
+++ b/Simplenote/BannerView.swift
@@ -27,11 +27,7 @@ class BannerView: UIView {
         }
     }
 
-    var onPress: (() -> Void)? {
-        didSet {
-            setupTapRecognizer()
-        }
-    }
+    var onPress: (() -> Void)?
 
     var preferredWidth: CGFloat? {
         didSet {
@@ -48,6 +44,7 @@ class BannerView: UIView {
     override func awakeFromNib() {
         super.awakeFromNib()
         refreshInterface()
+        setupTapRecognizer()
     }
 
     // MARK: - Actions

--- a/Simplenote/BannerView.xib
+++ b/Simplenote/BannerView.xib
@@ -10,12 +10,6 @@
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
-        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tapGestureRecognizer id="4op-51-Dvd">
-            <connections>
-                <action selector="bannerWasPresssed" destination="H3q-Rz-XVn" id="Nhw-t0-Xiw"/>
-            </connections>
-        </tapGestureRecognizer>
         <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" id="H3q-Rz-XVn" userLabel="BannerView" customClass="BannerView" customModule="Simplenote" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="390" height="72"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -90,10 +84,10 @@
                 <outlet property="titleLabel" destination="xLW-HX-XmH" id="G19-ww-50A"/>
                 <outlet property="topConstraint" destination="SUn-BD-pzh" id="e9F-8I-nc7"/>
                 <outlet property="widthConstraint" destination="kYU-Lx-Xbh" id="yEN-6g-UV9"/>
-                <outletCollection property="gestureRecognizers" destination="4op-51-Dvd" appends="YES" id="gpV-aI-zul"/>
             </connections>
             <point key="canvasLocation" x="87.692307692307693" y="-258.05687203791467"/>
         </view>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>
     <resources>
         <image name="simplenote-logo" width="64" height="64"/>

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.h
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.h
@@ -5,6 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SPAddCollaboratorsViewController;
+@class BannerView;
 @protocol SPCollaboratorDelegate <NSObject>
 
 @required
@@ -20,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SPAddCollaboratorsViewController : SPEntryListViewController
 
+@property (nonatomic, strong) BannerView *bannerView;
 @property (nonatomic, nullable, weak) id<SPCollaboratorDelegate> collaboratorDelegate;
 
 - (void)setupWithCollaborators:(NSArray<NSString *> *)collaborators;

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.m
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.m
@@ -50,6 +50,7 @@
     [self.primaryTableView reloadData];
     [self.contactsManager requestAuthorizationIfNeededWithCompletion:nil];
     [self setupBannerView];
+    [self setupViewContraints];
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.m
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.m
@@ -49,6 +49,7 @@
 
     [primaryTableView reloadData];
     [self.contactsManager requestAuthorizationIfNeededWithCompletion:nil];
+    [self setupBannerView];
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/Simplenote/Classes/SPAddCollaboratorsViewController.m
+++ b/Simplenote/Classes/SPAddCollaboratorsViewController.m
@@ -47,7 +47,7 @@
 {
     [super viewWillAppear:animated];
 
-    [primaryTableView reloadData];
+    [self.primaryTableView reloadData];
     [self.contactsManager requestAuthorizationIfNeededWithCompletion:nil];
     [self setupBannerView];
 }
@@ -114,7 +114,7 @@
 
     self.dataSource = [[[merged allObjects] sortedArrayUsingSelector:@selector(compareName:)] mutableCopy];
 
-    [primaryTableView reloadData];
+    [self.primaryTableView reloadData];
 }
 
 
@@ -127,7 +127,7 @@
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    if ([tableView isEqual:primaryTableView]) {
+    if ([tableView isEqual:self.primaryTableView]) {
         return self.dataSource.count;
     }
 
@@ -136,7 +136,7 @@
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
-    if ([tableView isEqual:primaryTableView]) {
+    if ([tableView isEqual:self.primaryTableView]) {
         return self.dataSource.count > 0 ? NSLocalizedString(@"Current Collaborators", nil) : nil;
     }
 
@@ -145,7 +145,7 @@
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    if ([tableView isEqual:primaryTableView]) {
+    if ([tableView isEqual:self.primaryTableView]) {
         if (self.dataSource.count > 0) {
             return nil;
         } else {
@@ -161,7 +161,7 @@
     SPEntryListCell *cell = (SPEntryListCell *)[super tableView:tableView cellForRowAtIndexPath:indexPath];
     PersonTag *personTag;
 
-    if ([tableView isEqual:primaryTableView]) {
+    if ([tableView isEqual:self.primaryTableView]) {
         personTag = self.dataSource[indexPath.row];
     } else {
         personTag = self.autoCompleteDataSource[indexPath.row];
@@ -192,7 +192,7 @@
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
     cell.selected = NO;
     
-    if ([tableView isEqual:primaryTableView]) {
+    if ([tableView isEqual:self.primaryTableView]) {
 
         PersonTag *person = self.dataSource[indexPath.row];
         person.active = !person.active;
@@ -228,7 +228,7 @@
         [self.dataSource addObject:person];
         
         entryTextField.text = @"";
-        [primaryTableView reloadSections:[NSIndexSet indexSetWithIndex:0]
+        [self.primaryTableView reloadSections:[NSIndexSet indexSetWithIndex:0]
                       withRowAnimation:UITableViewRowAnimationAutomatic];
         
         [self updateAutoCompleteMatchesForString:nil];

--- a/Simplenote/Classes/SPEntryListViewController.h
+++ b/Simplenote/Classes/SPEntryListViewController.h
@@ -9,6 +9,8 @@
 #import <UIKit/UIKit.h>
 #import "SPTextField.h"
 
+static CGFloat const EntryListCellHeight = 44;
+
 @interface SPEntryListViewController : UIViewController <UITableViewDataSource, UITableViewDelegate, UITextFieldDelegate> {
     
     SPTextField *entryTextField;

--- a/Simplenote/Classes/SPEntryListViewController.h
+++ b/Simplenote/Classes/SPEntryListViewController.h
@@ -11,14 +11,14 @@
 
 @interface SPEntryListViewController : UIViewController <UITableViewDataSource, UITableViewDelegate, UITextFieldDelegate> {
     
-    UITableView *primaryTableView;
-    UIView *entryFieldBackground;
     SPTextField *entryTextField;
     UIButton *entryFieldPlusButton;
     UITableView *autoCompleteTableView;
 
 }
 
+@property (nonatomic, strong) UITableView *primaryTableView;
+@property (nonatomic, strong) UIView *entryFieldBackground;
 @property (nonatomic, strong) NSMutableArray *dataSource;
 @property (nonatomic, strong) NSArray *autoCompleteDataSource;
 @property (nonatomic) BOOL showEntryFieldPlusButton;

--- a/Simplenote/Classes/SPEntryListViewController.m
+++ b/Simplenote/Classes/SPEntryListViewController.m
@@ -32,7 +32,7 @@ static CGFloat const EntryListCellHeight = 44;
 - (void)viewWillAppear:(BOOL)animated {
     
     [super viewWillAppear:animated];
-    [primaryTableView reloadData];
+    [self.primaryTableView reloadData];
 }
 
 - (void)setupViews {
@@ -40,25 +40,25 @@ static CGFloat const EntryListCellHeight = 44;
     // setup views
     CGFloat yOrigin = self.view.safeAreaInsets.top;
     
-    entryFieldBackground = [[UIView alloc] initWithFrame:CGRectMake(0,
+    self.entryFieldBackground = [[UIView alloc] initWithFrame:CGRectMake(0,
                                                                     yOrigin,
                                                                     self.view.frame.size.width,
                                                                     EntryListCellHeight)];
-    entryFieldBackground.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
-    [self.view addSubview:entryFieldBackground];
-    
+    self.entryFieldBackground.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
+    [self.view addSubview:self.entryFieldBackground];
+
     entryTextField = [[SPTextField alloc] initWithFrame:CGRectMake(EntryListTextFieldSidePadding,
                                                                    0,
-                                                                   entryFieldBackground.frame.size.width - 2 * EntryListTextFieldSidePadding,
-                                                                   entryFieldBackground.frame.size.height)];
+                                                                   self.entryFieldBackground.frame.size.width - 2 * EntryListTextFieldSidePadding,
+                                                                   self.entryFieldBackground.frame.size.height)];
     entryTextField.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
     entryTextField.keyboardType = UIKeyboardTypeEmailAddress;
 
     entryTextField.keyboardAppearance = SPUserInterface.isDark ? UIKeyboardAppearanceDark : UIKeyboardAppearanceDefault;
     entryTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     entryTextField.delegate = self;
-    [entryFieldBackground addSubview:entryTextField];
-    
+    [self.entryFieldBackground addSubview:entryTextField];
+
     entryFieldPlusButton = [UIButton buttonWithType:UIButtonTypeCustom];
     UIImage *pickerImage = [UIImage imageWithName:UIImageNameAdd];
     [entryFieldPlusButton setImage:pickerImage forState:UIControlStateNormal];
@@ -70,17 +70,17 @@ static CGFloat const EntryListCellHeight = 44;
     entryTextField.rightViewMode = UITextFieldViewModeAlways;
     
     
-    primaryTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, yOrigin + entryTextField.frame.size.height,
+    self.primaryTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, yOrigin + entryTextField.frame.size.height,
                                                                      self.view.frame.size.width, self.view.frame.size.height - (yOrigin + entryTextField.frame.size.height))
                                                     style:UITableViewStyleGrouped];
-    primaryTableView.rowHeight = EntryListCellHeight;
-    primaryTableView.delegate = self;
-    primaryTableView.dataSource = self;
-    primaryTableView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    [self.view addSubview:primaryTableView];
+    self.primaryTableView.rowHeight = EntryListCellHeight;
+    self.primaryTableView.delegate = self;
+    self.primaryTableView.dataSource = self;
+    self.primaryTableView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    [self.view addSubview:self.primaryTableView];
+
     
-    
-    [primaryTableView registerClass:[SPEntryListCell class]
+    [self.primaryTableView registerClass:[SPEntryListCell class]
              forCellReuseIdentifier:cellIdentifier];
     
     [autoCompleteTableView registerClass:[SPEntryListAutoCompleteCell class]
@@ -124,7 +124,7 @@ static CGFloat const EntryListCellHeight = 44;
     self.view.backgroundColor = tableBackgroundColor;
     
     // entry field
-    entryFieldBackground.backgroundColor = tableBackgroundColor;
+    self.entryFieldBackground.backgroundColor = tableBackgroundColor;
     entryTextField.backgroundColor = [UIColor clearColor];
     entryTextField.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     entryTextField.textColor = [UIColor simplenoteTextColor];
@@ -132,15 +132,15 @@ static CGFloat const EntryListCellHeight = 44;
     
     CALayer *entryFieldBorder = [[CALayer alloc] init];
     entryFieldBorder.frame = CGRectMake(0,
-                                        entryFieldBackground.bounds.size.height - 1.0 / [[UIScreen mainScreen] scale],
+                                        self.entryFieldBackground.bounds.size.height - 1.0 / [[UIScreen mainScreen] scale],
                                         MAX(self.view.frame.size.width, self.view.frame.size.height),
                                         1.0 / [[UIScreen mainScreen] scale]);
     entryFieldBorder.backgroundColor = tableSeparatorColor.CGColor;
-    [entryFieldBackground.layer addSublayer:entryFieldBorder];
-    
+    [self.entryFieldBackground.layer addSublayer:entryFieldBorder];
+
     // tableview
-    primaryTableView.backgroundColor = [UIColor clearColor];
-    primaryTableView.separatorColor = tableSeparatorColor;
+    self.primaryTableView.backgroundColor = [UIColor clearColor];
+    self.primaryTableView.separatorColor = tableSeparatorColor;
     autoCompleteTableView.backgroundColor = backgroundColor;
     autoCompleteTableView.separatorColor = tableSeparatorColor;
 }
@@ -169,7 +169,7 @@ static CGFloat const EntryListCellHeight = 44;
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     
-    if ([tableView isEqual:primaryTableView])
+    if ([tableView isEqual:self.primaryTableView])
         return 0; // this is implemented by subclassing
     else if ([tableView isEqual:autoCompleteTableView])
         return _autoCompleteDataSource.count;
@@ -192,8 +192,8 @@ static CGFloat const EntryListCellHeight = 44;
     
     UITableViewCell *finalCell;
     
-    if ([tableView isEqual:primaryTableView]) {
-        
+    if ([tableView isEqual:self.primaryTableView]) {
+
         
         SPEntryListCell *cell = (SPEntryListCell *)[tableView dequeueReusableCellWithIdentifier:cellIdentifier];
         if (!cell) {
@@ -220,7 +220,7 @@ static CGFloat const EntryListCellHeight = 44;
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     
-    return [tableView isEqual:primaryTableView] ? YES : NO;
+    return [tableView isEqual:self.primaryTableView] ? YES : NO;
 }
 
 - (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -238,10 +238,10 @@ static CGFloat const EntryListCellHeight = 44;
     if (editingStyle == UITableViewCellEditingStyleDelete) {
 
         [self removeItemFromDataSourceAtIndexPath:indexPath];
-        [primaryTableView beginUpdates];
-        [primaryTableView deleteRowsAtIndexPaths:@[indexPath]
+        [self.primaryTableView beginUpdates];
+        [self.primaryTableView deleteRowsAtIndexPaths:@[indexPath]
                                 withRowAnimation:UITableViewRowAnimationLeft];
-        [primaryTableView endUpdates];
+        [self.primaryTableView endUpdates];
     }
 }
 - (void)removeItemFromDataSourceAtIndexPath:(NSIndexPath *)indexPath {
@@ -295,7 +295,7 @@ static CGFloat const EntryListCellHeight = 44;
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView {
     
-    if ([scrollView isEqual:primaryTableView])
+    if ([scrollView isEqual:self.primaryTableView])
         [entryTextField resignFirstResponder];    
 }
 

--- a/Simplenote/Classes/SPEntryListViewController.m
+++ b/Simplenote/Classes/SPEntryListViewController.m
@@ -14,7 +14,6 @@
 static NSString *cellIdentifier = @"primaryCell";
 static NSString *autoCompleteCellIdentifier = @"autoCompleteCell";
 static CGFloat const EntryListTextFieldSidePadding = 15;
-static CGFloat const EntryListCellHeight = 44;
 
 @implementation SPEntryListViewController
 

--- a/Simplenote/SPAddCollaboratorsViewController.swift
+++ b/Simplenote/SPAddCollaboratorsViewController.swift
@@ -1,0 +1,33 @@
+//
+//  SPAddCollaboratorsViewController.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 4/24/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension SPAddCollaboratorsViewController {
+    @objc
+    func setupBannerView() {
+        let bannerView: BannerView = BannerView.instantiateFromNib()
+
+        bannerView.onPress = {
+            print("# Click me")
+        }
+
+        view.addSubview(bannerView)
+
+        bannerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            bannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bannerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        bannerView.refreshInterface(with: .collaborationRetirement)
+
+    }
+}

--- a/Simplenote/SPAddCollaboratorsViewController.swift
+++ b/Simplenote/SPAddCollaboratorsViewController.swift
@@ -15,7 +15,11 @@ extension SPAddCollaboratorsViewController {
         bannerView = BannerView.instantiateFromNib()
         bannerView.refreshInterface(with: .collaborationRetirement)
         bannerView.onPress = {
-            //TODO: load blog post for collaborator retirement details
+            guard let url = URL(string: "https://simplenote.com/2024/05/01/collaboration-feature-retirement") else {
+                return
+            }
+
+            UIApplication.shared.open(url)
         }
 
         view.addSubview(bannerView)

--- a/Simplenote/SPAddCollaboratorsViewController.swift
+++ b/Simplenote/SPAddCollaboratorsViewController.swift
@@ -12,14 +12,17 @@ import UIKit
 extension SPAddCollaboratorsViewController {
     @objc
     func setupBannerView() {
-        let bannerView: BannerView = BannerView.instantiateFromNib()
-
+        bannerView = BannerView.instantiateFromNib()
+        bannerView.refreshInterface(with: .collaborationRetirement)
         bannerView.onPress = {
             print("# Click me")
         }
 
         view.addSubview(bannerView)
+    }
 
+    @objc
+    func setupViewContraints() {
         bannerView.translatesAutoresizingMaskIntoConstraints = false
         primaryTableView.translatesAutoresizingMaskIntoConstraints = false
         entryFieldBackground.translatesAutoresizingMaskIntoConstraints = false
@@ -34,7 +37,7 @@ extension SPAddCollaboratorsViewController {
         NSLayoutConstraint.activate([
             entryFieldBackground.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             entryFieldBackground.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            entryFieldBackground.heightAnchor.constraint(equalToConstant: 44)
+            entryFieldBackground.heightAnchor.constraint(equalToConstant: EntryListCellHeight)
         ])
 
         NSLayoutConstraint.activate([
@@ -43,8 +46,5 @@ extension SPAddCollaboratorsViewController {
             primaryTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             primaryTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
-
-        bannerView.refreshInterface(with: .collaborationRetirement)
-
     }
 }

--- a/Simplenote/SPAddCollaboratorsViewController.swift
+++ b/Simplenote/SPAddCollaboratorsViewController.swift
@@ -15,7 +15,7 @@ extension SPAddCollaboratorsViewController {
         bannerView = BannerView.instantiateFromNib()
         bannerView.refreshInterface(with: .collaborationRetirement)
         bannerView.onPress = {
-            print("# Click me")
+            //TODO: load blog post for collaborator retirement details
         }
 
         view.addSubview(bannerView)

--- a/Simplenote/SPAddCollaboratorsViewController.swift
+++ b/Simplenote/SPAddCollaboratorsViewController.swift
@@ -21,10 +21,27 @@ extension SPAddCollaboratorsViewController {
         view.addSubview(bannerView)
 
         bannerView.translatesAutoresizingMaskIntoConstraints = false
+        primaryTableView.translatesAutoresizingMaskIntoConstraints = false
+        entryFieldBackground.translatesAutoresizingMaskIntoConstraints = false
+
         NSLayoutConstraint.activate([
             bannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bannerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            bannerView.topAnchor.constraint(equalTo: view.topAnchor),
+            bannerView.bottomAnchor.constraint(equalTo: entryFieldBackground.topAnchor)
+        ])
+
+        NSLayoutConstraint.activate([
+            entryFieldBackground.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            entryFieldBackground.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            entryFieldBackground.heightAnchor.constraint(equalToConstant: 44)
+        ])
+
+        NSLayoutConstraint.activate([
+            primaryTableView.topAnchor.constraint(equalTo: entryFieldBackground.bottomAnchor),
+            primaryTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            primaryTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            primaryTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
         bannerView.refreshInterface(with: .collaborationRetirement)


### PR DESCRIPTION
### Fix
We are removing collaboration from Simplenote.  The first step in doing this is to put a notice in the collaboration view that informs users that we will be removing this feature and then links to a url with more details.

<img src="https://cdn-std.droplr.net/files/acc_593859/54mIYw" />

### Test
1. go to any note > More menu > collaborate.  
- [ ] Confirm that the banner view appears with the retirement notice
- [ ] confirm tapping on the banner view loads safari (the post it points to doesn't exist yet, so that will load 404)

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
