### PR TITLE
Add find note by content intent

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 4.52
 -----
-
+- Extended support for iOS Shortcuts
 
 4.51
 -----

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -540,6 +540,7 @@
 		BABFFF2326CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2426CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BAC7264E2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC7264D2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift */; };
+		BAD0F1ED2BED49C200E73E45 /* FindNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAD0F1EC2BED49C200E73E45 /* FindNoteIntentHandler.swift */; };
 		BAE08626261282D1009D40CD /* Note+Publish.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE08625261282D1009D40CD /* Note+Publish.swift */; };
 		BAE63CAF26E05312002BF81A /* NSString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */; };
 		BAE63CB026E05313002BF81A /* NSString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59188C124005B8A0069EF96 /* NSString+Simplenote.swift */; };
@@ -1217,6 +1218,7 @@
 		BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewNoteIntentHandler.swift; sourceTree = "<group>"; };
 		BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDefaults.swift; sourceTree = "<group>"; };
 		BAC7264D2BD96E7C0002FA68 /* SPAddCollaboratorsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPAddCollaboratorsViewController.swift; sourceTree = "<group>"; };
+		BAD0F1EC2BED49C200E73E45 /* FindNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNoteIntentHandler.swift; sourceTree = "<group>"; };
 		BAE08625261282D1009D40CD /* Note+Publish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Publish.swift"; sourceTree = "<group>"; };
 		BAF4A96E26DB085D00C51C1D /* NSURLComponents+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSURLComponents+Simplenote.swift"; sourceTree = "<group>"; };
 		BAF8D42226AE10F100CA9383 /* Tag+Widget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tag+Widget.swift"; sourceTree = "<group>"; };
@@ -2347,6 +2349,7 @@
 				BA289B742BE45BBB000E6794 /* OpenNoteIntentHandler.swift */,
 				BA35808F2BE95BE100CE1590 /* AppendNoteIntentHandler.swift */,
 				BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */,
+				BAD0F1EC2BED49C200E73E45 /* FindNoteIntentHandler.swift */,
 			);
 			path = "Intent Handlers";
 			sourceTree = "<group>";
@@ -3776,6 +3779,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BA86620E26B3A73D00466746 /* UserDefaults+Simplenote.swift in Sources */,
+				BAD0F1ED2BED49C200E73E45 /* FindNoteIntentHandler.swift in Sources */,
 				BAF8D52826AE173D00CA9383 /* FileManager+Simplenote.swift in Sources */,
 				BA34B04D2BEAE9FE00580E15 /* SPConstants.m in Sources */,
 				BA289B5F2BE43728000E6794 /* NoteWidgetIntentHandler.swift in Sources */,

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -555,10 +555,6 @@
 						<true/>
 					</dict>
 					<dict>
-						<key>INIntentResponseCodeFormatString</key>
-						<string>${failureReason}</string>
-						<key>INIntentResponseCodeFormatStringID</key>
-						<string>ThMQV4</string>
 						<key>INIntentResponseCodeName</key>
 						<string>failure</string>
 					</dict>

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -87,6 +87,8 @@
 			<string>sqM3pN</string>
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
+			<key>INIntentInput</key>
+			<string>note</string>
 			<key>INIntentLastParameterTag</key>
 			<integer>2</integer>
 			<key>INIntentManagedParameterCombinations</key>

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -189,6 +189,8 @@
 			<string>EeqvcH</string>
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
+			<key>INIntentInput</key>
+			<string>note</string>
 			<key>INIntentLastParameterTag</key>
 			<integer>3</integer>
 			<key>INIntentManagedParameterCombinations</key>
@@ -418,6 +420,130 @@
 			<string>Custom</string>
 			<key>INIntentVerb</key>
 			<string>Create</string>
+		</dict>
+		<dict>
+			<key>INIntentCategory</key>
+			<string>search</string>
+			<key>INIntentClassName</key>
+			<string>FindNoteIntent</string>
+			<key>INIntentClassPrefix</key>
+			<string>SP</string>
+			<key>INIntentConfigurable</key>
+			<true/>
+			<key>INIntentDescription</key>
+			<string>Search the content of your notes to find a note to use in shortcuts</string>
+			<key>INIntentDescriptionID</key>
+			<string>V4ssp4</string>
+			<key>INIntentIneligibleForSuggestions</key>
+			<true/>
+			<key>INIntentLastParameterTag</key>
+			<integer>4</integer>
+			<key>INIntentManagedParameterCombinations</key>
+			<dict>
+				<key>content</key>
+				<dict>
+					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
+					<true/>
+					<key>INIntentParameterCombinationTitle</key>
+					<string>Find a note with ${content}</string>
+					<key>INIntentParameterCombinationTitleID</key>
+					<string>VDjU7n</string>
+					<key>INIntentParameterCombinationUpdatesLinked</key>
+					<true/>
+				</dict>
+			</dict>
+			<key>INIntentName</key>
+			<string>FindNote</string>
+			<key>INIntentParameters</key>
+			<array>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Content</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>VGM0yX</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>1</integer>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataCapitalization</key>
+						<string>Sentences</string>
+						<key>INIntentParameterMetadataDefaultValueID</key>
+						<string>g3QW1u</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>content</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+					</array>
+					<key>INIntentParameterTag</key>
+					<integer>4</integer>
+					<key>INIntentParameterType</key>
+					<string>String</string>
+				</dict>
+			</array>
+			<key>INIntentResponse</key>
+			<dict>
+				<key>INIntentResponseCodes</key>
+				<array>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>success</string>
+						<key>INIntentResponseCodeSuccess</key>
+						<true/>
+					</dict>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>failure</string>
+					</dict>
+				</array>
+				<key>INIntentResponseLastParameterTag</key>
+				<integer>4</integer>
+				<key>INIntentResponseOutput</key>
+				<string>note</string>
+				<key>INIntentResponseParameters</key>
+				<array>
+					<dict>
+						<key>INIntentResponseParameterDisplayName</key>
+						<string>Note</string>
+						<key>INIntentResponseParameterDisplayNameID</key>
+						<string>Mz9mrb</string>
+						<key>INIntentResponseParameterDisplayPriority</key>
+						<integer>1</integer>
+						<key>INIntentResponseParameterName</key>
+						<string>note</string>
+						<key>INIntentResponseParameterObjectType</key>
+						<string>IntentNote</string>
+						<key>INIntentResponseParameterObjectTypeNamespace</key>
+						<string>BxdWY5</string>
+						<key>INIntentResponseParameterTag</key>
+						<integer>4</integer>
+						<key>INIntentResponseParameterType</key>
+						<string>Object</string>
+					</dict>
+				</array>
+			</dict>
+			<key>INIntentTitle</key>
+			<string>Find Note With Content</string>
+			<key>INIntentTitleID</key>
+			<string>oawbyy</string>
+			<key>INIntentType</key>
+			<string>Custom</string>
+			<key>INIntentVerb</key>
+			<string>Search</string>
 		</dict>
 	</array>
 	<key>INTypes</key>

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -492,26 +492,6 @@
 							<key>INIntentParameterPromptDialogType</key>
 							<string>Primary</string>
 						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>There are ${count} options matching ‘${content}’.</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>NAzeXM</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>DisambiguationIntroduction</string>
-						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>Just to confirm, you wanted ‘${content}’?</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>wgf6Li</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>Confirmation</string>
-						</dict>
 					</array>
 					<key>INIntentParameterTag</key>
 					<integer>4</integer>
@@ -606,20 +586,6 @@
 						<integer>10</integer>
 						<key>INIntentResponseParameterType</key>
 						<string>Object</string>
-					</dict>
-					<dict>
-						<key>INIntentResponseParameterDisplayName</key>
-						<string>Failure Reason</string>
-						<key>INIntentResponseParameterDisplayNameID</key>
-						<string>Gde29V</string>
-						<key>INIntentResponseParameterDisplayPriority</key>
-						<integer>2</integer>
-						<key>INIntentResponseParameterName</key>
-						<string>failureReason</string>
-						<key>INIntentResponseParameterTag</key>
-						<integer>5</integer>
-						<key>INIntentResponseParameterType</key>
-						<string>String</string>
 					</dict>
 				</array>
 			</dict>

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -437,7 +437,7 @@
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
 			<key>INIntentLastParameterTag</key>
-			<integer>4</integer>
+			<integer>7</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
 				<key>content</key>
@@ -488,6 +488,26 @@
 							<key>INIntentParameterPromptDialogType</key>
 							<string>Primary</string>
 						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} options matching ‘${content}’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>NAzeXM</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${content}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>wgf6Li</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
 					</array>
 					<key>INIntentParameterTag</key>
 					<integer>4</integer>
@@ -506,12 +526,16 @@
 						<true/>
 					</dict>
 					<dict>
+						<key>INIntentResponseCodeFormatString</key>
+						<string>${failureReason}</string>
+						<key>INIntentResponseCodeFormatStringID</key>
+						<string>ThMQV4</string>
 						<key>INIntentResponseCodeName</key>
 						<string>failure</string>
 					</dict>
 				</array>
 				<key>INIntentResponseLastParameterTag</key>
-				<integer>4</integer>
+				<integer>5</integer>
 				<key>INIntentResponseOutput</key>
 				<string>note</string>
 				<key>INIntentResponseParameters</key>
@@ -533,6 +557,20 @@
 						<integer>4</integer>
 						<key>INIntentResponseParameterType</key>
 						<string>Object</string>
+					</dict>
+					<dict>
+						<key>INIntentResponseParameterDisplayName</key>
+						<string>Failure Reason</string>
+						<key>INIntentResponseParameterDisplayNameID</key>
+						<string>Gde29V</string>
+						<key>INIntentResponseParameterDisplayPriority</key>
+						<integer>2</integer>
+						<key>INIntentResponseParameterName</key>
+						<string>failureReason</string>
+						<key>INIntentResponseParameterTag</key>
+						<integer>5</integer>
+						<key>INIntentResponseParameterType</key>
+						<string>String</string>
 					</dict>
 				</array>
 			</dict>

--- a/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/ShortcutIntents.intentdefinition
@@ -437,10 +437,10 @@
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
 			<key>INIntentLastParameterTag</key>
-			<integer>7</integer>
+			<integer>13</integer>
 			<key>INIntentManagedParameterCombinations</key>
 			<dict>
-				<key>content</key>
+				<key>content,note</key>
 				<dict>
 					<key>INIntentParameterCombinationSupportsBackgroundExecution</key>
 					<true/>
@@ -485,6 +485,10 @@
 						<dict>
 							<key>INIntentParameterPromptDialogCustom</key>
 							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Which One?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>yuIu0n</string>
 							<key>INIntentParameterPromptDialogType</key>
 							<string>Primary</string>
 						</dict>
@@ -514,6 +518,51 @@
 					<key>INIntentParameterType</key>
 					<string>String</string>
 				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Note</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>pFkRQX</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>2</integer>
+					<key>INIntentParameterName</key>
+					<string>note</string>
+					<key>INIntentParameterObjectType</key>
+					<string>IntentNote</string>
+					<key>INIntentParameterObjectTypeNamespace</key>
+					<string>BxdWY5</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Which Note?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>OOdDHV</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Which One?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>sOjweW</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>13</integer>
+					<key>INIntentParameterType</key>
+					<string>Object</string>
+				</dict>
 			</array>
 			<key>INIntentResponse</key>
 			<dict>
@@ -535,7 +584,7 @@
 					</dict>
 				</array>
 				<key>INIntentResponseLastParameterTag</key>
-				<integer>5</integer>
+				<integer>10</integer>
 				<key>INIntentResponseOutput</key>
 				<string>note</string>
 				<key>INIntentResponseParameters</key>
@@ -554,7 +603,7 @@
 						<key>INIntentResponseParameterObjectTypeNamespace</key>
 						<string>BxdWY5</string>
 						<key>INIntentResponseParameterTag</key>
-						<integer>4</integer>
+						<integer>10</integer>
 						<key>INIntentResponseParameterType</key>
 						<string>Object</string>
 					</dict>

--- a/Simplenote/Supporting Files/Simplenote-Info.plist
+++ b/Simplenote/Supporting Files/Simplenote-Info.plist
@@ -76,6 +76,7 @@
 	<array>
 		<string>AppendNoteIntent</string>
 		<string>CreateNewNoteIntent</string>
+		<string>FindNoteIntent</string>
 		<string>ListWidgetIntent</string>
 		<string>NoteWidgetIntent</string>
 		<string>OpenNewNoteIntent</string>

--- a/SimplenoteIntents/Intent Handlers/FindNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/FindNoteIntentHandler.swift
@@ -1,0 +1,49 @@
+//
+//  FindNoteIntentHandler.swift
+//  SimplenoteIntents
+//
+//  Created by Charlie Scheer on 5/9/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Intents
+
+class FindNoteIntentHandler: NSObject, FindNoteIntentHandling {
+    let coreDataWrapper = ExtensionCoreDataWrapper()
+
+    func handle(intent: FindNoteIntent) async -> FindNoteIntentResponse {
+        guard let notes = coreDataWrapper.resultsController()?.notes() else {
+            return FindNoteIntentResponse(code: .failure, userActivity: nil)
+        }
+
+        guard let content = intent.content else {
+            return FindNoteIntentResponse(code: .unspecified, userActivity: nil)
+        }
+
+        let matchingNotes: [Note] = notes.compactMap({
+            if $0.content?.contains(content) == true {
+                return $0
+            }
+            return nil
+        })
+
+        guard matchingNotes.isEmpty == false else {
+            // TODO: Create custom respond code to alert user that no notes were found
+            return FindNoteIntentResponse(code: .failure, userActivity: nil)
+        }
+
+        guard matchingNotes.count == 1 else {
+            // TODO: Disambiguate the notes
+            return FindNoteIntentResponse(code: .failure, userActivity: nil)
+        }
+
+        guard let matchingNote = matchingNotes.first else {
+            return FindNoteIntentResponse(code: .failure, userActivity: nil)
+        }
+        let success = FindNoteIntentResponse(code: .success, userActivity: nil)
+        success.note = IntentNote(identifier: matchingNote.simperiumKey, display: matchingNote.title)
+
+        return success
+
+    }
+}

--- a/SimplenoteIntents/Intent Handlers/FindNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/FindNoteIntentHandler.swift
@@ -8,12 +8,26 @@
 
 import Intents
 
+enum FindNoteError: String {
+    case couldNotFetchNotes
+    case noMatchingNotesFound
+
+    var localizedDescription: String {
+        switch self {
+        case .couldNotFetchNotes:
+            NSLocalizedString("Could not fetch notes", comment: "Error warning user that their notes could not be fetched")
+        case .noMatchingNotesFound:
+            NSLocalizedString("Could not find notes matching the search terms", comment: "Error warning user that a matching note could not be found")
+        }
+    }
+}
+
 class FindNoteIntentHandler: NSObject, FindNoteIntentHandling {
     let coreDataWrapper = ExtensionCoreDataWrapper()
 
     func handle(intent: FindNoteIntent) async -> FindNoteIntentResponse {
         guard let notes = coreDataWrapper.resultsController()?.notes() else {
-            return FindNoteIntentResponse(code: .failure, userActivity: nil)
+            return FindNoteIntentResponse.failure(failureReason: FindNoteError.couldNotFetchNotes.localizedDescription)
         }
 
         guard let content = intent.content else {
@@ -28,8 +42,7 @@ class FindNoteIntentHandler: NSObject, FindNoteIntentHandling {
         })
 
         guard matchingNotes.isEmpty == false else {
-            // TODO: Create custom respond code to alert user that no notes were found
-            return FindNoteIntentResponse(code: .failure, userActivity: nil)
+            return FindNoteIntentResponse.failure(failureReason: FindNoteError.noMatchingNotesFound.localizedDescription)
         }
 
         guard matchingNotes.count == 1 else {

--- a/SimplenoteIntents/IntentHandler.swift
+++ b/SimplenoteIntents/IntentHandler.swift
@@ -17,8 +17,11 @@ class IntentHandler: INExtension {
             return AppendNoteIntentHandler()
         case is CreateNewNoteIntent:
             return CreateNewNoteIntentHandler()
+        case is FindNoteIntent:
+            return FindNoteIntentHandler()
         default:
             return self
         }
     }
 }
+

--- a/SimplenoteIntents/IntentHandler.swift
+++ b/SimplenoteIntents/IntentHandler.swift
@@ -24,4 +24,3 @@ class IntentHandler: INExtension {
         }
     }
 }
-

--- a/SimplenoteIntents/ResolutionResults/IntentNote+Helpers.swift
+++ b/SimplenoteIntents/ResolutionResults/IntentNote+Helpers.swift
@@ -21,6 +21,31 @@ extension IntentNoteResolutionResult {
 
         return IntentNoteResolutionResult.success(with: intentNote)
     }
+
+    static func resolveIntentNote(for content: String, in coreDataWrapper: ExtensionCoreDataWrapper) -> IntentNoteResolutionResult {
+        guard let notes = coreDataWrapper.resultsController()?.notes() else {
+            // TODO: Better error
+            return IntentNoteResolutionResult.unsupported()
+        }
+        let filteredNotes = notes.filter({ $0.content?.contains(content) == true })
+        let intentNotes = filteredNotes.map({ IntentNote(identifier: $0.simperiumKey, display: $0.title) })
+
+        guard intentNotes.isEmpty == false else {
+            // TODO: Better error
+            return IntentNoteResolutionResult.unsupported()
+        }
+
+        guard intentNotes.count == 1 else {
+            return IntentNoteResolutionResult.disambiguation(with: intentNotes)
+        }
+
+        //This shouldn't happen but we to unwrap the existing note we need to return something
+        guard let matchingNote = intentNotes.first else {
+            return IntentNoteResolutionResult.unsupported()
+        }
+
+        return IntentNoteResolutionResult.success(with: matchingNote)
+    }
 }
 
 extension IntentNote {

--- a/SimplenoteIntents/Supporting Files/Info.plist
+++ b/SimplenoteIntents/Supporting Files/Info.plist
@@ -32,6 +32,7 @@
 			<array>
 				<string>AppendNoteIntent</string>
 				<string>CreateNewNoteIntent</string>
+				<string>FindNoteIntent</string>
 				<string>ListWidgetIntent</string>
 				<string>NoteWidgetIntent</string>
 				<string>OpenNewNoteIntent</string>


### PR DESCRIPTION
### Fix
So another thing that might be useful for shortcuts is to be able to find a note by its content and not its title.  This intent itself doesn't do anything except for search notes and present them as an option, but if you connect it to Append Note then you can find a note by it's content, and add content to it in one shortcut.  pretty cool I think.  So that is what I have done in this PR.

As a bonus, While I was at it I realized that you might also want to open a note that you found based on its content.  So I have updated the Open Note Intent to accept a note from other shortcuts.

This is the last planned shortcut to be added, so this: 
fixes #1569 
fixes #1487 

### Test
okay, so testing this requires a bit of understanding of shortcuts.

### find and append to note
1. build app to device to ensure the entitlements are handled correctly
2. background the app, open shortcuts, add a shortcut and tap on add action.  Find Simplenote and add Find Note With Content
3. tap on content and choose "Ask each time" and hit done in the drawer
4. at the bottom of the page you should see Simplenote in a hidden modal, slide that up and select Append to note
5. tap on content and hit Ask each time
6. now run the shortcut. 
7. type in some text you know is in one of your notes and then hit done. (note if you have two notes with the same content you will be asked to choose which note you want.  Make sure to test this too)
8. then enter in some content in the next view and hit done

Open Simplenote and confirm your text was added to your note

### find and open note
1. background the app again, open shortcuts, add a shortcut and tap on add action.  Find Simplenote and add Find Note With Content
2. tap on content and choose "Ask each time" and hit done in the drawer
3. at the bottom of the page you should see Simplenote in a hidden modal, slide that up and select Open Note
4. now run the shortcut. 

confirm that the note you searched for is opened in Simplenote

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in fc201c with:
> 
> > Extended support for iOS Shortcuts
