### PR TITLE
Fixing Crash

### DIFF
--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -700,10 +700,12 @@ extension SPNoteListViewController {
 
     @objc
     func restoreSelectedRowsAfterBackgrounding() {
-        if selectedNotesEnteringBackground.isEmpty == false {
-            selectRows(with: selectedNotesEnteringBackground)
-            selectedNotesEnteringBackground.removeAll()
+        guard let selectedNotesEnteringBackground, selectedNotesEnteringBackground.isEmpty == false else {
+            return
         }
+
+        selectRows(with: selectedNotesEnteringBackground)
+        self.selectedNotesEnteringBackground = []
     }
 
     func selectRows(with indexPaths: [IndexPath]) {


### PR DESCRIPTION
### Fix
In this PR we're fixing a crash, triggered by a force unwrap of a nil property.

### Test
1. Launch Simplenote
2. Send the app to Background
3. Bring the app back into Foreground

- [x] Verify the app doesn't crash

### Review
Fixed a crash that occurred after switching to / from background

### Release
> These changes do not require release notes.
