### PR TITLE
Fixed an issue can activate the faceid switch without a passcode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.52
 -----
 - Extended support for iOS Shortcuts
+- Fixed an issue can activate the faceid switch without a passcode
 
 4.51
 -----

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -87,6 +87,7 @@ extension SPSettingsViewController: PinLockSetupControllerDelegate {
     func pinLockSetupControllerDidComplete(_ controller: PinLockSetupController) {
         SPTracker.trackSettingsPinlockEnabled(true)
         dismissPresentedViewController()
+        SPPinLockManager.shared.shouldUseBiometry = biometrySwitch.isOn
     }
 
     func pinLockSetupControllerDidCancel(_ controller: PinLockSetupController) {

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -87,7 +87,7 @@ extension SPSettingsViewController: PinLockSetupControllerDelegate {
     func pinLockSetupControllerDidComplete(_ controller: PinLockSetupController) {
         SPTracker.trackSettingsPinlockEnabled(true)
         dismissPresentedViewController()
-        SPPinLockManager.shared.shouldUseBiometry = biometrySwitch.isOn
+        SPPinLockManager.shared.shouldUseBiometry = true
     }
 
     func pinLockSetupControllerDidCancel(_ controller: PinLockSetupController) {

--- a/Simplenote/Classes/SPSettingsViewController.h
+++ b/Simplenote/Classes/SPSettingsViewController.h
@@ -2,11 +2,12 @@
 #import "SPTableViewController.h"
 
 @interface SPSettingsViewController : SPTableViewController <UIPickerViewDelegate, UIPickerViewDataSource> {
-    
     //Preferences
     NSNumber *sortOrderPref;
     NSNumber *numPreviewLinesPref;
 }
+
+@property (nonatomic, strong) UISwitch      *biometrySwitch;
 
 @end
 

--- a/Simplenote/Classes/SPSettingsViewController.h
+++ b/Simplenote/Classes/SPSettingsViewController.h
@@ -7,8 +7,6 @@
     NSNumber *numPreviewLinesPref;
 }
 
-@property (nonatomic, strong) UISwitch      *biometrySwitch;
-
 @end
 
 extern NSString *const SPAlphabeticalTagSortPref;

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -14,7 +14,6 @@ NSString *const SPSustainerAppIconName                              = @"AppIcon-
 @interface SPSettingsViewController ()
 @property (nonatomic, strong) UISwitch      *condensedNoteListSwitch;
 @property (nonatomic, strong) UISwitch      *alphabeticalTagSortSwitch;
-@property (nonatomic, strong) UISwitch      *biometrySwitch;
 @property (nonatomic, strong) UISwitch      *sustainerIconSwitch;
 @property (nonatomic, strong) UITextField   *pinTimeoutTextField;
 @property (nonatomic, strong) UIPickerView  *pinTimeoutPickerView;
@@ -747,11 +746,11 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
 
 - (void)touchIdSwitchDidChangeValue:(UISwitch *)sender
 {
-    SPPinLockManager.shared.shouldUseBiometry = sender.on;
-
     if (![self isPinLockEnabled] && [self.biometrySwitch isOn]) {
         UIAlertController* alert = [self pinLockRequiredAlert];
         [self presentViewController:alert animated:YES completion:nil];
+    } else {
+        SPPinLockManager.shared.shouldUseBiometry = sender.on;
     }
 }
 

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -14,6 +14,7 @@ NSString *const SPSustainerAppIconName                              = @"AppIcon-
 @interface SPSettingsViewController ()
 @property (nonatomic, strong) UISwitch      *condensedNoteListSwitch;
 @property (nonatomic, strong) UISwitch      *alphabeticalTagSortSwitch;
+@property (nonatomic, strong) UISwitch      *biometrySwitch;
 @property (nonatomic, strong) UISwitch      *sustainerIconSwitch;
 @property (nonatomic, strong) UITextField   *pinTimeoutTextField;
 @property (nonatomic, strong) UIPickerView  *pinTimeoutPickerView;


### PR DESCRIPTION
### Fix
Currently there is an issue where you can activate the FaceID/Biometry lock switch for Simplenote without entering a passcode.  We do not permit this, and the biometry doesn't actually activate, but default setting changes and the switch appears like it is active.  This PR fixes that.

Steps to repro on trunk:
1. with PIN code and biometry disabled go to the settings view
2. enable the faceID switch without putting in a passcode
3. Swipe up and close out of the app without dealing with the modal.
4. Relaunch the app and go back to settings, you will see that the biometry switch is active, but it shouldn't be.

### Test
1. with PIN code and biometry disabled go to the settings view
2. enable the faceID switch without putting in a passcode
3. Swipe up and close out of the app without dealing with the modal.
4. Relaunch the app and go back to settings, you will see that the biometry switch is not active

Confirm you can set a passcode and activate biometry.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in b2f88d with:
> 
> > Fixed an issue can activate the faceid switch without a passcode