### PR TITLE
Magic Links: Wires new Endpoints

### DIFF
--- a/Simplenote/Classes/MagicLinkAuthenticator.swift
+++ b/Simplenote/Classes/MagicLinkAuthenticator.swift
@@ -50,7 +50,7 @@ private extension MagicLinkAuthenticator {
 
     @discardableResult
     func attemptLoginWithAuthCode(queryItems: [URLQueryItem]) -> Bool {
-        guard let email = queryItems.value(for: Constants.emailField),
+        guard let email = queryItems.base64DecodedValue(for: Constants.emailField),
               let authCode = queryItems.value(for: Constants.authCodeField),
               !email.isEmpty, !authCode.isEmpty
         else {

--- a/Simplenote/Classes/MagicLinkAuthenticator.swift
+++ b/Simplenote/Classes/MagicLinkAuthenticator.swift
@@ -50,20 +50,20 @@ private extension MagicLinkAuthenticator {
 
     @discardableResult
     func attemptLoginWithAuthCode(queryItems: [URLQueryItem]) -> Bool {
-        guard let authKey = queryItems.value(for: Constants.authKeyField),
+        guard let email = queryItems.value(for: Constants.emailField),
               let authCode = queryItems.value(for: Constants.authCodeField),
-              !authKey.isEmpty, !authCode.isEmpty
+              !email.isEmpty, !authCode.isEmpty
         else {
             return false
         }
 
-        NSLog("[MagicLinkAuthenticator] Requesting SyncToken for \(authKey) and \(authCode)")
+        NSLog("[MagicLinkAuthenticator] Requesting SyncToken for \(email) and \(authCode)")
         NotificationCenter.default.post(name: .magicLinkAuthWillStart, object: nil)
 
         Task {
             do {
                 let remote = LoginRemote()
-                let confirmation = try await remote.requestLoginConfirmation(authKey: authKey, authCode: authCode)
+                let confirmation = try await remote.requestLoginConfirmation(email: email, authCode: authCode)
                 
                 Task { @MainActor in
                     NSLog("[MagicLinkAuthenticator] Should auth with token \(confirmation.syncToken)")
@@ -111,6 +111,5 @@ private struct AllowedHosts {
 private struct Constants {
     static let emailField = "email"
     static let tokenField = "token"
-    static let authKeyField = "auth_key"
     static let authCodeField = "auth_code"
 }

--- a/Simplenote/Classes/SimplenoteConstants.swift
+++ b/Simplenote/Classes/SimplenoteConstants.swift
@@ -45,8 +45,8 @@ class SimplenoteConstants: NSObject {
     ///
     static let resetPasswordURL     = currentEngineBaseURL.appendingPathComponent("/reset/?redirect=simplenote://launch&email=")
     static let settingsURL          = currentEngineBaseURL.appendingPathComponent("/settings")
-    static let loginRequestURL      = currentEngineBaseURL.appendingPathComponent("/account/request-login")
-    static let loginCompletionURL   = currentEngineBaseURL.appendingPathComponent("/account/complete-login")
+    static let loginRequestURL      = "https://magic-code-dot-simple-note-hrd.appspot.com/account/request-login" //googleAppEngineBaseURL.appendingPathComponent("/account/request-login")
+    static let loginCompletionURL   = "https://magic-code-dot-simple-note-hrd.appspot.com/account/complete-login" //googleAppEngineBaseURL.appendingPathComponent("/account/complete-login")
     static let signupURL            = currentEngineBaseURL.appendingPathComponent("/account/request-signup")
     static let verificationURL      = currentEngineBaseURL.appendingPathComponent("/account/verify-email/")
     static let accountDeletionURL   = currentEngineBaseURL.appendingPathComponent("/account/request-delete/")

--- a/Simplenote/Classes/SimplenoteConstants.swift
+++ b/Simplenote/Classes/SimplenoteConstants.swift
@@ -45,8 +45,8 @@ class SimplenoteConstants: NSObject {
     ///
     static let resetPasswordURL     = currentEngineBaseURL.appendingPathComponent("/reset/?redirect=simplenote://launch&email=")
     static let settingsURL          = currentEngineBaseURL.appendingPathComponent("/settings")
-    static let loginRequestURL      = "https://magic-code-dot-simple-note-hrd.appspot.com/account/request-login" //googleAppEngineBaseURL.appendingPathComponent("/account/request-login")
-    static let loginCompletionURL   = "https://magic-code-dot-simple-note-hrd.appspot.com/account/complete-login" //googleAppEngineBaseURL.appendingPathComponent("/account/complete-login")
+    static let loginRequestURL      = currentEngineBaseURL.appendingPathComponent("/account/request-login")
+    static let loginCompletionURL   = currentEngineBaseURL.appendingPathComponent("/account/complete-login")
     static let signupURL            = currentEngineBaseURL.appendingPathComponent("/account/request-signup")
     static let verificationURL      = currentEngineBaseURL.appendingPathComponent("/account/verify-email/")
     static let accountDeletionURL   = currentEngineBaseURL.appendingPathComponent("/account/request-delete/")

--- a/Simplenote/LoginRemote.swift
+++ b/Simplenote/LoginRemote.swift
@@ -9,8 +9,8 @@ class LoginRemote: Remote {
         performDataTask(with: request, completion: completion)
     }
 
-    func requestLoginConfirmation(authKey: String, authCode: String) async throws -> LoginConfirmationResponse {
-        let request = requestForLoginCompletion(authKey: authKey, authCode: authCode)
+    func requestLoginConfirmation(email: String, authCode: String) async throws -> LoginConfirmationResponse {
+        let request = requestForLoginCompletion(email: email, authCode: authCode)
         return try await performDataTask(with: request, type: LoginConfirmationResponse.self)
     }
 }
@@ -36,11 +36,11 @@ private extension LoginRemote {
         ])
     }
 
-    func requestForLoginCompletion(authKey: String, authCode: String) -> URLRequest {
+    func requestForLoginCompletion(username: String, authCode: String) -> URLRequest {
         let url = URL(string: SimplenoteConstants.loginCompletionURL)!
         return requestForURL(url, method: RemoteConstants.Method.POST, httpBody: [
             "auth_key": authKey,
-            "auth_code": authCode
+            "username": username
         ])
     }
 }

--- a/Simplenote/LoginRemote.swift
+++ b/Simplenote/LoginRemote.swift
@@ -5,7 +5,7 @@ import Foundation
 class LoginRemote: Remote {
 
     func requestLoginEmail(email: String, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        let request = requestForLoginRequest(with: email)
+        let request = requestForLoginRequest(email: email)
         performDataTask(with: request, completion: completion)
     }
 
@@ -28,7 +28,7 @@ struct LoginConfirmationResponse: Decodable {
 //
 private extension LoginRemote {
 
-    func requestForLoginRequest(with email: String) -> URLRequest {
+    func requestForLoginRequest(email: String) -> URLRequest {
         let url = URL(string: SimplenoteConstants.loginRequestURL)!
         return requestForURL(url, method: RemoteConstants.Method.POST, httpBody: [
             "request_source": SimplenoteConstants.simplenotePlatformName,
@@ -36,11 +36,11 @@ private extension LoginRemote {
         ])
     }
 
-    func requestForLoginCompletion(username: String, authCode: String) -> URLRequest {
+    func requestForLoginCompletion(email: String, authCode: String) -> URLRequest {
         let url = URL(string: SimplenoteConstants.loginCompletionURL)!
         return requestForURL(url, method: RemoteConstants.Method.POST, httpBody: [
-            "auth_key": authKey,
-            "username": username
+            "auth_code": authCode,
+            "username": email
         ])
     }
 }


### PR DESCRIPTION
### ⚠️ Important
- [x] Make sure the new endpoints are deployed before merging
- [x] Remove the staging URL!

### Fix
In this PR we're wiring the new code-based endpoints.

Ref. #1611

### Test
1. Logout from Simplenote macOS
2. Click on the `Log In` button
3. Enter your email
4. Click on `Instantly Log In with Email`

- [x] Verify that shortly after you get the Auth Email
- [ ] Verify that clicking on Log Into Simplenote button causes the mac app to Log In

### Release
> These changes do not require release notes.
