### PR TITLE
Preserve tableView selection when app entering background

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.52
 -----
 - Extended support for iOS Shortcuts
+- Fixed issue where notes selection was lost when app backgrounded
 
 4.51
 -----

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -697,6 +697,15 @@ extension SPNoteListViewController {
             return count > 0 ? Localization.selectedTitle(with: count) : notesListController.filter.title
         }()
     }
+
+    @objc
+    func selectRows(with indexPaths: [IndexPath]) {
+        guard isEditing else {
+            return
+        }
+
+        indexPaths.forEach({ tableView.selectRow(at: $0, animated: false, scrollPosition: .none) })
+    }
 }
 
 // MARK: - Row Actions

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -699,6 +699,13 @@ extension SPNoteListViewController {
     }
 
     @objc
+    func restoreSelectedRowsAfterBackgrounding() {
+        if selectedNotesEnteringBackground.isEmpty == false {
+            selectRows(with: selectedNotesEnteringBackground)
+            selectedNotesEnteringBackground.removeAll()
+        }
+    }
+
     func selectRows(with indexPaths: [IndexPath]) {
         guard isEditing else {
             return

--- a/Simplenote/Classes/SPNoteListViewController.h
+++ b/Simplenote/Classes/SPNoteListViewController.h
@@ -33,6 +33,7 @@
 @property (nonatomic, strong) UIBarButtonItem                               *selectAllButton;
 @property (nonatomic, weak) Note                                            *selectedNote;
 @property (nonatomic) BOOL                                                  navigatingUsingKeyboard;
+@property (nonatomic) NSArray<NSIndexPath *>                                *selectedNotesEnteringBackground;
 
 - (void)update;
 - (void)openNote:(Note *)note animated:(BOOL)animated;

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -529,8 +529,6 @@
     [self refreshTitle];
     [self refreshSearchBar];
 
-    BOOL isTrashOnScreen = self.isDeletedFilterActive;
-
     [self refreshEmptyTrashState];
     
     [self displayPlaceholdersIfNeeded];

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -197,6 +197,7 @@
 
     // App Background
     [nc addObserver:self selector:@selector(appWillEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    [nc addObserver:self selector:@selector(appWillEnterForeground) name:UIApplicationWillEnterForegroundNotification object:nil];
 }
 
 - (void)condensedPreferenceWasUpdated:(id)sender
@@ -220,6 +221,10 @@
 
 - (void)appWillEnterBackground {
     self.selectedNotesEnteringBackground = self.tableView.indexPathsForSelectedRows;
+}
+
+- (void)appWillEnterForeground {
+    [self restoreSelectedRowsAfterBackgrounding];
 }
 
 - (void)refreshStyle {

--- a/Simplenote/Classes/SPNoteListViewController.m
+++ b/Simplenote/Classes/SPNoteListViewController.m
@@ -63,6 +63,8 @@
         [self refreshStyle];
         [self update];
         self.mustScrollToFirstRow = YES;
+
+        self.selectedNotesEnteringBackground = [NSArray new];
     }
     
     return self;
@@ -192,6 +194,9 @@
 
     // Themes
     [nc addObserver:self selector:@selector(themeDidChange) name:SPSimplenoteThemeChangedNotification object:nil];
+
+    // App Background
+    [nc addObserver:self selector:@selector(appWillEnterBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
 }
 
 - (void)condensedPreferenceWasUpdated:(id)sender
@@ -211,6 +216,10 @@
 
 - (void)themeDidChange {
     [self refreshStyle];
+}
+
+- (void)appWillEnterBackground {
+    self.selectedNotesEnteringBackground = self.tableView.indexPathsForSelectedRows;
 }
 
 - (void)refreshStyle {

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -41,6 +41,7 @@
 @interface SPAppDelegate ()
 
 @property (weak,   nonatomic) SPModalActivityIndicator      *signOutActivityIndicator;
+@property (nonatomic) NSArray *selectedNotesEnteringBackground;
 
 @end
 
@@ -189,12 +190,19 @@
     [self cleanupScrollPositionCache];
     [self syncWidgetDefaults];
     [self resetWidgetTimelines];
+
+    self.selectedNotesEnteringBackground = self.noteListViewController.tableView.indexPathsForSelectedRows;
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
 {
     [self dismissPasscodeLockIfPossible];
     [self authenticateSimperiumIfAccountDeletionRequested];
+
+    if (self.selectedNotesEnteringBackground != nil) {
+        [self.noteListViewController selectRowsWith:self.selectedNotesEnteringBackground];
+        self.selectedNotesEnteringBackground = nil;
+    }
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -195,7 +195,6 @@
 {
     [self dismissPasscodeLockIfPossible];
     [self authenticateSimperiumIfAccountDeletionRequested];
-    [self.noteListViewController restoreSelectedRowsAfterBackgrounding];
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -41,7 +41,6 @@
 @interface SPAppDelegate ()
 
 @property (weak,   nonatomic) SPModalActivityIndicator      *signOutActivityIndicator;
-@property (nonatomic) NSArray *selectedNotesEnteringBackground;
 
 @end
 
@@ -190,19 +189,13 @@
     [self cleanupScrollPositionCache];
     [self syncWidgetDefaults];
     [self resetWidgetTimelines];
-
-    self.selectedNotesEnteringBackground = self.noteListViewController.tableView.indexPathsForSelectedRows;
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
 {
     [self dismissPasscodeLockIfPossible];
     [self authenticateSimperiumIfAccountDeletionRequested];
-
-    if (self.selectedNotesEnteringBackground != nil) {
-        [self.noteListViewController selectRowsWith:self.selectedNotesEnteringBackground];
-        self.selectedNotesEnteringBackground = nil;
-    }
+    [self.noteListViewController restoreSelectedRowsAfterBackgrounding];
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler

--- a/Simplenote/URL+Simplenote.swift
+++ b/Simplenote/URL+Simplenote.swift
@@ -29,7 +29,7 @@ extension URL {
     }
 
     static func newNoteWidgetURL() -> URL {
-        guard var components = URLComponents.simplenoteURLComponents(with: Constants.newNotePath) else {
+        guard let components = URLComponents.simplenoteURLComponents(with: Constants.newNotePath) else {
             return URL(string: .simplenotePath())!
         }
 


### PR DESCRIPTION
### Fix
Currently if you have notes selected in the notes table view and you put Simplenote into the background, the selection is lost.  Not an ideal situation, I would expect that you could background and then return to Simplenote and the state of the app should be the same, so the selection would be preserved.  So in this PR I have fixed that.

### Test
1. Open up the note list, long press on a note and choose Select. 
2. Pick a few notes
3. put the app in the background
4. Go back into Simplenote

- [ ] confirm that your notes are still selected

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in ea5992 with:
> 
> > Fixed issue where notes selection was lost when app backgrounded
