### PR TITLE
Add create note with content intent

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -535,7 +535,7 @@
 		BAB6C04426BA49F3007495C4 /* ContentSlice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64DE6E8255D1C9F001D0526 /* ContentSlice.swift */; };
 		BAB6C04526BA4A04007495C4 /* String+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */; };
 		BAB6C04726BA4CAF007495C4 /* WidgetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB6C04626BA4CAF007495C4 /* WidgetController.swift */; };
-		BAB898D32BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB898D22BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift */; };
+		BAB898D32BEC404200E238B8 /* CreateNewNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */; };
 		BABFFF2226CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2326CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2426CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
@@ -1214,7 +1214,7 @@
 		BAB5769226703F0E00B0C56F /* NoteWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWidgetProvider.swift; sourceTree = "<group>"; };
 		BAB576BD2670512C00B0C56F /* NoteWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWidget.swift; sourceTree = "<group>"; };
 		BAB6C04626BA4CAF007495C4 /* WidgetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetController.swift; sourceTree = "<group>"; };
-		BAB898D22BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewNoteWithContentIntentHandler.swift; sourceTree = "<group>"; };
+		BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewNoteIntentHandler.swift; sourceTree = "<group>"; };
 		BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDefaults.swift; sourceTree = "<group>"; };
 		BAC7264D2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPAddCollaboratorsViewController.swift; sourceTree = "<group>"; };
 		BAE08625261282D1009D40CD /* Note+Publish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Publish.swift"; sourceTree = "<group>"; };
@@ -2346,7 +2346,7 @@
 				BA289B632BE43963000E6794 /* OpenNewNoteIntentHandler.swift */,
 				BA289B742BE45BBB000E6794 /* OpenNoteIntentHandler.swift */,
 				BA35808F2BE95BE100CE1590 /* AppendNoteIntentHandler.swift */,
-				BAB898D22BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift */,
+				BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */,
 			);
 			path = "Intent Handlers";
 			sourceTree = "<group>";
@@ -3793,7 +3793,7 @@
 				BA289B592BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */,
 				BA0AF10D2BE996600050EEBD /* KeychainManager.swift in Sources */,
 				BA86625D26B3B14900466746 /* SortMode.swift in Sources */,
-				BAB898D32BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift in Sources */,
+				BAB898D32BEC404200E238B8 /* CreateNewNoteIntentHandler.swift in Sources */,
 				BA12B07026B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */,
 				BAF4A9AA26DB138600C51C1D /* NoteContentHelper.swift in Sources */,
 				BA6D7B8B2BE588F0006AE368 /* IntentsError.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -535,6 +535,7 @@
 		BAB6C04426BA49F3007495C4 /* ContentSlice.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64DE6E8255D1C9F001D0526 /* ContentSlice.swift */; };
 		BAB6C04526BA4A04007495C4 /* String+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */; };
 		BAB6C04726BA4CAF007495C4 /* WidgetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB6C04626BA4CAF007495C4 /* WidgetController.swift */; };
+		BAB898D32BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB898D22BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift */; };
 		BABFFF2226CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2326CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2426CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
@@ -1213,6 +1214,7 @@
 		BAB5769226703F0E00B0C56F /* NoteWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWidgetProvider.swift; sourceTree = "<group>"; };
 		BAB576BD2670512C00B0C56F /* NoteWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWidget.swift; sourceTree = "<group>"; };
 		BAB6C04626BA4CAF007495C4 /* WidgetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetController.swift; sourceTree = "<group>"; };
+		BAB898D22BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewNoteWithContentIntentHandler.swift; sourceTree = "<group>"; };
 		BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDefaults.swift; sourceTree = "<group>"; };
 		BAC7264D2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPAddCollaboratorsViewController.swift; sourceTree = "<group>"; };
 		BAE08625261282D1009D40CD /* Note+Publish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Publish.swift"; sourceTree = "<group>"; };
@@ -2344,6 +2346,7 @@
 				BA289B632BE43963000E6794 /* OpenNewNoteIntentHandler.swift */,
 				BA289B742BE45BBB000E6794 /* OpenNoteIntentHandler.swift */,
 				BA35808F2BE95BE100CE1590 /* AppendNoteIntentHandler.swift */,
+				BAB898D22BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift */,
 			);
 			path = "Intent Handlers";
 			sourceTree = "<group>";
@@ -3790,6 +3793,7 @@
 				BA289B592BE436EB000E6794 /* ShortcutIntents.intentdefinition in Sources */,
 				BA0AF10D2BE996600050EEBD /* KeychainManager.swift in Sources */,
 				BA86625D26B3B14900466746 /* SortMode.swift in Sources */,
+				BAB898D32BEC404200E238B8 /* CreateNewNoteWithContentIntentHandler.swift in Sources */,
 				BA12B07026B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */,
 				BAF4A9AA26DB138600C51C1D /* NoteContentHelper.swift in Sources */,
 				BA6D7B8B2BE588F0006AE368 /* IntentsError.swift in Sources */,

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -234,26 +234,6 @@
 							<key>INIntentParameterPromptDialogType</key>
 							<string>Primary</string>
 						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>There are ${count} options matching ‘${note}’.</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>5Cplu9</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>DisambiguationIntroduction</string>
-						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>Just to confirm, you wanted ‘${note}’?</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>P8Wb3q</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>Confirmation</string>
-						</dict>
 					</array>
 					<key>INIntentParameterSupportsDynamicEnumeration</key>
 					<true/>
@@ -333,6 +313,105 @@
 			<string>Custom</string>
 			<key>INIntentVerb</key>
 			<string>Do</string>
+		</dict>
+		<dict>
+			<key>INIntentCategory</key>
+			<string>create</string>
+			<key>INIntentClassPrefix</key>
+			<string>SP</string>
+			<key>INIntentConfigurable</key>
+			<true/>
+			<key>INIntentDescription</key>
+			<string>Creates a note with supplied content and saves it in Simplenote</string>
+			<key>INIntentDescriptionID</key>
+			<string>sXkMgW</string>
+			<key>INIntentIneligibleForSuggestions</key>
+			<true/>
+			<key>INIntentInput</key>
+			<string>content</string>
+			<key>INIntentLastParameterTag</key>
+			<integer>1</integer>
+			<key>INIntentManagedParameterCombinations</key>
+			<dict>
+				<key>content</key>
+				<dict>
+					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
+					<true/>
+					<key>INIntentParameterCombinationTitle</key>
+					<string>Create new note with ${content}</string>
+					<key>INIntentParameterCombinationTitleID</key>
+					<string>CNjhWs</string>
+					<key>INIntentParameterCombinationUpdatesLinked</key>
+					<true/>
+				</dict>
+			</dict>
+			<key>INIntentName</key>
+			<string>CreateNewNoteWithContent</string>
+			<key>INIntentParameters</key>
+			<array>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Content</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>U9Yl4n</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>1</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>hM7vDg</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>content</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+					</array>
+					<key>INIntentParameterTag</key>
+					<integer>1</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
+				</dict>
+			</array>
+			<key>INIntentResponse</key>
+			<dict>
+				<key>INIntentResponseCodes</key>
+				<array>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>success</string>
+						<key>INIntentResponseCodeSuccess</key>
+						<true/>
+					</dict>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>failure</string>
+					</dict>
+				</array>
+			</dict>
+			<key>INIntentTitle</key>
+			<string>Create New Note With Content</string>
+			<key>INIntentTitleID</key>
+			<string>Ag8ugh</string>
+			<key>INIntentType</key>
+			<string>Custom</string>
+			<key>INIntentVerb</key>
+			<string>Create</string>
 		</dict>
 	</array>
 	<key>INTypes</key>

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -25,6 +25,8 @@
 			<string>SP</string>
 			<key>INIntentConfigurable</key>
 			<true/>
+			<key>INIntentDescription</key>
+			<string>Open Simplenote and create a new note</string>
 			<key>INIntentDescriptionID</key>
 			<string>fgSbr5</string>
 			<key>INIntentIneligibleForSuggestions</key>
@@ -181,6 +183,8 @@
 			<string>SP</string>
 			<key>INIntentConfigurable</key>
 			<true/>
+			<key>INIntentDescription</key>
+			<string>Append content to an existing note in Simplenote</string>
 			<key>INIntentDescriptionID</key>
 			<string>EeqvcH</string>
 			<key>INIntentIneligibleForSuggestions</key>
@@ -317,12 +321,14 @@
 		<dict>
 			<key>INIntentCategory</key>
 			<string>create</string>
+			<key>INIntentClassName</key>
+			<string>CreateNewNoteIntent</string>
 			<key>INIntentClassPrefix</key>
 			<string>SP</string>
 			<key>INIntentConfigurable</key>
 			<true/>
 			<key>INIntentDescription</key>
-			<string>Creates a note with supplied content and saves it in Simplenote</string>
+			<string>Creates a note with supplied content and save it in Simplenote</string>
 			<key>INIntentDescriptionID</key>
 			<string>sXkMgW</string>
 			<key>INIntentIneligibleForSuggestions</key>
@@ -346,7 +352,7 @@
 				</dict>
 			</dict>
 			<key>INIntentName</key>
-			<string>CreateNewNoteWithContent</string>
+			<string>CreateNewNote</string>
 			<key>INIntentParameters</key>
 			<array>
 				<dict>

--- a/Simplenote/Supporting Files/Simplenote-Info.plist
+++ b/Simplenote/Supporting Files/Simplenote-Info.plist
@@ -79,6 +79,7 @@
 		<string>NoteWidgetIntent</string>
 		<string>OpenNewNoteIntent</string>
 		<string>OpenNoteIntent</string>
+		<string>SPCreateNewNoteWithContentIntent</string>
 		<string>com.codality.NotationalFlow.launch</string>
 		<string>com.codality.NotationalFlow.newNote</string>
 		<string>com.codality.NotationalFlow.openNote</string>

--- a/Simplenote/Supporting Files/Simplenote-Info.plist
+++ b/Simplenote/Supporting Files/Simplenote-Info.plist
@@ -75,11 +75,11 @@
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>AppendNoteIntent</string>
+		<string>CreateNewNoteIntent</string>
 		<string>ListWidgetIntent</string>
 		<string>NoteWidgetIntent</string>
 		<string>OpenNewNoteIntent</string>
 		<string>OpenNoteIntent</string>
-		<string>SPCreateNewNoteWithContentIntent</string>
 		<string>com.codality.NotationalFlow.launch</string>
 		<string>com.codality.NotationalFlow.newNote</string>
 		<string>com.codality.NotationalFlow.openNote</string>

--- a/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
@@ -1,5 +1,5 @@
 //
-//  CreateNewNoteWithContentIntentHandler.swift
+//  CreateNewNoteIntentHandler.swift
 //  SimplenoteIntents
 //
 //  Created by Charlie Scheer on 5/8/24.
@@ -8,7 +8,7 @@
 
 import Intents
 
-class CreateNewNoteWithContentIntentHandler: NSObject, CreateNewNoteIntentHandling {
+class CreateNewNoteIntentHandler: NSObject, CreateNewNoteIntentHandling {
 
     func handle(intent: CreateNewNoteIntent) async -> CreateNewNoteIntentResponse {
         CreateNewNoteIntentResponse(code: .failure, userActivity: nil)

--- a/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
@@ -9,8 +9,24 @@
 import Intents
 
 class CreateNewNoteIntentHandler: NSObject, CreateNewNoteIntentHandling {
+    let coreDataWrapper = ExtensionCoreDataWrapper()
 
     func handle(intent: CreateNewNoteIntent) async -> CreateNewNoteIntentResponse {
-        CreateNewNoteIntentResponse(code: .failure, userActivity: nil)
+        guard let content = intent.content,
+              let token = KeychainManager.extensionToken else {
+            return CreateNewNoteIntentResponse(code: .failure, userActivity: nil)
+        }
+
+        Uploader(simperiumToken: token).send(note(with: content))
+        return CreateNewNoteIntentResponse(code: .success, userActivity: nil)
+    }
+
+    private func note(with content: String) -> Note {
+        let note = Note(context: coreDataWrapper.context())
+        note.creationDate = .now
+        note.modificationDate = .now
+        note.content = content
+
+        return note
     }
 }

--- a/SimplenoteIntents/Intent Handlers/CreateNewNoteWithContentIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/CreateNewNoteWithContentIntentHandler.swift
@@ -1,0 +1,16 @@
+//
+//  CreateNewNoteWithContentIntentHandler.swift
+//  SimplenoteIntents
+//
+//  Created by Charlie Scheer on 5/8/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Intents
+
+class CreateNewNoteWithContentIntentHandler: NSObject, CreateNewNoteIntentHandling {
+
+    func handle(intent: CreateNewNoteIntent) async -> CreateNewNoteIntentResponse {
+        CreateNewNoteIntentResponse(code: .failure, userActivity: nil)
+    }
+}

--- a/SimplenoteIntents/IntentHandler.swift
+++ b/SimplenoteIntents/IntentHandler.swift
@@ -15,6 +15,8 @@ class IntentHandler: INExtension {
             return OpenNoteIntentHandler()
         case is AppendNoteIntent:
             return AppendNoteIntentHandler()
+        case is CreateNewNoteIntent:
+            return CreateNewNoteIntentHandler()
         default:
             return self
         }

--- a/SimplenoteIntents/Supporting Files/Info.plist
+++ b/SimplenoteIntents/Supporting Files/Info.plist
@@ -35,6 +35,7 @@
 				<string>NoteWidgetIntent</string>
 				<string>OpenNewNoteIntent</string>
 				<string>OpenNoteIntent</string>
+				<string>SPCreateNewNoteWithContentIntent</string>
 			</array>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/SimplenoteIntents/Supporting Files/Info.plist
+++ b/SimplenoteIntents/Supporting Files/Info.plist
@@ -31,11 +31,11 @@
 			<key>IntentsSupported</key>
 			<array>
 				<string>AppendNoteIntent</string>
+				<string>CreateNewNoteIntent</string>
 				<string>ListWidgetIntent</string>
 				<string>NoteWidgetIntent</string>
 				<string>OpenNewNoteIntent</string>
 				<string>OpenNoteIntent</string>
-				<string>SPCreateNewNoteWithContentIntent</string>
 			</array>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/SimplenoteWidgets/Models/Note+Widget.swift
+++ b/SimplenoteWidgets/Models/Note+Widget.swift
@@ -16,6 +16,14 @@ extension Note {
         return NSFetchRequest<Note>(entityName: "Note")
     }
 
+    public override func awakeFromInsert() {
+        super.awakeFromInsert()
+
+        if simperiumKey.isEmpty {
+            simperiumKey = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        }
+    }
+
     @NSManaged public var content: String?
     @NSManaged public var creationDate: Date?
     @NSManaged public override var isDeleted: Bool


### PR DESCRIPTION
### Fix
Okay so if we are talking about shortcuts, one I think would be really useful is to be able to paste or write content into a new note and send that over to Simplenote so you can reference it later.  So this PR adds that shortcut intent.

With the new "Create New Note" intent you can create a new note with any given content and push it to Simplenote.  This shortcut does not require you to launch the app, it is pushed to the server directly from the shortcut and is available on all connected devices.

moves forward #1569 
relies on #1582 

### Test
1. Launch branch on device (the entitlements need to load on device before they work, so this may be required to access the api token) 
2. Background the app and go to shortcuts
3. Add a shortcut, add an action, find Simplenote, and select "create new note with content" 
4. Run the shortcut, add some content.
5. Confirm that the new note is created and available next time you launch Simplenote 

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
 (Will add release notes when I add the last shortcut)