### PR TITLE
Updated SPNoteListVC to allow for viewing notes in the trash

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -523,7 +523,6 @@
     BOOL isTrashOnScreen = self.isDeletedFilterActive;
 
     [self refreshEmptyTrashState];
-    self.tableView.allowsSelection = !isTrashOnScreen;
     
     [self displayPlaceholdersIfNeeded];
     [self refershNavigationButtons];


### PR DESCRIPTION
### Fix
It was noted in #1126 that other platforms allow for viewing notes in the trash but SNiOS did not.

In this PR I have updated the note list view controller to allow for viewing trashed notes to bring it in line with the rest of our platforms.

fixes #1126
### Test
1. go to the side menu, select trash
2. select a note in the trash

- [x] Confirm that you can see and edit notes in the trash

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
