### PR TITLE
Universal Links

### DIFF
--- a/Simplenote/Classes/MagicLinkAuthenticator.swift
+++ b/Simplenote/Classes/MagicLinkAuthenticator.swift
@@ -16,7 +16,7 @@ struct MagicLinkAuthenticator {
     let authenticator: SPAuthenticator
 
     func handle(url: URL) -> Bool {
-        guard url.host == Constants.host else {
+        guard AllowedHosts.all.contains(url.host) else {
             return false
         }
 
@@ -102,8 +102,13 @@ private extension Array where Element == URLQueryItem {
 
 // MARK: - Constants
 //
+private struct AllowedHosts {
+    static let hostForSimplenoteSchema = "login"
+    static let hostForUniversalLinks = URL(string: SPCredentials.defaultEngineURL)!.host
+    static let all = [hostForSimplenoteSchema, hostForUniversalLinks]
+}
+
 private struct Constants {
-    static let host = "login"
     static let emailField = "email"
     static let tokenField = "token"
     static let authKeyField = "auth_key"

--- a/Simplenote/Classes/MagicLinkAuthenticator.swift
+++ b/Simplenote/Classes/MagicLinkAuthenticator.swift
@@ -15,20 +15,20 @@ extension NSNotification.Name {
 struct MagicLinkAuthenticator {
     let authenticator: SPAuthenticator
 
-    func handle(url: URL) {
+    func handle(url: URL) -> Bool {
         guard url.host == Constants.host else {
-            return
+            return false
         }
 
         guard let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else {
-            return
+            return false
         }
 
         if attemptLoginWithToken(queryItems: queryItems) {
-            return
+            return false
         }
 
-        attemptLoginWithAuthCode(queryItems: queryItems)
+        return attemptLoginWithAuthCode(queryItems: queryItems)
     }
 }
 

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -447,9 +447,19 @@ private extension SPAppDelegate {
 // MARK: - Magic Link authentication
 //
 extension SPAppDelegate {
-    @objc
-    func performMagicLinkAuthentication(with url: URL) {
+
+    @objc @discardableResult
+    func performMagicLinkAuthentication(with url: URL) -> Bool {
         MagicLinkAuthenticator(authenticator: simperium.authenticator).handle(url: url)
+    }
+    
+    @objc(performMagicLinkAuthenticationWithUserActivity:)
+    func performMagicLinkAuthentication(with userActivity: NSUserActivity) -> Bool {
+        guard let url = userActivity.webpageURL else {
+            return false
+        }
+        
+        return performMagicLinkAuthentication(with: url)
     }
 }
 

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -199,6 +199,10 @@
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
 {
+    if ([self performMagicLinkAuthenticationWithUserActivity:userActivity]) {
+        return YES;
+    }
+    
     return [[ShortcutsHandler shared] handleUserActivity:userActivity];
 }
 

--- a/Simplenote/Supporting Files/Simplenote-Internal.entitlements
+++ b/Simplenote/Supporting Files/Simplenote-Internal.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:simplenote.com</string>
+		<string>applinks:app.simplenote.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/Simplenote/Supporting Files/Simplenote.entitlements
+++ b/Simplenote/Supporting Files/Simplenote.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:simplenote.com</string>
+		<string>applinks:app.simplenote.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
### Details
In this PR we're implementing Universal Links support for Email Authentication. 
This implies that the URL `https://app.simplenote.com/login` will be, from now on, trapped by Simplenote iOS, and will attempt to authenticate the user (if needed).

### Test
1. Fresh install Simplenote iOS
2. Press on the `Login` button
3. Enter your email and request a Magic Link
4. Wait until you get the Auth email

- [ ] Verify that, in the email you got, the callback link is a regular `https://` URL
- [ ] Verify that gmail doesn't filter this out!
- [ ] Verify that pressing on the `Log In` button gets you back into the Simplenote app
- [ ] Verify that shortly after you're logged in!

### Release
> These changes do not require release notes.
