### PR TITLE
Updated note list view controller top content inset

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -157,8 +157,8 @@ extension SPNoteListViewController {
     ///
     @objc
     func refreshTableViewTopInsets() {
-        tableView.contentInset.top = searchBarStackView.frame.height / 2
-        tableView.verticalScrollIndicatorInsets.top = searchBarStackView.frame.height / 2
+        tableView.contentInset.top = searchBarStackView.frame.height / 1.75
+        tableView.verticalScrollIndicatorInsets.top = searchBarStackView.frame.height / 1.75
     }
 
     /// Scrolls to the First Row whenever the flag `mustScrollToFirstRow` was set to true

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -157,8 +157,8 @@ extension SPNoteListViewController {
     ///
     @objc
     func refreshTableViewTopInsets() {
-        tableView.contentInset.top = searchBarStackView.frame.height
-        tableView.verticalScrollIndicatorInsets.top = searchBarStackView.frame.height
+        tableView.contentInset.top = searchBarStackView.frame.height / 2
+        tableView.verticalScrollIndicatorInsets.top = searchBarStackView.frame.height / 2
     }
 
     /// Scrolls to the First Row whenever the flag `mustScrollToFirstRow` was set to true


### PR DESCRIPTION
### Fix
There is a small gap at the top of the note list right now that doesn't look correct.
![image](https://github.com/Automattic/simplenote-ios/assets/22015538/27cb1c2a-7262-4122-97ab-6cac03e19e05)

This PR updates the content inserts on the list view so that the gap isn't there.

### Test
1. Open up Simplenote and go to the notes list.  Confirm there isn't a weird gap at the top of the list above the first note.
2. scroll and make sure the notes still look correct

Try on a few devices and orientations to guard against any regressions

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
