### PR TITLE
Dont use tags on shortcut

### DIFF
--- a/Simplenote/Classes/ActivityType.swift
+++ b/Simplenote/Classes/ActivityType.swift
@@ -11,12 +11,12 @@ enum ActivityType: String {
     /// New Note Activity
     ///
     case newNote = "com.codality.NotationalFlow.newNote"
-    case newNoteShortcut = "SPOpenNewNoteIntent"
+    case newNoteShortcut = "OpenNewNoteIntent"
 
     /// Open a Note!
     ///
     case openNote = "com.codality.NotationalFlow.openNote"
-    case openNoteShortcut = "SPOpenNoteIntent"
+    case openNoteShortcut = "OpenNoteIntent"
 
     /// Open an Item that was indexed by Spotlight
     ///

--- a/Simplenote/Classes/ShortcutsHandler.swift
+++ b/Simplenote/Classes/ShortcutsHandler.swift
@@ -49,7 +49,7 @@ class ShortcutsHandler: NSObject {
         case .launch:
             break
         case .newNote, .newNoteShortcut:
-            SPAppDelegate.shared().presentNewNoteEditor()
+            SPAppDelegate.shared().presentNewNoteEditor(useSelectedTag: false)
         case .openNote, .openSpotlightItem:
             presentNote(for: userActivity)
         case .openNoteShortcut:
@@ -105,7 +105,7 @@ extension ShortcutsHandler {
         case .search:
             SPAppDelegate.shared().presentSearch()
         case .newNote:
-            SPAppDelegate.shared().presentNewNoteEditor()
+            SPAppDelegate.shared().presentNewNoteEditor(useSelectedTag: false)
         case .note:
             if let simperiumKey = shortcut.userInfo?[shortcutUserInfoNoteIdentifierKey] as? String {
                 SPAppDelegate.shared().presentNoteWithSimperiumKey(simperiumKey)

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -165,6 +165,11 @@ extension SPAppDelegate {
         }
     }
 
+    @objc
+    func presentNewNoteEditor(animated: Bool = false) {
+        presentNewNoteEditor(useSelectedTag: true, animated: animated)
+    }
+
     var verifyController: PinLockVerifyController? {
         (pinLockWindow?.rootViewController as? PinLockViewController)?.controller as? PinLockVerifyController
     }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -151,13 +151,17 @@ extension SPAppDelegate {
     /// Opens editor with a new note
     ///
     @objc
-    func presentNewNoteEditor(animated: Bool = false) {
-        if isPresentingPasscodeLock && SPPinLockManager.shared.isEnabled {
-            verifyController?.addOnSuccesBlock {
+    func presentNewNoteEditor(useSelectedTag: Bool = true, animated: Bool = false) {
+        performActionAfterUnlock {
+            if useSelectedTag {
                 self.presentNote(nil, animated: animated)
+            } else {
+                // If we use the standard new note option and a tag is selected then the tag is applied
+                // in some cases, like shortcuts, we don't want it do apply the tag cause you can't see
+                // what tag is selected when the shortcut runs
+                let note = SPObjectManager.shared().newDefaultNote()
+                self.presentNote(note, animated: true)
             }
-        } else {
-            presentNote(nil, animated: animated)
         }
     }
 
@@ -203,6 +207,16 @@ extension SPAppDelegate {
     @objc
     func setupNoticeController() {
         NoticeController.shared.setupNoticeController()
+    }
+
+    func performActionAfterUnlock(action: @escaping () -> Void) {
+        if isPresentingPasscodeLock && SPPinLockManager.shared.isEnabled {
+            verifyController?.addOnSuccesBlock {
+                action()
+            }
+        } else {
+            action()
+        }
     }
 }
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -508,7 +508,7 @@
     }
 
     if ([[components host] isEqualToString:@"widgetNew"]) {
-        [self presentNewNoteEditorWithAnimated: NO];
+        [self presentNewNoteEditorWithUseSelectedTag:NO animated:NO];
     }
 
     return YES;


### PR DESCRIPTION
### Fix
Currently we have a few different ways to create and open new notes from outside of Simplenote:
- The new note widget
- The long press Home Screen shortcut
- The Open New Note shortcut

If you select one of those options and inside the app you have a tag selected then the new note that is created is tagged.  This is probably fine ish... but since you can't see what the tag is when the shortcuts are run it is a little odd if you weren't expecting it.  We shouldn't add the tag when making a new note.  So here we are not doing that.

fixes #1424 

### Test
1.  In Simplenote select a tag from the sidebar
2. background the app and long press on the Simplenote icon, select new note.  When the editor appears confirm that the new note does not have a tag
3. Go to the shortcut app, create a new shortcut, add action, select Simplenote and add an Open New Note action.  Run the action and confirm that the new note that is opened is not tagged
4. Go to the desktop and long press on the Home Screen, when the home screen edit appears tap on the plus, search the widgets for Simplenote, and add the new note widget.  Tap on that widget, confirm that no tag is added to the note that is created.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
