### PR TITLE
Passkeys: UI interaction feedback and errors

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - Extended support for iOS Shortcuts
 - Fixed issue where notes selection was lost when app backgrounded
 - Fixed an issue can activate the faceid switch without a passcode
+- Added passkey authentication support
 
 4.51
 -----

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 		BA12B06F26B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA12B06C26B0D0150026F31D /* SPManagedObject+Widget.swift */; };
 		BA12B07026B0D0150026F31D /* SPManagedObject+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA12B06C26B0D0150026F31D /* SPManagedObject+Widget.swift */; };
 		BA18532826488DBC00D9A347 /* SignupRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */; };
+		BA1B70142C1CEC6F008282D7 /* SPModalActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1B70132C1CEC6F008282D7 /* SPModalActivityIndicator.swift */; };
 		BA2015BB2B57384F005E59AA /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = BA2015BA2B57384F005E59AA /* AutomatticTracks */; };
 		BA289B5C2BE4371A000E6794 /* ListWidgetIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA289B5A2BE4371A000E6794 /* ListWidgetIntentHandler.swift */; };
 		BA289B5F2BE43728000E6794 /* NoteWidgetIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA289B5D2BE43728000E6794 /* NoteWidgetIntentHandler.swift */; };
@@ -1158,6 +1159,7 @@
 		BA12B06C26B0D0150026F31D /* SPManagedObject+Widget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SPManagedObject+Widget.swift"; sourceTree = "<group>"; };
 		BA16C6A82BC4968400C9079F /* Simplenote 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 7.xcdatamodel"; sourceTree = "<group>"; };
 		BA18532726488DBC00D9A347 /* SignupRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRemoteTests.swift; sourceTree = "<group>"; };
+		BA1B70132C1CEC6F008282D7 /* SPModalActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPModalActivityIndicator.swift; sourceTree = "<group>"; };
 		BA289B5A2BE4371A000E6794 /* ListWidgetIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListWidgetIntentHandler.swift; sourceTree = "<group>"; };
 		BA289B5D2BE43728000E6794 /* NoteWidgetIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWidgetIntentHandler.swift; sourceTree = "<group>"; };
 		BA289B632BE43963000E6794 /* OpenNewNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenNewNoteIntentHandler.swift; sourceTree = "<group>"; };
@@ -2588,6 +2590,7 @@
 				B56A696422F9D54600B90398 /* SPLabel.swift */,
 				E230E39C17D0F33B009B5EBB /* SPModalActivityIndicator.h */,
 				E230E39D17D0F33B009B5EBB /* SPModalActivityIndicator.m */,
+				BA1B70132C1CEC6F008282D7 /* SPModalActivityIndicator.swift */,
 				B5D982D122F8644000C37C29 /* SPSquaredButton.swift */,
 				E215C79B180B228800AD36B5 /* SPTextField.h */,
 				E215C79C180B228800AD36B5 /* SPTextField.m */,
@@ -3599,6 +3602,7 @@
 				375D24BA21E01131007AB25A /* document.c in Sources */,
 				BA6DA19126DB5F1B000464C8 /* URLComponents.swift in Sources */,
 				46A3C98317DFA81A002865AE /* main.m in Sources */,
+				BA1B70142C1CEC6F008282D7 /* SPModalActivityIndicator.swift in Sources */,
 				B58C9F5723F2FCEC008C3480 /* SPPlaceholderView.swift in Sources */,
 				BAB6C04726BA4CAF007495C4 /* WidgetController.swift in Sources */,
 				A6E1E79E24BDE401008A44BC /* SPCardTransitioningManager.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -420,8 +420,8 @@
 		BA0890A526BB9B680035CA48 /* NoteListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0890A426BB9B680035CA48 /* NoteListRow.swift */; };
 		BA0890A726BB9BE20035CA48 /* ListWidgetHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0890A626BB9BE20035CA48 /* ListWidgetHeaderView.swift */; };
 		BA0890A926BB9BF80035CA48 /* NewNoteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0890A826BB9BF80035CA48 /* NewNoteButton.swift */; };
-		BA0AC5442C1A0C65002964DB /* PasskeyRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0AC5432C1A0C65002964DB /* PasskeyRegistration.swift */; };
-		BA0AC5462C1A0C71002964DB /* PasskeyChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0AC5452C1A0C71002964DB /* PasskeyChallenge.swift */; };
+		BA0AC5442C1A0C65002964DB /* PasskeyRegistrationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0AC5432C1A0C65002964DB /* PasskeyRegistrationResponse.swift */; };
+		BA0AC5462C1A0C71002964DB /* PasskeyRegistrationChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0AC5452C1A0C71002964DB /* PasskeyRegistrationChallenge.swift */; };
 		BA0AF10D2BE996600050EEBD /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59560DF251A46D500A06788 /* KeychainManager.swift */; };
 		BA0AF10E2BE996630050EEBD /* KeychainPasswordItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD30471FC4CFA2008D0B78 /* KeychainPasswordItem.swift */; };
 		BA0ED16E26D708AC002533B6 /* Color+Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0ED16D26D708AC002533B6 /* Color+Widgets.swift */; };
@@ -1146,8 +1146,8 @@
 		BA0890A426BB9B680035CA48 /* NoteListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListRow.swift; sourceTree = "<group>"; };
 		BA0890A626BB9BE20035CA48 /* ListWidgetHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListWidgetHeaderView.swift; sourceTree = "<group>"; };
 		BA0890A826BB9BF80035CA48 /* NewNoteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteButton.swift; sourceTree = "<group>"; };
-		BA0AC5432C1A0C65002964DB /* PasskeyRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistration.swift; sourceTree = "<group>"; };
-		BA0AC5452C1A0C71002964DB /* PasskeyChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyChallenge.swift; sourceTree = "<group>"; };
+		BA0AC5432C1A0C65002964DB /* PasskeyRegistrationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrationResponse.swift; sourceTree = "<group>"; };
+		BA0AC5452C1A0C71002964DB /* PasskeyRegistrationChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrationChallenge.swift; sourceTree = "<group>"; };
 		BA0ED16D26D708AC002533B6 /* Color+Widgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Widgets.swift"; sourceTree = "<group>"; };
 		BA0F5E0326B62A8B0098C605 /* RemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteError.swift; sourceTree = "<group>"; };
 		BA113E4C269E860500F3E3B4 /* markdown-light.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-light.css"; sourceTree = "<group>"; };
@@ -2401,6 +2401,8 @@
 				BAF694B12C1B753F000090E7 /* PasskeyAuthenticator.swift */,
 				BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */,
 				BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */,
+				BA0AC5432C1A0C65002964DB /* PasskeyRegistrationResponse.swift */,
+				BA0AC5452C1A0C71002964DB /* PasskeyRegistrationChallenge.swift */,
 			);
 			name = Passkeys;
 			sourceTree = "<group>";
@@ -2436,8 +2438,6 @@
 			children = (
 				A6C7647F25E9131C00A39067 /* SignupRemote.swift */,
 				A6CC0B0625B8287F00F12A85 /* AccountRemote.swift */,
-				BA0AC5432C1A0C65002964DB /* PasskeyRegistration.swift */,
-				BA0AC5452C1A0C71002964DB /* PasskeyChallenge.swift */,
 				BA5768E2269A803F008B510E /* Remote.swift */,
 				BA0F5E0326B62A8B0098C605 /* RemoteError.swift */,
 			);
@@ -3476,7 +3476,7 @@
 				B56E763422BD394C00C5AA47 /* UIImage+Simplenote.swift in Sources */,
 				B543C7E323CF76EA00003A80 /* NotesListFilter.swift in Sources */,
 				46A3C96717DFA81A002865AE /* NSManagedObjectContext+CoreDataExtensions.m in Sources */,
-				BA0AC5442C1A0C65002964DB /* PasskeyRegistration.swift in Sources */,
+				BA0AC5442C1A0C65002964DB /* PasskeyRegistrationResponse.swift in Sources */,
 				A6C0DFA725C0992D00B9BE39 /* NoteScrollPositionCache.swift in Sources */,
 				B59314D81A486B3800B651ED /* SPConstants.m in Sources */,
 				375D24B421E01131007AB25A /* escape.c in Sources */,
@@ -3528,7 +3528,7 @@
 				A60DF31025A4524100FDADF3 /* PinLockBaseController.swift in Sources */,
 				A6F487ED25A85F970050CFA8 /* TagTextFieldInputValidator.swift in Sources */,
 				B5AB169822FA124F00B4EBA5 /* SPSheetController.swift in Sources */,
-				BA0AC5462C1A0C71002964DB /* PasskeyChallenge.swift in Sources */,
+				BA0AC5462C1A0C71002964DB /* PasskeyRegistrationChallenge.swift in Sources */,
 				B511AEDA255A0A2A005B2159 /* InterlinkResultsController.swift in Sources */,
 				B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */,
 				B5DF734222A565DA00602CE7 /* Options.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		BA2E30E02C1B8B45002C7B10 /* PasskeyAuthChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */; };
 		BA2E30E22C1B8B4E002C7B10 /* PasskeyAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */; };
 		BA2E30E42C1B8F13002C7B10 /* PasskeyVerifyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30E32C1B8F13002C7B10 /* PasskeyVerifyResponse.swift */; };
+		BA2E30E62C1B8FD3002C7B10 /* Data+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30E52C1B8FD3002C7B10 /* Data+Simplenote.swift */; };
 		BA32A90F26B7469F00727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
 		BA32A91926B746A200727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
 		BA32A91A26B746A300727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
@@ -1166,6 +1167,7 @@
 		BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAuthChallenge.swift; sourceTree = "<group>"; };
 		BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAuthResponse.swift; sourceTree = "<group>"; };
 		BA2E30E32C1B8F13002C7B10 /* PasskeyVerifyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyVerifyResponse.swift; sourceTree = "<group>"; };
+		BA2E30E52C1B8FD3002C7B10 /* Data+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Simplenote.swift"; sourceTree = "<group>"; };
 		BA32A90E26B7469F00727247 /* WidgetError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetError.swift; sourceTree = "<group>"; };
 		BA34B04F2BEAEF4800580E15 /* SimplenoteIntentsRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SimplenoteIntentsRelease.entitlements; sourceTree = "<group>"; };
 		BA34B0562BEC216B00580E15 /* IntentNote+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntentNote+Helpers.swift"; sourceTree = "<group>"; };
@@ -2066,6 +2068,7 @@
 				BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */,
 				BAF4A96E26DB085D00C51C1D /* NSURLComponents+Simplenote.swift */,
 				BA6DA19026DB5F1B000464C8 /* URLComponents.swift */,
+				BA2E30E52C1B8FD3002C7B10 /* Data+Simplenote.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -3531,6 +3534,7 @@
 				B575736A232C567000443C2E /* UIImage+Dynamic.swift in Sources */,
 				A60DF31025A4524100FDADF3 /* PinLockBaseController.swift in Sources */,
 				A6F487ED25A85F970050CFA8 /* TagTextFieldInputValidator.swift in Sources */,
+				BA2E30E62C1B8FD3002C7B10 /* Data+Simplenote.swift in Sources */,
 				B5AB169822FA124F00B4EBA5 /* SPSheetController.swift in Sources */,
 				BA0AC5462C1A0C71002964DB /* PasskeyRegistrationChallenge.swift in Sources */,
 				B511AEDA255A0A2A005B2159 /* InterlinkResultsController.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -452,6 +452,7 @@
 		BA2D82C6261522F100A1695B /* PublishNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */; };
 		BA2E30E02C1B8B45002C7B10 /* PasskeyAuthChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */; };
 		BA2E30E22C1B8B4E002C7B10 /* PasskeyAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */; };
+		BA2E30E42C1B8F13002C7B10 /* PasskeyVerifyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30E32C1B8F13002C7B10 /* PasskeyVerifyResponse.swift */; };
 		BA32A90F26B7469F00727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
 		BA32A91926B746A200727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
 		BA32A91A26B746A300727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
@@ -1164,6 +1165,7 @@
 		BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishNoticePresenter.swift; sourceTree = "<group>"; };
 		BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAuthChallenge.swift; sourceTree = "<group>"; };
 		BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAuthResponse.swift; sourceTree = "<group>"; };
+		BA2E30E32C1B8F13002C7B10 /* PasskeyVerifyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyVerifyResponse.swift; sourceTree = "<group>"; };
 		BA32A90E26B7469F00727247 /* WidgetError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetError.swift; sourceTree = "<group>"; };
 		BA34B04F2BEAEF4800580E15 /* SimplenoteIntentsRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SimplenoteIntentsRelease.entitlements; sourceTree = "<group>"; };
 		BA34B0562BEC216B00580E15 /* IntentNote+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntentNote+Helpers.swift"; sourceTree = "<group>"; };
@@ -2403,6 +2405,7 @@
 				BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */,
 				BA0AC5432C1A0C65002964DB /* PasskeyRegistrationResponse.swift */,
 				BA0AC5452C1A0C71002964DB /* PasskeyRegistrationChallenge.swift */,
+				BA2E30E32C1B8F13002C7B10 /* PasskeyVerifyResponse.swift */,
 			);
 			name = Passkeys;
 			sourceTree = "<group>";
@@ -3511,6 +3514,7 @@
 				B550F93622BA7E9100091939 /* NSUserActivity+Simplenote.swift in Sources */,
 				B5BE054E1AB75902002417BF /* NSProcessInfo+Util.m in Sources */,
 				BA4C6CFC264C744300B723A7 /* SeparatorsView.swift in Sources */,
+				BA2E30E42C1B8F13002C7B10 /* PasskeyVerifyResponse.swift in Sources */,
 				375D24B821E01131007AB25A /* hash.c in Sources */,
 				BA5768EC269BE4D0008B510E /* AccountDeletionController.swift in Sources */,
 				A6D5AE6525483F8A00326C76 /* NSTextStorage+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -509,13 +509,13 @@
 		BA8FC2A5267AC7470082962E /* SharedStorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */; };
 		BA9B19F926A8EF3200692366 /* SpinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */; };
 		BA9B59022685549F00DAD1ED /* StorageSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B59012685549F00DAD1ED /* StorageSettings.swift */; };
-		BA9C7EFB2BF2CC3E007A8460 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */; };
-		BA9C7EFC2BF2CCAE007A8460 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */; };
 		BA9C7EC92BED7AB1007A8460 /* CopyNoteContentIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EC82BED7AB1007A8460 /* CopyNoteContentIntentHandler.swift */; };
 		BA9C7ECB2BED7F7B007A8460 /* FindNoteWithTagIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7ECA2BED7F7B007A8460 /* FindNoteWithTagIntentHandler.swift */; };
 		BA9C7ECD2BED813B007A8460 /* IntentTag+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7ECC2BED813B007A8460 /* IntentTag+Helpers.swift */; };
 		BA9C7ED02BEE9BA7007A8460 /* ShortcutIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7ECF2BEE9BA7007A8460 /* ShortcutIntents.intentdefinition */; };
 		BA9C7ED12BEE9BA7007A8460 /* ShortcutIntents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7ECF2BEE9BA7007A8460 /* ShortcutIntents.intentdefinition */; };
+		BA9C7EFB2BF2CC3E007A8460 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */; };
+		BA9C7EFC2BF2CCAE007A8460 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */; };
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		BAA59E79269F9FE30068BD3D /* Date+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */; };
 		BAA63C3325EEDA83001589D7 /* NoteLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */; };
@@ -1199,7 +1199,6 @@
 		BA8FC2A4267AC7470082962E /* SharedStorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStorageMigrator.swift; sourceTree = "<group>"; };
 		BA9B19F826A8EF3200692366 /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		BA9B59012685549F00DAD1ED /* StorageSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSettings.swift; sourceTree = "<group>"; };
-		BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
 		BA9C7EC82BED7AB1007A8460 /* CopyNoteContentIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyNoteContentIntentHandler.swift; sourceTree = "<group>"; };
 		BA9C7ECA2BED7F7B007A8460 /* FindNoteWithTagIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNoteWithTagIntentHandler.swift; sourceTree = "<group>"; };
 		BA9C7ECC2BED813B007A8460 /* IntentTag+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntentTag+Helpers.swift"; sourceTree = "<group>"; };
@@ -1224,6 +1223,7 @@
 		BA9C7EF52BEE9C3D007A8460 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/ShortcutIntents.strings; sourceTree = "<group>"; };
 		BA9C7EF72BEE9C3E007A8460 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/ShortcutIntents.strings"; sourceTree = "<group>"; };
 		BA9C7EF92BEE9C3F007A8460 /* zh-Hans-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans-CN"; path = "zh-Hans-CN.lproj/ShortcutIntents.strings"; sourceTree = "<group>"; };
+		BA9C7EFA2BF2CC3E007A8460 /* Downloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteLinkTests.swift; sourceTree = "<group>"; };

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -420,6 +420,8 @@
 		BA0890A526BB9B680035CA48 /* NoteListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0890A426BB9B680035CA48 /* NoteListRow.swift */; };
 		BA0890A726BB9BE20035CA48 /* ListWidgetHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0890A626BB9BE20035CA48 /* ListWidgetHeaderView.swift */; };
 		BA0890A926BB9BF80035CA48 /* NewNoteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0890A826BB9BF80035CA48 /* NewNoteButton.swift */; };
+		BA0AC5442C1A0C65002964DB /* PasskeyRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0AC5432C1A0C65002964DB /* PasskeyRegistration.swift */; };
+		BA0AC5462C1A0C71002964DB /* PasskeyChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0AC5452C1A0C71002964DB /* PasskeyChallenge.swift */; };
 		BA0AF10D2BE996600050EEBD /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59560DF251A46D500A06788 /* KeychainManager.swift */; };
 		BA0AF10E2BE996630050EEBD /* KeychainPasswordItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD30471FC4CFA2008D0B78 /* KeychainPasswordItem.swift */; };
 		BA0ED16E26D708AC002533B6 /* Color+Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0ED16D26D708AC002533B6 /* Color+Widgets.swift */; };
@@ -1141,6 +1143,8 @@
 		BA0890A426BB9B680035CA48 /* NoteListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteListRow.swift; sourceTree = "<group>"; };
 		BA0890A626BB9BE20035CA48 /* ListWidgetHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListWidgetHeaderView.swift; sourceTree = "<group>"; };
 		BA0890A826BB9BF80035CA48 /* NewNoteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteButton.swift; sourceTree = "<group>"; };
+		BA0AC5432C1A0C65002964DB /* PasskeyRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistration.swift; sourceTree = "<group>"; };
+		BA0AC5452C1A0C71002964DB /* PasskeyChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyChallenge.swift; sourceTree = "<group>"; };
 		BA0ED16D26D708AC002533B6 /* Color+Widgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Widgets.swift"; sourceTree = "<group>"; };
 		BA0F5E0326B62A8B0098C605 /* RemoteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteError.swift; sourceTree = "<group>"; };
 		BA113E4C269E860500F3E3B4 /* markdown-light.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = "markdown-light.css"; sourceTree = "<group>"; };
@@ -2415,6 +2419,8 @@
 			children = (
 				A6C7647F25E9131C00A39067 /* SignupRemote.swift */,
 				A6CC0B0625B8287F00F12A85 /* AccountRemote.swift */,
+				BA0AC5432C1A0C65002964DB /* PasskeyRegistration.swift */,
+				BA0AC5452C1A0C71002964DB /* PasskeyChallenge.swift */,
 				BA5768E2269A803F008B510E /* Remote.swift */,
 				BA0F5E0326B62A8B0098C605 /* RemoteError.swift */,
 			);
@@ -3453,6 +3459,7 @@
 				B56E763422BD394C00C5AA47 /* UIImage+Simplenote.swift in Sources */,
 				B543C7E323CF76EA00003A80 /* NotesListFilter.swift in Sources */,
 				46A3C96717DFA81A002865AE /* NSManagedObjectContext+CoreDataExtensions.m in Sources */,
+				BA0AC5442C1A0C65002964DB /* PasskeyRegistration.swift in Sources */,
 				A6C0DFA725C0992D00B9BE39 /* NoteScrollPositionCache.swift in Sources */,
 				B59314D81A486B3800B651ED /* SPConstants.m in Sources */,
 				375D24B421E01131007AB25A /* escape.c in Sources */,
@@ -3503,6 +3510,7 @@
 				A60DF31025A4524100FDADF3 /* PinLockBaseController.swift in Sources */,
 				A6F487ED25A85F970050CFA8 /* TagTextFieldInputValidator.swift in Sources */,
 				B5AB169822FA124F00B4EBA5 /* SPSheetController.swift in Sources */,
+				BA0AC5462C1A0C71002964DB /* PasskeyChallenge.swift in Sources */,
 				B511AEDA255A0A2A005B2159 /* InterlinkResultsController.swift in Sources */,
 				B5476BC123D8E5D0000E7723 /* String+Simplenote.swift in Sources */,
 				B5DF734222A565DA00602CE7 /* Options.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -450,6 +450,8 @@
 		BA289B762BE45BBB000E6794 /* OpenNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA289B742BE45BBB000E6794 /* OpenNoteIntentHandler.swift */; };
 		BA289B782BE45BFB000E6794 /* ActivityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B550F93022BA65CD00091939 /* ActivityType.swift */; };
 		BA2D82C6261522F100A1695B /* PublishNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */; };
+		BA2E30E02C1B8B45002C7B10 /* PasskeyAuthChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */; };
+		BA2E30E22C1B8B4E002C7B10 /* PasskeyAuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */; };
 		BA32A90F26B7469F00727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
 		BA32A91926B746A200727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
 		BA32A91A26B746A300727247 /* WidgetError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA32A90E26B7469F00727247 /* WidgetError.swift */; };
@@ -1160,6 +1162,8 @@
 		BA289B702BE45A39000E6794 /* IntentsConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentsConstants.swift; sourceTree = "<group>"; };
 		BA289B742BE45BBB000E6794 /* OpenNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenNoteIntentHandler.swift; sourceTree = "<group>"; };
 		BA2D82C5261522F100A1695B /* PublishNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishNoticePresenter.swift; sourceTree = "<group>"; };
+		BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAuthChallenge.swift; sourceTree = "<group>"; };
+		BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAuthResponse.swift; sourceTree = "<group>"; };
 		BA32A90E26B7469F00727247 /* WidgetError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetError.swift; sourceTree = "<group>"; };
 		BA34B04F2BEAEF4800580E15 /* SimplenoteIntentsRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SimplenoteIntentsRelease.entitlements; sourceTree = "<group>"; };
 		BA34B0562BEC216B00580E15 /* IntentNote+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntentNote+Helpers.swift"; sourceTree = "<group>"; };
@@ -2067,6 +2071,7 @@
 		B56A695122F9CCF400B90398 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				BA2E30DE2C1B8B0D002C7B10 /* Passkeys */,
 				B56A695722F9CD1500B90398 /* SPOnboardingViewController.swift */,
 				B56A695622F9CD1500B90398 /* SPOnboardingViewController.xib */,
 				B56A695D22F9D53300B90398 /* SPAuthError.swift */,
@@ -2076,7 +2081,6 @@
 				B5AB169722FA124F00B4EBA5 /* SPSheetController.swift */,
 				B5AB169922FA128000B4EBA5 /* SPSheetController.xib */,
 				A6CDD9C725F0163D00E0BC4D /* MagicLinkAuthenticator.swift */,
-				BAF694B12C1B753F000090E7 /* PasskeyAuthenticator.swift */,
 				A628BEB425ECD97900121B64 /* SignupVerificationViewController.swift */,
 				A628BEB525ECD97900121B64 /* SignupVerificationViewController.xib */,
 			);
@@ -2389,6 +2393,16 @@
 				BA9C7ECA2BED7F7B007A8460 /* FindNoteWithTagIntentHandler.swift */,
 			);
 			path = "Intent Handlers";
+			sourceTree = "<group>";
+		};
+		BA2E30DE2C1B8B0D002C7B10 /* Passkeys */ = {
+			isa = PBXGroup;
+			children = (
+				BAF694B12C1B753F000090E7 /* PasskeyAuthenticator.swift */,
+				BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */,
+				BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */,
+			);
+			name = Passkeys;
 			sourceTree = "<group>";
 		};
 		BA34B0552BEC214800580E15 /* ResolutionResults */ = {
@@ -3580,6 +3594,7 @@
 				B58C9F5723F2FCEC008C3480 /* SPPlaceholderView.swift in Sources */,
 				BAB6C04726BA4CAF007495C4 /* WidgetController.swift in Sources */,
 				A6E1E79E24BDE401008A44BC /* SPCardTransitioningManager.swift in Sources */,
+				BA2E30E02C1B8B45002C7B10 /* PasskeyAuthChallenge.swift in Sources */,
 				74388F4622CFFA8B001C5EC0 /* NSObject+Helpers.swift in Sources */,
 				46A3C98617DFA81A002865AE /* SPEntryListViewController.m in Sources */,
 				A6ABB689256D95EB00E2A076 /* PinLockProgressView.swift in Sources */,
@@ -3599,6 +3614,7 @@
 				B5185CFB23427F2F0060145A /* SearchDisplayController.swift in Sources */,
 				B524AE0F2352BE9200EA11D4 /* UITableView+Simplenote.swift in Sources */,
 				A6FDF73E2542BDE100415C87 /* NoteInformationController.swift in Sources */,
+				BA2E30E22C1B8B4E002C7B10 /* PasskeyAuthResponse.swift in Sources */,
 				A604DB22255A993E00B802CA /* SearchMapView.swift in Sources */,
 				B5E951E624FEE2A8004B10B8 /* Note+Links.swift in Sources */,
 				A6BBDA46255034E6005C8343 /* SPEditorTextView+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -556,6 +556,7 @@
 		BAF4A97926DB10BD00C51C1D /* NoteContentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64DE6F0255D1CD9001D0526 /* NoteContentHelper.swift */; };
 		BAF4A9AA26DB138600C51C1D /* NoteContentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64DE6F0255D1CD9001D0526 /* NoteContentHelper.swift */; };
 		BAF4A9BD26DB13B400C51C1D /* Note+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF8D42326AE10F100CA9383 /* Note+Widget.swift */; };
+		BAF694B22C1B753F000090E7 /* PasskeyAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF694B12C1B753F000090E7 /* PasskeyAuthenticator.swift */; };
 		BAF8D44B26AE10FC00CA9383 /* Tag+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF8D42226AE10F100CA9383 /* Tag+Widget.swift */; };
 		BAF8D44C26AE10FC00CA9383 /* Note+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF8D42326AE10F100CA9383 /* Note+Widget.swift */; };
 		BAF8D45526AE10FC00CA9383 /* Tag+Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF8D42226AE10F100CA9383 /* Tag+Widget.swift */; };
@@ -1252,6 +1253,7 @@
 		BAD0F1EC2BED49C200E73E45 /* FindNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNoteIntentHandler.swift; sourceTree = "<group>"; };
 		BAE08625261282D1009D40CD /* Note+Publish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Publish.swift"; sourceTree = "<group>"; };
 		BAF4A96E26DB085D00C51C1D /* NSURLComponents+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSURLComponents+Simplenote.swift"; sourceTree = "<group>"; };
+		BAF694B12C1B753F000090E7 /* PasskeyAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyAuthenticator.swift; sourceTree = "<group>"; };
 		BAF8D42226AE10F100CA9383 /* Tag+Widget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tag+Widget.swift"; sourceTree = "<group>"; };
 		BAF8D42326AE10F100CA9383 /* Note+Widget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Note+Widget.swift"; sourceTree = "<group>"; };
 		BAF8D48126AE125B00CA9383 /* Simplenote-Widgets-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Simplenote-Widgets-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -2074,6 +2076,7 @@
 				B5AB169722FA124F00B4EBA5 /* SPSheetController.swift */,
 				B5AB169922FA128000B4EBA5 /* SPSheetController.xib */,
 				A6CDD9C725F0163D00E0BC4D /* MagicLinkAuthenticator.swift */,
+				BAF694B12C1B753F000090E7 /* PasskeyAuthenticator.swift */,
 				A628BEB425ECD97900121B64 /* SignupVerificationViewController.swift */,
 				A628BEB525ECD97900121B64 /* SignupVerificationViewController.xib */,
 			);
@@ -3506,6 +3509,7 @@
 				B5CDE61F2150834C00C3FED4 /* Simperium+Simplenote.m in Sources */,
 				A60A1A1E25655D840041701E /* ApplicationShortcutItemType.swift in Sources */,
 				B51F6DD12460C3EE0074DDD9 /* AuthenticationValidator.swift in Sources */,
+				BAF694B22C1B753F000090E7 /* PasskeyAuthenticator.swift in Sources */,
 				B575736A232C567000443C2E /* UIImage+Dynamic.swift in Sources */,
 				A60DF31025A4524100FDADF3 /* PinLockBaseController.swift in Sources */,
 				A6F487ED25A85F970050CFA8 /* TagTextFieldInputValidator.swift in Sources */,

--- a/Simplenote/AccountRemote.swift
+++ b/Simplenote/AccountRemote.swift
@@ -137,8 +137,19 @@ class AccountRemote: Remote {
         return urlRequest
     }
 
-    func verifyPasskeyLogin(with data: Data) async throws {
+    func verifyPasskeyLogin(with data: Data) async throws -> (String?, String?)? {
         let request = verifyPassKeyRequest(with: data)
-        try await _ = performDataTask(with: request)
+        let data = try await performDataTask(with: request)
+
+        return parseUser(from: data)
+    }
+
+    private func parseUser(from data: Data?) -> (String?, String?)? {
+        guard let data else {
+            return nil
+        }
+
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return (json?["username"] as? String, json?["access_token"] as? String)
     }
 }

--- a/Simplenote/AccountRemote.swift
+++ b/Simplenote/AccountRemote.swift
@@ -62,10 +62,10 @@ class AccountRemote: Remote {
         ] as [String: Any]
 
         let boundary = "Boundary-\(UUID().uuidString)"
-        var request = URLRequest(url: URL(string: "https://passkey-dev-dot-simple-note-hrd.appspot.com/api2/login")!, timeoutInterval: Double.infinity)
+        var request = URLRequest(url: SimplenoteConstants.passkeyCredentialCreationURL)
         request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
-        request.httpMethod = "POST"
+        request.httpMethod = RemoteConstants.Method.POST
         request.httpBody = body(with: boundary, parameters: params)
 
         return request
@@ -92,4 +92,20 @@ class AccountRemote: Remote {
 
         return try await performDataTask(with: request)
     }
+
+    func passkeyCredentialRegistration(withData data: Data) -> URLRequest {
+        var urlRequest = URLRequest(url: SimplenoteConstants.passkeyRegistrationURL)
+        urlRequest.httpMethod = RemoteConstants.Method.POST
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        urlRequest.httpBody = data
+
+        return urlRequest
+    }
+
+    func registerCredential(with data: Data) async throws {
+        let request = passkeyCredentialRegistration(withData: data)
+        try await _ = performDataTask(with: request)
+    }
+
 }

--- a/Simplenote/AccountRemote.swift
+++ b/Simplenote/AccountRemote.swift
@@ -93,7 +93,7 @@ class AccountRemote: Remote {
         return try await performDataTask(with: request)
     }
 
-    func passkeyCredentialRegistration(withData data: Data) -> URLRequest {
+    private func passkeyCredentialRegistration(withData data: Data) -> URLRequest {
         var urlRequest = URLRequest(url: SimplenoteConstants.passkeyRegistrationURL)
         urlRequest.httpMethod = RemoteConstants.Method.POST
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -108,4 +108,23 @@ class AccountRemote: Remote {
         try await _ = performDataTask(with: request)
     }
 
+    private func passkeyAuthChallengeRequest(forEmail email: String) -> URLRequest {
+        var urlRequest = URLRequest(url: SimplenoteConstants.passkeyAuthChallengeURL)
+        urlRequest.httpMethod = RemoteConstants.Method.POST
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body = [
+            "email": email.lowercased()
+        ]
+        let json = try? JSONEncoder().encode(body)
+
+        urlRequest.httpBody = json
+
+        return urlRequest
+    }
+
+    func passkeyAuthChallenge(for email: String) async throws -> Data? {
+        let request = passkeyAuthChallengeRequest(forEmail: email)
+        return try await performDataTask(with: request)
+    }
 }

--- a/Simplenote/AccountRemote.swift
+++ b/Simplenote/AccountRemote.swift
@@ -127,4 +127,18 @@ class AccountRemote: Remote {
         let request = passkeyAuthChallengeRequest(forEmail: email)
         return try await performDataTask(with: request)
     }
+
+    private func verifyPassKeyRequest(with data: Data) -> URLRequest {
+        var urlRequest = URLRequest(url: SimplenoteConstants.verifyPasskeyAuthChallengeURL)
+        urlRequest.httpMethod = RemoteConstants.Method.POST
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = data
+
+        return urlRequest
+    }
+
+    func verifyPasskeyLogin(with data: Data) async throws {
+        let request = verifyPassKeyRequest(with: data)
+        try await _ = performDataTask(with: request)
+    }
 }

--- a/Simplenote/AccountRemote.swift
+++ b/Simplenote/AccountRemote.swift
@@ -137,19 +137,8 @@ class AccountRemote: Remote {
         return urlRequest
     }
 
-    func verifyPasskeyLogin(with data: Data) async throws -> (String?, String?)? {
+    func verifyPasskeyLogin(with data: Data) async throws -> Data? {
         let request = verifyPassKeyRequest(with: data)
-        let data = try await performDataTask(with: request)
-
-        return parseUser(from: data)
-    }
-
-    private func parseUser(from data: Data?) -> (String?, String?)? {
-        guard let data else {
-            return nil
-        }
-
-        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        return (json?["username"] as? String, json?["access_token"] as? String)
+        return try await performDataTask(with: request)
     }
 }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -657,10 +657,6 @@ extension SPAuthViewController: ASAuthorizationControllerPresentationContextProv
     }
 }
 
-
-
-
-
 // MARK: - AuthenticationMode: Signup / Login
 //
 struct AuthenticationMode {
@@ -773,25 +769,4 @@ private extension AuthenticationStrings {
 private enum AuthenticationConstants {
     static let accessoryViewInsets  = NSDirectionalEdgeInsets(top: .zero, leading: 16, bottom: .zero, trailing: 16)
     static let warningInsets        = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
-}
-
-// TODO Move this to a better place :)
-extension Data {
-    static func decodeUrlSafeBase64(_ value: String) throws -> Data {
-        var stringtoDecode: String = value.replacingOccurrences(of: "-", with: "+")
-        stringtoDecode = stringtoDecode.replacingOccurrences(of: "_", with: "/")
-        switch stringtoDecode.utf8.count % 4 {
-            case 2:
-                stringtoDecode += "=="
-            case 3:
-                stringtoDecode += "="
-            default:
-                break
-        }
-        guard let data = Data(base64Encoded: stringtoDecode, options: [.ignoreUnknownCharacters]) else {
-            throw NSError(domain: "decodeUrlSafeBase64", code: 1,
-                        userInfo: [NSLocalizedDescriptionKey: "Can't decode base64 string"])
-        }
-        return data
-    }
 }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -644,11 +644,11 @@ extension SPAuthViewController: ASAuthorizationControllerPresentationContextProv
 }
 
 extension SPAuthViewController: PasskeyDelegate {
-    func passkeyRegistrationSucceed() async {
+    func passkeyRegistrationSucceed() {
         unlockInterface()
     }
 
-    func passkeyRegistrationFailed(_ error: any Error) async {
+    func passkeyRegistrationFailed(_ error: any Error) {
         unlockInterface()
     }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -332,8 +332,7 @@ private extension SPAuthViewController {
             do {
                 try await passkeyAuthenticator.attemptPasskeyAuth(for: email, in: self)
             } catch {
-                unlockInterface()
-                //TODO: Show error message
+                failed(error)
             }
         }
     }
@@ -644,14 +643,20 @@ extension SPAuthViewController: ASAuthorizationControllerPresentationContextProv
 }
 
 extension SPAuthViewController: PasskeyDelegate {
-    func passkeyRegistrationSucceed() {
+    func succeed() {
         unlockInterface()
     }
 
-    func passkeyRegistrationFailed(_ error: any Error) {
+    func failed(_ error: any Error) {
         unlockInterface()
+        presentPasskeyAuthError(error)
     }
 
+    private func presentPasskeyAuthError(_ error: any Error) {
+        let alert = UIAlertController(title: AuthenticationStrings.passkeyAuthFailureTitle, message: error.localizedDescription, preferredStyle: .alert)
+        alert.addCancelActionWithTitle(AuthenticationStrings.unverifiedCancelText)
+        present(alert, animated: true)
+    }
 }
 
 // MARK: - AuthenticationMode: Signup / Login
@@ -737,6 +742,7 @@ private enum AuthenticationStrings {
     static let unverifiedErrorMessage       = NSLocalizedString("There was an preparing your verification email, please try again later", comment: "Request error alert message")
     static let verificationSentTitle        = NSLocalizedString("Check your Email", comment: "Vefification sent alert title")
     static let verificationSentTemplate     = NSLocalizedString("We’ve sent a verification email to %1$@. Please check your inbox and follow the instructions.", comment: "Confirmation that an email has been sent")
+    static let passkeyAuthFailureTitle      = NSLocalizedString("Passkey Authentication Failed", comment: "Title for passkey authentication failure")
 }
 
 // MARK: - PasswordInsecure Alert Strings

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -325,10 +325,16 @@ private extension SPAuthViewController {
         }
 
         Task {
-            //TODO: Handle errors
+            lockdownInterface()
 
             let passkeyAuthenticator = SPAppDelegate.shared().passkeyAuthenticator
-            try? await passkeyAuthenticator.attemptPasskeyAuth(for: email, in: self)
+            passkeyAuthenticator.delegate = self
+            do {
+                try await passkeyAuthenticator.attemptPasskeyAuth(for: email, in: self)
+            } catch {
+                unlockInterface()
+                //TODO: Show error message
+            }
         }
     }
 
@@ -630,10 +636,22 @@ extension SPAuthViewController: SPTextInputViewDelegate {
     }
 }
 
+// MARK: - Passkeys
 extension SPAuthViewController: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         view.window!
     }
+}
+
+extension SPAuthViewController: PasskeyDelegate {
+    func passkeyRegistrationSucceed() async {
+        unlockInterface()
+    }
+
+    func passkeyRegistrationFailed(_ error: any Error) async {
+        unlockInterface()
+    }
+
 }
 
 // MARK: - AuthenticationMode: Signup / Login

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -412,7 +412,15 @@ private extension SPAuthViewController {
         let updatedJson = try! JSONSerialization.data(withJSONObject: jsonObject)
 
         Task {
-            try? await AccountRemote().verifyPasskeyLogin(with: updatedJson)
+
+            guard let tuple = try? await AccountRemote().verifyPasskeyLogin(with: updatedJson),
+                  let email = tuple.0,
+                  let token = tuple.1 else {
+                return
+            }
+            
+            let authenticator = SPAppDelegate.shared().simperium.authenticator
+            authenticator.authenticate(withUsername: email, token: token)
         }
     }
 }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -76,17 +76,6 @@ class SPAuthViewController: UIViewController {
         }
     }
 
-    /// # Passkey Button Action
-    ///
-    @IBOutlet weak var passkeySigninButton: SPSquaredButton! {
-        didSet {
-            passkeySigninButton.isHidden = !mode.isLogin
-            passkeySigninButton.setTitle(AuthenticationStrings.passkeyActionButton, for: .normal)
-            passkeySigninButton.setTitleColor(.white, for: .normal)
-            passkeySigninButton.addTarget(self, action: #selector(passkeyAuthAction), for: .touchUpInside)
-        }
-    }
-
     /// # Primary Action Spinner!
     ///
     @IBOutlet private var primaryActionSpinner: UIActivityIndicatorView! {
@@ -111,14 +100,6 @@ class SPAuthViewController: UIViewController {
             secondaryActionButton.titleLabel?.textAlignment = .center
             secondaryActionButton.titleLabel?.numberOfLines = 0
             secondaryActionButton.addTarget(self, action: mode.secondaryActionSelector, for: .touchUpInside)
-        }
-    }
-
-    /// # Passkey Action Spinner
-    ///
-    @IBOutlet weak var passkeyActivitySpinner: UIActivityIndicatorView! {
-        didSet {
-            passkeyActivitySpinner.style = .medium
         }
     }
 
@@ -261,7 +242,6 @@ private extension SPAuthViewController {
 
     func ensureStylesMatchValidationState() {
         primaryActionButton.backgroundColor = isInputValid ? .simplenoteBlue50Color : .simplenoteGray20Color
-        passkeySigninButton.backgroundColor = isInputValid ? .simplenoteBlue50Color : .simplenoteGray20Color
     }
 
     @objc
@@ -306,11 +286,6 @@ private extension SPAuthViewController {
 
     @IBAction func performLogIn() {
         guard ensureWarningsAreOnScreenWhenNeeded() else {
-            return
-        }
-
-        if passwordInputView.isHidden == true && passwordInputView.text?.isEmpty == true {
-            passwordInputView.isHidden = false
             return
         }
 
@@ -685,7 +660,7 @@ extension AuthenticationMode {
                      secondaryActionSelector: #selector(SPAuthViewController.presentPasswordReset),
                      secondaryActionText: AuthenticationStrings.loginSecondaryAction,
                      secondaryActionAttributedText: nil,
-                     isPasswordHidden: true,
+                     isPasswordHidden: false,
                      isLogin: true)
     }
 
@@ -701,6 +676,18 @@ extension AuthenticationMode {
                      secondaryActionAttributedText: AuthenticationStrings.signupSecondaryAttributedAction,
                      isPasswordHidden: true,
                      isLogin: false)
+    }
+
+    static var loginWithPasskeys: AuthenticationMode {
+        return .init(title: AuthenticationStrings.loginTitle,
+                     validationStyle: .legacy,
+                     primaryActionSelector: #selector(SPAuthViewController.passkeyAuthAction),
+                     primaryActionText: AuthenticationStrings.passkeyActionButton,
+                     secondaryActionSelector: #selector(SPAuthViewController.presentPasswordReset),
+                     secondaryActionText: AuthenticationStrings.loginSecondaryAction,
+                     secondaryActionAttributedText: nil,
+                     isPasswordHidden: true,
+                     isLogin: true)
     }
 }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -712,7 +712,7 @@ extension SPAuthViewController: ASAuthorizationControllerDelegate {
         }
 
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: challenge.relayingParty)
-        let request = provider.createCredentialAssertionRequest(challenge: challenge.challenge)
+        let request = provider.createCredentialAssertionRequest(challenge: challenge.challenge.data(using: .utf8)!)
 
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
@@ -753,7 +753,7 @@ extension SPAuthViewController: ASAuthorizationControllerPresentationContextProv
 
 struct PasskeyAuthChallenge: Decodable {
     let relayingParty: String
-    let challenge: Data
+    let challenge: String
 
     enum CodingKeys: String, CodingKey {
         case relayingParty = "rpId"

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -657,35 +657,9 @@ extension SPAuthViewController: ASAuthorizationControllerPresentationContextProv
     }
 }
 
-struct PasskeyAuthChallenge: Decodable {
-    let relayingParty: String
-    let challenge: String
 
-    enum CodingKeys: String, CodingKey {
-        case relayingParty = "rpId"
-        case challenge
-    }
-}
 
-struct WebAuthnResponse: Codable {
-    let id: String
-    let rawId: String
-    let response: Response
-    var type: String = "public-key"
 
-    init(from credential: ASAuthorizationPlatformPublicKeyCredentialAssertion) {
-        self.id = credential.credentialID.base64EncodedString().toBase64url()
-        self.rawId = credential.credentialID.base64EncodedString().toBase64url()
-        self.response = WebAuthnResponse.Response(clientDataJSON: credential.rawClientDataJSON.base64EncodedString(), authenticatorData: credential.rawAuthenticatorData.base64EncodedString(), signature: credential.signature.base64EncodedString(), userHandle: credential.userID.base64EncodedString())
-    }
-
-    struct Response: Codable {
-        let clientDataJSON: String
-        let authenticatorData: String
-        let signature: String
-        let userHandle: String
-    }
-}
 
 // MARK: - AuthenticationMode: Signup / Login
 //

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -320,9 +320,13 @@ private extension SPAuthViewController {
     }
 
     @objc func passkeyAuthAction() {
+        guard ensureWarningsAreOnScreenWhenNeeded() else {
+            return
+        }
+
         Task {
             //TODO: Handle errors
-            //TODO: Handle email not valid
+
             let passkeyAuthenticator = SPAppDelegate.shared().passkeyAuthenticator
             try? await passkeyAuthenticator.attemptPasskeyAuth(for: email, in: self)
         }

--- a/Simplenote/Classes/SPAuthViewController.xib
+++ b/Simplenote/Classes/SPAuthViewController.xib
@@ -13,8 +13,6 @@
             <connections>
                 <outlet property="emailInputView" destination="hW6-K1-OyV" id="TyC-Uh-Kaf"/>
                 <outlet property="emailWarningLabel" destination="n7T-Gj-plH" id="STx-wz-jKg"/>
-                <outlet property="passkeyActivitySpinner" destination="1r4-a8-hNr" id="1yP-oN-4Fg"/>
-                <outlet property="passkeySigninButton" destination="h9W-v8-WKk" id="9pc-1i-vUF"/>
                 <outlet property="passwordInputView" destination="pdF-nK-gXE" id="18P-SU-c90"/>
                 <outlet property="passwordWarningLabel" destination="UyC-If-pXj" id="D2M-PR-Tph"/>
                 <outlet property="primaryActionButton" destination="q3p-Ji-dOm" id="l1t-x0-zva"/>
@@ -31,7 +29,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CJS-5O-pxK">
-                    <rect key="frame" x="332" y="60" width="360" height="304"/>
+                    <rect key="frame" x="332" y="60" width="360" height="252"/>
                     <subviews>
                         <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-K1-OyV" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -88,31 +86,8 @@
                                 <constraint firstItem="o3M-2A-urw" firstAttribute="centerY" secondItem="CGr-O3-MBQ" secondAttribute="centerY" id="wvA-qg-zbY"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5h1-31-jFW" userLabel="Passkey Button">
-                            <rect key="frame" x="0.0" y="208" width="360" height="44"/>
-                            <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h9W-v8-WKk" userLabel="Passkey" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                    <state key="normal" title="#Passkey#"/>
-                                </button>
-                                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="1r4-a8-hNr">
-                                    <rect key="frame" x="322" y="12" width="20" height="20"/>
-                                </activityIndicatorView>
-                            </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                            <constraints>
-                                <constraint firstItem="h9W-v8-WKk" firstAttribute="leading" secondItem="5h1-31-jFW" secondAttribute="leading" id="11w-Lz-NjB"/>
-                                <constraint firstAttribute="bottom" secondItem="h9W-v8-WKk" secondAttribute="bottom" id="JvA-Ah-SyT"/>
-                                <constraint firstItem="h9W-v8-WKk" firstAttribute="top" secondItem="5h1-31-jFW" secondAttribute="top" id="LcI-bp-W2p"/>
-                                <constraint firstItem="1r4-a8-hNr" firstAttribute="centerY" secondItem="5h1-31-jFW" secondAttribute="centerY" id="QHO-xZ-PfH"/>
-                                <constraint firstAttribute="trailing" secondItem="h9W-v8-WKk" secondAttribute="trailing" id="cNB-id-tDI"/>
-                                <constraint firstAttribute="trailing" secondItem="1r4-a8-hNr" secondAttribute="trailing" constant="18" id="ewS-87-pUI"/>
-                                <constraint firstAttribute="height" constant="44" id="sXy-jP-JIm"/>
-                            </constraints>
-                        </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
-                            <rect key="frame" x="0.0" y="260" width="360" height="44"/>
+                            <rect key="frame" x="0.0" y="208" width="360" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="u8s-d9-Em4"/>
                             </constraints>
@@ -123,10 +98,8 @@
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="PfS-vU-7i3" secondAttribute="trailing" id="0QL-Iw-KLz"/>
                         <constraint firstItem="PfS-vU-7i3" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="314-fc-3eX"/>
-                        <constraint firstItem="5h1-31-jFW" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="36P-F4-cGU"/>
                         <constraint firstAttribute="trailing" secondItem="pdF-nK-gXE" secondAttribute="trailing" id="51g-0D-Oyv"/>
                         <constraint firstItem="CGr-O3-MBQ" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="BIX-Fy-gqY"/>
-                        <constraint firstAttribute="trailing" secondItem="5h1-31-jFW" secondAttribute="trailing" id="N0i-ud-dYk"/>
                         <constraint firstAttribute="trailing" secondItem="hW6-K1-OyV" secondAttribute="trailing" id="RSC-Vk-xbB"/>
                         <constraint firstItem="hW6-K1-OyV" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="UoC-hu-yxe"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="nLp-JP-Ott"/>
@@ -150,9 +123,6 @@
         <designable name="UyC-If-pXj">
             <size key="intrinsicContentSize" width="132" height="18"/>
         </designable>
-        <designable name="h9W-v8-WKk">
-            <size key="intrinsicContentSize" width="87" height="33"/>
-        </designable>
         <designable name="n7T-Gj-plH">
             <size key="intrinsicContentSize" width="102.5" height="18"/>
         </designable>
@@ -165,10 +135,10 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemPinkColor">
-            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Simplenote/Classes/SPAuthViewController.xib
+++ b/Simplenote/Classes/SPAuthViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +13,8 @@
             <connections>
                 <outlet property="emailInputView" destination="hW6-K1-OyV" id="TyC-Uh-Kaf"/>
                 <outlet property="emailWarningLabel" destination="n7T-Gj-plH" id="STx-wz-jKg"/>
+                <outlet property="passkeyActivitySpinner" destination="1r4-a8-hNr" id="1yP-oN-4Fg"/>
+                <outlet property="passkeySigninButton" destination="h9W-v8-WKk" id="9pc-1i-vUF"/>
                 <outlet property="passwordInputView" destination="pdF-nK-gXE" id="18P-SU-c90"/>
                 <outlet property="passwordWarningLabel" destination="UyC-If-pXj" id="D2M-PR-Tph"/>
                 <outlet property="primaryActionButton" destination="q3p-Ji-dOm" id="l1t-x0-zva"/>
@@ -28,7 +31,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CJS-5O-pxK">
-                    <rect key="frame" x="332" y="40" width="360" height="252"/>
+                    <rect key="frame" x="332" y="60" width="360" height="304"/>
                     <subviews>
                         <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-K1-OyV" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -43,7 +46,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#Invalid email#" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n7T-Gj-plH" customClass="SPLabel" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="52" width="102.5" height="18"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <color key="textColor" systemColor="systemPinkColor" red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="textColor" systemColor="systemPinkColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="pdF-nK-gXE" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
@@ -59,13 +62,13 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#Invalid password#" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UyC-If-pXj" customClass="SPLabel" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="130" width="132" height="18"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <color key="textColor" systemColor="systemRedColor" red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="textColor" systemColor="systemRedColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CGr-O3-MBQ" userLabel="Primary Action View">
                             <rect key="frame" x="0.0" y="156" width="360" height="44"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3p-Ji-dOm" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3p-Ji-dOm" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                     <state key="normal" title="#Primary#"/>
@@ -74,7 +77,7 @@
                                     <rect key="frame" x="322" y="12" width="20" height="20"/>
                                 </activityIndicatorView>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="q3p-Ji-dOm" secondAttribute="bottom" id="42P-Dw-g8A"/>
                                 <constraint firstAttribute="trailing" secondItem="o3M-2A-urw" secondAttribute="trailing" constant="18" id="5zP-Ho-8zY"/>
@@ -85,8 +88,31 @@
                                 <constraint firstItem="o3M-2A-urw" firstAttribute="centerY" secondItem="CGr-O3-MBQ" secondAttribute="centerY" id="wvA-qg-zbY"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5h1-31-jFW" userLabel="Passkey Button">
                             <rect key="frame" x="0.0" y="208" width="360" height="44"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h9W-v8-WKk" userLabel="Passkey" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                    <state key="normal" title="#Passkey#"/>
+                                </button>
+                                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="1r4-a8-hNr">
+                                    <rect key="frame" x="322" y="12" width="20" height="20"/>
+                                </activityIndicatorView>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstItem="h9W-v8-WKk" firstAttribute="leading" secondItem="5h1-31-jFW" secondAttribute="leading" id="11w-Lz-NjB"/>
+                                <constraint firstAttribute="bottom" secondItem="h9W-v8-WKk" secondAttribute="bottom" id="JvA-Ah-SyT"/>
+                                <constraint firstItem="h9W-v8-WKk" firstAttribute="top" secondItem="5h1-31-jFW" secondAttribute="top" id="LcI-bp-W2p"/>
+                                <constraint firstItem="1r4-a8-hNr" firstAttribute="centerY" secondItem="5h1-31-jFW" secondAttribute="centerY" id="QHO-xZ-PfH"/>
+                                <constraint firstAttribute="trailing" secondItem="h9W-v8-WKk" secondAttribute="trailing" id="cNB-id-tDI"/>
+                                <constraint firstAttribute="trailing" secondItem="1r4-a8-hNr" secondAttribute="trailing" constant="18" id="ewS-87-pUI"/>
+                                <constraint firstAttribute="height" constant="44" id="sXy-jP-JIm"/>
+                            </constraints>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
+                            <rect key="frame" x="0.0" y="260" width="360" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="u8s-d9-Em4"/>
                             </constraints>
@@ -97,8 +123,10 @@
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="PfS-vU-7i3" secondAttribute="trailing" id="0QL-Iw-KLz"/>
                         <constraint firstItem="PfS-vU-7i3" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="314-fc-3eX"/>
+                        <constraint firstItem="5h1-31-jFW" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="36P-F4-cGU"/>
                         <constraint firstAttribute="trailing" secondItem="pdF-nK-gXE" secondAttribute="trailing" id="51g-0D-Oyv"/>
                         <constraint firstItem="CGr-O3-MBQ" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="BIX-Fy-gqY"/>
+                        <constraint firstAttribute="trailing" secondItem="5h1-31-jFW" secondAttribute="trailing" id="N0i-ud-dYk"/>
                         <constraint firstAttribute="trailing" secondItem="hW6-K1-OyV" secondAttribute="trailing" id="RSC-Vk-xbB"/>
                         <constraint firstItem="hW6-K1-OyV" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="UoC-hu-yxe"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="nLp-JP-Ott"/>
@@ -107,6 +135,7 @@
                     </constraints>
                 </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="CJS-5O-pxK" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="40" id="Cyh-nE-ql7"/>
@@ -114,8 +143,32 @@
                 <constraint firstItem="CJS-5O-pxK" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="H6h-v9-Uwb"/>
                 <constraint firstItem="CJS-5O-pxK" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" priority="999" constant="24" id="Odu-ev-HSV"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="137.68115942028987" y="152.67857142857142"/>
         </view>
     </objects>
+    <designables>
+        <designable name="UyC-If-pXj">
+            <size key="intrinsicContentSize" width="132" height="18"/>
+        </designable>
+        <designable name="h9W-v8-WKk">
+            <size key="intrinsicContentSize" width="87" height="33"/>
+        </designable>
+        <designable name="n7T-Gj-plH">
+            <size key="intrinsicContentSize" width="102.5" height="18"/>
+        </designable>
+        <designable name="q3p-Ji-dOm">
+            <size key="intrinsicContentSize" width="84" height="33"/>
+        </designable>
+    </designables>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -151,13 +151,18 @@ private extension SPOnboardingViewController {
         let sheetController = SPSheetController()
 
         sheetController.setTitleForButton0(title: OnboardingStrings.loginWithEmailText)
-        sheetController.setTitleForButton1(title: OnboardingStrings.loginWithWpcomText)
+        sheetController.setTitleForButton1(title: OnboardingStrings.loginWithPasskeysText)
+        sheetController.setTitleForButton2(title: OnboardingStrings.loginWithWpcomText)
 
         sheetController.onClickButton0 = { [weak self] in
             self?.presentAuthenticationInterface(mode: .login)
         }
 
         sheetController.onClickButton1 = { [weak self] in
+            self?.presentAuthenticationInterface(mode: .loginWithPasskeys)
+        }
+
+        sheetController.onClickButton2 = { [weak self] in
             self?.presentWordpressSSO()
         }
 
@@ -224,6 +229,7 @@ private struct OnboardingStrings {
     static let headerText = NSLocalizedString("The simplest way to keep notes.", comment: "Onboarding Header Text")
     static let loginWithEmailText = NSLocalizedString("Log in with email", comment: "Presents the regular Email signin flow")
     static let loginWithWpcomText = NSLocalizedString("Log in with WordPress.com", comment: "Allows the user to SignIn using their WPCOM Account")
+    static let loginWithPasskeysText = NSLocalizedString("Log in with Passkeys", comment: "Allows the user to SignIn using Passkeys")
 }
 
 private struct SignInError {

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -246,7 +246,7 @@ extension SPSettingsViewController {
                     let authenticator = appDelegate.passkeyAuthenticator
                     try await authenticator.registerPasskey(for: email, password: password, in: self)
                 } catch {
-                    await self.passkeyRegistrationFailed(error)
+                    self.failed(error)
                 }
             }
         }
@@ -273,12 +273,12 @@ extension SPSettingsViewController: ASAuthorizationControllerPresentationContext
 }
 
 extension SPSettingsViewController: PasskeyDelegate {
-    func passkeyRegistrationSucceed() {
+    func succeed() {
         removeActivityIndicator()
         presentPasskeySuccessAlert()
     }
 
-    func passkeyRegistrationFailed(_ error: any Error) {
+    func failed(_ error: any Error) {
         removeActivityIndicator()
         self.presentPasskeyRegistrationFailureAlert()
         NSLog("Failed to register Passkey.  Error: %@", error.localizedDescription)

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -238,8 +238,10 @@ extension SPSettingsViewController {
             }
 
             Task {
+
                 do {
-                    try await self.passkeyAuthenticator.registerPasskey(for: email, password: password, in: self)
+                    let authenticator = SPAppDelegate.shared().passkeyAuthenticator
+                    try await authenticator.registerPasskey(for: email, password: password, in: self)
                 } catch {
                     // TODO: Display some action for failure
                 }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -239,16 +239,31 @@ extension SPSettingsViewController {
 
             Task {
                 guard let response = try? await AccountRemote().requestChallengeResponseToCreatePasskey(forEmail: email, password: password),
-                      let json = try? JSONSerialization.jsonObject(with: response, options: .topLevelDictionaryAssumed) as? [String: Any] else {
+                      let passkeyChallenge = try? JSONDecoder().decode(PasskeyChallenge.self, from: response) else {
+                    //TODO: Throw instead
                     return
                 }
-                print(json)
+                self.attemptRegisteringPasskey(with: passkeyChallenge)
             }
         }
         alert.addAction(action)
         alert.addCancelActionWithTitle("Cancel")
 
         present(alert, animated: true)
+    }
+
+    private func attemptRegisteringPasskey(with passkeyChallenge: PasskeyChallenge) {
+        guard let challengeData = passkeyChallenge.challengeData,
+              let userID = passkeyChallenge.userID else {
+            return
+        }
+
+        let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: passkeyChallenge.relayingPartyIdentifier)
+        let platformKeyRequest = platformProvider.createCredentialRegistrationRequest(challenge: challengeData, name: passkeyChallenge.displayName, userID: userID)
+        let authController = ASAuthorizationController(authorizationRequests: [platformKeyRequest])
+        authController.delegate = self
+        authController.presentationContextProvider = self
+        authController.performRequests()
     }
 }
 
@@ -259,6 +274,17 @@ extension SPSettingsViewController: ASAuthorizationControllerDelegate {
 
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
 
+        if let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
+            guard let registrationObject = PasskeyRegistration(from: credential),
+                  let data = try? JSONEncoder().encode(registrationObject) else {
+                //TODO: Should handle error
+                return
+            }
+
+            Task {
+                try? await AccountRemote().registerCredential(with: data)
+            }
+        }
     }
 }
 

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -273,19 +273,19 @@ extension SPSettingsViewController: ASAuthorizationControllerPresentationContext
 }
 
 extension SPSettingsViewController: PasskeyDelegate {
-    func passkeyRegistrationSucceed() async {
-        await removeActivityIndicator()
+    func passkeyRegistrationSucceed() {
+        removeActivityIndicator()
         presentPasskeySuccessAlert()
     }
 
-    func passkeyRegistrationFailed(_ error: any Error) async {
-        await removeActivityIndicator()
+    func passkeyRegistrationFailed(_ error: any Error) {
+        removeActivityIndicator()
         self.presentPasskeyRegistrationFailureAlert()
         NSLog("Failed to register Passkey.  Error: %@", error.localizedDescription)
     }
 
-    private func removeActivityIndicator() async {
-        await activityIndicator?.dismiss(true)
+    private func removeActivityIndicator() {
+        activityIndicator?.dismiss(true)
         activityIndicator = nil
     }
 

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -229,10 +229,11 @@ extension SPSettingsViewController {
             textField.textContentType = .password
             textField.isSecureTextEntry = true
         }
+        SPAppDelegate.shared().passkeyAuthenticator.registrationDelegate = self
 
         let action = UIAlertAction(title: PasskeyAuthentication.submit, style: .default) { [unowned alert] _ in
             let appDelegate = SPAppDelegate.shared()
-            let activityIndicator = SPModalActivityIndicator.show(in: appDelegate.window)
+            self.activityIndicator = SPModalActivityIndicator.show(in: appDelegate.window)
 
             guard let textfield = alert.textFields?.first,
                   let password = textfield.text,
@@ -244,10 +245,8 @@ extension SPSettingsViewController {
                 do {
                     let authenticator = appDelegate.passkeyAuthenticator
                     try await authenticator.registerPasskey(for: email, password: password, in: self)
-                    await activityIndicator?.dismiss(true)
                 } catch {
-                    await self.presentPasskeyRegistrationFailureAlert(activityIndicator: activityIndicator)
-                    NSLog("Failed to register Passkey.  Error: %@", error.localizedDescription)
+                    await self.passkeyRegistrationFailed(error)
                 }
             }
         }
@@ -257,17 +256,42 @@ extension SPSettingsViewController {
         present(alert, animated: true)
     }
 
-    private func presentPasskeyRegistrationFailureAlert(activityIndicator: SPModalActivityIndicator?) async {
-        await activityIndicator?.dismiss(true)
+    private func presentPasskeyRegistrationFailureAlert() {
         let failureAlert = UIAlertController(title: PasskeyAuthentication.failureTitle, message: PasskeyAuthentication.failureMessage, preferredStyle: .alert)
         failureAlert.addCancelActionWithTitle(PasskeyAuthentication.okay)
         self.present(failureAlert, animated: true)
     }
 }
 
+// MARK: - Passkeys
+//
 extension SPSettingsViewController: ASAuthorizationControllerPresentationContextProviding {
+    // To present the passkey modals we need to give it a window to appear in
     public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         view.window!
+    }
+}
+
+extension SPSettingsViewController: PasskeyRegistrationDelegate {
+    func passkeyRegistrationSucceed() async {
+        await removeActivityIndicator()
+        presentPasskeySuccessAlert()
+    }
+    
+    func passkeyRegistrationFailed(_ error: any Error) async {
+        await removeActivityIndicator()
+        self.presentPasskeyRegistrationFailureAlert()
+        NSLog("Failed to register Passkey.  Error: %@", error.localizedDescription)
+    }
+    
+    private func removeActivityIndicator() async {
+        await activityIndicator?.dismiss(true)
+        activityIndicator = nil
+    }
+
+    private func presentPasskeySuccessAlert() {
+        let alert = UIAlertController(title: PasskeyAuthentication.registrationSuccessfullTitle, message: nil, preferredStyle: .alert)
+        alert.addCancelActionWithTitle(PasskeyAuthentication.okay)
     }
 }
 
@@ -302,10 +326,11 @@ private struct PasskeyAuthentication {
     static let alertTitle = NSLocalizedString("Passkey Setup", comment: "Alert title for setting up passkeys")
     static let message = NSLocalizedString("To add passkeys you must enter your password", comment: "Message prompting user for password to create passkey")
     static let submit = NSLocalizedString("Submit", comment: "Submit button title")
-    static let cancel = NSLocalizedString("cancel", comment: "Cancel button title")
+    static let cancel = NSLocalizedString("Cancel", comment: "Cancel button title")
     static let failureTitle = NSLocalizedString("Passkey Registration Failed", comment: "Title for alert when passkey registration fails")
     static let failureMessage = NSLocalizedString("Could not register passkey.  Please try again later", comment: "Message for when passkey registration fails")
     static let okay = NSLocalizedString("Okay", comment: "confirm button title")
+    static let registrationSuccessfullTitle = NSLocalizedString("Passkey Registration Successful", comment: "Alert title confirm passkey registration")
 }
 
 // MARK: - RestorationAlert

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -229,7 +229,7 @@ extension SPSettingsViewController {
             textField.textContentType = .password
             textField.isSecureTextEntry = true
         }
-        SPAppDelegate.shared().passkeyAuthenticator.registrationDelegate = self
+        SPAppDelegate.shared().passkeyAuthenticator.delegate = self
 
         let action = UIAlertAction(title: PasskeyAuthentication.submit, style: .default) { [unowned alert] _ in
             let appDelegate = SPAppDelegate.shared()
@@ -272,18 +272,18 @@ extension SPSettingsViewController: ASAuthorizationControllerPresentationContext
     }
 }
 
-extension SPSettingsViewController: PasskeyRegistrationDelegate {
+extension SPSettingsViewController: PasskeyDelegate {
     func passkeyRegistrationSucceed() async {
         await removeActivityIndicator()
         presentPasskeySuccessAlert()
     }
-    
+
     func passkeyRegistrationFailed(_ error: any Error) async {
         await removeActivityIndicator()
         self.presentPasskeyRegistrationFailureAlert()
         NSLog("Failed to register Passkey.  Error: %@", error.localizedDescription)
     }
-    
+
     private func removeActivityIndicator() async {
         await activityIndicator?.dismiss(true)
         activityIndicator = nil

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -223,24 +223,24 @@ extension SPSettingsViewController {
 //
 extension SPSettingsViewController {
     @objc
-    func presentEnterPasswordAlert() {
-        let alert = UIAlertController(title: "Passkey Setup", message: "To add passkeys you must enter your password", preferredStyle: .alert)
+    func presentPasskeyAuthenticationSetupAlert() {
+        let alert = UIAlertController(title: PasskeyAuthentication.alertTitle, message: PasskeyAuthentication.message, preferredStyle: .alert)
         alert.addTextField { textField in
             textField.textContentType = .password
             textField.isSecureTextEntry = true
         }
 
-        let action = UIAlertAction(title: "Submit", style: .default) { [unowned alert] _ in
+        let action = UIAlertAction(title: PasskeyAuthentication.submit, style: .default) { [unowned alert] _ in
+            let appDelegate = SPAppDelegate.shared()
             guard let textfield = alert.textFields?.first,
                   let password = textfield.text,
-                  let email = SPAppDelegate.shared().simperium.user?.email else {
+                  let email = appDelegate.simperium.user?.email else {
                 return
             }
 
             Task {
-
                 do {
-                    let authenticator = SPAppDelegate.shared().passkeyAuthenticator
+                    let authenticator = appDelegate.passkeyAuthenticator
                     try await authenticator.registerPasskey(for: email, password: password, in: self)
                 } catch {
                     // TODO: Display some action for failure
@@ -248,7 +248,7 @@ extension SPSettingsViewController {
             }
         }
         alert.addAction(action)
-        alert.addCancelActionWithTitle("Cancel")
+        alert.addCancelActionWithTitle(PasskeyAuthentication.cancel)
 
         present(alert, animated: true)
     }
@@ -285,6 +285,13 @@ private struct AccountDeletion {
     static func successMessage(email: String) -> String {
         String(format: successAlertMessage, email)
     }
+}
+
+private struct PasskeyAuthentication {
+    static let alertTitle = NSLocalizedString("Passkey Setup", comment: "Alert title for setting up passkeys")
+    static let message = NSLocalizedString("To add passkeys you must enter your password", comment: "Message prompting user for password to create passkey")
+    static let submit = NSLocalizedString("Submit", comment: "Submit button title")
+    static let cancel = NSLocalizedString("cancel", comment: "Cancel button title")
 }
 
 // MARK: - RestorationAlert

--- a/Simplenote/Classes/SPSettingsViewController.h
+++ b/Simplenote/Classes/SPSettingsViewController.h
@@ -1,15 +1,11 @@
 #import <UIKit/UIKit.h>
 #import "SPTableViewController.h"
 
-@class  PasskeyAuthenticator;
-
 @interface SPSettingsViewController : SPTableViewController <UIPickerViewDelegate, UIPickerViewDataSource> {
     //Preferences
     NSNumber *sortOrderPref;
     NSNumber *numPreviewLinesPref;
 }
-
-@property (nonatomic, strong) PasskeyAuthenticator *passkeyAuthenticator;
 
 @end
 

--- a/Simplenote/Classes/SPSettingsViewController.h
+++ b/Simplenote/Classes/SPSettingsViewController.h
@@ -1,11 +1,15 @@
 #import <UIKit/UIKit.h>
 #import "SPTableViewController.h"
 
+@class  PasskeyAuthenticator;
+
 @interface SPSettingsViewController : SPTableViewController <UIPickerViewDelegate, UIPickerViewDataSource> {
     //Preferences
     NSNumber *sortOrderPref;
     NSNumber *numPreviewLinesPref;
 }
+
+@property (nonatomic, strong) PasskeyAuthenticator *passkeyAuthenticator;
 
 @end
 

--- a/Simplenote/Classes/SPSettingsViewController.h
+++ b/Simplenote/Classes/SPSettingsViewController.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 #import "SPTableViewController.h"
+#import "SPModalActivityIndicator.h"
 
 @interface SPSettingsViewController : SPTableViewController <UIPickerViewDelegate, UIPickerViewDataSource> {
     //Preferences
@@ -7,7 +8,9 @@
     NSNumber *numPreviewLinesPref;
 }
 
+@property (nonatomic, strong, nullable) SPModalActivityIndicator *activityIndicator;
+
 @end
 
-extern NSString *const SPAlphabeticalTagSortPref;
-extern NSString *const SPSustainerAppIconName;
+extern NSString * _Nonnull const SPAlphabeticalTagSortPref;
+extern NSString * _Nonnull const SPSustainerAppIconName;

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -11,6 +11,8 @@ NSString *const SPAlphabeticalTagSortPref                           = @"SPAlphab
 NSString *const SPThemePref                                         = @"SPThemePref";
 NSString *const SPSustainerAppIconName                              = @"AppIcon-Sustainer";
 
+
+
 @interface SPSettingsViewController ()
 @property (nonatomic, strong) UISwitch      *condensedNoteListSwitch;
 @property (nonatomic, strong) UISwitch      *alphabeticalTagSortSwitch;
@@ -25,6 +27,7 @@ NSString *const SPSustainerAppIconName                              = @"AppIcon-
 @implementation SPSettingsViewController {
     NSArray *timeoutPickerOptions;
 }
+
 
 #define kTagNoteListSort        1
 #define kTagTagsListSort        2
@@ -190,6 +193,8 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                                object:nil];
 
     [self refreshThemeStyles];
+
+    self.passkeyAuthenticator = [[PasskeyAuthenticator alloc] initWithAuthenticator: SPAppDelegate.sharedDelegate.simperium.authenticator];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -193,8 +193,6 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                                                object:nil];
 
     [self refreshThemeStyles];
-
-    self.passkeyAuthenticator = [[PasskeyAuthenticator alloc] initWithAuthenticator: SPAppDelegate.sharedDelegate.simperium.authenticator];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -11,8 +11,6 @@ NSString *const SPAlphabeticalTagSortPref                           = @"SPAlphab
 NSString *const SPThemePref                                         = @"SPThemePref";
 NSString *const SPSustainerAppIconName                              = @"AppIcon-Sustainer";
 
-
-
 @interface SPSettingsViewController ()
 @property (nonatomic, strong) UISwitch      *condensedNoteListSwitch;
 @property (nonatomic, strong) UISwitch      *alphabeticalTagSortSwitch;
@@ -27,7 +25,6 @@ NSString *const SPSustainerAppIconName                              = @"AppIcon-
 @implementation SPSettingsViewController {
     NSArray *timeoutPickerOptions;
 }
-
 
 #define kTagNoteListSort        1
 #define kTagTagsListSort        2
@@ -587,7 +584,7 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
             
             switch (indexPath.row) {
                 case SPOptionsAccountRowPasskeys: {
-                    [self presentEnterPasswordAlert];
+                    [self presentPasskeyAuthenticationSetupAlert];
                     break;
                 }
                 case SPOptionsAccountRowPrivacy: {

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -51,9 +51,10 @@ typedef NS_ENUM(NSInteger, SPOptionsViewSections) {
 
 typedef NS_ENUM(NSInteger, SPOptionsAccountRow) {
     SPOptionsAccountRowDescription      = 0,
-    SPOptionsAccountRowPrivacy          = 1,
-    SPOptionsAccountRowLogout           = 2,
-    SPOptionsAccountRowCount            = 3
+    SPOptionsAccountRowPasskeys         = 1,
+    SPOptionsAccountRowPrivacy          = 2,
+    SPOptionsAccountRowLogout           = 3,
+    SPOptionsAccountRowCount            = 4
 };
 
 typedef NS_ENUM(NSInteger, SPOptionsNotesRow) {
@@ -449,6 +450,11 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
                     cell.selectionStyle = UITableViewCellSelectionStyleNone;
                     break;
                 }
+                case SPOptionsAccountRowPasskeys: {
+                    cell.textLabel.text = NSLocalizedString(@"Add Passkey Authentication", @"Add passkeys to an account");
+                    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+                    break;
+                }
                 case SPOptionsAccountRowPrivacy: {
                     cell.textLabel.text = NSLocalizedString(@"Privacy Settings", @"Privacy Settings");
                     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
@@ -577,6 +583,10 @@ typedef NS_ENUM(NSInteger, SPOptionsDebugRow) {
         } case SPOptionsViewSectionsAccount: {
             
             switch (indexPath.row) {
+                case SPOptionsAccountRowPasskeys: {
+                    [self presentEnterPasswordAlert];
+                    break;
+                }
                 case SPOptionsAccountRowPrivacy: {
                     SPPrivacyViewController *test = [[SPPrivacyViewController alloc] initWithStyle:UITableViewStyleGrouped];
                     [self.navigationController pushViewController:test animated:true];

--- a/Simplenote/Classes/SPSettingsViewController.m
+++ b/Simplenote/Classes/SPSettingsViewController.m
@@ -20,6 +20,7 @@ NSString *const SPSustainerAppIconName                              = @"AppIcon-
 @property (nonatomic, strong) UIPickerView  *pinTimeoutPickerView;
 @property (nonatomic, strong) UIToolbar     *doneToolbar;
 @property (nonatomic, strong) UISwitch      *indexNotesSwitch;
+
 @end
 
 @implementation SPSettingsViewController {

--- a/Simplenote/Classes/SPSheetController.swift
+++ b/Simplenote/Classes/SPSheetController.swift
@@ -29,7 +29,13 @@ class SPSheetController: UIViewController {
     ///
     @IBOutlet private var button1: SPSquaredButton! {
         didSet {
-            button1.backgroundColor = .simplenoteWPBlue50Color
+            button1.backgroundColor = .simplenoteBlue50Color
+        }
+    }
+
+    @IBOutlet weak var button2: SPSquaredButton! {
+        didSet {
+            button2.backgroundColor = .simplenoteWPBlue50Color
         }
     }
 
@@ -40,6 +46,10 @@ class SPSheetController: UIViewController {
     /// Closure to be executed whenever button1 is clicked
     ///
     var onClickButton1: (() -> Void)?
+
+    /// Closure to be executed whenever button2 is clicked
+    ///
+    var onClickButton2: (() -> Void)?
 
     /// Designated Initializer
     ///
@@ -86,6 +96,11 @@ class SPSheetController: UIViewController {
         loadViewIfNeeded()
         button1.setTitle(title, for: .normal)
     }
+
+    func setTitleForButton2(title: String) {
+        loadViewIfNeeded()
+        button2.setTitle(title, for: .normal)
+    }
 }
 
 // MARK: - Private Methods
@@ -123,6 +138,11 @@ private extension SPSheetController {
     @IBAction func button1WasPressed() {
         dismissWithAnimation()
         onClickButton1?()
+    }
+
+    @IBAction func button2WasPressed() {
+        dismissWithAnimation()
+        onClickButton2?()
     }
 
     @IBAction func backgroundWasPressed() {

--- a/Simplenote/Classes/SPSheetController.xib
+++ b/Simplenote/Classes/SPSheetController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,6 +16,7 @@
                 <outlet property="backgroundView" destination="WuN-6h-ONb" id="UXH-AM-GBI"/>
                 <outlet property="button0" destination="SQq-Wy-YFf" id="g5R-Lb-yHg"/>
                 <outlet property="button1" destination="LEy-5c-bV7" id="vAR-mR-2Ko"/>
+                <outlet property="button2" destination="QnZ-JW-aWw" id="fhS-11-53r"/>
                 <outlet property="view" destination="Jfs-a1-Lyq" id="7qw-wv-Mkf"/>
             </connections>
         </placeholder>
@@ -31,10 +33,10 @@
                     </connections>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5iK-Jf-G9m" userLabel="Actions View">
-                    <rect key="frame" x="0.0" y="718" width="414" height="144"/>
+                    <rect key="frame" x="0.0" y="658" width="414" height="204"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZKe-xk-oRG" userLabel="Container View">
-                            <rect key="frame" x="27" y="24" width="360" height="96"/>
+                            <rect key="frame" x="27" y="24" width="360" height="156"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SQq-Wy-YFf" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -61,24 +63,41 @@
                                         <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </state>
                                     <connections>
-                                        <action selector="button1WasPressed" destination="-1" eventType="touchUpInside" id="57k-IQ-lug"/>
+                                        <action selector="button1WasPressed" destination="-1" eventType="touchUpInside" id="vOv-Jj-9I3"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QnZ-JW-aWw" userLabel="#Button 2#" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="104" width="360" height="44"/>
+                                    <color key="backgroundColor" red="0.28777331109999998" green="0.45977264639999998" blue="0.66279113290000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="44" id="lHI-Cm-B7z"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                    <state key="normal" title="#Button 2#">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="button2WasPressed" destination="-1" eventType="touchUpInside" id="qk9-ke-jIJ"/>
                                     </connections>
                                 </button>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstAttribute="bottom" secondItem="LEy-5c-bV7" secondAttribute="bottom" id="0AW-Ci-QoN"/>
                                 <constraint firstAttribute="trailing" secondItem="LEy-5c-bV7" secondAttribute="trailing" id="8YM-7L-3vS"/>
+                                <constraint firstAttribute="trailing" secondItem="QnZ-JW-aWw" secondAttribute="trailing" id="R6d-PU-jcS"/>
                                 <constraint firstItem="LEy-5c-bV7" firstAttribute="leading" secondItem="ZKe-xk-oRG" secondAttribute="leading" id="Upr-8M-zJh"/>
                                 <constraint firstAttribute="trailing" secondItem="SQq-Wy-YFf" secondAttribute="trailing" id="VzR-zg-65e"/>
                                 <constraint firstItem="SQq-Wy-YFf" firstAttribute="top" secondItem="ZKe-xk-oRG" secondAttribute="top" id="ZA8-X6-c4m"/>
                                 <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="geH-Ek-mc3"/>
                                 <constraint firstItem="LEy-5c-bV7" firstAttribute="top" secondItem="SQq-Wy-YFf" secondAttribute="bottom" constant="8" id="jxH-XY-Ops"/>
+                                <constraint firstItem="QnZ-JW-aWw" firstAttribute="top" secondItem="LEy-5c-bV7" secondAttribute="bottom" constant="8" id="m4B-bp-Tme"/>
+                                <constraint firstAttribute="bottom" secondItem="QnZ-JW-aWw" secondAttribute="bottom" constant="8" id="pNi-fb-X9c"/>
+                                <constraint firstItem="QnZ-JW-aWw" firstAttribute="leading" secondItem="ZKe-xk-oRG" secondAttribute="leading" id="pZx-NO-2Z4"/>
                                 <constraint firstItem="SQq-Wy-YFf" firstAttribute="leading" secondItem="ZKe-xk-oRG" secondAttribute="leading" id="zmo-wf-fbm"/>
                             </constraints>
                         </view>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="ZKe-xk-oRG" secondAttribute="trailing" priority="999" constant="24" id="EPl-S5-QMu"/>
                         <constraint firstAttribute="trailing" secondItem="ZKe-xk-oRG" secondAttribute="trailing" priority="999" id="WuI-WY-Vs9"/>
@@ -91,9 +110,10 @@
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7mM-lJ-jc1" userLabel="Bottom View">
                     <rect key="frame" x="0.0" y="862" width="414" height="34"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="3nE-EP-iDe"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="7mM-lJ-jc1" secondAttribute="trailing" id="0Jh-eK-hO0"/>
@@ -108,7 +128,6 @@
                 <constraint firstItem="7mM-lJ-jc1" firstAttribute="leading" secondItem="Jfs-a1-Lyq" secondAttribute="leading" id="iLq-7J-k6T"/>
                 <constraint firstAttribute="trailing" secondItem="WuN-6h-ONb" secondAttribute="trailing" id="sRv-1y-ZUQ"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="3nE-EP-iDe"/>
             <point key="canvasLocation" x="137.68115942028987" y="-547.76785714285711"/>
         </view>
         <tapGestureRecognizer id="vHm-tY-brA">
@@ -117,4 +136,20 @@
             </connections>
         </tapGestureRecognizer>
     </objects>
+    <designables>
+        <designable name="LEy-5c-bV7">
+            <size key="intrinsicContentSize" width="87" height="33"/>
+        </designable>
+        <designable name="QnZ-JW-aWw">
+            <size key="intrinsicContentSize" width="90" height="33"/>
+        </designable>
+        <designable name="SQq-Wy-YFf">
+            <size key="intrinsicContentSize" width="90" height="33"/>
+        </designable>
+    </designables>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Simplenote/Classes/SimplenoteConstants.swift
+++ b/Simplenote/Classes/SimplenoteConstants.swift
@@ -44,4 +44,9 @@ class SimplenoteConstants: NSObject {
     static let signupURL            = currentEngineBaseURL.appendingPathComponent("/account/request-signup")
     static let verificationURL      = currentEngineBaseURL.appendingPathComponent("/account/verify-email/")
     static let accountDeletionURL   = currentEngineBaseURL.appendingPathComponent("/account/request-delete/")
+
+    /// Passkey: Endpoints
+    ///
+    static let currentPasskeyBaseURL = URL(string: "https://passkey-dev-dot-simple-note-hrd.appspot.com")!
+    static let passkeyCredentialCreationURL = currentPasskeyBaseURL.appendingPathComponent("/api2/login")
 }

--- a/Simplenote/Classes/SimplenoteConstants.swift
+++ b/Simplenote/Classes/SimplenoteConstants.swift
@@ -49,4 +49,5 @@ class SimplenoteConstants: NSObject {
     ///
     static let currentPasskeyBaseURL = URL(string: "https://passkey-dev-dot-simple-note-hrd.appspot.com")!
     static let passkeyCredentialCreationURL = currentPasskeyBaseURL.appendingPathComponent("/api2/login")
+    static let passkeyRegistrationURL = currentPasskeyBaseURL.appendingPathComponent("/auth/add-credential")
 }

--- a/Simplenote/Classes/SimplenoteConstants.swift
+++ b/Simplenote/Classes/SimplenoteConstants.swift
@@ -50,4 +50,6 @@ class SimplenoteConstants: NSObject {
     static let currentPasskeyBaseURL = URL(string: "https://passkey-dev-dot-simple-note-hrd.appspot.com")!
     static let passkeyCredentialCreationURL = currentPasskeyBaseURL.appendingPathComponent("/api2/login")
     static let passkeyRegistrationURL = currentPasskeyBaseURL.appendingPathComponent("/auth/add-credential")
+    static let passkeyAuthChallengeURL = currentPasskeyBaseURL.appendingPathComponent("/auth/prepare-auth-challenge")
+    static let verifyPasskeyAuthChallengeURL = currentPasskeyBaseURL.appendingPathComponent("/auth/verify-login-credential")
 }

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -194,6 +194,14 @@ extension String {
 
         return base + host + "/"
     }
+
+    func toBase64url() -> String {
+        let base64url = self
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return base64url
+    }
 }
 
 // MARK: Replacing newlines with spaces

--- a/Simplenote/Data+Simplenote.swift
+++ b/Simplenote/Data+Simplenote.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Data {
+    static func decodeUrlSafeBase64(_ value: String) throws -> Data {
+        var stringtoDecode: String = value.replacingOccurrences(of: "-", with: "+")
+        stringtoDecode = stringtoDecode.replacingOccurrences(of: "_", with: "/")
+        switch stringtoDecode.utf8.count % 4 {
+            case 2:
+                stringtoDecode += "=="
+            case 3:
+                stringtoDecode += "="
+            default:
+                break
+        }
+        guard let data = Data(base64Encoded: stringtoDecode, options: [.ignoreUnknownCharacters]) else {
+            throw NSError(domain: "decodeUrlSafeBase64", code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Can't decode base64 string"])
+        }
+        return data
+    }
+}

--- a/Simplenote/PasskeyAuthChallenge.swift
+++ b/Simplenote/PasskeyAuthChallenge.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct PasskeyAuthChallenge: Decodable {
+    let relayingParty: String
+    let challenge: String
+
+    enum CodingKeys: String, CodingKey {
+        case relayingParty = "rpId"
+        case challenge
+    }
+}

--- a/Simplenote/PasskeyAuthResponse.swift
+++ b/Simplenote/PasskeyAuthResponse.swift
@@ -1,0 +1,22 @@
+import Foundation
+import AuthenticationServices
+
+struct PasskeyAuthResponse: Codable {
+    let id: String
+    let rawId: String
+    let response: Response
+    var type: String = "public-key"
+
+    init(from credential: ASAuthorizationPlatformPublicKeyCredentialAssertion) {
+        self.id = credential.credentialID.base64EncodedString().toBase64url()
+        self.rawId = credential.credentialID.base64EncodedString().toBase64url()
+        self.response = PasskeyAuthResponse.Response(clientDataJSON: credential.rawClientDataJSON.base64EncodedString(), authenticatorData: credential.rawAuthenticatorData.base64EncodedString(), signature: credential.signature.base64EncodedString(), userHandle: credential.userID.base64EncodedString())
+    }
+
+    struct Response: Codable {
+        let clientDataJSON: String
+        let authenticatorData: String
+        let signature: String
+        let userHandle: String
+    }
+}

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -1,0 +1,79 @@
+//
+//  PasskeyAuthenticator.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 6/13/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Foundation
+import AuthenticationServices
+
+enum PasskeyError: Error {
+    case couldNotRequestRegistrationChallenge
+}
+
+@objcMembers
+class PasskeyAuthenticator: NSObject {
+    typealias PresentationContext = ASAuthorizationControllerPresentationContextProviding
+    let authenticator: SPAuthenticator
+    let accountRemote: AccountRemote
+
+    @objc
+    init(authenticator: SPAuthenticator) {
+        self.authenticator = authenticator
+        self.accountRemote = AccountRemote()
+    }
+
+    func registerPasskey(for email: String, password: String, in presentationContext: PresentationContext) async throws {
+        do {
+            guard let data = try await accountRemote.requestChallengeResponseToCreatePasskey(forEmail: email, password: password) else {
+                throw PasskeyError.couldNotRequestRegistrationChallenge
+            }
+            let passkeyChallenge = try JSONDecoder().decode(PasskeyChallenge.self, from: data)
+            attemptRegistration(with: passkeyChallenge, presentationContext: presentationContext)
+        } catch {
+            throw PasskeyError.couldNotRequestRegistrationChallenge
+        }
+    }
+
+    private func attemptRegistration(with passkeyChallenge: PasskeyChallenge, presentationContext: PresentationContext) {
+        guard let challengeData = passkeyChallenge.challengeData,
+              let userID = passkeyChallenge.userID else {
+            return
+        }
+
+        let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: passkeyChallenge.relayingPartyIdentifier)
+        let platformKeyRequest = platformProvider.createCredentialRegistrationRequest(challenge: challengeData, name: passkeyChallenge.displayName, userID: userID)
+        let authController = ASAuthorizationController(authorizationRequests: [platformKeyRequest])
+        authController.delegate = self
+        authController.presentationContextProvider = presentationContext
+        authController.performRequests()
+    }
+}
+
+extension PasskeyAuthenticator: ASAuthorizationControllerDelegate {
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
+        // TODO: handle error
+        print(error.localizedDescription)
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+
+        if let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
+            guard let registrationObject = PasskeyRegistration(from: credential) else {
+                //TODO: Should handle error
+                return
+            }
+
+            Task {
+                do {
+                    let data = try JSONEncoder().encode(registrationObject)
+                    try await accountRemote.registerCredential(with: data)
+                } catch {
+                    //TODO: Display error
+                }
+            }
+        }
+    }
+}

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -1,11 +1,3 @@
-//
-//  PasskeyAuthenticator.swift
-//  Simplenote
-//
-//  Created by Charlie Scheer on 6/13/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
-
 import Foundation
 import AuthenticationServices
 
@@ -71,7 +63,7 @@ class PasskeyAuthenticator: NSObject {
 
     // MARK: - Auth
     //
-    public func attemptPasskeyAuth(for email: String, in presentationContext: PresentationContext) async throws {
+    func attemptPasskeyAuth(for email: String, in presentationContext: PresentationContext) async throws {
         guard let challenge = try await fetchAuthChallenge(for: email) else {
             return
         }

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -75,7 +75,7 @@ class PasskeyAuthenticator: NSObject {
         return challenge
     }
 
-    private func performPasskeyAuthentication(with response: WebAuthnResponse) {
+    private func performPasskeyAuthentication(with response: PasskeyAuthResponse) {
         let json = try! JSONEncoder().encode(response)
 
         Task {
@@ -120,7 +120,7 @@ extension PasskeyAuthenticator: ASAuthorizationControllerDelegate {
                 performPasskeyRegistration(with: credential)
 
         case let credential as ASAuthorizationPlatformPublicKeyCredentialAssertion:
-                let response = WebAuthnResponse(from: credential)
+                let response = PasskeyAuthResponse(from: credential)
 
                 performPasskeyAuthentication(with: response)
         default:

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -90,7 +90,7 @@ class PasskeyAuthenticator: NSObject {
     private func performPasskeyAuthentication(with response: PasskeyAuthResponse) {
         let json = try! JSONEncoder().encode(response)
 
-        Task {
+        Task { @MainActor in
             guard let response = try? await accountRemote.verifyPasskeyLogin(with: json),
                   let verifyResponse = try? JSONDecoder().decode(PasskeyVerifyResponse.self, from: response) else {
                 return

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -30,14 +30,14 @@ class PasskeyAuthenticator: NSObject {
             guard let data = try await accountRemote.requestChallengeResponseToCreatePasskey(forEmail: email, password: password) else {
                 throw PasskeyError.couldNotRequestRegistrationChallenge
             }
-            let passkeyChallenge = try JSONDecoder().decode(PasskeyChallenge.self, from: data)
+            let passkeyChallenge = try JSONDecoder().decode(PasskeyRegistrationChallenge.self, from: data)
             attemptRegistration(with: passkeyChallenge, presentationContext: presentationContext)
         } catch {
             throw PasskeyError.couldNotRequestRegistrationChallenge
         }
     }
 
-    private func attemptRegistration(with passkeyChallenge: PasskeyChallenge, presentationContext: PresentationContext) {
+    private func attemptRegistration(with passkeyChallenge: PasskeyRegistrationChallenge, presentationContext: PresentationContext) {
         guard let challengeData = passkeyChallenge.challengeData,
               let userID = passkeyChallenge.userID else {
             return
@@ -91,7 +91,7 @@ class PasskeyAuthenticator: NSObject {
     }
 
     private func performPasskeyRegistration(with credential: ASAuthorizationPlatformPublicKeyCredentialRegistration) {
-        guard let registrationObject = PasskeyRegistration(from: credential) else {
+        guard let registrationObject = PasskeyRegistrationResponse(from: credential) else {
             //TODO: Should handle error
             return
         }

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -99,14 +99,12 @@ class PasskeyAuthenticator: NSObject {
         let json = try! JSONEncoder().encode(response)
 
         Task {
-
-            guard let tuple = try? await accountRemote.verifyPasskeyLogin(with: json),
-                  let email = tuple.0,
-                  let token = tuple.1 else {
+            guard let response = try? await accountRemote.verifyPasskeyLogin(with: json),
+                  let verifyResponse = try? JSONDecoder().decode(PasskeyVerifyResponse.self, from: response) else {
                 return
             }
 
-            authenticator.authenticate(withUsername: email, token: token)
+            authenticator.authenticate(withUsername: verifyResponse.username, token: verifyResponse.accessToken)
         }
     }
 }

--- a/Simplenote/PasskeyChallenge.swift
+++ b/Simplenote/PasskeyChallenge.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct PasskeyChallenge: Decodable {
+    private struct User: Decodable {
+        let name: String
+        let userID: String
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case userID = "id"
+        }
+    }
+
+    private struct RelayingParty: Decodable {
+        let id: String
+    }
+
+    private let relayingParty: PasskeyChallenge.RelayingParty
+    private let user: PasskeyChallenge.User
+    private let challenge: String
+
+    enum CodingKeys: String, CodingKey {
+        case relayingParty = "rp"
+        case user
+        case challenge
+    }
+
+    var relayingPartyIdentifier: String {
+        relayingParty.id
+    }
+
+    var challengeData: Data? {
+        challenge.data(using: .utf8)
+    }
+
+    var displayName: String {
+        user.name
+    }
+
+    var userID: Data? {
+        user.userID.data(using: .utf8)
+    }
+}

--- a/Simplenote/PasskeyRegistration.swift
+++ b/Simplenote/PasskeyRegistration.swift
@@ -1,0 +1,46 @@
+import Foundation
+import AuthenticationServices
+
+struct PasskeyRegistration: Encodable {
+    struct Response: Encodable {
+        let clientDataJSON: String
+        let attestationObject: String
+    }
+
+    private let email: String
+    private let id: String
+    private let rawId: String
+    private let type: String
+    private let response: PasskeyRegistration.Response
+
+    init?(from credentialRegistration: ASAuthorizationPlatformPublicKeyCredentialRegistration) {
+        guard let email = SPAppDelegate.shared().simperium.user?.email,
+        let clientJson = Self.prepareJSON(from: credentialRegistration.rawClientDataJSON),
+        let rawAttestationObject = credentialRegistration.rawAttestationObject else {
+            return nil
+        }
+
+        let idString = credentialRegistration.credentialID.base64EncodedString().toBase64url()
+        let response = Response(clientDataJSON: clientJson.base64EncodedString(), attestationObject: rawAttestationObject.base64EncodedString())
+
+
+        self.email = email
+        self.id = idString
+        self.rawId = idString
+        self.type = "public-key"
+        self.response = response
+    }
+
+    private static func prepareJSON(from data: Data) -> Data? {
+        guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var base64challenge = json["challenge"] as? String,
+              var challengeData = Data(base64Encoded: base64challenge + "="),
+        var challenge = String(data: challengeData, encoding: .utf8) else {
+            return nil
+        }
+
+        json["challenge"] = challenge
+
+        return try? JSONSerialization.data(withJSONObject: json)
+    }
+}

--- a/Simplenote/PasskeyRegistration.swift
+++ b/Simplenote/PasskeyRegistration.swift
@@ -23,7 +23,6 @@ struct PasskeyRegistration: Encodable {
         let idString = credentialRegistration.credentialID.base64EncodedString().toBase64url()
         let response = Response(clientDataJSON: clientJson.base64EncodedString(), attestationObject: rawAttestationObject.base64EncodedString())
 
-
         self.email = email
         self.id = idString
         self.rawId = idString
@@ -33,9 +32,9 @@ struct PasskeyRegistration: Encodable {
 
     private static func prepareJSON(from data: Data) -> Data? {
         guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              var base64challenge = json["challenge"] as? String,
-              var challengeData = Data(base64Encoded: base64challenge + "="),
-        var challenge = String(data: challengeData, encoding: .utf8) else {
+              let base64challenge = json["challenge"] as? String,
+              let challengeData = Data(base64Encoded: base64challenge + "="),
+              let challenge = String(data: challengeData, encoding: .utf8) else {
             return nil
         }
 

--- a/Simplenote/PasskeyRegistrationChallenge.swift
+++ b/Simplenote/PasskeyRegistrationChallenge.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct PasskeyChallenge: Decodable {
+struct PasskeyRegistrationChallenge: Decodable {
     private struct User: Decodable {
         let name: String
         let userID: String
@@ -15,8 +15,8 @@ struct PasskeyChallenge: Decodable {
         let id: String
     }
 
-    private let relayingParty: PasskeyChallenge.RelayingParty
-    private let user: PasskeyChallenge.User
+    private let relayingParty: PasskeyRegistrationChallenge.RelayingParty
+    private let user: PasskeyRegistrationChallenge.User
     private let challenge: String
 
     enum CodingKeys: String, CodingKey {

--- a/Simplenote/PasskeyRegistrationResponse.swift
+++ b/Simplenote/PasskeyRegistrationResponse.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AuthenticationServices
 
-struct PasskeyRegistration: Encodable {
+struct PasskeyRegistrationResponse: Encodable {
     struct Response: Encodable {
         let clientDataJSON: String
         let attestationObject: String
@@ -11,7 +11,7 @@ struct PasskeyRegistration: Encodable {
     private let id: String
     private let rawId: String
     private let type: String
-    private let response: PasskeyRegistration.Response
+    private let response: PasskeyRegistrationResponse.Response
 
     init?(from credentialRegistration: ASAuthorizationPlatformPublicKeyCredentialRegistration) {
         guard let email = SPAppDelegate.shared().simperium.user?.email,

--- a/Simplenote/PasskeyVerifyResponse.swift
+++ b/Simplenote/PasskeyVerifyResponse.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct PasskeyVerifyResponse: Decodable {
+    let username: String
+    let accessToken: String
+    let verify: String
+
+    enum CodingKeys: String, CodingKey {
+        case username
+        case accessToken = "access_token"
+        case verify
+    }
+}

--- a/Simplenote/PasskeyVerifyResponse.swift
+++ b/Simplenote/PasskeyVerifyResponse.swift
@@ -3,11 +3,11 @@ import Foundation
 struct PasskeyVerifyResponse: Decodable {
     let username: String
     let accessToken: String
-    let verify: String
+    let verified: Bool
 
     enum CodingKeys: String, CodingKey {
         case username
         case accessToken = "access_token"
-        case verify
+        case verified
     }
 }

--- a/Simplenote/Remote.swift
+++ b/Simplenote/Remote.swift
@@ -16,6 +16,7 @@ class Remote {
                 let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
 
                 // Check for 2xx status code
+                print("# statusCode: \(statusCode)")
                 guard statusCode / 100 == 2 else {
                     let error = statusCode > 0 ?
                         RemoteError.requestError(statusCode, dataTaskError):

--- a/Simplenote/Remote.swift
+++ b/Simplenote/Remote.swift
@@ -30,4 +30,17 @@ class Remote {
 
         dataTask.resume()
     }
+
+    func performDataTask(with request: URLRequest) async throws -> Data? {
+        try await withCheckedThrowingContinuation { continuation in
+            performDataTask(with: request) { result in
+                switch result {
+                case .success(let data):
+                    continuation.resume(returning: data)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 }

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -40,6 +40,10 @@ extension SPAppDelegate {
     func setupStoreManager() {
         StoreManager.shared.initialize()
     }
+
+    @objc func setupPasskeyAuthenticator() {
+        passkeyAuthenticator = PasskeyAuthenticator(authenticator: simperium.authenticator)
+    }
 }
 
 // MARK: - Internal Methods

--- a/Simplenote/SPAppDelegate.h
+++ b/Simplenote/SPAppDelegate.h
@@ -14,6 +14,7 @@
 @class PublishStateObserver;
 @class AccountDeletionController;
 @class CoreDataManager;
+@class PasskeyAuthenticator;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,6 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL										bSigningUserOut;
 
 @property (nullable, strong, nonatomic) AccountDeletionController       *accountDeletionController;
+
+@property (strong, nonatomic) PasskeyAuthenticator *passkeyAuthenticator;
 
 - (void)presentSettingsViewController;
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -123,6 +123,7 @@
     [self setupThemeNotifications];
     [self setupSimperium];
     [self setupAuthenticator];
+    [self setupPasskeyAuthenticator];
     [self setupAppCenter];
     [self setupCrashLogging];
     [self configureVersionsController];

--- a/Simplenote/SPModalActivityIndicator.swift
+++ b/Simplenote/SPModalActivityIndicator.swift
@@ -1,12 +1,7 @@
 import Foundation
 
 extension SPModalActivityIndicator {
-    // Swift is automatically creating an async version of this function for us, but then it is failing to build
-    // If you use the completion handler version of this method it complains.
-    // So you can't use the async version and you can't use the completion handler version... rock meet hard place
-    // This method is here to handle that issue
     func dismiss(_ animated: Bool) {
-        // Wrapping the dismiss in an anonymous closure silences the completion handler warning.
-        { dismiss(animated, completion: nil) }()
+        dismiss(animated, completion: nil)
     }
 }

--- a/Simplenote/SPModalActivityIndicator.swift
+++ b/Simplenote/SPModalActivityIndicator.swift
@@ -5,7 +5,7 @@ extension SPModalActivityIndicator {
     // If you use the completion handler version of this method it complains.
     // So you can't use the async version and you can't use the completion handler version... rock meet hard place
     // This method is here to handle that issue
-    func dismiss(_ animated: Bool) async {
+    func dismiss(_ animated: Bool) {
         // Wrapping the dismiss in an anonymous closure silences the completion handler warning.
         { dismiss(animated, completion: nil) }()
     }

--- a/Simplenote/SPModalActivityIndicator.swift
+++ b/Simplenote/SPModalActivityIndicator.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension SPModalActivityIndicator {
+    // Swift is automatically creating an async version of this function for us, but then it is failing to build
+    // If you use the completion handler version of this method it complains.
+    // So you can't use the async version and you can't use the completion handler version... rock meet hard place
+    // This method is here to handle that issue
+    func dismiss(_ animated: Bool) async {
+        // Wrapping the dismiss in an anonymous closure silences the completion handler warning.
+        { dismiss(animated, completion: nil) }()
+    }
+}

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -33,6 +33,7 @@
 #import "SPTagEntryField.h"
 #import "WPAuthHandler.h"
 #import "NSManagedObjectContext+CoreDataExtensions.h"
+#import "SPModalActivityIndicator.h"
 
 
 #pragma mark - Extensions

--- a/Simplenote/Supporting Files/Simplenote-Internal.entitlements
+++ b/Simplenote/Supporting Files/Simplenote-Internal.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:simplenote.com</string>
+		<string>webcredentials:passkey-dev-dot-simple-note-hrd.appspot.com?mode=developer</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/Simplenote/Supporting Files/Simplenote.entitlements
+++ b/Simplenote/Supporting Files/Simplenote.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:simplenote.com</string>
+		<string>webcredentials:passkey-dev-dot-simple-note-hrd.appspot.com?mode=developer</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
### Fix
Soooo... the first PR for implementing passkeys into iOS has some user interaction issues.  None of the errors are handled, so if it fails it just does nothing.... and the registration and auth processes happen over time and can be slow, but the UI give no activity indication, and isn't locked in anyway so you can keep poking and clicking all over the place... not great....

So I have fixed that in this PR.  Here you will see:

- When registering a passkey a full screen modal spinner appears
- if registration succeeds you see a success message
- if registration fails you see an error
- When logging in using passkeys the ui locks and the sign in button activity indicator animates
- if auth fails you will see an alert

### Test
Registration:
1. Log into an account with email and password
2. go to Settings and tap on Add Passkey authentication. Confirm that you see a spinner
3. When the passkey modal pops up, dismiss it.  Confirm you see an error message
4. Tap on the app passkey button again and this time complete the registration.  Confirm you see a success message (note if you already have a passkey registered you will need to delete it from the [server](https://console.cloud.google.com/datastore/databases/-default-/entities;kind=WebauthnCredential;ns=__$DEFAULT$__/query/kind?project=simple-note-hrd)

Auth:
1. log out of your account
2. tap on login -> Login with passkeys
3. enter an email address that isn't valid.  Confirm no login attempt is done and you get an alert that the email is invalid
4. enter the email address you registered with.  When the passkey modal pops up, dismiss it.  You should see an alert and the ui should unlock
5. Try logging in again with the correct email and this time confirm the passkey auth.  Confirm you get logged in and the ui unlocks


### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
