### PR TITLE
Charlie/shortcut data loss failsafe

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -485,6 +485,8 @@
 		BA6DA19226DB5F1B000464C8 /* URLComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6DA19026DB5F1B000464C8 /* URLComponents.swift */; };
 		BA7071E526BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */; };
 		BA7071E626BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */; };
+		BA7240222C1BA1210088EC11 /* ContentRecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7240212C1BA1210088EC11 /* ContentRecoveryManager.swift */; };
+		BA7240232C1BA1930088EC11 /* ContentRecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7240212C1BA1210088EC11 /* ContentRecoveryManager.swift */; };
 		BA75D8A326C084E900883FFA /* Text+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75D87D26C0843600883FFA /* Text+Simplenote.swift */; };
 		BA75D8AE26C0862E00883FFA /* View+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75D8AD26C0862E00883FFA /* View+Simplenote.swift */; };
 		BA75D8BA26C0865C00883FFA /* Filling.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75D8B926C0865C00883FFA /* Filling.swift */; };
@@ -509,13 +511,13 @@
 		BA8FC2A5267AC7470082962E /* SharedStorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */; };
 		BA9B19F926A8EF3200692366 /* SpinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */; };
 		BA9B59022685549F00DAD1ED /* StorageSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B59012685549F00DAD1ED /* StorageSettings.swift */; };
-		BA9C7EFB2BF2CC3E007A8460 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */; };
-		BA9C7EFC2BF2CCAE007A8460 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */; };
 		BA9C7EC92BED7AB1007A8460 /* CopyNoteContentIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EC82BED7AB1007A8460 /* CopyNoteContentIntentHandler.swift */; };
 		BA9C7ECB2BED7F7B007A8460 /* FindNoteWithTagIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7ECA2BED7F7B007A8460 /* FindNoteWithTagIntentHandler.swift */; };
 		BA9C7ECD2BED813B007A8460 /* IntentTag+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7ECC2BED813B007A8460 /* IntentTag+Helpers.swift */; };
 		BA9C7ED02BEE9BA7007A8460 /* ShortcutIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7ECF2BEE9BA7007A8460 /* ShortcutIntents.intentdefinition */; };
 		BA9C7ED12BEE9BA7007A8460 /* ShortcutIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7ECF2BEE9BA7007A8460 /* ShortcutIntents.intentdefinition */; };
+		BA9C7EFB2BF2CC3E007A8460 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */; };
+		BA9C7EFC2BF2CCAE007A8460 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */; };
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		BAA59E79269F9FE30068BD3D /* Date+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */; };
 		BAA63C3325EEDA83001589D7 /* NoteLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */; };
@@ -1185,6 +1187,7 @@
 		BA6D7B8A2BE588F0006AE368 /* IntentsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentsError.swift; sourceTree = "<group>"; };
 		BA6DA19026DB5F1B000464C8 /* URLComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponents.swift; sourceTree = "<group>"; };
 		BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = ListWidgetIntent.intentdefinition; sourceTree = "<group>"; };
+		BA7240212C1BA1210088EC11 /* ContentRecoveryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentRecoveryManager.swift; sourceTree = "<group>"; };
 		BA75D87D26C0843600883FFA /* Text+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Simplenote.swift"; sourceTree = "<group>"; };
 		BA75D8AD26C0862E00883FFA /* View+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Simplenote.swift"; sourceTree = "<group>"; };
 		BA75D8B926C0865C00883FFA /* Filling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filling.swift; sourceTree = "<group>"; };
@@ -1199,7 +1202,6 @@
 		BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStorageMigrator.swift; sourceTree = "<group>"; };
 		BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		BA9B59012685549F00DAD1ED /* StorageSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSettings.swift; sourceTree = "<group>"; };
-		BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
 		BA9C7EC82BED7AB1007A8460 /* CopyNoteContentIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyNoteContentIntentHandler.swift; sourceTree = "<group>"; };
 		BA9C7ECA2BED7F7B007A8460 /* FindNoteWithTagIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNoteWithTagIntentHandler.swift; sourceTree = "<group>"; };
 		BA9C7ECC2BED813B007A8460 /* IntentTag+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntentTag+Helpers.swift"; sourceTree = "<group>"; };
@@ -1224,6 +1226,7 @@
 		BA9C7EF52BEE9C3D007A8460 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/ShortcutIntents.strings; sourceTree = "<group>"; };
 		BA9C7EF72BEE9C3E007A8460 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/ShortcutIntents.strings"; sourceTree = "<group>"; };
 		BA9C7EF92BEE9C3F007A8460 /* zh-Hans-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans-CN"; path = "zh-Hans-CN.lproj/ShortcutIntents.strings"; sourceTree = "<group>"; };
+		BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteLinkTests.swift; sourceTree = "<group>"; };
@@ -2233,6 +2236,7 @@
 				BA3856CC2681715700F388CC /* CoreDataManager.swift */,
 				BA9B59012685549F00DAD1ED /* StorageSettings.swift */,
 				BA32A90E26B7469F00727247 /* WidgetError.swift */,
+				BA7240212C1BA1210088EC11 /* ContentRecoveryManager.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -3454,6 +3458,7 @@
 				B543C7E323CF76EA00003A80 /* NotesListFilter.swift in Sources */,
 				46A3C96717DFA81A002865AE /* NSManagedObjectContext+CoreDataExtensions.m in Sources */,
 				A6C0DFA725C0992D00B9BE39 /* NoteScrollPositionCache.swift in Sources */,
+				BA7240222C1BA1210088EC11 /* ContentRecoveryManager.swift in Sources */,
 				B59314D81A486B3800B651ED /* SPConstants.m in Sources */,
 				375D24B421E01131007AB25A /* escape.c in Sources */,
 				B50F47A61D1D791B00822748 /* NSURL+Extensions.swift in Sources */,
@@ -3858,6 +3863,7 @@
 				BAF8D45526AE10FC00CA9383 /* Tag+Widget.swift in Sources */,
 				BAFFCEA726DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift in Sources */,
 				BAF8D53C26AE175C00CA9383 /* Bundle+Simplenote.swift in Sources */,
+				BA7240232C1BA1930088EC11 /* ContentRecoveryManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 		BA4499B325ED8AB0000C563E /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499B225ED8AB0000C563E /* NoticeView.swift */; };
 		BA4499BC25ED95D0000C563E /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499BB25ED95D0000C563E /* Notice.swift */; };
 		BA4499C525ED95E5000C563E /* NoticeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4499C425ED95E5000C563E /* NoticeAction.swift */; };
+		BA4A01902C1CCEC100EEE567 /* RecoveryArchiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4A018F2C1CCEC100EEE567 /* RecoveryArchiver.swift */; };
 		BA4C6CFC264C744300B723A7 /* SeparatorsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4C6CFB264C744300B723A7 /* SeparatorsView.swift */; };
 		BA5249FD26DF0BC600DAC945 /* WidgetWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5249FC26DF0BC600DAC945 /* WidgetWarningView.swift */; };
 		BA524A0226DF1AE800DAC945 /* WidgetsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA524A0126DF1AE800DAC945 /* WidgetsState.swift */; };
@@ -485,8 +486,7 @@
 		BA6DA19226DB5F1B000464C8 /* URLComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6DA19026DB5F1B000464C8 /* URLComponents.swift */; };
 		BA7071E526BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */; };
 		BA7071E626BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */; };
-		BA7240222C1BA1210088EC11 /* ContentRecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7240212C1BA1210088EC11 /* ContentRecoveryManager.swift */; };
-		BA7240232C1BA1930088EC11 /* ContentRecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7240212C1BA1210088EC11 /* ContentRecoveryManager.swift */; };
+		BA7240222C1BA1210088EC11 /* RecoveryUnarchiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA7240212C1BA1210088EC11 /* RecoveryUnarchiver.swift */; };
 		BA75D8A326C084E900883FFA /* Text+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75D87D26C0843600883FFA /* Text+Simplenote.swift */; };
 		BA75D8AE26C0862E00883FFA /* View+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75D8AD26C0862E00883FFA /* View+Simplenote.swift */; };
 		BA75D8BA26C0865C00883FFA /* Filling.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA75D8B926C0865C00883FFA /* Filling.swift */; };
@@ -1168,6 +1168,7 @@
 		BA4499B225ED8AB0000C563E /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		BA4499BB25ED95D0000C563E /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
 		BA4499C425ED95E5000C563E /* NoticeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAction.swift; sourceTree = "<group>"; };
+		BA4A018F2C1CCEC100EEE567 /* RecoveryArchiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryArchiver.swift; sourceTree = "<group>"; };
 		BA4C6CFB264C744300B723A7 /* SeparatorsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorsView.swift; sourceTree = "<group>"; };
 		BA5249FC26DF0BC600DAC945 /* WidgetWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetWarningView.swift; sourceTree = "<group>"; };
 		BA524A0126DF1AE800DAC945 /* WidgetsState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetsState.swift; sourceTree = "<group>"; };
@@ -1187,7 +1188,7 @@
 		BA6D7B8A2BE588F0006AE368 /* IntentsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentsError.swift; sourceTree = "<group>"; };
 		BA6DA19026DB5F1B000464C8 /* URLComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponents.swift; sourceTree = "<group>"; };
 		BA7071E426BB68A300D5DFF0 /* ListWidgetIntent.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = ListWidgetIntent.intentdefinition; sourceTree = "<group>"; };
-		BA7240212C1BA1210088EC11 /* ContentRecoveryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentRecoveryManager.swift; sourceTree = "<group>"; };
+		BA7240212C1BA1210088EC11 /* RecoveryUnarchiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryUnarchiver.swift; sourceTree = "<group>"; };
 		BA75D87D26C0843600883FFA /* Text+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Simplenote.swift"; sourceTree = "<group>"; };
 		BA75D8AD26C0862E00883FFA /* View+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Simplenote.swift"; sourceTree = "<group>"; };
 		BA75D8B926C0865C00883FFA /* Filling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filling.swift; sourceTree = "<group>"; };
@@ -2236,7 +2237,7 @@
 				BA3856CC2681715700F388CC /* CoreDataManager.swift */,
 				BA9B59012685549F00DAD1ED /* StorageSettings.swift */,
 				BA32A90E26B7469F00727247 /* WidgetError.swift */,
-				BA7240212C1BA1210088EC11 /* ContentRecoveryManager.swift */,
+				BA7240212C1BA1210088EC11 /* RecoveryUnarchiver.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -2414,6 +2415,14 @@
 			name = Notices;
 			sourceTree = "<group>";
 		};
+		BA4A018E2C1CCEB300EEE567 /* Tools */ = {
+			isa = PBXGroup;
+			children = (
+				BA4A018F2C1CCEC100EEE567 /* RecoveryArchiver.swift */,
+			);
+			path = Tools;
+			sourceTree = "<group>";
+		};
 		BA57692A269D2103008B510E /* Remotes */ = {
 			isa = PBXGroup;
 			children = (
@@ -2461,6 +2470,7 @@
 		BAB5762526703C8200B0C56F /* SimplenoteIntents */ = {
 			isa = PBXGroup;
 			children = (
+				BA4A018E2C1CCEB300EEE567 /* Tools */,
 				BA34B04F2BEAEF4800580E15 /* SimplenoteIntentsRelease.entitlements */,
 				092FD78026D7BB72006BE8E2 /* Supporting Files */,
 				BAB5762626703C8200B0C56F /* IntentHandler.swift */,
@@ -3458,7 +3468,7 @@
 				B543C7E323CF76EA00003A80 /* NotesListFilter.swift in Sources */,
 				46A3C96717DFA81A002865AE /* NSManagedObjectContext+CoreDataExtensions.m in Sources */,
 				A6C0DFA725C0992D00B9BE39 /* NoteScrollPositionCache.swift in Sources */,
-				BA7240222C1BA1210088EC11 /* ContentRecoveryManager.swift in Sources */,
+				BA7240222C1BA1210088EC11 /* RecoveryUnarchiver.swift in Sources */,
 				B59314D81A486B3800B651ED /* SPConstants.m in Sources */,
 				375D24B421E01131007AB25A /* escape.c in Sources */,
 				B50F47A61D1D791B00822748 /* NSURL+Extensions.swift in Sources */,
@@ -3845,6 +3855,7 @@
 				BA86622426B3AE4A00466746 /* ExtensionResultsController.swift in Sources */,
 				BABFFF2426CF9094003A4C25 /* WidgetDefaults.swift in Sources */,
 				BA289B762BE45BBB000E6794 /* OpenNoteIntentHandler.swift in Sources */,
+				BA4A01902C1CCEC100EEE567 /* RecoveryArchiver.swift in Sources */,
 				BAF8D46E26AE118800CA9383 /* SPCredentials.swift in Sources */,
 				BAF8D5C526AE254100CA9383 /* Simplenote.xcdatamodeld in Sources */,
 				BAB6C04426BA49F3007495C4 /* ContentSlice.swift in Sources */,
@@ -3863,7 +3874,6 @@
 				BAF8D45526AE10FC00CA9383 /* Tag+Widget.swift in Sources */,
 				BAFFCEA726DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift in Sources */,
 				BAF8D53C26AE175C00CA9383 /* Bundle+Simplenote.swift in Sources */,
-				BA7240232C1BA1930088EC11 /* ContentRecoveryManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Simplenote/Classes/FileManager+Simplenote.swift
+++ b/Simplenote/Classes/FileManager+Simplenote.swift
@@ -20,8 +20,25 @@ extension FileManager {
         containerURL(forSecurityApplicationGroupIdentifier: SimplenoteConstants.sharedGroupDomain)!
     }
 
-    var recoveryDirectoryURL: URL {
-        sharedContainerURL.appendingPathComponent(Constants.recoveryDir)
+    func recoveryDirectoryURL() -> URL? {
+        let dir = sharedContainerURL.appendingPathComponent(Constants.recoveryDir)
+
+        do {
+            try createDirectoryIfNeeded(at: dir)
+        } catch {
+            NSLog("Could not create recovery directory because: $@", error.localizedDescription)
+            return nil
+        }
+
+        return dir
+    }
+
+    func createDirectoryIfNeeded(at url: URL, withIntermediateDirectories: Bool = true) throws {
+        if directoryExistsAtURL(url) {
+            return
+        }
+
+        try createDirectory(at: url, withIntermediateDirectories: true)
     }
 
     func directoryExistsAtURL(_ url: URL) -> Bool {

--- a/Simplenote/Classes/FileManager+Simplenote.swift
+++ b/Simplenote/Classes/FileManager+Simplenote.swift
@@ -19,4 +19,18 @@ extension FileManager {
     var sharedContainerURL: URL {
         containerURL(forSecurityApplicationGroupIdentifier: SimplenoteConstants.sharedGroupDomain)!
     }
+
+    var recoveryDirectoryURL: URL {
+        sharedContainerURL.appendingPathComponent(Constants.recoveryDir)
+    }
+
+    func directoryExistsAtURL(_ url: URL) -> Bool {
+        var isDir: ObjCBool = false
+        let exists = self.fileExists(atPath: url.path, isDirectory: &isDir)
+        return exists && isDir.boolValue
+    }
+}
+
+private struct Constants {
+    static let recoveryDir = "Recovery"
 }

--- a/Simplenote/ContentRecoveryManager.swift
+++ b/Simplenote/ContentRecoveryManager.swift
@@ -56,20 +56,19 @@ public class ContentRecoveryManager {
 
     private func prepareNoteContent(at url: URL, in context: NSManagedObjectContext) -> String? {
         guard let data = fileManager.contents(atPath: url.path),
-              let content = String(data: data, encoding: .utf8) else {
+              let recoveredContent = String(data: data, encoding: .utf8) else {
             return nil
         }
-        return content
-    }
 
-    private func identifier(from url: URL) -> String? {
-        let fileName = url.deletingPathExtension().lastPathComponent
-        let components = fileName.components(separatedBy: "-")
-        return components.last
+        var content = Constants.recoveredContentHeader
+        content += "\n\n"
+        content += recoveredContent
+        return content
     }
  }
 
 private struct Constants {
     static let recoveredContent = "recoveredContent"
     static let richTextKey = "richText"
+    static let recoveredContentHeader = NSLocalizedString("Recovered Note Cotent - ", comment: "Header to put on any files that need to be recovered")
 }

--- a/Simplenote/ContentRecoveryManager.swift
+++ b/Simplenote/ContentRecoveryManager.swift
@@ -1,0 +1,75 @@
+import Foundation
+import UniformTypeIdentifiers
+import CoreData
+
+public class ContentRecoveryManager {
+    private let fileManager: FileManager
+
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    private func createRecoveryDirIfNeeded() {
+        guard !fileManager.directoryExistsAtURL(fileManager.recoveryDirectoryURL) else {
+            return
+        }
+
+        try? fileManager.createDirectory(at: fileManager.recoveryDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    // MARK: Archive
+    //
+    public func archiveContent(_ content: String) {
+        createRecoveryDirIfNeeded()
+
+        guard let data = content.data(using: .utf8) else {
+            return
+        }
+        try? data.write(to: url(for: UUID().uuidString))
+    }
+
+    private func url(for identifier: String) -> URL {
+        let formattedID = identifier.replacingOccurrences(of: "/", with: "-")
+        let fileName = "\(Constants.recoveredContent)-\(formattedID)"
+        return fileManager.recoveryDirectoryURL.appendingPathComponent(fileName, conformingTo: UTType.json)
+    }
+
+    // MARK: Restore
+    //
+    public func prepareRecoveredNoteContentIfNeeded(in context: NSManagedObjectContext) async -> [String] {
+        createRecoveryDirIfNeeded()
+
+        guard let recoveryFiles = try? fileManager.contentsOfDirectory(at: fileManager.recoveryDirectoryURL, includingPropertiesForKeys: nil),
+        !recoveryFiles.isEmpty else {
+            return []
+        }
+
+        return recoveryFiles.compactMap { url in
+            guard let content =  prepareNoteContent(at: url, in: context) else {
+                return nil
+            }
+
+            try? fileManager.removeItem(at: url)
+            return content
+        }
+    }
+
+    private func prepareNoteContent(at url: URL, in context: NSManagedObjectContext) -> String? {
+        guard let data = fileManager.contents(atPath: url.path),
+              let content = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return content
+    }
+
+    private func identifier(from url: URL) -> String? {
+        let fileName = url.deletingPathExtension().lastPathComponent
+        let components = fileName.components(separatedBy: "-")
+        return components.last
+    }
+ }
+
+private struct Constants {
+    static let recoveredContent = "recoveredContent"
+    static let richTextKey = "richText"
+}

--- a/Simplenote/RecoveryUnarchiver.swift
+++ b/Simplenote/RecoveryUnarchiver.swift
@@ -15,7 +15,7 @@ public class RecoveryUnarchiver {
 
     // MARK: Restore
     //
-    public func prepareRecoveredNoteContentIfNeeded() {
+    public func insertNotesFromRecoveryFilesIfNeeded() {
         guard let recoveryURL = fileManager.recoveryDirectoryURL(),
               let recoveryFiles = try? fileManager.contentsOfDirectory(at: recoveryURL, includingPropertiesForKeys: nil),
               !recoveryFiles.isEmpty else {

--- a/Simplenote/RecoveryUnarchiver.swift
+++ b/Simplenote/RecoveryUnarchiver.swift
@@ -2,7 +2,7 @@ import Foundation
 import UniformTypeIdentifiers
 import CoreData
 
-public class ContentRecoveryManager {
+public class RecoveryUnarchiver {
     private let fileManager: FileManager
 
     public init(fileManager: FileManager = .default) {
@@ -15,23 +15,6 @@ public class ContentRecoveryManager {
         }
 
         try? fileManager.createDirectory(at: fileManager.recoveryDirectoryURL, withIntermediateDirectories: true)
-    }
-
-    // MARK: Archive
-    //
-    public func archiveContent(_ content: String) {
-        createRecoveryDirIfNeeded()
-
-        guard let data = content.data(using: .utf8) else {
-            return
-        }
-        try? data.write(to: url(for: UUID().uuidString))
-    }
-
-    private func url(for identifier: String) -> URL {
-        let formattedID = identifier.replacingOccurrences(of: "/", with: "-")
-        let fileName = "\(Constants.recoveredContent)-\(formattedID)"
-        return fileManager.recoveryDirectoryURL.appendingPathComponent(fileName, conformingTo: UTType.json)
     }
 
     // MARK: Restore
@@ -68,7 +51,6 @@ public class ContentRecoveryManager {
  }
 
 private struct Constants {
-    static let recoveredContent = "recoveredContent"
     static let richTextKey = "richText"
     static let recoveredContentHeader = NSLocalizedString("Recovered Note Cotent - ", comment: "Header to put on any files that need to be recovered")
 }

--- a/Simplenote/RecoveryUnarchiver.swift
+++ b/Simplenote/RecoveryUnarchiver.swift
@@ -13,20 +13,12 @@ public class RecoveryUnarchiver {
         SPAppDelegate.shared().simperium
     }
 
-    private func createRecoveryDirIfNeeded() {
-        guard !fileManager.directoryExistsAtURL(fileManager.recoveryDirectoryURL) else {
-            return
-        }
-
-        try? fileManager.createDirectory(at: fileManager.recoveryDirectoryURL, withIntermediateDirectories: true)
-    }
-
     // MARK: Restore
     //
     public func prepareRecoveredNoteContentIfNeeded() {
-        createRecoveryDirIfNeeded()
-        guard let recoveryFiles = try? fileManager.contentsOfDirectory(at: fileManager.recoveryDirectoryURL, includingPropertiesForKeys: nil),
-        !recoveryFiles.isEmpty else {
+        guard let recoveryURL = fileManager.recoveryDirectoryURL(),
+              let recoveryFiles = try? fileManager.contentsOfDirectory(at: recoveryURL, includingPropertiesForKeys: nil),
+              !recoveryFiles.isEmpty else {
             return
         }
 

--- a/Simplenote/RecoveryUnarchiver.swift
+++ b/Simplenote/RecoveryUnarchiver.swift
@@ -4,13 +4,11 @@ import CoreData
 
 public class RecoveryUnarchiver {
     private let fileManager: FileManager
+    private let simperium: Simperium
 
-    public init(fileManager: FileManager = .default) {
+    public init(fileManager: FileManager = .default, simperium: Simperium) {
         self.fileManager = fileManager
-    }
-
-    var simperium: Simperium {
-        SPAppDelegate.shared().simperium
+        self.simperium = simperium
     }
 
     // MARK: Restore

--- a/Simplenote/RecoveryUnarchiver.swift
+++ b/Simplenote/RecoveryUnarchiver.swift
@@ -50,7 +50,7 @@ public class RecoveryUnarchiver {
 
         note.modificationDate = Date()
         note.creationDate = Date()
-        note.markdown = UserDefaults.standard.bool(forKey: "kMarkdownPreferencesKey")
+        note.markdown = UserDefaults.standard.bool(forKey: .markdown)
 
         simperium.save()
     }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -563,6 +563,6 @@ extension SPAppDelegate {
 extension SPAppDelegate {
     @objc
     func attemptContentRecoveryIfNeeded() {
-        RecoveryUnarchiver().prepareRecoveredNoteContentIfNeeded()
+        RecoveryUnarchiver().insertNotesFromRecoveryFilesIfNeeded()
     }
 }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -563,8 +563,6 @@ extension SPAppDelegate {
 extension SPAppDelegate {
     @objc
     func attemptContentRecoveryIfNeeded() {
-        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
-        context.persistentStoreCoordinator = coreDataManager.persistentStoreCoordinator
         RecoveryUnarchiver().prepareRecoveredNoteContentIfNeeded()
     }
 }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -563,6 +563,6 @@ extension SPAppDelegate {
 extension SPAppDelegate {
     @objc
     func attemptContentRecoveryIfNeeded() {
-        RecoveryUnarchiver().insertNotesFromRecoveryFilesIfNeeded()
+        RecoveryUnarchiver(simperium: simperium).insertNotesFromRecoveryFilesIfNeeded()
     }
 }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -557,3 +557,29 @@ extension SPAppDelegate {
         UserDefaults.standard.set(true, forKey: .hasMigratedSustainerPreferences)
     }
 }
+
+// MARK: - Content Recovery
+//
+extension SPAppDelegate {
+    @objc
+    func attemptContentRecoveryIfNeeded() {
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.persistentStoreCoordinator = coreDataManager.persistentStoreCoordinator
+
+        Task {
+            let restoredContent = await ContentRecoveryManager().prepareRecoveredNoteContentIfNeeded(in: context)
+            restoredContent.forEach({ insertNote(with: $0) })
+        }
+    }
+
+    private func insertNote(with content: String) {
+        guard let note = simperium.notesBucket.insertNewObject() as? Note else {
+            return
+        }
+        note.modificationDate = Date()
+        note.creationDate = Date()
+        note.content = content
+        note.markdown = UserDefaults.standard.bool(forKey: "kMarkdownPreferencesKey")
+        simperium.save()
+    }
+}

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -567,7 +567,7 @@ extension SPAppDelegate {
         context.persistentStoreCoordinator = coreDataManager.persistentStoreCoordinator
 
         Task {
-            let restoredContent = await ContentRecoveryManager().prepareRecoveredNoteContentIfNeeded(in: context)
+            let restoredContent = await RecoveryUnarchiver().prepareRecoveredNoteContentIfNeeded(in: context)
             restoredContent.forEach({ insertNote(with: $0) })
         }
     }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -565,21 +565,6 @@ extension SPAppDelegate {
     func attemptContentRecoveryIfNeeded() {
         let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         context.persistentStoreCoordinator = coreDataManager.persistentStoreCoordinator
-
-        Task {
-            let restoredContent = await RecoveryUnarchiver().prepareRecoveredNoteContentIfNeeded(in: context)
-            restoredContent.forEach({ insertNote(with: $0) })
-        }
-    }
-
-    private func insertNote(with content: String) {
-        guard let note = simperium.notesBucket.insertNewObject() as? Note else {
-            return
-        }
-        note.modificationDate = Date()
-        note.creationDate = Date()
-        note.content = content
-        note.markdown = UserDefaults.standard.bool(forKey: "kMarkdownPreferencesKey")
-        simperium.save()
+        RecoveryUnarchiver().prepareRecoveredNoteContentIfNeeded()
     }
 }

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -167,7 +167,6 @@
 
     [self setupNoticeController];
 
-    [self attemptContentRecoveryIfNeeded];
     return YES;
 }
 
@@ -175,6 +174,7 @@
 {
     [SPTracker trackApplicationOpened];
     [self syncWidgetDefaults];
+    [self attemptContentRecoveryIfNeeded];
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -167,6 +167,7 @@
 
     [self setupNoticeController];
 
+    [self attemptContentRecoveryIfNeeded];
     return YES;
 }
 

--- a/Simplenote/Supporting Files/Base.lproj/ShortcutIntents.intentdefinition
+++ b/Simplenote/Supporting Files/Base.lproj/ShortcutIntents.intentdefinition
@@ -11,9 +11,9 @@
 	<key>INIntentDefinitionSystemVersion</key>
 	<string>23E214</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
-	<string>15E204a</string>
+	<string>15F31d</string>
 	<key>INIntentDefinitionToolsVersion</key>
-	<string>15.3</string>
+	<string>15.4</string>
 	<key>INIntents</key>
 	<array>
 		<dict>
@@ -308,8 +308,31 @@
 						<true/>
 					</dict>
 					<dict>
+						<key>INIntentResponseCodeFormatString</key>
+						<string>${failureReason}</string>
+						<key>INIntentResponseCodeFormatStringID</key>
+						<string>Lyqq4K</string>
 						<key>INIntentResponseCodeName</key>
 						<string>failure</string>
+					</dict>
+				</array>
+				<key>INIntentResponseLastParameterTag</key>
+				<integer>1</integer>
+				<key>INIntentResponseParameters</key>
+				<array>
+					<dict>
+						<key>INIntentResponseParameterDisplayName</key>
+						<string>Failure Reason</string>
+						<key>INIntentResponseParameterDisplayNameID</key>
+						<string>PueDbo</string>
+						<key>INIntentResponseParameterDisplayPriority</key>
+						<integer>1</integer>
+						<key>INIntentResponseParameterName</key>
+						<string>failureReason</string>
+						<key>INIntentResponseParameterTag</key>
+						<integer>1</integer>
+						<key>INIntentResponseParameterType</key>
+						<string>String</string>
 					</dict>
 				</array>
 			</dict>
@@ -409,8 +432,31 @@
 						<true/>
 					</dict>
 					<dict>
+						<key>INIntentResponseCodeFormatString</key>
+						<string>${failureReason}</string>
+						<key>INIntentResponseCodeFormatStringID</key>
+						<string>d67xB8</string>
 						<key>INIntentResponseCodeName</key>
 						<string>failure</string>
+					</dict>
+				</array>
+				<key>INIntentResponseLastParameterTag</key>
+				<integer>1</integer>
+				<key>INIntentResponseParameters</key>
+				<array>
+					<dict>
+						<key>INIntentResponseParameterDisplayName</key>
+						<string>Failure Reason</string>
+						<key>INIntentResponseParameterDisplayNameID</key>
+						<string>2w6Mce</string>
+						<key>INIntentResponseParameterDisplayPriority</key>
+						<integer>1</integer>
+						<key>INIntentResponseParameterName</key>
+						<string>failureReason</string>
+						<key>INIntentResponseParameterTag</key>
+						<integer>1</integer>
+						<key>INIntentResponseParameterType</key>
+						<string>String</string>
 					</dict>
 				</array>
 			</dict>
@@ -660,26 +706,6 @@
 							<key>INIntentParameterPromptDialogType</key>
 							<string>Primary</string>
 						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>There are ${count} options matching ‘${note}’.</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>VBtgac</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>DisambiguationIntroduction</string>
-						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>Just to confirm, you wanted ‘${note}’?</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>MdiZid</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>Confirmation</string>
-						</dict>
 					</array>
 					<key>INIntentParameterSupportsDynamicEnumeration</key>
 					<true/>
@@ -796,26 +822,6 @@
 							<true/>
 							<key>INIntentParameterPromptDialogType</key>
 							<string>Primary</string>
-						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>There are ${count} options matching ‘${tag}’.</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>U4ce2H</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>DisambiguationIntroduction</string>
-						</dict>
-						<dict>
-							<key>INIntentParameterPromptDialogCustom</key>
-							<true/>
-							<key>INIntentParameterPromptDialogFormatString</key>
-							<string>Just to confirm, you wanted ‘${tag}’?</string>
-							<key>INIntentParameterPromptDialogFormatStringID</key>
-							<string>qYKqOP</string>
-							<key>INIntentParameterPromptDialogType</key>
-							<string>Confirmation</string>
 						</dict>
 					</array>
 					<key>INIntentParameterSupportsDynamicEnumeration</key>

--- a/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
@@ -27,9 +27,6 @@ class AppendNoteIntentHandler: NSObject, AppendNoteIntentHandling {
             return AppendNoteIntentResponse(code: .failure, userActivity: nil)
         }
 
-        guard let existingContent = try? await Downloader(simperiumToken: token).getNoteContent(for: identifier) else {
-            return AppendNoteIntentResponse(code: .failure, userActivity: nil)
-        }
         do {
             let existingContent = try await Downloader(simperiumToken: token).getNoteContent(for: identifier) ?? String()
             note.content = existingContent + "\n\(content)"

--- a/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
@@ -32,6 +32,7 @@ class AppendNoteIntentHandler: NSObject, AppendNoteIntentHandling {
             note.content = existingContent + "\n\(content)"
 
             try await uploadNoteContent(note, token: token)
+            return AppendNoteIntentResponse(code: .success, userActivity: nil)
         } catch {
             return handleFailure(with: error, content: content)
         }

--- a/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
@@ -48,7 +48,7 @@ class AppendNoteIntentHandler: NSObject, AppendNoteIntentHandling {
     }
 
     private func handleFailure(with error: Error, content: String) -> AppendNoteIntentResponse {
-        ContentRecoveryManager().archiveContent(content)
+        RecoveryArchiver().archiveContent(content)
         return AppendNoteIntentResponse.failure(failureReason: error.localizedDescription)
     }
 }

--- a/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
@@ -46,6 +46,6 @@ class AppendNoteIntentHandler: NSObject, AppendNoteIntentHandling {
 
     private func handleFailure(with error: Error, content: String) -> AppendNoteIntentResponse {
         RecoveryArchiver().archiveContent(content)
-        return AppendNoteIntentResponse.failure(failureReason: error.localizedDescription)
+        return AppendNoteIntentResponse.failure(failureReason: "\(error.localizedDescription) - \(IntentsConstants.recoveryMessage)")
     }
 }

--- a/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/AppendNoteIntentHandler.swift
@@ -48,6 +48,7 @@ class AppendNoteIntentHandler: NSObject, AppendNoteIntentHandling {
     }
 
     private func handleFailure(with error: Error, content: String) -> AppendNoteIntentResponse {
+        ContentRecoveryManager().archiveContent(content)
         return AppendNoteIntentResponse.failure(failureReason: error.localizedDescription)
     }
 }

--- a/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
@@ -13,7 +13,7 @@ class CreateNewNoteIntentHandler: NSObject, CreateNewNoteIntentHandling {
             _ = try await Uploader(simperiumToken: token).send(note(with: content))
             return CreateNewNoteIntentResponse(code: .success, userActivity: nil)
         } catch {
-            ContentRecoveryManager().archiveContent(content)
+            RecoveryArchiver().archiveContent(content)
             return CreateNewNoteIntentResponse.failure(failureReason: error.localizedDescription)
         }
     }

--- a/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
@@ -14,7 +14,7 @@ class CreateNewNoteIntentHandler: NSObject, CreateNewNoteIntentHandling {
             return CreateNewNoteIntentResponse(code: .success, userActivity: nil)
         } catch {
             RecoveryArchiver().archiveContent(content)
-            return CreateNewNoteIntentResponse.failure(failureReason: error.localizedDescription)
+            return CreateNewNoteIntentResponse.failure(failureReason: "\(error.localizedDescription) - \(IntentsConstants.recoveryMessage)")
         }
     }
 

--- a/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
@@ -13,6 +13,7 @@ class CreateNewNoteIntentHandler: NSObject, CreateNewNoteIntentHandling {
             _ = try await Uploader(simperiumToken: token).send(note(with: content))
             return CreateNewNoteIntentResponse(code: .success, userActivity: nil)
         } catch {
+            ContentRecoveryManager().archiveContent(content)
             return CreateNewNoteIntentResponse.failure(failureReason: error.localizedDescription)
         }
     }

--- a/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
+++ b/SimplenoteIntents/Intent Handlers/CreateNewNoteIntentHandler.swift
@@ -1,11 +1,3 @@
-//
-//  CreateNewNoteIntentHandler.swift
-//  SimplenoteIntents
-//
-//  Created by Charlie Scheer on 5/8/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
-
 import Intents
 
 class CreateNewNoteIntentHandler: NSObject, CreateNewNoteIntentHandling {
@@ -17,8 +9,12 @@ class CreateNewNoteIntentHandler: NSObject, CreateNewNoteIntentHandling {
             return CreateNewNoteIntentResponse(code: .failure, userActivity: nil)
         }
 
-        Uploader(simperiumToken: token).send(note(with: content))
-        return CreateNewNoteIntentResponse(code: .success, userActivity: nil)
+        do {
+            _ = try await Uploader(simperiumToken: token).send(note(with: content))
+            return CreateNewNoteIntentResponse(code: .success, userActivity: nil)
+        } catch {
+            return CreateNewNoteIntentResponse.failure(failureReason: error.localizedDescription)
+        }
     }
 
     private func note(with content: String) -> Note {

--- a/SimplenoteIntents/IntentsConstants.swift
+++ b/SimplenoteIntents/IntentsConstants.swift
@@ -10,4 +10,6 @@ import Foundation
 
 struct IntentsConstants {
     static let noteIdentifierKey = "OpenNoteIntentHandlerIdentifierKey"
+
+    static let recoveryMessage = NSLocalizedString("Will attempt to recover shortcut content on next launch", comment: "Alerting users that we will attempt to restore lost content on next launch")
 }

--- a/SimplenoteIntents/Tools/RecoveryArchiver.swift
+++ b/SimplenoteIntents/Tools/RecoveryArchiver.swift
@@ -1,0 +1,39 @@
+import Foundation
+import UniformTypeIdentifiers
+
+public class RecoveryArchiver {
+    private let fileManager: FileManager
+
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    private func createRecoveryDirIfNeeded() {
+        guard !fileManager.directoryExistsAtURL(fileManager.recoveryDirectoryURL) else {
+            return
+        }
+
+        try? fileManager.createDirectory(at: fileManager.recoveryDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    // MARK: Archive
+    //
+    public func archiveContent(_ content: String) {
+        createRecoveryDirIfNeeded()
+
+        guard let data = content.data(using: .utf8) else {
+            return
+        }
+        try? data.write(to: url(for: UUID().uuidString))
+    }
+
+    private func url(for identifier: String) -> URL {
+        let formattedID = identifier.replacingOccurrences(of: "/", with: "-")
+        let fileName = "\(Constants.recoveredContent)-\(formattedID)"
+        return fileManager.recoveryDirectoryURL.appendingPathComponent(fileName, conformingTo: UTType.json)
+    }
+}
+
+private struct Constants {
+    static let recoveredContent = "recoveredContent"
+}

--- a/SimplenoteIntents/Tools/RecoveryArchiver.swift
+++ b/SimplenoteIntents/Tools/RecoveryArchiver.swift
@@ -8,29 +8,26 @@ public class RecoveryArchiver {
         self.fileManager = fileManager
     }
 
-    private func createRecoveryDirIfNeeded() {
-        guard !fileManager.directoryExistsAtURL(fileManager.recoveryDirectoryURL) else {
-            return
-        }
-
-        try? fileManager.createDirectory(at: fileManager.recoveryDirectoryURL, withIntermediateDirectories: true)
-    }
-
     // MARK: Archive
     //
     public func archiveContent(_ content: String) {
-        createRecoveryDirIfNeeded()
+        guard let fileURL = url(for: UUID().uuidString) else {
+            return
+        }
 
         guard let data = content.data(using: .utf8) else {
             return
         }
-        try? data.write(to: url(for: UUID().uuidString))
+        try? data.write(to: fileURL)
     }
 
-    private func url(for identifier: String) -> URL {
+    private func url(for identifier: String) -> URL? {
+        guard let recoveryDirURL = fileManager.recoveryDirectoryURL() else {
+            return nil
+        }
         let formattedID = identifier.replacingOccurrences(of: "/", with: "-")
         let fileName = "\(Constants.recoveredContent)-\(formattedID)"
-        return fileManager.recoveryDirectoryURL.appendingPathComponent(fileName, conformingTo: UTType.json)
+        return recoveryDirURL.appendingPathComponent(fileName, conformingTo: UTType.json)
     }
 }
 

--- a/SimplenoteShare/Simperium/Downloader.swift
+++ b/SimplenoteShare/Simperium/Downloader.swift
@@ -8,6 +8,24 @@
 
 import Foundation
 
+enum DownloaderError: Error {
+    case couldNotFetchNoteContent
+
+    var title: String {
+        switch self {
+        case .couldNotFetchNoteContent:
+            return NSLocalizedString("Could not fetch note content", comment: "note content fetch error title")
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .couldNotFetchNoteContent:
+            return NSLocalizedString("Attempt to fetch current note content failed.  Please try again later.", comment: "Data Fetch error message")
+        }
+    }
+}
+
 class Downloader: NSObject {
 
     /// Simperium's Token
@@ -39,7 +57,11 @@ class Downloader: NSObject {
 
     func extractNoteContent(from data: Data) throws -> String? {
         let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        return jsonObject?["content"] as? String
+        guard let content =  jsonObject?["content"] as? String else {
+            throw DownloaderError.couldNotFetchNoteContent
+        }
+
+        return content
     }
 }
 

--- a/SimplenoteShare/Simperium/Uploader.swift
+++ b/SimplenoteShare/Simperium/Uploader.swift
@@ -17,6 +17,24 @@ class Uploader: NSObject {
 
     // MARK: - Public Methods
     func send(_ note: Note) {
+        let request = requestToSend(note)
+
+        // Task!
+        let sc = URLSessionConfiguration.backgroundSessionConfigurationWithRandomizedIdentifier()
+
+        let session = Foundation.URLSession(configuration: sc, delegate: self, delegateQueue: .main)
+        let task = session.downloadTask(with: request)
+        task.resume()
+    }
+
+    func send(_ note: Note) async throws -> (URL, URLResponse) {
+        let request = requestToSend(note)
+
+        let session = Foundation.URLSession(configuration: .default)
+        return try await session.download(for: request)
+    }
+
+    private func requestToSend(_ note: Note) -> URLRequest {
         // Build the targetURL
         let endpoint = String(format: "%@/%@/%@/i/%@", kSimperiumBaseURL, SPCredentials.simperiumAppID, Settings.bucketName, note.simperiumKey)
         let targetURL = URL(string: endpoint.lowercased())!
@@ -27,12 +45,7 @@ class Uploader: NSObject {
         request.httpBody = note.toJsonData()
         request.setValue(token, forHTTPHeaderField: Settings.authHeader)
 
-        // Task!
-        let sc = URLSessionConfiguration.backgroundSessionConfigurationWithRandomizedIdentifier()
-
-        let session = Foundation.URLSession(configuration: sc, delegate: self, delegateQueue: .main)
-        let task = session.downloadTask(with: request)
-        task.resume()
+        return request
     }
 }
 


### PR DESCRIPTION
### Fix
With the new append shortcuts there is the possibility that your shortcut fails and if that happens the content you sent to the shortcut will be lost.  There isn't a lot we can do to prevent that unfortunately, but we can attempt to save the content locally and then restore it on the next launch.  So in this PR I have added a content recovery mechanism incase a shortcut fails.  That way the user doesn't have to restore the written content if a shortcut fails.


### Test
1. Build and run simplenote ios
2. Open up the shortcuts app and create an append to note or a create note with content shortcut
3. Disable the internet connections
4. run the shortcut
6. launch simplenote.

 - [ ] Confirm that a new note is created with the content from your shortcut

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
> These changes do not require release notes.
