### PR TITLE
Universal Links

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,9 +42,9 @@ only_rules:
   - trailing_semicolon
 
   # Lines should not have trailing whitespace.
-  - trailing_whitespace
+#  - trailing_whitespace
 
-  - vertical_whitespace
+#  - vertical_whitespace
 
   - custom_rules
 

--- a/Simplenote/Classes/MagicLinkAuthenticator.swift
+++ b/Simplenote/Classes/MagicLinkAuthenticator.swift
@@ -6,7 +6,7 @@ struct MagicLinkAuthenticator {
     let authenticator: SPAuthenticator
 
     func handle(url: URL) -> Bool {
-        guard url.host == Constants.host else {
+        guard AllowedHosts.all.contains(url.host) else {
             return false
         }
 
@@ -44,8 +44,13 @@ private extension Array where Element == URLQueryItem {
 
 // MARK: - Constants
 //
+private struct AllowedHosts {
+    static let hostForSimplenoteSchema = "login"
+    static let hostForUniversalLinks = URL(string: SPCredentials.defaultEngineURL)!.host
+    static let all = [hostForSimplenoteSchema, hostForUniversalLinks]
+}
+
 private struct Constants {
-    static let host = "login"
     static let emailField = "email"
     static let tokenField = "token"
 }

--- a/Simplenote/Classes/MagicLinkAuthenticator.swift
+++ b/Simplenote/Classes/MagicLinkAuthenticator.swift
@@ -5,22 +5,23 @@ import Foundation
 struct MagicLinkAuthenticator {
     let authenticator: SPAuthenticator
 
-    func handle(url: URL) {
+    func handle(url: URL) -> Bool {
         guard url.host == Constants.host else {
-            return
+            return false
         }
 
         guard let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else {
-            return
+            return false
         }
 
         guard let email = queryItems.base64DecodedValue(for: Constants.emailField),
               let token = queryItems.value(for: Constants.tokenField),
               !email.isEmpty, !token.isEmpty else {
-            return
+            return false
         }
 
         authenticator.authenticate(withUsername: email, token: token)
+        return true
     }
 }
 

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -447,9 +447,19 @@ private extension SPAppDelegate {
 // MARK: - Magic Link authentication
 //
 extension SPAppDelegate {
-    @objc
-    func performMagicLinkAuthentication(with url: URL) {
+
+    @objc @discardableResult
+    func performMagicLinkAuthentication(with url: URL) -> Bool {
         MagicLinkAuthenticator(authenticator: simperium.authenticator).handle(url: url)
+    }
+    
+    @objc(performMagicLinkAuthenticationWithUserActivity:)
+    func performMagicLinkAuthentication(with userActivity: NSUserActivity) -> Bool {
+        guard let url = userActivity.webpageURL else {
+            return false
+        }
+        
+        return performMagicLinkAuthentication(with: url)
     }
 }
 

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -452,13 +452,13 @@ extension SPAppDelegate {
     func performMagicLinkAuthentication(with url: URL) -> Bool {
         MagicLinkAuthenticator(authenticator: simperium.authenticator).handle(url: url)
     }
-    
+
     @objc(performMagicLinkAuthenticationWithUserActivity:)
     func performMagicLinkAuthentication(with userActivity: NSUserActivity) -> Bool {
         guard let url = userActivity.webpageURL else {
             return false
         }
-        
+
         return performMagicLinkAuthentication(with: url)
     }
 }

--- a/Simplenote/SPAppDelegate.m
+++ b/Simplenote/SPAppDelegate.m
@@ -200,6 +200,10 @@
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
 {
+    if ([self performMagicLinkAuthenticationWithUserActivity:userActivity]) {
+        return YES;
+    }
+    
     return [[ShortcutsHandler shared] handleUserActivity:userActivity];
 }
 

--- a/Simplenote/Supporting Files/Simplenote-Internal.entitlements
+++ b/Simplenote/Supporting Files/Simplenote-Internal.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:simplenote.com</string>
+		<string>applinks:app.simplenote.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/Simplenote/Supporting Files/Simplenote.entitlements
+++ b/Simplenote/Supporting Files/Simplenote.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:simplenote.com</string>
+		<string>applinks:app.simplenote.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
### Details
In this PR we're implementing Universal Links support for Email Authentication. 
This implies that the URL `https://app.simplenote.com/login` will be, from now on, trapped by Simplenote iOS, and will attempt to authenticate the user (if needed).

Ref. #1605

### Test
This PR can only be tested with the Magic Link Authentication support. Test steps coming up in a follow up PR!

- [ ] Verify the Unit Tests are green
- [ ] Verify the changes make sense!

### Release
> These changes do not require release notes.
