### PR TITLE
Passkeys: Errors, Alerts, UI Feedback

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -591,6 +591,7 @@
 		BAFFCEA626DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFCEA526DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift */; };
 		BAFFCEA726DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFCEA526DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift */; };
 		BAFFE74C2C3490A300673C1C /* PasskeyRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFE74B2C3490A300673C1C /* PasskeyRemote.swift */; };
+		BAFFE7502C34BF3A00673C1C /* PasskeyRegistrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFE74F2C34BF3A00673C1C /* PasskeyRegistrator.swift */; };
 		D435D38FCA5863E8447D5C2C /* Pods_Automattic_SimplenoteShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */; };
 		D82BFE4B2624A8AB003DFA32 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BFE4A2624A8AB003DFA32 /* Settings.swift */; };
 		D82BFE542624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BFE532624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift */; };
@@ -1282,6 +1283,7 @@
 		BAFDBBD726B88BD200119615 /* Date+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Simplenote.swift"; sourceTree = "<group>"; };
 		BAFFCEA526DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCoreDataWrapper.swift; sourceTree = "<group>"; };
 		BAFFE74B2C3490A300673C1C /* PasskeyRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRemote.swift; sourceTree = "<group>"; };
+		BAFFE74F2C34BF3A00673C1C /* PasskeyRegistrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrator.swift; sourceTree = "<group>"; };
 		C07B32800E3C783BDF105B3A /* Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		D82BFE4A2624A8AB003DFA32 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		D82BFE532624A8C5003DFA32 /* SimplenoteUISmokeTestsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplenoteUISmokeTestsSettings.swift; sourceTree = "<group>"; };
@@ -2411,6 +2413,7 @@
 			isa = PBXGroup;
 			children = (
 				BAF694B12C1B753F000090E7 /* PasskeyAuthenticator.swift */,
+				BAFFE74F2C34BF3A00673C1C /* PasskeyRegistrator.swift */,
 				BA2E30DF2C1B8B45002C7B10 /* PasskeyAuthChallenge.swift */,
 				BA2E30E12C1B8B4E002C7B10 /* PasskeyAuthResponse.swift */,
 				BA0AC5432C1A0C65002964DB /* PasskeyRegistrationResponse.swift */,
@@ -3715,6 +3718,7 @@
 				B51F6DD52460D7540074DDD9 /* NSPredicate+Email.swift in Sources */,
 				B5C2EDF0255AFB6C00C09B32 /* PassthruView.swift in Sources */,
 				A6F4882325A8889E0050CFA8 /* UITextField+Tag.swift in Sources */,
+				BAFFE7502C34BF3A00673C1C /* PasskeyRegistrator.swift in Sources */,
 				A64DE6F1255D1CD9001D0526 /* NoteContentHelper.swift in Sources */,
 				A628BEB625ECD97900121B64 /* SignupVerificationViewController.swift in Sources */,
 				B550F93322BA6A3300091939 /* ShortcutsHandler.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -591,6 +591,7 @@
 		BAFFCEA626DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFCEA526DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift */; };
 		BAFFCEA726DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFCEA526DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift */; };
 		BAFFE74C2C3490A300673C1C /* PasskeyRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFE74B2C3490A300673C1C /* PasskeyRemote.swift */; };
+		BAFFE74E2C34BE7800673C1C /* SPModalActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFE74D2C34BE7800673C1C /* SPModalActivityIndicator.swift */; };
 		BAFFE7502C34BF3A00673C1C /* PasskeyRegistrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAFFE74F2C34BF3A00673C1C /* PasskeyRegistrator.swift */; };
 		D435D38FCA5863E8447D5C2C /* Pods_Automattic_SimplenoteShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 183BAB896957F07FDCAB6DF5 /* Pods_Automattic_SimplenoteShare.framework */; };
 		D82BFE4B2624A8AB003DFA32 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82BFE4A2624A8AB003DFA32 /* Settings.swift */; };
@@ -1283,6 +1284,7 @@
 		BAFDBBD726B88BD200119615 /* Date+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Simplenote.swift"; sourceTree = "<group>"; };
 		BAFFCEA526DDA9F6007F5EE3 /* ExtensionCoreDataWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionCoreDataWrapper.swift; sourceTree = "<group>"; };
 		BAFFE74B2C3490A300673C1C /* PasskeyRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRemote.swift; sourceTree = "<group>"; };
+		BAFFE74D2C34BE7800673C1C /* SPModalActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPModalActivityIndicator.swift; sourceTree = "<group>"; };
 		BAFFE74F2C34BF3A00673C1C /* PasskeyRegistrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyRegistrator.swift; sourceTree = "<group>"; };
 		C07B32800E3C783BDF105B3A /* Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; path = "Pods/Target Support Files/Pods-Automattic-SimplenoteShare/Pods-Automattic-SimplenoteShare.distribution alpha.xcconfig"; sourceTree = "<group>"; };
 		D82BFE4A2624A8AB003DFA32 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
@@ -2608,6 +2610,7 @@
 				B56A696422F9D54600B90398 /* SPLabel.swift */,
 				E230E39C17D0F33B009B5EBB /* SPModalActivityIndicator.h */,
 				E230E39D17D0F33B009B5EBB /* SPModalActivityIndicator.m */,
+				BAFFE74D2C34BE7800673C1C /* SPModalActivityIndicator.swift */,
 				B5D982D122F8644000C37C29 /* SPSquaredButton.swift */,
 				E215C79B180B228800AD36B5 /* SPTextField.h */,
 				E215C79C180B228800AD36B5 /* SPTextField.m */,
@@ -3752,6 +3755,7 @@
 				B575736C232D454300443C2E /* UIColor+Helpers.swift in Sources */,
 				37E55A6721BF2B1800F14241 /* SPTextAttachment.swift in Sources */,
 				BA8FC2A5267AC7470082962E /* SharedStorageMigrator.swift in Sources */,
+				BAFFE74E2C34BE7800673C1C /* SPModalActivityIndicator.swift in Sources */,
 				A69F850F253EC2B2005140F2 /* SPCardConfigurable.swift in Sources */,
 				B5BE05541AB75C3B002417BF /* Settings.m in Sources */,
 				B58039862322D4F90083C916 /* UIView+ImageRepresentation.swift in Sources */,

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -324,7 +324,7 @@ private extension SPAuthViewController {
             return
         }
 
-        Task {
+        Task { @MainActor in
             lockdownInterface()
             do {
                 let passkeyAuthenticator = PasskeyAuthenticator()

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -331,6 +331,7 @@ private extension SPAuthViewController {
             } catch {
                 passkeyAuthFailed(error)
             }
+            unlockInterface()
         }
     }
 
@@ -339,7 +340,6 @@ private extension SPAuthViewController {
         let challenge = try await passkeyAuthenticator.fetchAuthChallenge(for: email)
         let verify = try await passkeyAuthenticator.attemptPasskeyAuth(challenge: challenge, in: self)
         controller.simperiumService.authenticate(withUsername: verify.username, token: verify.accessToken)
-        unlockInterface()
     }
 
     @IBAction func presentPasswordReset() {
@@ -648,7 +648,6 @@ extension SPAuthViewController: ASAuthorizationControllerPresentationContextProv
     }
 
     private func passkeyAuthFailed(_ error: any Error) {
-        unlockInterface()
         presentPasskeyAuthError(error)
     }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -337,8 +337,7 @@ private extension SPAuthViewController {
 
     private func attemptPasskeyAuthentication(for email: String) async throws {
         let passkeyAuthenticator = PasskeyAuthenticator()
-        let challenge = try await passkeyAuthenticator.fetchAuthChallenge(for: email)
-        let verify = try await passkeyAuthenticator.attemptPasskeyAuth(challenge: challenge, in: self)
+        let verify = try await passkeyAuthenticator.attemptPasskeyAuth(for: email, in: self)
         controller.simperiumService.authenticate(withUsername: verify.username, token: verify.accessToken)
     }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -329,7 +329,9 @@ private extension SPAuthViewController {
             do {
                 let passkeyAuthenticator = PasskeyAuthenticator()
                 let challenge = try await passkeyAuthenticator.fetchAuthChallenge(for: email)
-                try await passkeyAuthenticator.attemptPasskeyAuth(challenge: challenge, in: self, delegate: self)
+                let verify = try await passkeyAuthenticator.attemptPasskeyAuth(challenge: challenge, in: self, delegate: self)
+                controller.simperiumService.authenticate(withUsername: verify.username, token: verify.accessToken)
+                unlockInterface()
             } catch {
                 unlockInterface()
                 passkeyAuthFailed(error)

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -322,9 +322,13 @@ private extension SPAuthViewController {
     }
 
     @objc func passkeyAuthAction() {
+        guard ensureWarningsAreOnScreenWhenNeeded() else {
+            return
+        }
+
         Task {
             //TODO: Handle errors
-            //TODO: Handle email not valid
+
             passkeyAuthenticator = PasskeyAuthenticator(authenticator: controller.simperiumService)
             try? await passkeyAuthenticator?.attemptPasskeyAuth(for: email, in: self)
         }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -329,7 +329,6 @@ private extension SPAuthViewController {
             do {
                 try await attemptPasskeyAuthentication(for: email)
             } catch {
-                unlockInterface()
                 passkeyAuthFailed(error)
             }
         }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -273,9 +273,7 @@ extension SPSettingsViewController {
     }
 
     private func presentPasskeyRegistrationFailureAlert() {
-        Task { @MainActor in
-            await passkeyActivityIndicator?.dismiss(true)
-        }
+        removeActivityIndicator()
 
         let failureAlert = UIAlertController(title: PasskeyAuthentication.failureTitle, message: PasskeyAuthentication.failureMessage, preferredStyle: .alert)
         failureAlert.addCancelActionWithTitle(PasskeyAuthentication.okay)
@@ -310,11 +308,16 @@ extension SPSettingsViewController: ASAuthorizationControllerDelegate {
             do {
                 let data = try JSONEncoder().encode(registrationObject)
                 try await PasskeyRemote().registerCredential(with: data)
-                await passkeyActivityIndicator?.dismiss(true)
+                removeActivityIndicator()
             } catch {
                 //TODO: Display error
             }
         }
+    }
+
+    private func removeActivityIndicator() {
+        passkeyActivityIndicator?.dismiss(true)
+        passkeyActivityIndicator = nil
     }
 }
 

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -253,6 +253,7 @@ extension SPSettingsViewController {
             Task {
                 do {
                     try await self.registerPasskey(for: email, password: password)
+                    self.presentPasskeyRegistrationAlert(succeeded: true)
                 } catch {
                     NSLog("[PasskeyRegistration] Could not register passkey: %@", error.localizedDescription)
                     self.presentPasskeyRegistrationAlert(succeeded: false)
@@ -269,7 +270,8 @@ extension SPSettingsViewController {
         let registrator = PasskeyRegistrator()
 
         let challenge = try await registrator.requestChallenge(for: email, password: password)
-        registrator.attemptRegistration(with: challenge, presentationContext: self, delegate: self)
+        let registrationData = try await registrator.attemptRegistration(with: challenge, presentationContext: self, delegate: self)
+        try await PasskeyRemote().registerCredential(with: registrationData)
     }
 
     private func presentPasskeyRegistrationAlert(succeeded: Bool) {

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -254,7 +254,7 @@ extension SPSettingsViewController {
                 do {
                     try await self.registerPasskey(for: email, password: password)
                 } catch {
-                    // TODO: Display some action for failure
+                    await self.presentPasskeyRegistrationFailureAlert()
                 }
             }
         }
@@ -269,6 +269,13 @@ extension SPSettingsViewController {
 
         let challenge = try await registrator.requestChallenge(for: email, password: password)
         registrator.attemptRegistration(with: challenge, presentationContext: self, delegate: self)
+    }
+
+    private func presentPasskeyRegistrationFailureAlert() async {
+        await passkeyActivityIndicator?.dismiss(true)
+        let failureAlert = UIAlertController(title: PasskeyAuthentication.failureTitle, message: PasskeyAuthentication.failureMessage, preferredStyle: .alert)
+        failureAlert.addCancelActionWithTitle(PasskeyAuthentication.okay)
+        self.present(failureAlert, animated: true)
     }
 }
 

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -248,10 +248,11 @@ extension SPSettingsViewController {
                   let password = textfield.text else {
                 return
             }
-            self.passkeyActivityIndicator = SPModalActivityIndicator.show(in: SPAppDelegate.shared().window)
+            let passkeyActivityIndicator = SPModalActivityIndicator.show(in: SPAppDelegate.shared().window)
 
-            Task {
+            Task { @MainActor in
                 await self.attemptPasskeyRegistration(for: email, password: password)
+                passkeyActivityIndicator?.dismiss(animated: true)
             }
         }
         alert.addAction(action)
@@ -269,7 +270,6 @@ extension SPSettingsViewController {
             NSLog("[PasskeyRegistration] Could not register passkey: %@", error.localizedDescription)
             presentPasskeyRegistrationAlert(succeeded: false)
         }
-        self.removeActivityIndicator()
     }
 
     private func presentPasskeyRegistrationAlert(succeeded: Bool) {
@@ -279,13 +279,6 @@ extension SPSettingsViewController {
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alert.addCancelActionWithTitle(PasskeyAuthentication.okay)
             self.present(alert, animated: true)
-        }
-    }
-
-    private func removeActivityIndicator() {
-        DispatchQueue.main.async {
-            self.passkeyActivityIndicator?.dismiss(true)
-            self.passkeyActivityIndicator = nil
         }
     }
 }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -262,21 +262,14 @@ extension SPSettingsViewController {
 
     private func attemptPasskeyRegistration(for email: String, password: String) async {
         do {
-            try await self.registerPasskey(for: email, password: password)
+            let registrator = PasskeyRegistrator()
+            try await registrator.attemptPasskeyRegistration(for: email, password: password, presentationContext: self)
             presentPasskeyRegistrationAlert(succeeded: true)
         } catch {
             NSLog("[PasskeyRegistration] Could not register passkey: %@", error.localizedDescription)
             presentPasskeyRegistrationAlert(succeeded: false)
         }
         self.removeActivityIndicator()
-    }
-
-    private func registerPasskey(for email: String, password: String) async throws {
-        let registrator = PasskeyRegistrator()
-
-        let challenge = try await registrator.requestChallenge(for: email, password: password)
-        let registrationData = try await registrator.attemptRegistration(with: challenge, presentationContext: self)
-        try await PasskeyRemote().registerCredential(with: registrationData)
     }
 
     private func presentPasskeyRegistrationAlert(succeeded: Bool) {

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -268,6 +268,7 @@ extension SPSettingsViewController {
             NSLog("[PasskeyRegistration] Could not register passkey: %@", error.localizedDescription)
             presentPasskeyRegistrationAlert(succeeded: false)
         }
+        self.removeActivityIndicator()
     }
 
     private func registerPasskey(for email: String, password: String) async throws {
@@ -280,8 +281,6 @@ extension SPSettingsViewController {
 
     private func presentPasskeyRegistrationAlert(succeeded: Bool) {
         DispatchQueue.main.async {
-            self.removeActivityIndicator()
-
             let title = succeeded ? PasskeyAuthentication.successTitle : PasskeyAuthentication.failureTitle
             let message = succeeded ? PasskeyAuthentication.successMessage : PasskeyAuthentication.failureMessage
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
@@ -291,8 +290,10 @@ extension SPSettingsViewController {
     }
 
     private func removeActivityIndicator() {
-        passkeyActivityIndicator?.dismiss(true)
-        passkeyActivityIndicator = nil
+        DispatchQueue.main.async {
+            self.passkeyActivityIndicator?.dismiss(true)
+            self.passkeyActivityIndicator = nil
+        }
     }
 }
 

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -254,7 +254,8 @@ extension SPSettingsViewController {
                 do {
                     try await self.registerPasskey(for: email, password: password)
                 } catch {
-                    await self.presentPasskeyRegistrationFailureAlert()
+                    NSLog("[PasskeyRegistration] Could not register passkey: %@", error.localizedDescription)
+                    self.presentPasskeyRegistrationFailureAlert()
                 }
             }
         }
@@ -271,8 +272,11 @@ extension SPSettingsViewController {
         registrator.attemptRegistration(with: challenge, presentationContext: self, delegate: self)
     }
 
-    private func presentPasskeyRegistrationFailureAlert() async {
-        await passkeyActivityIndicator?.dismiss(true)
+    private func presentPasskeyRegistrationFailureAlert() {
+        Task { @MainActor in
+            await passkeyActivityIndicator?.dismiss(true)
+        }
+
         let failureAlert = UIAlertController(title: PasskeyAuthentication.failureTitle, message: PasskeyAuthentication.failureMessage, preferredStyle: .alert)
         failureAlert.addCancelActionWithTitle(PasskeyAuthentication.okay)
         self.present(failureAlert, animated: true)
@@ -281,8 +285,8 @@ extension SPSettingsViewController {
 
 extension SPSettingsViewController: ASAuthorizationControllerDelegate {
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
-        // TODO: handle error
-        print(error.localizedDescription)
+        NSLog("[PasskeyRegistration] Could not register passkey: %@", error.localizedDescription)
+        presentPasskeyRegistrationFailureAlert()
     }
 
     public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -248,6 +248,7 @@ extension SPSettingsViewController {
                   let password = textfield.text else {
                 return
             }
+            self.passkeyActivityIndicator = SPModalActivityIndicator.show(in: SPAppDelegate.shared().window)
 
             Task {
                 do {
@@ -298,6 +299,7 @@ extension SPSettingsViewController: ASAuthorizationControllerDelegate {
             do {
                 let data = try JSONEncoder().encode(registrationObject)
                 try await PasskeyRemote().registerCredential(with: data)
+                await passkeyActivityIndicator?.dismiss(true)
             } catch {
                 //TODO: Display error
             }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -273,13 +273,15 @@ extension SPSettingsViewController {
     }
 
     private func presentPasskeyRegistrationAlert(succeeded: Bool) {
-        removeActivityIndicator()
+        DispatchQueue.main.async {
+            self.removeActivityIndicator()
 
-        let title = succeeded ? PasskeyAuthentication.successTitle : PasskeyAuthentication.failureTitle
-        let message = succeeded ? PasskeyAuthentication.successMessage : PasskeyAuthentication.failureMessage
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addCancelActionWithTitle(PasskeyAuthentication.okay)
-        self.present(alert, animated: true)
+            let title = succeeded ? PasskeyAuthentication.successTitle : PasskeyAuthentication.failureTitle
+            let message = succeeded ? PasskeyAuthentication.successMessage : PasskeyAuthentication.failureMessage
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addCancelActionWithTitle(PasskeyAuthentication.okay)
+            self.present(alert, animated: true)
+        }
     }
 
 }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -222,7 +222,7 @@ extension SPSettingsViewController {
 // MARK: - Passkeys
 //
 extension SPSettingsViewController {
-    var userEmail: String? {
+    private var userEmail: String? {
         SPAppDelegate.shared().simperium.user?.email
     }
 

--- a/Simplenote/Classes/SPSettingsViewController.h
+++ b/Simplenote/Classes/SPSettingsViewController.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 #import "SPTableViewController.h"
+#import "SPModalActivityIndicator.h"
 
 @class PasskeyAuthenticator;
 
@@ -9,9 +10,9 @@
     NSNumber *numPreviewLinesPref;
 }
 
-@property (nonatomic, strong) PasskeyAuthenticator     *passkeyAuthenticator;
+@property (nonatomic, strong, nullable) SPModalActivityIndicator *passkeyActivityIndicator;
 
 @end
 
-extern NSString *const SPAlphabeticalTagSortPref;
-extern NSString *const SPSustainerAppIconName;
+extern NSString * _Nonnull const SPAlphabeticalTagSortPref;
+extern NSString * _Nonnull const SPSustainerAppIconName;

--- a/Simplenote/Classes/SPSettingsViewController.h
+++ b/Simplenote/Classes/SPSettingsViewController.h
@@ -10,9 +10,7 @@
     NSNumber *numPreviewLinesPref;
 }
 
-@property (nonatomic, strong, nullable) SPModalActivityIndicator *passkeyActivityIndicator;
-
 @end
 
-extern NSString * _Nonnull const SPAlphabeticalTagSortPref;
-extern NSString * _Nonnull const SPSustainerAppIconName;
+extern NSString * const SPAlphabeticalTagSortPref;
+extern NSString * const SPSustainerAppIconName;

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -88,8 +88,7 @@ class PasskeyAuthenticator: NSObject {
     }
 
     private func performPasskeyAuthentication(with response: PasskeyAuthResponse) async throws -> PasskeyVerifyResponse {
-        guard let json = try? JSONEncoder().encode(response),
-              let response = try? await passkeyRemote.verifyPasskeyLogin(with: json) else {
+        guard let response = try? await passkeyRemote.verifyPasskeyLogin(with: response) else {
             throw PasskeyError.authFailed
         }
 

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -66,7 +66,12 @@ class PasskeyAuthenticator: NSObject {
         controller.presentationContextProvider = presentationContext
 
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PasskeyVerifyResponse, any Error>) in
-            internalAuthControllerDelegate.onCompletion = { result in
+            internalAuthControllerDelegate.onCompletion = { [weak self] result in
+                guard let self else {
+                    continuation.resume(throwing: PasskeyError.authFailed)
+                    return
+                }
+
                 switch result {
                 case .success(let response):
                     Task {

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -3,27 +3,21 @@ import AuthenticationServices
 
 enum PasskeyError: Error {
     case couldNotRequestRegistrationChallenge
+    case counldNotFetchAuthChallenge
 }
 
 typealias PresentationContext = ASAuthorizationControllerPresentationContextProviding
 
-@objcMembers
 class PasskeyAuthenticator: NSObject {
-    let authenticator: SPAuthenticator
-    let passkeyRemote = PasskeyRemote()
+    let passkeyRemote: PasskeyRemote
 
-    var registrationEmail: String?
-
-    @objc
-    init(authenticator: SPAuthenticator) {
-        self.authenticator = authenticator
+    init(passkeyRemote: PasskeyRemote = PasskeyRemote()) {
+        self.passkeyRemote = passkeyRemote
     }
 
-    // MARK: - Auth
-    //
-    func attemptPasskeyAuth(for email: String, in presentationContext: PresentationContext) async throws {
-        guard let challenge = try await fetchAuthChallenge(for: email) else {
-            return
+    func attemptPasskeyAuth(challenge: PasskeyAuthChallenge?, in presentationContext: PresentationContext, delegate: ASAuthorizationControllerDelegate) async throws {
+        guard let challenge else {
+            throw PasskeyError.counldNotFetchAuthChallenge
         }
 
         let challengeData = try Data.decodeUrlSafeBase64(challenge.challenge)
@@ -31,52 +25,17 @@ class PasskeyAuthenticator: NSObject {
         let request = provider.createCredentialAssertionRequest(challenge: challengeData)
 
         let controller = ASAuthorizationController(authorizationRequests: [request])
-        controller.delegate = self
+        controller.delegate = delegate
         controller.presentationContextProvider = presentationContext
         controller.performRequests()
     }
 
-    private func fetchAuthChallenge(for email: String) async throws -> PasskeyAuthChallenge? {
+    func fetchAuthChallenge(for email: String) async throws -> PasskeyAuthChallenge? {
         guard let data = try await passkeyRemote.passkeyAuthChallenge(for: email) else {
             return nil
         }
 
         let challenge = try JSONDecoder().decode(PasskeyAuthChallenge.self, from: data)
         return challenge
-    }
-
-    private func performPasskeyAuthentication(with response: PasskeyAuthResponse) {
-        Task { @MainActor in
-            guard let json = try? JSONEncoder().encode(response),
-                  let response = try? await passkeyRemote.verifyPasskeyLogin(with: json),
-                  let verifyResponse = try? JSONDecoder().decode(PasskeyVerifyResponse.self, from: response) else {
-                // TODO: handle auth failure
-                return
-            }
-
-            authenticator.authenticate(withUsername: verifyResponse.username, token: verifyResponse.accessToken)
-        }
-    }
-}
-
-// MARK: - ASAuthorizationControllerDelegate
-//
-extension PasskeyAuthenticator: ASAuthorizationControllerDelegate {
-    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
-        // TODO: handle error
-        print(error.localizedDescription)
-    }
-
-    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-
-        switch authorization.credential {
-
-        case let credential as ASAuthorizationPlatformPublicKeyCredentialAssertion:
-            let response = PasskeyAuthResponse(from: credential)
-
-            performPasskeyAuthentication(with: response)
-        default:
-            break
-        }
     }
 }

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -3,7 +3,19 @@ import AuthenticationServices
 
 enum PasskeyError: Error {
     case couldNotRequestRegistrationChallenge
-    case counldNotFetchAuthChallenge
+    case couldNotFetchAuthChallenge
+    case authFailed
+
+    var localizedDescription: String {
+        switch self {
+        case .couldNotRequestRegistrationChallenge:
+            return NSLocalizedString("Could not prepare an registration challenge", comment: "Error message that registering passkeys could not receive needed challeng")
+        case .couldNotFetchAuthChallenge:
+            return NSLocalizedString("Could not prepare an authorization challenge", comment: "Error message that authorizing passkeys could not receive needed challeng")
+        case .authFailed:
+            return NSLocalizedString("Authorization Failed", comment: "Error message that passkey authorization failed")
+        }
+    }
 }
 
 typealias PresentationContext = ASAuthorizationControllerPresentationContextProviding
@@ -17,7 +29,7 @@ class PasskeyAuthenticator: NSObject {
 
     func attemptPasskeyAuth(challenge: PasskeyAuthChallenge?, in presentationContext: PresentationContext, delegate: ASAuthorizationControllerDelegate) async throws {
         guard let challenge else {
-            throw PasskeyError.counldNotFetchAuthChallenge
+            throw PasskeyError.couldNotFetchAuthChallenge
         }
 
         let challengeData = try Data.decodeUrlSafeBase64(challenge.challenge)

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -66,7 +66,7 @@ class PasskeyAuthenticator: NSObject {
         self.internalAuthControllerDelegate = authControllerDelegate
     }
 
-    func attemptPasskeyAuth(challenge: PasskeyAuthChallenge?, in presentationContext: PresentationContext, delegate: ASAuthorizationControllerDelegate) async throws -> PasskeyVerifyResponse {
+    func attemptPasskeyAuth(challenge: PasskeyAuthChallenge?, in presentationContext: PresentationContext) async throws -> PasskeyVerifyResponse {
         guard let challenge else {
             throw PasskeyError.couldNotFetchAuthChallenge
         }
@@ -78,6 +78,7 @@ class PasskeyAuthenticator: NSObject {
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = internalAuthControllerDelegate
         controller.presentationContextProvider = presentationContext
+
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<PasskeyVerifyResponse, any Error>) in
             internalAuthControllerDelegate.onCompletion = { result in
                 switch result {

--- a/Simplenote/PasskeyAuthenticator.swift
+++ b/Simplenote/PasskeyAuthenticator.swift
@@ -5,6 +5,7 @@ enum PasskeyError: Error {
     case couldNotRequestRegistrationChallenge
     case couldNotFetchAuthChallenge
     case authFailed
+    case registrationFailed
 
     var localizedDescription: String {
         switch self {
@@ -14,6 +15,8 @@ enum PasskeyError: Error {
             return NSLocalizedString("Could not prepare an authorization challenge", comment: "Error message that authorizing passkeys could not receive needed challeng")
         case .authFailed:
             return NSLocalizedString("Authorization Failed", comment: "Error message that passkey authorization failed")
+        case .registrationFailed:
+            return NSLocalizedString("Registration Failed", comment: "Error message that passkey registration failed")
         }
     }
 }

--- a/Simplenote/PasskeyRegistrator.swift
+++ b/Simplenote/PasskeyRegistrator.swift
@@ -61,7 +61,12 @@ class PasskeyRegistrator {
         authController.presentationContextProvider = presentationContext
 
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
-            internalAuthControllerDelegate.onCompletion = { result in
+            internalAuthControllerDelegate.onCompletion = { [weak self] result in
+                guard let self else {
+                    continuation.resume(throwing: PasskeyError.registrationFailed)
+                    return
+                }
+
                 switch result {
                 case .success(let credential):
                     do {

--- a/Simplenote/PasskeyRegistrator.swift
+++ b/Simplenote/PasskeyRegistrator.swift
@@ -42,7 +42,7 @@ class PasskeyRegistrator {
         }
     }
 
-    func attemptRegistration(with passkeyChallenge: PasskeyRegistrationChallenge, presentationContext: PresentationContext, delegate: ASAuthorizationControllerDelegate) async throws -> Data {
+    func attemptRegistration(with passkeyChallenge: PasskeyRegistrationChallenge, presentationContext: PresentationContext) async throws -> Data {
         guard let challengeData = passkeyChallenge.challengeData,
               let userID = passkeyChallenge.userID else {
             throw PasskeyError.couldNotRequestRegistrationChallenge

--- a/Simplenote/PasskeyRegistrator.swift
+++ b/Simplenote/PasskeyRegistrator.swift
@@ -1,14 +1,37 @@
 import Foundation
 import AuthenticationServices
 
+class PasskeyRegistrationControllerDelegate: NSObject, ASAuthorizationControllerDelegate {
+    var onCompletion: ((Result<PublicKeyCredentialRegistration, Error>) -> Void)?
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
+        onCompletion?(.failure(error))
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let credential = authorization.credential as? PublicKeyCredentialRegistration else {
+            onCompletion?(.failure(PasskeyError.couldNotRequestRegistrationChallenge))
+            return
+        }
+
+        onCompletion?(.success(credential))
+    }
+}
+
+typealias PublicKeyCredentialRegistration = ASAuthorizationPlatformPublicKeyCredentialRegistration
+
 class PasskeyRegistrator {
     let passkeyRemote: PasskeyRemote
+    let internalAuthControllerDelegate: PasskeyRegistrationControllerDelegate
+    var userEmail: String? = nil
 
-    init(passkeyRemote: PasskeyRemote = PasskeyRemote()) {
+    init(passkeyRemote: PasskeyRemote = PasskeyRemote(), registrationDelegate: PasskeyRegistrationControllerDelegate = .init()) {
         self.passkeyRemote = passkeyRemote
+        self.internalAuthControllerDelegate = registrationDelegate
     }
 
     func requestChallenge(for email: String, password: String) async throws -> PasskeyRegistrationChallenge {
+        userEmail = email
         do {
             guard let data = try await passkeyRemote.requestChallengeResponseToCreatePasskey(forEmail: email, password: password) else {
                 throw PasskeyError.couldNotRequestRegistrationChallenge
@@ -19,17 +42,42 @@ class PasskeyRegistrator {
         }
     }
 
-    func attemptRegistration(with passkeyChallenge: PasskeyRegistrationChallenge, presentationContext: PresentationContext, delegate: ASAuthorizationControllerDelegate) {
+    func attemptRegistration(with passkeyChallenge: PasskeyRegistrationChallenge, presentationContext: PresentationContext, delegate: ASAuthorizationControllerDelegate) async throws -> Data {
         guard let challengeData = passkeyChallenge.challengeData,
               let userID = passkeyChallenge.userID else {
-            return
+            throw PasskeyError.couldNotRequestRegistrationChallenge
         }
 
         let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: passkeyChallenge.relayingPartyIdentifier)
         let platformKeyRequest = platformProvider.createCredentialRegistrationRequest(challenge: challengeData, name: passkeyChallenge.displayName, userID: userID)
         let authController = ASAuthorizationController(authorizationRequests: [platformKeyRequest])
-        authController.delegate = delegate
+        authController.delegate = internalAuthControllerDelegate
         authController.presentationContextProvider = presentationContext
-        authController.performRequests()
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
+            internalAuthControllerDelegate.onCompletion = { result in
+                switch result {
+                case .success(let credential):
+                    do {
+                        let registrationData = try self.registrationData(from: credential)
+                        continuation.resume(returning: registrationData)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            authController.performRequests()
+        }
+    }
+
+    private func registrationData(from credential: PublicKeyCredentialRegistration) throws -> Data {
+        guard let registrationObject = PasskeyRegistrationResponse(from: credential, with: userEmail) else {
+            throw PasskeyError.registrationFailed
+        }
+
+        return try JSONEncoder().encode(registrationObject)
     }
 }

--- a/Simplenote/PasskeyRegistrator.swift
+++ b/Simplenote/PasskeyRegistrator.swift
@@ -21,9 +21,9 @@ class PasskeyRegistrationControllerDelegate: NSObject, ASAuthorizationController
 typealias PublicKeyCredentialRegistration = ASAuthorizationPlatformPublicKeyCredentialRegistration
 
 class PasskeyRegistrator {
-    let passkeyRemote: PasskeyRemote
-    let internalAuthControllerDelegate: PasskeyRegistrationControllerDelegate
-    var userEmail: String? = nil
+    private let passkeyRemote: PasskeyRemote
+    private let internalAuthControllerDelegate: PasskeyRegistrationControllerDelegate
+    private var userEmail: String? = nil
 
     init(passkeyRemote: PasskeyRemote = PasskeyRemote(), registrationDelegate: PasskeyRegistrationControllerDelegate = .init()) {
         self.passkeyRemote = passkeyRemote

--- a/Simplenote/PasskeyRegistrator.swift
+++ b/Simplenote/PasskeyRegistrator.swift
@@ -1,0 +1,35 @@
+import Foundation
+import AuthenticationServices
+
+class PasskeyRegistrator {
+    let passkeyRemote: PasskeyRemote
+
+    init(passkeyRemote: PasskeyRemote = PasskeyRemote()) {
+        self.passkeyRemote = passkeyRemote
+    }
+
+    func requestChallenge(for email: String, password: String) async throws -> PasskeyRegistrationChallenge {
+        do {
+            guard let data = try await passkeyRemote.requestChallengeResponseToCreatePasskey(forEmail: email, password: password) else {
+                throw PasskeyError.couldNotRequestRegistrationChallenge
+            }
+            return try JSONDecoder().decode(PasskeyRegistrationChallenge.self, from: data)
+        } catch {
+            throw PasskeyError.couldNotRequestRegistrationChallenge
+        }
+    }
+
+    func attemptRegistration(with passkeyChallenge: PasskeyRegistrationChallenge, presentationContext: PresentationContext, delegate: ASAuthorizationControllerDelegate) {
+        guard let challengeData = passkeyChallenge.challengeData,
+              let userID = passkeyChallenge.userID else {
+            return
+        }
+
+        let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: passkeyChallenge.relayingPartyIdentifier)
+        let platformKeyRequest = platformProvider.createCredentialRegistrationRequest(challenge: challengeData, name: passkeyChallenge.displayName, userID: userID)
+        let authController = ASAuthorizationController(authorizationRequests: [platformKeyRequest])
+        authController.delegate = delegate
+        authController.presentationContextProvider = presentationContext
+        authController.performRequests()
+    }
+}

--- a/Simplenote/PasskeyRemote.swift
+++ b/Simplenote/PasskeyRemote.swift
@@ -70,9 +70,13 @@ class PasskeyRemote: Remote {
         return urlRequest
     }
 
-    func passkeyAuthChallenge(for email: String) async throws -> Data? {
+    func passkeyAuthChallenge(for email: String) async throws -> PasskeyAuthChallenge? {
         let request = passkeyAuthChallengeRequest(forEmail: email)
-        return try await performDataTask(with: request)
+        guard let data = try await performDataTask(with: request) else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(PasskeyAuthChallenge.self, from: data)
     }
 
     private func verifyPassKeyRequest(with data: Data) -> URLRequest {
@@ -84,8 +88,12 @@ class PasskeyRemote: Remote {
         return urlRequest
     }
 
-    func verifyPasskeyLogin(with data: Data) async throws -> Data? {
+    func verifyPasskeyLogin(with data: Data) async throws -> PasskeyVerifyResponse? {
         let request = verifyPassKeyRequest(with: data)
-        return try await performDataTask(with: request)
+        guard let data = try await performDataTask(with: request) else {
+            throw PasskeyError.authFailed
+        }
+
+        return try JSONDecoder().decode(PasskeyVerifyResponse.self, from: data)
     }
 }

--- a/Simplenote/PasskeyRemote.swift
+++ b/Simplenote/PasskeyRemote.swift
@@ -88,7 +88,11 @@ class PasskeyRemote: Remote {
         return urlRequest
     }
 
-    func verifyPasskeyLogin(with data: Data) async throws -> PasskeyVerifyResponse? {
+    func verifyPasskeyLogin(with response: PasskeyAuthResponse) async throws -> PasskeyVerifyResponse? {
+        guard let data = try? JSONEncoder().encode(response) else {
+            throw PasskeyError.authFailed
+        }
+
         let request = verifyPassKeyRequest(with: data)
         guard let data = try await performDataTask(with: request) else {
             throw PasskeyError.authFailed

--- a/Simplenote/SPModalActivityIndicator.swift
+++ b/Simplenote/SPModalActivityIndicator.swift
@@ -1,12 +1,7 @@
 import Foundation
 
 extension SPModalActivityIndicator {
-    // Swift is automatically creating an async version of this function for us, but then it is failing to build
-    // If you use the completion handler version of this method it complains.
-    // So you can't use the async version and you can't use the completion handler version... rock meet hard place
-    // This method is here to handle that issue
-    func dismiss(_ animated: Bool) async {
-        // Wrapping the dismiss in an anonymous closure silences the completion handler warning.
-        { dismiss(animated, completion: nil) }()
+    func dismiss(_ animated: Bool) {
+        dismiss(animated, completion: nil)
     }
 }

--- a/Simplenote/SPModalActivityIndicator.swift
+++ b/Simplenote/SPModalActivityIndicator.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension SPModalActivityIndicator {
+    // Swift is automatically creating an async version of this function for us, but then it is failing to build
+    // If you use the completion handler version of this method it complains.
+    // So you can't use the async version and you can't use the completion handler version... rock meet hard place
+    // This method is here to handle that issue
+    func dismiss(_ animated: Bool) async {
+        // Wrapping the dismiss in an anonymous closure silences the completion handler warning.
+        { dismiss(animated, completion: nil) }()
+    }
+}

--- a/Simplenote/SPModalActivityIndicator.swift
+++ b/Simplenote/SPModalActivityIndicator.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension SPModalActivityIndicator {
-    func dismiss(_ animated: Bool) {
+    func dismiss(animated: Bool) {
         dismiss(animated, completion: nil)
     }
 }

--- a/Simplenote/Simplenote-Bridging-Header.h
+++ b/Simplenote/Simplenote-Bridging-Header.h
@@ -33,7 +33,7 @@
 #import "SPTagEntryField.h"
 #import "WPAuthHandler.h"
 #import "NSManagedObjectContext+CoreDataExtensions.h"
-
+#import "SPModalActivityIndicator.h"
 
 #pragma mark - Extensions
 

--- a/Simplenote/Supporting Files/Simplenote-Internal.entitlements
+++ b/Simplenote/Supporting Files/Simplenote-Internal.entitlements
@@ -5,7 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:simplenote.com</string>
-		<string>webcredentials:passkey-dev-dot-simple-note-hrd.appspot.com?mode=developer</string>
+		<string>webcredentials:passkey-dev-dot-simple-note-hrd.appspot.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/Simplenote/Supporting Files/Simplenote.entitlements
+++ b/Simplenote/Supporting Files/Simplenote.entitlements
@@ -5,7 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:simplenote.com</string>
-		<string>webcredentials:passkey-dev-dot-simple-note-hrd.appspot.com?mode=developer</string>
+		<string>webcredentials:passkey-dev-dot-simple-note-hrd.appspot.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
### Fix
The first implementation of passkeys works to create passkeys and allow for users to authenticate with them, but it lacks some UI refinement.  There is no indication of progress happening, the UI remains unlocked, and there is no indication if the process is succeeding or failing.... Not a great user experience.

So to improve that I have added spinners, ui locking, errors, and alerts so that users have a better idea of what is going on when they use passkeys.

### Test
Setup: 
1. Go to the passkey DB and delete any existing passkeys you have (ping me if you need a link to the db)
2. On a Mac linked to the same iCloud as your testing device, go to Apple Settings > Passwords and search for any existing passkeys for simplenote at the testing url and delete them

Registration:
1.  Log into simplenote using email/password and go to the settings view
2. Put your device into airplane mode and then try to register a passkey by tapping on Add Passkey Authentication
3. Confirm that you see a spinner for a moment and then an alert appears that you failed to register
4. Go out of airplane mode, Tap on Add Passkey Authentication again.  Enter your email and confirm the spinner appears
5. When the FaceID modal pops up, dismiss it without confirming.  Confirm that an alert pops up saying you failed to register.  Also confirm that the UI is unlocked
6. Tap on Add Passkey Authentication again and this time let it scan your face.  You should succeed this time.  Confirm that you get a Success alert

Login:
1. Logout of the account you just registered a passkey for
2. On the login screen go to Login > Login with Passkeys and enter your email address
3. Put the device in airplane mode and then tap on the login with passkey button.  Confirm you see an error alert
4. Take the device out of airplane mode, tap on the login button again.  When the faceID ui appears dismiss it.  Confirm you see an alert
5. Tap on the login button again and this time go through the whole process.  Confirm you see a login spinner on the button, the ui is locked, and then when it succeeds confirm you are logged into your account

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
