### PR TITLE
Shortcuts update part 2: refactor widget intents

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -438,6 +438,10 @@
 		BA2015BB2B57384F005E59AA /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA2015BA2B57384F005E59AA /* AutomatticTracks */; };
 		BA289B582BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA289B572BE436EB000E6794 /* ShortcutIntents.intentdefinition */; };
 		BA289B592BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA289B572BE436EB000E6794 /* ShortcutIntents.intentdefinition */; };
+		BA289B5C2BE4371A000E6794 /* ListWidgetIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA289B5A2BE4371A000E6794 /* ListWidgetIntentHandler.swift */; };
+		BA289B5F2BE43728000E6794 /* NoteWidgetIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA289B5D2BE43728000E6794 /* NoteWidgetIntentHandler.swift */; };
+		BA289B602BE43816000E6794 /* NoteWidgetIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA289B5D2BE43728000E6794 /* NoteWidgetIntentHandler.swift */; };
+		BA289B612BE43825000E6794 /* ListWidgetIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA289B5A2BE4371A000E6794 /* ListWidgetIntentHandler.swift */; };
 		BA2D82C6261522F100A1695B /* PublishNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */; };
 		BA3101A926C8C76A00C95F93 /* ListWidgetIntent.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		BA32A90F26B7469F00727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
@@ -1130,6 +1134,8 @@
 		BA16C6A82BC4968400C9079F /* Simplenote 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 7.xcdatamodel"; sourceTree = "<group>"; };
 		BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
 		BA289B572BE436EB000E6794 /* ShortcutIntents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = ShortcutIntents.intentdefinition; sourceTree = "<group>"; };
+		BA289B5A2BE4371A000E6794 /* ListWidgetIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListWidgetIntentHandler.swift; sourceTree = "<group>"; };
+		BA289B5D2BE43728000E6794 /* NoteWidgetIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWidgetIntentHandler.swift; sourceTree = "<group>"; };
 		BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishNoticePresenter.swift; sourceTree = "<group>"; };
 		BA32A90E26B7469F00727247 /* WidgetError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetError.swift; sourceTree = "<group>"; };
 		BA3856CC2681715700F388CC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
@@ -2379,6 +2385,8 @@
 			children = (
 				092FD78026D7BB72006BE8E2 /* Supporting Files */,
 				BAB5762626703C8200B0C56F /* IntentHandler.swift */,
+				BA289B5D2BE43728000E6794 /* NoteWidgetIntentHandler.swift */,
+				BA289B5A2BE4371A000E6794 /* ListWidgetIntentHandler.swift */,
 				BAF8D4AD26AE136D00CA9383 /* Simplenote-Intents-Bridging-Header.h */,
 			);
 			path = SimplenoteIntents;
@@ -3727,10 +3735,12 @@
 			files = (
 				BA86620E26B3A73D00466746 /* UserDefaults+Simplenote.swift in Sources */,
 				BAF8D52826AE173D00CA9383 /* FileManager+Simplenote.swift in Sources */,
+				BA289B5F2BE43728000E6794 /* NoteWidgetIntentHandler.swift in Sources */,
 				BAF8D50026AE171400CA9383 /* CoreDataManager.swift in Sources */,
 				BAE63CB026E05313002BF81A /* NSString+Simplenote.swift in Sources */,
 				BAE63CB226E05325002BF81A /* NSPredicate+Email.swift in Sources */,
 				BAF8D51426AE172600CA9383 /* StorageSettings.swift in Sources */,
+				BA289B5C2BE4371A000E6794 /* ListWidgetIntentHandler.swift in Sources */,
 				BA86616326B35CF000466746 /* BuildConfiguration.swift in Sources */,
 				BAB5762726703C8200B0C56F /* IntentHandler.swift in Sources */,
 				BA289B592BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */,
@@ -3796,10 +3806,12 @@
 				BA608EF926BB6F4C00A9D94E /* ListWidgetView.swift in Sources */,
 				BAE63CAF26E05312002BF81A /* NSString+Simplenote.swift in Sources */,
 				BA86626726B3B1B600466746 /* NSSortDescriptor+Simplenote.swift in Sources */,
+				BA289B612BE43825000E6794 /* ListWidgetIntentHandler.swift in Sources */,
 				BAF8D46426AE118800CA9383 /* SPCredentials.swift in Sources */,
 				BA122DC1265EF4C5003D3BC5 /* UITraitCollection+Simplenote.swift in Sources */,
 				BA12B06F26B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */,
 				BAFA93F4265DE4A70009DCFB /* NewNoteWidgetProvider.swift in Sources */,
+				BA289B602BE43816000E6794 /* NoteWidgetIntentHandler.swift in Sources */,
 				BAB27BD726BA425C00AE4ACC /* Color+Simplenote.swift in Sources */,
 				BAB5768726703EA000B0C56F /* NoteWidgetView.swift in Sources */,
 				BAF8D44C26AE10FC00CA9383 /* Note+Widget.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -436,6 +436,8 @@
 		BA12B07026B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA12B06C26B0D0150026F31D /* SPManagedObject+Widget.swift */; };
 		BA18532826488DBC00D9A347 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */; };
 		BA2015BB2B57384F005E59AA /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA2015BA2B57384F005E59AA /* AutomatticTracks */; };
+		BA289B582BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA289B572BE436EB000E6794 /* ShortcutIntents.intentdefinition */; };
+		BA289B592BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA289B572BE436EB000E6794 /* ShortcutIntents.intentdefinition */; };
 		BA2D82C6261522F100A1695B /* PublishNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */; };
 		BA3101A926C8C76A00C95F93 /* ListWidgetIntent.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		BA32A90F26B7469F00727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
@@ -1127,6 +1129,7 @@
 		BA12B06C26B0D0150026F31D /* SPManagedObject+Widget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SPManagedObject+Widget.swift"; sourceTree = "<group>"; };
 		BA16C6A82BC4968400C9079F /* Simplenote 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 7.xcdatamodel"; sourceTree = "<group>"; };
 		BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
+		BA289B572BE436EB000E6794 /* ShortcutIntents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = ShortcutIntents.intentdefinition; sourceTree = "<group>"; };
 		BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishNoticePresenter.swift; sourceTree = "<group>"; };
 		BA32A90E26B7469F00727247 /* WidgetError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetError.swift; sourceTree = "<group>"; };
 		BA3856CC2681715700F388CC /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
@@ -2618,6 +2621,7 @@
 				B5250A6B22B922F900AE7797 /* Simplenote-Internal.entitlements */,
 				E29ADD4717848E8500E55842 /* main.m */,
 				E29ADD4917848E8500E55842 /* Simplenote-Prefix.pch */,
+				BA289B572BE436EB000E6794 /* ShortcutIntents.intentdefinition */,
 			);
 			path = "Supporting Files";
 			sourceTree = "<group>";
@@ -3372,6 +3376,7 @@
 				B52BB74E22CFD1660042C162 /* SimplenoteActivityItemSource.swift in Sources */,
 				B537730F252E14C600BC78C5 /* OptionsViewController.swift in Sources */,
 				B56A696722F9D55F00B90398 /* UIView+Animations.swift in Sources */,
+				BA289B582BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */,
 				BA3856CD2681715700F388CC /* CoreDataManager.swift in Sources */,
 				A60DF30825A44F0F00FDADF3 /* PinLockRemoveController.swift in Sources */,
 				A694ABAB25D1549D00CC3A2D /* FileStorage.swift in Sources */,
@@ -3728,6 +3733,7 @@
 				BAF8D51426AE172600CA9383 /* StorageSettings.swift in Sources */,
 				BA86616326B35CF000466746 /* BuildConfiguration.swift in Sources */,
 				BAB5762726703C8200B0C56F /* IntentHandler.swift in Sources */,
+				BA289B592BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */,
 				BA86625D26B3B14900466746 /* SortMode.swift in Sources */,
 				BA12B07026B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */,
 				BAF4A9AA26DB138600C51C1D /* NoteContentHelper.swift in Sources */,

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>INIntents</key>
+  <array>
+  </array>
+  <key>INEnums</key>
+  <array>
+  </array>
+</dict>
+</plist>

--- a/SimplenoteIntents/IntentHandler.swift
+++ b/SimplenoteIntents/IntentHandler.swift
@@ -2,76 +2,15 @@ import Intents
 import CoreData
 
 class IntentHandler: INExtension {
-    let coreDataWrapper = WidgetCoreDataWrapper()
-
     override func handler(for intent: INIntent) -> Any {
-        return self
-    }
-}
 
-extension IntentHandler: NoteWidgetIntentHandling {
-    func provideNoteOptionsCollection(for intent: NoteWidgetIntent, with completion: @escaping (INObjectCollection<WidgetNote>?, Error?) -> Void) {
-        guard WidgetDefaults.shared.loggedIn else {
-            completion(nil, WidgetError.appConfigurationError)
-            return
+        switch intent {
+        case is NoteWidgetIntent:
+            return NoteWidgetIntentHandler()
+        case is ListWidgetIntent:
+            return ListWidgetIntentHandler()
+        default:
+            return self
         }
-
-        guard let notes = coreDataWrapper.resultsController()?.notes() else {
-            completion(nil, WidgetError.fetchError)
-            return
-        }
-
-        let collection = widgetNoteInObjectCollection(from: notes)
-        completion(collection, nil)
-    }
-
-    private func widgetNoteInObjectCollection(from notes: [Note]) -> INObjectCollection<WidgetNote> {
-        let widgetNotes = notes.map({ note in
-            WidgetNote(identifier: note.simperiumKey, display: note.title)
-        })
-        return INObjectCollection(items: widgetNotes)
-    }
-
-    func defaultNote(for intent: NoteWidgetIntent) -> WidgetNote? {
-        guard WidgetDefaults.shared.loggedIn,
-              let note = coreDataWrapper.resultsController()?.firstNote() else {
-            return nil
-        }
-
-        return WidgetNote(identifier: note.simperiumKey, display: note.title)
-    }
-}
-
-extension IntentHandler: ListWidgetIntentHandling {
-    func provideTagOptionsCollection(for intent: ListWidgetIntent, with completion: @escaping (INObjectCollection<WidgetTag>?, Error?) -> Void) {
-        guard WidgetDefaults.shared.loggedIn else {
-            completion(nil, WidgetError.appConfigurationError)
-            return
-        }
-
-        guard let tags = coreDataWrapper.resultsController()?.tags() else {
-            completion(nil, WidgetError.fetchError)
-            return
-        }
-
-        // Return collection to intents
-        let collection = tagNoteInObjectCollection(from: tags)
-        completion(collection, nil)
-    }
-
-    private func tagNoteInObjectCollection(from tags: [Tag]) -> INObjectCollection<WidgetTag> {
-        var items = [WidgetTag(kind: .allNotes)]
-
-        tags.forEach { tag in
-            let tag = WidgetTag(kind: .tag, name: tag.name)
-            tag.kind = .tag
-            items.append(tag)
-        }
-
-        return INObjectCollection(items: items)
-    }
-
-    func defaultTag(for intent: ListWidgetIntent) -> WidgetTag? {
-        WidgetTag(kind: .allNotes)
     }
 }

--- a/SimplenoteIntents/ListWidgetIntentHandler.swift
+++ b/SimplenoteIntents/ListWidgetIntentHandler.swift
@@ -1,0 +1,45 @@
+//
+//  ListWidgetIntentHandler.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 5/2/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Intents
+
+class ListWidgetIntentHandler: NSObject, ListWidgetIntentHandling {
+    let coreDataWrapper = WidgetCoreDataWrapper()
+
+    func provideTagOptionsCollection(for intent: ListWidgetIntent, with completion: @escaping (INObjectCollection<WidgetTag>?, Error?) -> Void) {
+        guard WidgetDefaults.shared.loggedIn else {
+            completion(nil, WidgetError.appConfigurationError)
+            return
+        }
+
+        guard let tags = coreDataWrapper.resultsController()?.tags() else {
+            completion(nil, WidgetError.fetchError)
+            return
+        }
+
+        // Return collection to intents
+        let collection = tagNoteInObjectCollection(from: tags)
+        completion(collection, nil)
+    }
+
+    private func tagNoteInObjectCollection(from tags: [Tag]) -> INObjectCollection<WidgetTag> {
+        var items = [WidgetTag(kind: .allNotes)]
+
+        tags.forEach { tag in
+            let tag = WidgetTag(kind: .tag, name: tag.name)
+            tag.kind = .tag
+            items.append(tag)
+        }
+
+        return INObjectCollection(items: items)
+    }
+
+    func defaultTag(for intent: ListWidgetIntent) -> WidgetTag? {
+        WidgetTag(kind: .allNotes)
+    }
+}

--- a/SimplenoteIntents/NoteWidgetIntentHandler.swift
+++ b/SimplenoteIntents/NoteWidgetIntentHandler.swift
@@ -1,0 +1,44 @@
+//
+//  NoteWidgetIntentHandler.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 5/2/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Intents
+
+class NoteWidgetIntentHandler: NSObject, NoteWidgetIntentHandling {
+    let coreDataWrapper = WidgetCoreDataWrapper()
+
+    func provideNoteOptionsCollection(for intent: NoteWidgetIntent, with completion: @escaping (INObjectCollection<WidgetNote>?, Error?) -> Void) {
+        guard WidgetDefaults.shared.loggedIn else {
+            completion(nil, WidgetError.appConfigurationError)
+            return
+        }
+
+        guard let notes = coreDataWrapper.resultsController()?.notes() else {
+            completion(nil, WidgetError.fetchError)
+            return
+        }
+
+        let collection = widgetNoteInObjectCollection(from: notes)
+        completion(collection, nil)
+    }
+
+    private func widgetNoteInObjectCollection(from notes: [Note]) -> INObjectCollection<WidgetNote> {
+        let widgetNotes = notes.map({ note in
+            WidgetNote(identifier: note.simperiumKey, display: note.title)
+        })
+        return INObjectCollection(items: widgetNotes)
+    }
+
+    func defaultNote(for intent: NoteWidgetIntent) -> WidgetNote? {
+        guard WidgetDefaults.shared.loggedIn,
+              let note = coreDataWrapper.resultsController()?.firstNote() else {
+            return nil
+        }
+
+        return WidgetNote(identifier: note.simperiumKey, display: note.title)
+    }
+}


### PR DESCRIPTION
### Fix
Step two for implementing siri kit intents is to refactor the widget intents.  Currently the only intents on Simplenote iOS are for the widgets, so the intents extension handler is the class that handles all intents.  That is gonna get messy, so I am breaking out the widget intent handlers into their own classes and using the IntentHandler class to martial the intents to the correct handler.

### Test
Confirm that you can still add and use all three Simplenote iOS widgets.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
