### PR TITLE
Login Flow: Splitting Username / Password Interfaces

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - Fixed issue where notes selection was lost when app backgrounded
 - Fixed an issue can activate the faceid switch without a passcode
 - Magic Link Login Support
+- Login UI has been overhauled
 
 4.51
 -----

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -214,6 +214,7 @@ class SPAuthViewController: UIViewController {
         setupNavigationController()
         startListeningToNotifications()
 
+        emailInputView.isHidden = mode.isUsernameHidden
         passwordInputView.isHidden = mode.isPasswordHidden
 
         // hiding text from back button
@@ -232,7 +233,9 @@ class SPAuthViewController: UIViewController {
         // Note: running becomeFirstResponder in `viewWillAppear` has the weird side effect of breaking caret
         // repositioning in the Text Field. Seriously.
         // Ref. https://github.com/Automattic/simplenote-ios/issues/453
-        self.emailInputView.becomeFirstResponder()
+        //
+        let initialFirstResponder = mode.isPasswordHidden ? emailInputView : passwordInputView
+        initialFirstResponder?.becomeFirstResponder()
     }
 }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -185,7 +185,7 @@ class SPAuthViewController: UIViewController {
     ///
     private var mustResetPasswordField = false
 
-    /// # Authentication Mode: Signup or Login
+    /// # Authentication Mode: Signup / Login with Password / Login with Link
     ///
     private let mode: AuthenticationMode
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -318,6 +318,10 @@ private extension SPAuthViewController {
         }
     }
     
+    @IBAction func performLogInWithWPCOM() {
+        WPAuthHandler.presentWordPressSSO(from: self)
+    }
+    
     @IBAction func performSignUp() {
         guard ensureWarningsAreOnScreenWhenNeeded() else {
             return

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -100,7 +100,10 @@ class SPAuthViewController: UIViewController {
 
             secondaryActionButton.titleLabel?.textAlignment = .center
             secondaryActionButton.titleLabel?.numberOfLines = 0
-            secondaryActionButton.addTarget(self, action: mode.secondaryActionSelector, for: .touchUpInside)
+            
+            if let action = mode.secondaryActionSelector {
+                secondaryActionButton.addTarget(self, action: action, for: .touchUpInside)
+            }
         }
     }
 
@@ -118,6 +121,29 @@ class SPAuthViewController: UIViewController {
 
         return button
     }()
+
+    /// # Tertiary Action: Container View
+    ///
+    @IBOutlet private var tertiaryActionContainerView: UIView! {
+        didSet {
+            tertiaryActionContainerView.isHidden = mode.tertiaryActionSelector == nil
+        }
+    }
+
+    /// # Tertiary Action: WPCOM SSO
+    ///
+    @IBOutlet private var tertiaryActionButton: SPSquaredButton! {
+        didSet {
+            guard let title = mode.tertiaryActionText, let action = mode.tertiaryActionSelector else {
+                return
+            }
+            
+            tertiaryActionButton.setTitle(title, for: .normal)
+            tertiaryActionButton.setTitleColor(.white, for: .normal)
+            tertiaryActionButton.backgroundColor = .simplenoteWPBlue50Color
+            tertiaryActionButton.addTarget(self, action: action, for: .touchUpInside)
+        }
+    }
 
     /// # Simperium's Authenticator Instance
     ///

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -805,7 +805,7 @@ private enum PasswordInsecureString {
 // MARK: - Mode: .loginWithPassword
 //
 private enum PasswordStrings {
-    static let title            = NSLocalizedString("Log In", comment: "LogIn Interface Title")
+    static let title            = NSLocalizedString("Log In with Password", comment: "LogIn Interface Title")
     static let login            = NSLocalizedString("Log In", comment: "LogIn Action")
     static let forgotPassword   = NSLocalizedString("Forgot your password?", comment: "Password Reset Action")
 }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -161,11 +161,7 @@ class SPAuthViewController: UIViewController {
 
     /// # Authentication Mode: Signup or Login
     ///
-    private(set) var mode: AuthenticationMode {
-        didSet {
-            refreshInterface(mode: mode)
-        }
-    }
+    private let mode: AuthenticationMode
 
     /// Indicates if the Extended Debug Mode is enabled
     ///
@@ -659,59 +655,6 @@ extension SPAuthViewController: SPTextInputViewDelegate {
         }
 
         return false
-    }
-}
-
-// MARK: - Mode Switching
-//
-extension SPAuthViewController {
-    
-    func refreshInterface(mode: AuthenticationMode, animated: Bool = true) {
-        title = mode.title
-        
-        dismissAllValidationWarnings()
-
-        refreshPasswordInput(isHidden: mode.isPasswordHidden, animated: animated)
-        refreshPrimaryAction(mode: mode)
-        refreshSecondaryAction(mode: mode)
-
-        /// Workaround:
-        /// When revealing the Password Field, iOS's Autofill mechanism may not properly fill the password field!
-        passwordInputView.becomeFirstResponder()
-        emailInputView.becomeFirstResponder()
-    }
-    
-    func refreshPasswordInput(isHidden: Bool, animated: Bool) {
-        let work = {
-            self.passwordInputView.isHidden = isHidden
-        }
-        
-        guard animated else {
-            work()
-            return
-        }
-
-        UIView.animate(withDuration: UIKitConstants.animationDelayShort, animations: work)
-    }
-    
-    func refreshPrimaryAction(mode: AuthenticationMode) {
-        primaryActionButton.setTitleWithoutAnimation(mode.primaryActionText, for: .normal)
-        primaryActionButton.removeTarget(self, action: nil, for: .touchUpInside)
-        primaryActionButton.addTarget(self, action: mode.primaryActionSelector, for: .touchUpInside)
-    }
-    
-    func refreshSecondaryAction(mode: AuthenticationMode) {
-        if let title = mode.secondaryActionText {
-            secondaryActionButton.setTitleWithoutAnimation(title, for: .normal)
-        }
-        
-        if let attributedTitle = mode.secondaryActionAttributedText {
-            secondaryActionButton.setAttributedTitleWithoutAnimation(attributedTitle, for: .normal)
-        }
-
-        secondaryActionButton.setTitleColor(.simplenoteBlue60Color, for: .normal)
-        secondaryActionButton.removeTarget(self, action: nil, for: .touchUpInside)
-        secondaryActionButton.addTarget(self, action: mode.secondaryActionSelector, for: .touchUpInside)
     }
 }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -73,6 +73,7 @@ class SPAuthViewController: UIViewController {
             primaryActionButton.setTitle(mode.primaryActionText, for: .normal)
             primaryActionButton.setTitleColor(.white, for: .normal)
             primaryActionButton.addTarget(self, action: mode.primaryActionSelector, for: .touchUpInside)
+            primaryActionButton.accessibilityIdentifier = "Main Action"
         }
     }
 
@@ -361,19 +362,24 @@ private extension SPAuthViewController {
             return
         }
 
-        lockdownInterface()
-
-        let email = self.email
-        controller.requestLoginEmail(username: email) { error in
-            if let error {
-                self.handleError(error: error)
-            } else {
-                self.presentMagicLinkRequestedView(email: email)
-                SPTracker.trackUserRequestedLoginLink()
-            }
-
-            self.unlockInterface()
-        }
+        presentPasswordInterface()
+        
+// TODO: Restore Mail + Code Auth Flow
+//        lockdownInterface()
+//
+//        let email = self.email
+//        controller.requestLoginEmail(username: email) { error in
+//            // TODO: 429 (Rate Limited)? push PW auth instead
+//            self.presentPasswordInterface()
+//            
+//            if let error {
+//                self.handleError(error: error)
+//            } else {
+//                SPTracker.trackUserRequestedLoginLink()
+//            }
+//            
+//            self.unlockInterface()
+//        }
     }
     
     @IBAction func performLogInWithWPCOM() {

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -340,10 +340,6 @@ private extension SPAuthViewController {
         }
     }
     
-    @IBAction func switchToLoginWithPassword() {
-        mode = .loginWithPassword
-    }
-
     @IBAction func presentPasswordReset() {
         controller.presentPasswordReset(from: self, username: email)
     }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -357,20 +357,22 @@ private extension SPAuthViewController {
         safariViewController.modalPresentationStyle = .overFullScreen
         present(safariViewController, animated: true, completion: nil)
     }
+}
 
-    private func presentSignupVerification() {
+
+// MARK: - Navigation Helpers
+//
+private extension SPAuthViewController {
+
+    func presentSignupVerification() {
         let viewController = SignupVerificationViewController(email: email)
         viewController.title = title
         navigationController?.pushViewController(viewController, animated: true)
     }
     
-    private func presentMagicLinkRequestedView(email: String) {
-        let rootView = MagicLinkRequestedView(email: email)
-        let hostingController = UIHostingController(rootView: rootView)
-        hostingController.modalPresentationStyle = .formSheet
-        hostingController.sheetPresentationController?.detents = [.medium()]
-
-        present(hostingController, animated: true)
+    func presentPasswordInterface() {
+        let viewController = SPAuthViewController(controller: controller, mode: .loginWithPassword)
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -313,8 +313,8 @@ private extension SPAuthViewController {
 
         perform(mode.primaryActionSelector)
     }
-
-    @IBAction func performLogIn() {
+    
+    @IBAction func performLogInWithPassword() {
         guard ensureWarningsAreOnScreenWhenNeeded() else {
             return
         }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -602,16 +602,21 @@ private extension SPAuthViewController {
 private extension SPAuthViewController {
 
     func performUsernameValidation() -> AuthenticationValidator.Result {
-        validator.performUsernameValidation(username: email)
+        if mode.isUsernameHidden {
+            return .success
+        }
+
+        return validator.performUsernameValidation(username: email)
     }
 
     /// When we're in `.login` mode, password requirements are relaxed (since we must allow users with old passwords to sign in).
     /// That's where the `validationStyle` comes in.
     ///
     func performPasswordValidation() -> AuthenticationValidator.Result {
-        guard !mode.isPasswordHidden else {
+        if mode.isPasswordHidden {
             return .success
         }
+
         return validator.performPasswordValidation(username: email, password: password, style: mode.validationStyle)
     }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -122,6 +122,22 @@ class SPAuthViewController: UIViewController {
         return button
     }()
 
+    /// # Tertiary Separator: COntainer
+    ///
+    @IBOutlet private var tertiaryTopSeparator: UIView! {
+        didSet {
+            tertiaryTopSeparator.isHidden = mode.tertiaryActionSelector == nil
+        }
+    }
+
+    /// # Tertiary Separator: Label (Or)
+    ///
+    @IBOutlet private var tertiaryTopSeparatorLabel: UILabel! {
+        didSet {
+            tertiaryTopSeparatorLabel.text = AuthenticationStrings.separatorText
+        }
+    }
+    
     /// # Tertiary Action: Container View
     ///
     @IBOutlet private var tertiaryActionContainerView: UIView! {
@@ -214,6 +230,7 @@ class SPAuthViewController: UIViewController {
         setupNavigationController()
         startListeningToNotifications()
 
+        refreshActions()
         refreshInputViews()
 
         // hiding text from back button
@@ -267,6 +284,11 @@ private extension SPAuthViewController {
 
     func ensureNavigationBarIsVisible() {
         navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+
+    func refreshActions() {
+        secondaryActionButton.isHidden = mode.secondaryActionSelector == nil
+        tertiaryActionButton.isHidden = mode.tertiaryActionSelector == nil
     }
 
     func refreshInputViews() {
@@ -790,6 +812,7 @@ extension AuthenticationMode {
 // MARK: - Authentication Strings
 //
 private enum AuthenticationStrings {
+    static let separatorText                = NSLocalizedString("Or", comment: "Or, used as a separator between Actions")
     static let emailPlaceholder             = NSLocalizedString("Email", comment: "Email TextField Placeholder")
     static let passwordPlaceholder          = NSLocalizedString("Password", comment: "Password TextField Placeholder")
     static let acceptActionText             = NSLocalizedString("Accept", comment: "Accept Action")

--- a/Simplenote/Classes/SPAuthViewController.xib
+++ b/Simplenote/Classes/SPAuthViewController.xib
@@ -22,6 +22,8 @@
                 <outlet property="stackViewTopConstraint" destination="Cyh-nE-ql7" id="WHM-m6-Cht"/>
                 <outlet property="tertiaryActionButton" destination="Uy8-va-3uF" id="NfE-QO-aLc"/>
                 <outlet property="tertiaryActionContainerView" destination="nxG-8M-wxx" id="FtU-Ac-O5T"/>
+                <outlet property="tertiaryTopSeparator" destination="Kpm-3a-0Z7" id="vyp-IY-5NB"/>
+                <outlet property="tertiaryTopSeparatorLabel" destination="223-DD-dLN" id="4cS-eP-Gg8"/>
                 <outlet property="view" destination="iN0-l3-epB" id="bxN-Zo-xBW"/>
             </connections>
         </placeholder>
@@ -31,7 +33,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CJS-5O-pxK">
-                    <rect key="frame" x="332" y="60" width="360" height="304"/>
+                    <rect key="frame" x="332" y="60" width="360" height="356"/>
                     <subviews>
                         <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-K1-OyV" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -88,8 +90,55 @@
                                 <constraint firstItem="o3M-2A-urw" firstAttribute="centerY" secondItem="CGr-O3-MBQ" secondAttribute="centerY" id="wvA-qg-zbY"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nxG-8M-wxx" userLabel="Tertiary Action View">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
                             <rect key="frame" x="0.0" y="208" width="360" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="44" id="u8s-d9-Em4"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                            <state key="normal" title="#Secondary#">
+                                <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </state>
+                        </button>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kpm-3a-0Z7" userLabel="Tertiary Separator View">
+                            <rect key="frame" x="0.0" y="260" width="360" height="44"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Ls-SS-l0Q" userLabel="Leading View">
+                                    <rect key="frame" x="0.0" y="21.5" width="167" height="1"/>
+                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="rVl-M6-Cd1"/>
+                                    </constraints>
+                                </view>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Or" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="223-DD-dLN">
+                                    <rect key="frame" x="172" y="13.5" width="16" height="17"/>
+                                    <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
+                                    <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zDI-3J-P7n" userLabel="Trailing View">
+                                    <rect key="frame" x="193" y="21.5" width="167" height="1"/>
+                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="q0n-gB-kwQ"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstItem="223-DD-dLN" firstAttribute="leading" secondItem="1Ls-SS-l0Q" secondAttribute="trailing" constant="5" id="6eB-VO-Lvv"/>
+                                <constraint firstItem="223-DD-dLN" firstAttribute="centerY" secondItem="Kpm-3a-0Z7" secondAttribute="centerY" id="I7a-xZ-3cO"/>
+                                <constraint firstAttribute="trailing" secondItem="zDI-3J-P7n" secondAttribute="trailing" id="Jk5-Jv-Cgt"/>
+                                <constraint firstItem="223-DD-dLN" firstAttribute="centerX" secondItem="Kpm-3a-0Z7" secondAttribute="centerX" id="WH4-zc-WJ7"/>
+                                <constraint firstAttribute="height" constant="44" id="m11-VH-7Ya"/>
+                                <constraint firstItem="1Ls-SS-l0Q" firstAttribute="leading" secondItem="Kpm-3a-0Z7" secondAttribute="leading" id="nl1-rW-o3J"/>
+                                <constraint firstItem="zDI-3J-P7n" firstAttribute="centerY" secondItem="Kpm-3a-0Z7" secondAttribute="centerY" id="oQH-pJ-ASQ"/>
+                                <constraint firstItem="1Ls-SS-l0Q" firstAttribute="centerY" secondItem="Kpm-3a-0Z7" secondAttribute="centerY" id="peR-N9-64H"/>
+                                <constraint firstItem="zDI-3J-P7n" firstAttribute="leading" secondItem="223-DD-dLN" secondAttribute="trailing" constant="5" id="vE8-Zf-q7V"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nxG-8M-wxx" userLabel="Tertiary Action View">
+                            <rect key="frame" x="0.0" y="312" width="360" height="44"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uy8-va-3uF" userLabel="#Tertiary#" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -106,21 +155,15 @@
                                 <constraint firstItem="Uy8-va-3uF" firstAttribute="top" secondItem="nxG-8M-wxx" secondAttribute="top" id="rt4-P1-Ygd"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
-                            <rect key="frame" x="0.0" y="260" width="360" height="44"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="44" id="u8s-d9-Em4"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <state key="normal" title="#Secondary#"/>
-                        </button>
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="PfS-vU-7i3" secondAttribute="trailing" id="0QL-Iw-KLz"/>
                         <constraint firstItem="PfS-vU-7i3" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="314-fc-3eX"/>
                         <constraint firstAttribute="trailing" secondItem="pdF-nK-gXE" secondAttribute="trailing" id="51g-0D-Oyv"/>
+                        <constraint firstAttribute="trailing" secondItem="Kpm-3a-0Z7" secondAttribute="trailing" id="7SY-4J-Rv5"/>
                         <constraint firstItem="CGr-O3-MBQ" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="BIX-Fy-gqY"/>
                         <constraint firstAttribute="trailing" secondItem="hW6-K1-OyV" secondAttribute="trailing" id="RSC-Vk-xbB"/>
+                        <constraint firstItem="Kpm-3a-0Z7" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="S94-pS-Aza"/>
                         <constraint firstItem="hW6-K1-OyV" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="UoC-hu-yxe"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="nLp-JP-Ott"/>
                         <constraint firstItem="nxG-8M-wxx" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="sEH-qo-ZdT"/>
@@ -138,7 +181,7 @@
                 <constraint firstItem="CJS-5O-pxK" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="H6h-v9-Uwb"/>
                 <constraint firstItem="CJS-5O-pxK" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" priority="999" constant="24" id="Odu-ev-HSV"/>
             </constraints>
-            <point key="canvasLocation" x="137.68115942028987" y="152.67857142857142"/>
+            <point key="canvasLocation" x="137.109375" y="152.34375"/>
         </view>
     </objects>
     <designables>
@@ -160,10 +203,10 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemPinkColor">
-            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Simplenote/Classes/SPAuthViewController.xib
+++ b/Simplenote/Classes/SPAuthViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,6 +20,8 @@
                 <outlet property="secondaryActionButton" destination="PfS-vU-7i3" id="zj3-Ly-5X9"/>
                 <outlet property="stackView" destination="CJS-5O-pxK" id="Grg-ZD-DYy"/>
                 <outlet property="stackViewTopConstraint" destination="Cyh-nE-ql7" id="WHM-m6-Cht"/>
+                <outlet property="tertiaryActionButton" destination="Uy8-va-3uF" id="NfE-QO-aLc"/>
+                <outlet property="tertiaryActionContainerView" destination="nxG-8M-wxx" id="FtU-Ac-O5T"/>
                 <outlet property="view" destination="iN0-l3-epB" id="bxN-Zo-xBW"/>
             </connections>
         </placeholder>
@@ -28,7 +31,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CJS-5O-pxK">
-                    <rect key="frame" x="332" y="40" width="360" height="252"/>
+                    <rect key="frame" x="332" y="60" width="360" height="304"/>
                     <subviews>
                         <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-K1-OyV" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -43,7 +46,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#Invalid email#" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n7T-Gj-plH" customClass="SPLabel" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="52" width="102.5" height="18"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <color key="textColor" systemColor="systemPinkColor" red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="textColor" systemColor="systemPinkColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="pdF-nK-gXE" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
@@ -59,13 +62,13 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#Invalid password#" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UyC-If-pXj" customClass="SPLabel" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="130" width="132" height="18"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <color key="textColor" systemColor="systemRedColor" red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="textColor" systemColor="systemRedColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CGr-O3-MBQ" userLabel="Primary Action View">
                             <rect key="frame" x="0.0" y="156" width="360" height="44"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3p-Ji-dOm" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3p-Ji-dOm" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                     <state key="normal" title="#Primary#"/>
@@ -74,7 +77,7 @@
                                     <rect key="frame" x="322" y="12" width="20" height="20"/>
                                 </activityIndicatorView>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="q3p-Ji-dOm" secondAttribute="bottom" id="42P-Dw-g8A"/>
                                 <constraint firstAttribute="trailing" secondItem="o3M-2A-urw" secondAttribute="trailing" constant="18" id="5zP-Ho-8zY"/>
@@ -85,8 +88,26 @@
                                 <constraint firstItem="o3M-2A-urw" firstAttribute="centerY" secondItem="CGr-O3-MBQ" secondAttribute="centerY" id="wvA-qg-zbY"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nxG-8M-wxx" userLabel="Tertiary Action View">
                             <rect key="frame" x="0.0" y="208" width="360" height="44"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uy8-va-3uF" userLabel="#Tertiary#" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                    <state key="normal" title="#Tertiary#"/>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="Uy8-va-3uF" secondAttribute="trailing" id="4sz-wJ-Fm5"/>
+                                <constraint firstAttribute="bottom" secondItem="Uy8-va-3uF" secondAttribute="bottom" id="7XH-hU-NF8"/>
+                                <constraint firstItem="Uy8-va-3uF" firstAttribute="leading" secondItem="nxG-8M-wxx" secondAttribute="leading" id="F1T-yV-yFY"/>
+                                <constraint firstAttribute="height" constant="44" id="jJo-79-bms"/>
+                                <constraint firstItem="Uy8-va-3uF" firstAttribute="top" secondItem="nxG-8M-wxx" secondAttribute="top" id="rt4-P1-Ygd"/>
+                            </constraints>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
+                            <rect key="frame" x="0.0" y="260" width="360" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="u8s-d9-Em4"/>
                             </constraints>
@@ -102,11 +123,14 @@
                         <constraint firstAttribute="trailing" secondItem="hW6-K1-OyV" secondAttribute="trailing" id="RSC-Vk-xbB"/>
                         <constraint firstItem="hW6-K1-OyV" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="UoC-hu-yxe"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="nLp-JP-Ott"/>
+                        <constraint firstItem="nxG-8M-wxx" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="sEH-qo-ZdT"/>
                         <constraint firstAttribute="trailing" secondItem="CGr-O3-MBQ" secondAttribute="trailing" id="vUF-qZ-Vmm"/>
+                        <constraint firstAttribute="trailing" secondItem="nxG-8M-wxx" secondAttribute="trailing" id="w8N-O1-2au"/>
                         <constraint firstItem="pdF-nK-gXE" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="xzh-aD-Ag5"/>
                     </constraints>
                 </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="CJS-5O-pxK" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="40" id="Cyh-nE-ql7"/>
@@ -114,8 +138,32 @@
                 <constraint firstItem="CJS-5O-pxK" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="H6h-v9-Uwb"/>
                 <constraint firstItem="CJS-5O-pxK" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" priority="999" constant="24" id="Odu-ev-HSV"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="137.68115942028987" y="152.67857142857142"/>
         </view>
     </objects>
+    <designables>
+        <designable name="Uy8-va-3uF">
+            <size key="intrinsicContentSize" width="83" height="33"/>
+        </designable>
+        <designable name="UyC-If-pXj">
+            <size key="intrinsicContentSize" width="132" height="18"/>
+        </designable>
+        <designable name="n7T-Gj-plH">
+            <size key="intrinsicContentSize" width="102.5" height="18"/>
+        </designable>
+        <designable name="q3p-Ji-dOm">
+            <size key="intrinsicContentSize" width="84" height="33"/>
+        </designable>
+    </designables>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -149,20 +149,7 @@ private extension SPOnboardingViewController {
 
     @IBAction
     func loginWasPressed() {
-        let sheetController = SPSheetController()
-
-        sheetController.setTitleForButton0(title: OnboardingStrings.loginWithEmailText)
-        sheetController.setTitleForButton1(title: OnboardingStrings.loginWithWpcomText)
-
-        sheetController.onClickButton0 = { [weak self] in
-            self?.presentAuthenticationInterface(mode: .loginWithMagicLink)
-        }
-
-        sheetController.onClickButton1 = { [weak self] in
-            self?.presentWordpressSSO()
-        }
-
-        sheetController.present(from: self)
+        presentAuthenticationInterface(mode: .loginWithMagicLink)
     }
 
     @IBAction
@@ -184,10 +171,6 @@ private extension SPOnboardingViewController {
         let viewController = SPAuthViewController(controller: controller, mode: mode)
         viewController.debugEnabled = debugEnabled
         navigationController?.pushViewController(viewController, animated: true)
-    }
-
-    func presentWordpressSSO() {
-        WPAuthHandler.presentWordPressSSO(from: self)
     }
 }
 
@@ -246,10 +229,6 @@ private extension SPOnboardingViewController {
     /// - Note: Whenever the required AuthUI is already onscreen, we'll do nothing
     ///
     func presentAuthenticationInterfaceIfNeeded(mode: AuthenticationMode) {
-        if let authController = navigationController?.topViewController as? SPAuthViewController, authController.mode == mode {
-            return
-        }
-
         navigationController?.popToRootViewController(animated: true)
         presentAuthenticationInterface(mode: mode)
     }
@@ -265,8 +244,6 @@ private struct OnboardingStrings {
     static let signupText = NSLocalizedString("Sign Up", comment: "Signup Action")
     static let loginText = NSLocalizedString("Log In", comment: "Login Action")
     static let headerText = NSLocalizedString("The simplest way to keep notes.", comment: "Onboarding Header Text")
-    static let loginWithEmailText = NSLocalizedString("Log in with email", comment: "Presents the regular Email signin flow")
-    static let loginWithWpcomText = NSLocalizedString("Log in with WordPress.com", comment: "Allows the user to SignIn using their WPCOM Account")
 }
 
 private struct SignInError {

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -5,8 +5,6 @@ class EmailLogin {
     class func open() {
         app.buttons[UID.Button.logIn].waitForIsHittable()
         app.buttons[UID.Button.logIn].tap()
-        app.buttons[UID.Button.logInWithEmail].waitForIsHittable()
-        app.buttons[UID.Button.logInWithEmail].tap()
     }
 
     class func close() {
@@ -34,13 +32,18 @@ class EmailLogin {
 
     class func logIn(email: String, password: String) {
         enterEmail(enteredValue: email)
-        app.buttons[UID.Button.continueWithPassword].tap()
+        app.buttons[UID.Button.logInWithEmail].tap()
         _ = app.buttons[UID.Button.logIn].waitForExistence(timeout: minLoadTimeout)
         enterPassword(enteredValue: password)
-        app.buttons[UID.Button.logIn].tap()
+        app.buttons[UID.Button.mainAction].tap()
         handleSavePasswordPrompt()
         waitForSpinnerToDisappear()
     }
+    
+    class func enterEmailAndAttemptLogin(email: String) {
+        enterEmail(enteredValue: email)
+        app.buttons[UID.Button.logInWithEmail].tap()
+     }
 
     class func enterEmail(enteredValue: String) {
         let field = app.textFields[UID.TextField.email]

--- a/SimplenoteUITests/EmailLogin.swift
+++ b/SimplenoteUITests/EmailLogin.swift
@@ -8,10 +8,19 @@ class EmailLogin {
     }
 
     class func close() {
-        let backButton = app.navigationBars[UID.NavBar.logIn].buttons[UID.Button.back]
-        guard backButton.isHittable else { return }
+        /// Back from Password > Email UI
+        let backFromPasswordUI = app.navigationBars[UID.NavBar.logInWithPassword].buttons.element(boundBy: 0)
+        if backFromPasswordUI.exists {
+            backFromPasswordUI.tap()
+            _ = app.navigationBars[UID.NavBar.logIn].waitForExistence(timeout: minLoadTimeout)
+        }
 
-        backButton.tap()
+        /// Back from Email UI > Onboarding
+        let backButton = app.navigationBars[UID.NavBar.logIn].buttons.element(boundBy: 0)
+        if backButton.isHittable {
+            backButton.tap()
+        }
+
         handleSavePasswordPrompt()
     }
 

--- a/SimplenoteUITests/SimplenoteUITestsLogin.swift
+++ b/SimplenoteUITests/SimplenoteUITestsLogin.swift
@@ -17,24 +17,13 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
         let _ = attemptLogOut()
     }
 
-    func testLogInWithNoEmailNoPassword() throws {
-        trackTest()
-
-        trackStep()
-        EmailLogin.open()
-        EmailLogin.logIn(email: "", password: "")
-        app.assertLabelExists(withText: Text.loginEmailInvalid)
-        app.assertLabelExists(withText: Text.loginPasswordShort)
-    }
-
     func testLogInWithNoEmail() throws {
         trackTest()
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: "", password: testDataPassword)
+        EmailLogin.enterEmailAndAttemptLogin(email: "")
         Assert.labelExists(labelText: Text.loginEmailInvalid)
-        Assert.labelAbsent(labelText: Text.loginPasswordShort)
     }
 
     func testLogInWithInvalidEmail() throws {
@@ -42,7 +31,7 @@ class SimplenoteUISmokeTestsLogin: XCTestCase {
 
         trackStep()
         EmailLogin.open()
-        EmailLogin.logIn(email: testDataInvalidEmail, password: testDataPassword)
+        EmailLogin.enterEmailAndAttemptLogin(email: testDataInvalidEmail)
         Assert.labelExists(labelText: Text.loginEmailInvalid)
         Assert.labelAbsent(labelText: Text.loginPasswordShort)
     }

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -11,6 +11,7 @@ enum UID {
     enum NavBar {
         static let allNotes = "All Notes"
         static let logIn = "Log In"
+        static let logInWithPassword = "Log In with Password"
         static let noteEditorPreview = "Preview"
         static let noteEditorOptions = "Options"
         static let trash = "Trash"

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -26,7 +26,7 @@ enum UID {
         static let menu = "menu"
         static let signUp = "Sign Up"
         static let logIn = "Log In"
-        static let continueWithPassword = "Continue with Password"
+        static let mainAction = "Main Action"
         static let logInWithEmail = "Log in with email"
         static let allNotes = "All Notes"
         static let trash = "Trash"


### PR DESCRIPTION
### Details:
Our new Authentication UX involves a multi staged flow, where Username and Password aren't necessarily entered in the same UI.

In this PR we're updating `SPAuthViewController` as follows:

- `AuthenticationMode` has been enhanced, to support new fields
- `AuthenticationMode` can no longer be modified, which helps us drop several methods
- Implemented `AuthenticationState`, which allows us to pass on the State across different screens
- And finally, new UI elements have been added to the nib itself

**Plus** the Onboarding UI no longer displays a **sheet** when you tap `Log In`.

Ref. #1611

### Test
1. Fresh install Simplenote
2. Press on `Log In`

- [x] Verify that if you enter an invalid email, you get an error
- [x] Verify that if you enter a valid email, the `Log in with email` button turns blue
- [x] Verify that if you press on it, you get into the Password UI
- [x] Verify that pressing `Forgot your Password `opens the PW recovery website
- [x] Verify that if you enter your password, and pres son `Log in`, you get authenticated

### Test: WPCOM SSO
1. Fresh install Simplenote
2. Press on `Log In`
3. Press on `Log in with WordPress.com`

- [x] Verify you can auth with your WPCOM account

### Release
`RELEASE-NOTES.txt` was updated in 05869f28 with
 
> Login UI has been overhauled