### PR TITLE
Shortcuts update part 1: remove existing shortcuts

### DIFF
--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "4c803bfc0eef41e640a11de86de8bd9cb6ec711e343dadfe7d14d904ae2a7283",
   "pins" : [
     {
       "identity" : "automattic-tracks-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "bd981ad3a08c6af6113834eb62ee7466cb8aa71c",
-        "version" : "3.4.0"
+        "revision" : "b6979ef69b4b094c8809ba83661222dcd0d7667e",
+        "version" : "3.2.0"
       }
     },
     {
@@ -24,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "82af013792dca3784a2dc5e7f975159fb9d263b3",
-        "version" : "8.25.0"
+        "revision" : "3b9a8e69ca296bd8cd0e317ad7a448e5daf4a342",
+        "version" : "8.18.0"
       }
     },
     {
@@ -83,5 +82,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "4c803bfc0eef41e640a11de86de8bd9cb6ec711e343dadfe7d14d904ae2a7283",
   "pins" : [
     {
       "identity" : "automattic-tracks-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "b6979ef69b4b094c8809ba83661222dcd0d7667e",
-        "version" : "3.2.0"
+        "revision" : "bd981ad3a08c6af6113834eb62ee7466cb8aa71c",
+        "version" : "3.4.0"
       }
     },
     {
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "3b9a8e69ca296bd8cd0e317ad7a448e5daf4a342",
-        "version" : "8.18.0"
+        "revision" : "82af013792dca3784a2dc5e7f975159fb9d263b3",
+        "version" : "8.25.0"
       }
     },
     {
@@ -82,5 +83,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Simplenote/Classes/ShortcutsHandler.swift
+++ b/Simplenote/Classes/ShortcutsHandler.swift
@@ -23,23 +23,6 @@ class ShortcutsHandler: NSObject {
         NSUserActivity.launchActivity()
     ]
 
-    /// Registers all of the Simplenote-Y Activities.
-    ///
-    /// - Note:
-    ///     1. Calling `becomeCurrent()` sequentially causes the OS not to register anything, (OR) register
-    ///        just the last activity.
-    ///     2. Not keeping the Activities around... also causes `becomeCurrent` to fail. That's why `activities` is
-    ///        an ivar!
-    ///
-    func registerSimplenoteActivities() {
-        for (index, activity) in activities.enumerated() {
-            let delay = DispatchTime.now() + DispatchTimeInterval.seconds(index)
-            DispatchQueue.main.asyncAfter(deadline: delay) {
-                activity.becomeCurrent()
-            }
-        }
-    }
-
     /// Removes all of the shared UserActivities, whenever the API allows.
     ///
     @objc

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -284,7 +284,6 @@ extension SPAppDelegate: SimperiumDelegate {
         SPTracker.refreshMetadata(withEmail: user.email)
 
         // Shortcuts!
-        ShortcutsHandler.shared.registerSimplenoteActivities()
         ShortcutsHandler.shared.updateHomeScreenQuickActionsIfNeeded()
 
         // Now that the user info is present, cache it for use by the crash logging system.


### PR DESCRIPTION
### Fix
We are reimplementing the current shortcuts using Siri kit intents.  This will open up a lot more interesting possibilities for shortcuts, it will also add the intents into shortcuts automatically, (where our current system is using donation to add the intents which means they may not appear in shortcuts) This is going to happen in several steps and the first one is to drop the existing NSUserActivity donation so it no longer is contributed to shortcuts.


### Test
Run this PR and then go to the shortcuts app -> Create a new shortcut - > Add action -> Find Simplenote and confirm you don't have new note or open note (you will still see publish to Wordpress, that comes from elsewhere and I don't think needs to be replaced)

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
