### PR TITLE
Login: Auth Code Interface

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -383,6 +383,7 @@
 		B5C2EDD4255ACB4900C09B32 /* InterlinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C2EDD1255ACB4800C09B32 /* InterlinkViewController.swift */; };
 		B5C2EDF0255AFB6C00C09B32 /* PassthruView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C2EDEF255AFB6C00C09B32 /* PassthruView.swift */; };
 		B5C2EDFE255B19D300C09B32 /* NSAttributedString+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C2EDFD255B19D300C09B32 /* NSAttributedString+Simplenote.swift */; };
+		B5C99A512C45B94600728813 /* AuthenticationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C99A502C45B94600728813 /* AuthenticationMode.swift */; };
 		B5C9F71E193E75FE00FD2491 /* SPDebugViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5C9F71C193E75FE00FD2491 /* SPDebugViewController.m */; };
 		B5CBEF4022D3AD92009DBE67 /* MigrationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBEF3F22D3AD92009DBE67 /* MigrationsHandler.swift */; };
 		B5CBEF4222D3B419009DBE67 /* Bundle+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBEF4122D3B419009DBE67 /* Bundle+Simplenote.swift */; };
@@ -1103,6 +1104,7 @@
 		B5C2EDD1255ACB4800C09B32 /* InterlinkViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InterlinkViewController.swift; path = Classes/InterlinkViewController.swift; sourceTree = "<group>"; };
 		B5C2EDEF255AFB6C00C09B32 /* PassthruView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PassthruView.swift; path = Classes/PassthruView.swift; sourceTree = "<group>"; };
 		B5C2EDFD255B19D300C09B32 /* NSAttributedString+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "NSAttributedString+Simplenote.swift"; path = "Classes/NSAttributedString+Simplenote.swift"; sourceTree = "<group>"; };
+		B5C99A502C45B94600728813 /* AuthenticationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationMode.swift; sourceTree = "<group>"; };
 		B5C9F71B193E75FE00FD2491 /* SPDebugViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SPDebugViewController.h; path = Classes/SPDebugViewController.h; sourceTree = "<group>"; };
 		B5C9F71C193E75FE00FD2491 /* SPDebugViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SPDebugViewController.m; path = Classes/SPDebugViewController.m; sourceTree = "<group>"; };
 		B5CA3E0D22B1503700AC0D47 /* RELEASE-NOTES.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "RELEASE-NOTES.txt"; sourceTree = "<group>"; };
@@ -2078,6 +2080,7 @@
 				B56A695622F9CD1500B90398 /* SPOnboardingViewController.xib */,
 				B56A695D22F9D53300B90398 /* SPAuthError.swift */,
 				B56A695C22F9D53300B90398 /* SPAuthHandler.swift */,
+				B5C99A502C45B94600728813 /* AuthenticationMode.swift */,
 				B56A695F22F9D53400B90398 /* SPAuthViewController.swift */,
 				B56A695E22F9D53300B90398 /* SPAuthViewController.xib */,
 				B5AB169722FA124F00B4EBA5 /* SPSheetController.swift */,
@@ -3735,6 +3738,7 @@
 				A6BF0E352567B29B008DE8E0 /* RoundedCrossButton.swift in Sources */,
 				375D24B121E01131007AB25A /* html5_blocks.c in Sources */,
 				B504D4DE23D2014200AEED27 /* IndexPath+Simplenote.swift in Sources */,
+				B5C99A512C45B94600728813 /* AuthenticationMode.swift in Sources */,
 				A6CC0B0725B8287F00F12A85 /* AccountRemote.swift in Sources */,
 				A61471B925D70C190065D849 /* PopoverViewController.swift in Sources */,
 				B536988D25646C9400817E30 /* CGRect+Simplenote.swift in Sources */,

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -1,0 +1,185 @@
+//
+//  AuthenticationMode.swift
+//  Simplenote
+//
+//  Created by Jorge Leandro Perez on 7/15/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - State
+//
+struct AuthenticationState {
+    var username = String()
+    var password = String()
+    var code = String()
+}
+
+struct AuthenticationElements: OptionSet {
+    let rawValue: UInt
+    
+    static let username         = AuthenticationElements(rawValue: 1 << 0)
+    static let password         = AuthenticationElements(rawValue: 1 << 1)
+    static let code             = AuthenticationElements(rawValue: 1 << 2)
+    static let actionSeparator  = AuthenticationElements(rawValue: 1 << 7)
+}
+
+
+// MARK: - Authentication Actions
+//
+enum AuthenticationActionName {
+    case primary
+    case secondary
+    case tertiary
+    case quaternary
+}
+
+struct AuthenticationActionDescriptor {
+    let name: AuthenticationActionName
+    let selector: Selector
+    let text: String?
+    let attributedText: NSAttributedString?
+}
+
+
+// MARK: - AuthenticationMode: Signup / Login
+//
+struct AuthenticationMode {
+    let title: String
+    let validationStyle: AuthenticationValidator.Style
+    let visibleElements: AuthenticationElements
+    let actions: [AuthenticationActionDescriptor]
+}
+
+// MARK: - Default Operation Modes
+//
+extension AuthenticationMode {
+
+    /// Login Operation Mode: Contains all of the strings + delegate wirings, so that the AuthUI handles authentication scenarios.
+    ///
+    static var loginWithPassword: AuthenticationMode {
+        return .init(title: PasswordStrings.title,
+                     validationStyle: .legacy,
+                     visibleElements: [.password],
+                     actions: [
+                        AuthenticationActionDescriptor(name: .primary,
+                                                       selector: #selector(SPAuthViewController.performLogInWithPassword),
+                                                       text: PasswordStrings.login,
+                                                       attributedText: nil),
+                        AuthenticationActionDescriptor(name: .secondary,
+                                                       selector: #selector(SPAuthViewController.presentPasswordReset),
+                                                       text: PasswordStrings.forgotPassword,
+                                                       attributedText: nil)
+                     ])
+    }
+
+    /// Login Operation Mode: Request Login Code
+    ///
+    static var requestLoginCode: AuthenticationMode {
+        return .init(title: RequestCodeStrings.title,
+                     validationStyle: .legacy,
+                     visibleElements: [.username, .actionSeparator],
+                     actions: [
+                        AuthenticationActionDescriptor(name: .primary,
+                                                       selector: #selector(SPAuthViewController.requestLogInCode),
+                                                       text: RequestCodeStrings.loginWithEmail,
+                                                       attributedText: nil),
+                        AuthenticationActionDescriptor(name: .tertiary,
+                                                       selector: #selector(SPAuthViewController.performLogInWithWPCOM),
+                                                       text: RequestCodeStrings.loginWithWPCOM,
+                                                       attributedText: nil),
+                     ])
+    }
+    
+    /// Login Operation Mode: Submit Code + Authenticate the user
+    ///
+    static var loginWithCode: AuthenticationMode {
+        return .init(title: LoginWithCodeStrings.title,
+                     validationStyle: .legacy,
+                     visibleElements: [.code, .actionSeparator],
+                     actions: [
+                        AuthenticationActionDescriptor(name: .primary,
+                                                       selector: #selector(SPAuthViewController.performLogInWithCode),
+                                                       text: LoginWithCodeStrings.login,
+                                                       attributedText: nil),
+                        AuthenticationActionDescriptor(name: .quaternary,
+                                                       selector: #selector(SPAuthViewController.presentPasswordInterface),
+                                                       text: LoginWithCodeStrings.enterPassword,
+                                                       attributedText: nil),
+                     ])
+    }
+
+    /// Signup Operation Mode: Contains all of the strings + delegate wirings, so that the AuthUI handles user account creation scenarios.
+    ///
+    static var signup: AuthenticationMode {
+        return .init(title: SignupStrings.title,
+                     validationStyle: .strong,
+                     visibleElements: [.username],
+                     actions: [
+                        AuthenticationActionDescriptor(name: .primary,
+                                                       selector: #selector(SPAuthViewController.performSignUp),
+                                                       text: SignupStrings.signup,
+                                                       attributedText: nil),
+                        AuthenticationActionDescriptor(name: .secondary,
+                                                       selector: #selector(SPAuthViewController.presentTermsOfService),
+                                                       text: nil,
+                                                       attributedText: SignupStrings.termsOfService)
+                     ])
+    }
+}
+
+
+// MARK: - Mode: .loginWithPassword
+//
+private enum PasswordStrings {
+    static let title            = NSLocalizedString("Log In with Password", comment: "LogIn Interface Title")
+    static let login            = NSLocalizedString("Log In", comment: "LogIn Action")
+    static let forgotPassword   = NSLocalizedString("Forgot your password?", comment: "Password Reset Action")
+}
+
+
+// MARK: - Mode: .requestLoginCode
+//
+private enum RequestCodeStrings {
+    static let title            = NSLocalizedString("Log In", comment: "LogIn Interface Title")
+    static let loginWithEmail   = NSLocalizedString("Log in with email", comment: "Sends the User an email with an Authentication Code")
+    static let loginWithWPCOM   = NSLocalizedString("Log in with WordPress.com", comment: "Password fallback Action")
+}
+
+
+// MARK: - Mode: .code
+//
+private enum LoginWithCodeStrings {
+    static let title            = NSLocalizedString("Enter Code", comment: "LogIn Interface Title")
+    static let login            = NSLocalizedString("Log In", comment: "LogIn Interface Title")
+    static let enterPassword    = NSLocalizedString("Enter password", comment: "Enter Password fallback Action")
+}
+
+
+// MARK: - Mode: .signup
+//
+private enum SignupStrings {
+    static let title                = NSLocalizedString("Sign Up", comment: "SignUp Interface Title")
+    static let signup               = NSLocalizedString("Sign Up", comment: "SignUp Action")
+    static let termsOfServicePrefix = NSLocalizedString("By creating an account you agree to our", comment: "Terms of Service Legend *PREFIX*: printed in dark color")
+    static let termsOfServiceSuffix = NSLocalizedString("Terms and Conditions", comment: "Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue")
+}
+
+private extension SignupStrings {
+
+    /// Returns a properly formatted Secondary Action String for Signup
+    ///
+    static var termsOfService: NSAttributedString {
+        let output = NSMutableAttributedString(string: String(), attributes: [
+            .font: UIFont.preferredFont(forTextStyle: .subheadline)
+        ])
+
+        output.append(string: termsOfServicePrefix, foregroundColor: .simplenoteGray60Color)
+        output.append(string: " ")
+        output.append(string: termsOfServiceSuffix, foregroundColor: .simplenoteBlue60Color)
+
+        return output
+    }
+}

--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -1,11 +1,3 @@
-//
-//  AuthenticationMode.swift
-//  Simplenote
-//
-//  Created by Jorge Leandro Perez on 7/15/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
-
 import Foundation
 
 

--- a/Simplenote/AuthenticationValidator.swift
+++ b/Simplenote/AuthenticationValidator.swift
@@ -11,6 +11,10 @@ struct AuthenticationValidator {
     /// Minimum Password Length: SignUp
     ///
     private let strongPasswordLength = UInt(8)
+    
+    /// Login Code Length
+    ///
+    private let loginCodeLength = UInt(6)
 
     /// Returns the Validation Result for a given Username
     ///
@@ -48,6 +52,14 @@ struct AuthenticationValidator {
     private func minimumPasswordLength(for style: Style) -> UInt {
         return (style == .legacy) ? legacyPasswordLength : strongPasswordLength
     }
+    
+    func performCodeValidation(code: String) -> Result {
+        if code.count >= loginCodeLength {
+            return .success
+        }
+        
+        return .codeTooShort
+    }
 }
 
 // MARK: - Nested Types
@@ -65,6 +77,7 @@ extension AuthenticationValidator {
         case passwordMatchesUsername
         case passwordTooShort(length: UInt)
         case passwordContainsInvalidCharacter
+        case codeTooShort
     }
 }
 
@@ -91,6 +104,8 @@ extension AuthenticationValidator.Result: CustomStringConvertible {
         case .passwordContainsInvalidCharacter:
             return NSLocalizedString("Password must not contain tabs nor newlines", comment: "Message displayed when a password contains a disallowed character")
 
+        case .codeTooShort:
+            return NSLocalizedString("Login Code is too short", comment: "Message displayed when a login code is too short")
         }
     }
 }

--- a/Simplenote/Classes/SPAuthHandler.swift
+++ b/Simplenote/Classes/SPAuthHandler.swift
@@ -53,7 +53,7 @@ class SPAuthHandler {
         })
     }
 
-    /// Requests an Authentication Magic Link
+    /// Requests an Authentication Email
     ///
     func requestLoginEmail(username: String, onCompletion: @escaping (SPAuthError?) -> Void) {
         let remote = LoginRemote()
@@ -64,6 +64,20 @@ class SPAuthHandler {
             case .failure(let error):
                 onCompletion(self.authenticationError(for: error))
             }
+        }
+    }
+
+    /// Performs LogIn the User with an Authentication Code
+    ///
+    @MainActor
+    func loginWithCode(username: String, code: String) async throws {
+        let remote = LoginRemote()
+        do {
+            let confirmation = try await remote.requestLoginConfirmation(email: username, authCode: code.uppercased())
+            simperiumService.authenticate(withUsername: confirmation.username, token: confirmation.syncToken)
+            
+        } catch let error as RemoteError {
+            throw authenticationError(for: error)
         }
     }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -434,24 +434,19 @@ private extension SPAuthViewController {
     
     @IBAction func performLogInWithCode() {
         Task { @MainActor in
-            await performLogInWithCodeInTask()
-        }
-    }
-    
-    @MainActor
-    private func performLogInWithCodeInTask() async {
-        lockdownInterface()
-        
-        do {
-            try await controller.loginWithCode(username: state.username, code: state.code)
-            SPTracker.trackUserConfirmedLoginLink()
-        } catch let error as SPAuthError {
-            self.handleError(error: error)
-        } catch {
+            lockdownInterface()
+            
+            do {
+                try await controller.loginWithCode(username: state.username, code: state.code)
+                SPTracker.trackUserConfirmedLoginLink()
+            } catch let error as SPAuthError {
+                self.handleError(error: error)
+            } catch {
 // TODO: Fixme
+            }
+            
+            unlockInterface()
         }
-        
-        unlockInterface()
     }
     
     @IBAction func performLogInWithWPCOM() {

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -122,27 +122,15 @@ class SPAuthViewController: UIViewController {
         return button
     }()
 
-    /// # Tertiary Separator: COntainer
+    /// # Actions Separator: Container
     ///
-    @IBOutlet private var tertiaryTopSeparator: UIView! {
-        didSet {
-            tertiaryTopSeparator.isHidden = mode.tertiaryActionSelector == nil
-        }
-    }
+    @IBOutlet private var actionsSeparator: UIView!
 
     /// # Tertiary Separator: Label (Or)
     ///
-    @IBOutlet private var tertiaryTopSeparatorLabel: UILabel! {
+    @IBOutlet private var actionsSeparatorLabel: UILabel! {
         didSet {
-            tertiaryTopSeparatorLabel.text = AuthenticationStrings.separatorText
-        }
-    }
-    
-    /// # Tertiary Action: Container View
-    ///
-    @IBOutlet private var tertiaryActionContainerView: UIView! {
-        didSet {
-            tertiaryActionContainerView.isHidden = mode.tertiaryActionSelector == nil
+            actionsSeparatorLabel.text = AuthenticationStrings.separatorText
         }
     }
 
@@ -150,15 +138,34 @@ class SPAuthViewController: UIViewController {
     ///
     @IBOutlet private var tertiaryActionButton: SPSquaredButton! {
         didSet {
-            guard let title = mode.tertiaryActionText, let action = mode.tertiaryActionSelector else {
-                return
-            }
-            
-            tertiaryActionButton.setTitle(title, for: .normal)
             tertiaryActionButton.setTitleColor(.white, for: .normal)
             tertiaryActionButton.backgroundColor = .simplenoteWPBlue50Color
-            tertiaryActionButton.addTarget(self, action: action, for: .touchUpInside)
         }
+    }
+    
+    /// # Tertiary Action:
+    ///
+    @IBOutlet private var quaternaryActionButton: SPSquaredButton! {
+        didSet {
+            quaternaryActionButton.setTitleColor(.black, for: .normal)
+            quaternaryActionButton.backgroundColor = .clear
+            quaternaryActionButton.layer.borderWidth = 1
+            quaternaryActionButton.layer.borderColor = UIColor.black.cgColor
+        }
+    }
+
+    /// # Tertiary Action: WPCOM SSO
+    ///
+    private var visibleInputViews: [SPTextInputView] {
+        [emailInputView, passwordInputView, codeInputView].filter { inputView in
+            inputView.isHidden == false
+        }
+    }
+    
+    /// # All of the Action Views
+    ///
+    private var allActionViews: [UIButton] {
+        [primaryActionButton, secondaryActionButton, tertiaryActionButton, quaternaryActionButton]
     }
 
     /// # Simperium's Authenticator Instance

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -386,10 +386,10 @@ extension SPAuthViewController {
     /// Whenever the input is Valid, we'll perform the Primary Action
     ///
     func performPrimaryActionIfPossible() {
-        guard isInputValid else {
+        guard ensureWarningsAreOnScreenWhenNeeded() else {
             return
         }
-        
+
         guard let primaryActionDescriptor = mode.actions.first(where: { $0.name == .primary}) else {
             assertionFailure()
             return
@@ -433,6 +433,10 @@ extension SPAuthViewController {
     }
     
     @IBAction func performLogInWithCode() {
+        guard ensureWarningsAreOnScreenWhenNeeded() else {
+            return
+        }
+
         Task { @MainActor in
             lockdownInterface()
             
@@ -803,42 +807,7 @@ extension SPAuthViewController: SPTextInputViewDelegate {
     }
 
     func textInputShouldReturn(_ textInput: SPTextInputView) -> Bool {
-        switch textInput {
-        case emailInputView:
-            switch performUsernameValidation() {
-            case .success:
-                if mode.inputElements.contains(.password) {
-                    passwordInputView.becomeFirstResponder()
-                } else {
-                    performPrimaryActionIfPossible()
-                }
-
-            case let error:
-                displayEmailValidationWarning(error.description)
-            }
-
-        case passwordInputView:
-            switch performPasswordValidation() {
-            case .success:
-                performPrimaryActionIfPossible()
-
-            case let error:
-                displayPasswordValidationWarning(error.description)
-            }
-
-        case codeInputView:
-            switch performCodeValidation() {
-            case .success:
-                performPrimaryActionIfPossible()
-                
-            case let error:
-                displayCodeValidationWarning(error.description)
-            }
-            
-        default:
-            break
-        }
-
+        performPrimaryActionIfPossible()
         return false
     }
 }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -65,6 +65,19 @@ class SPAuthViewController: UIViewController {
             passwordWarningLabel.isHidden = true
         }
     }
+    
+    /// # Password: Input Field
+    ///
+    @IBOutlet private var codeInputView: SPTextInputView! {
+        didSet {
+            codeInputView.placeholder = AuthenticationStrings.codePlaceholder
+            codeInputView.passwordRules = UITextInputPasswordRules(descriptor: SimplenoteConstants.passwordRules)
+            codeInputView.returnKeyType = .done
+            codeInputView.textColor = .simplenoteGray80Color
+            codeInputView.delegate = self
+            codeInputView.textContentType = .oneTimeCode
+        }
+    }
 
     /// # Primary Action: LogIn / SignUp
     ///

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -247,7 +247,7 @@ class SPAuthViewController: UIViewController {
         setupNavigationController()
         startListeningToNotifications()
 
-        refreshVisibleElements()
+        refreshInputViews()
         refreshActionViews()
         reloadInputViewsFromState()
 
@@ -303,13 +303,13 @@ private extension SPAuthViewController {
         navigationController?.setNavigationBarHidden(false, animated: true)
     }
 
-    func refreshVisibleElements() {
-        let visibleElements = mode.visibleElements
+    func refreshInputViews() {
+        let inputElements = mode.inputElements
         
-        emailInputView.isHidden         = !visibleElements.contains(.username)
-        passwordInputView.isHidden      = !visibleElements.contains(.password)
-        codeInputView.isHidden          = !visibleElements.contains(.code)
-        actionsSeparator.isHidden       = !visibleElements.contains(.actionSeparator)
+        emailInputView.isHidden     = !inputElements.contains(.username)
+        passwordInputView.isHidden  = !inputElements.contains(.password)
+        codeInputView.isHidden      = !inputElements.contains(.code)
+        actionsSeparator.isHidden   = !inputElements.contains(.actionSeparator)
     }
     
     func refreshActionViews() {
@@ -716,7 +716,7 @@ private extension SPAuthViewController {
 private extension SPAuthViewController {
 
     func performUsernameValidation() -> AuthenticationValidator.Result {
-        guard mode.visibleElements.contains(.username) else {
+        guard mode.inputElements.contains(.username) else {
             return .success
         }
 
@@ -727,7 +727,7 @@ private extension SPAuthViewController {
     /// That's where the `validationStyle` comes in.
     ///
     func performPasswordValidation() -> AuthenticationValidator.Result {
-        guard mode.visibleElements.contains(.password) else {
+        guard mode.inputElements.contains(.password) else {
             return .success
         }
 
@@ -735,7 +735,7 @@ private extension SPAuthViewController {
     }
     
     func performCodeValidation() -> AuthenticationValidator.Result {
-        guard mode.visibleElements.contains(.code) else {
+        guard mode.inputElements.contains(.code) else {
             return .success
         }
         
@@ -807,7 +807,7 @@ extension SPAuthViewController: SPTextInputViewDelegate {
         case emailInputView:
             switch performUsernameValidation() {
             case .success:
-                if mode.visibleElements.contains(.password) {
+                if mode.inputElements.contains(.password) {
                     passwordInputView.becomeFirstResponder()
                 } else {
                     performPrimaryActionIfPossible()

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -230,7 +230,7 @@ class SPAuthViewController: UIViewController {
 
     /// Designated Initializer
     ///
-    init(controller: SPAuthHandler, mode: AuthenticationMode = .loginWithMagicLink, state: AuthenticationState = .init()) {
+    init(controller: SPAuthHandler, mode: AuthenticationMode = .requestLoginCode, state: AuthenticationState = .init()) {
         self.controller = controller
         self.mode = mode
         self.state = state

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -466,6 +466,11 @@ private extension SPAuthViewController {
         safariViewController.modalPresentationStyle = .overFullScreen
         present(safariViewController, animated: true, completion: nil)
     }
+    
+    @IBAction func presentPasswordInterface() {
+        let viewController = SPAuthViewController(controller: controller, mode: .loginWithPassword, state: state)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
 }
 
 
@@ -478,9 +483,9 @@ private extension SPAuthViewController {
         viewController.title = title
         navigationController?.pushViewController(viewController, animated: true)
     }
-    
-    func presentPasswordInterface() {
-        let viewController = SPAuthViewController(controller: controller, mode: .loginWithPassword, state: state)
+        
+    func presentCodeInterface() {
+        let viewController = SPAuthViewController(controller: controller, mode: .loginWithCode, state: state)
         navigationController?.pushViewController(viewController, animated: true)
     }
 }
@@ -741,6 +746,8 @@ extension SPAuthViewController: SPTextInputViewDelegate {
             state.username = textInput.text ?? ""
         case passwordInputView:
             state.password = textInput.text ?? ""
+        case codeInputView:
+            state.code = textInput.text ?? ""
         default:
             break
         }
@@ -751,10 +758,10 @@ extension SPAuthViewController: SPTextInputViewDelegate {
         case emailInputView:
             switch performUsernameValidation() {
             case .success:
-                if mode.isPasswordHidden {
-                    performPrimaryActionIfPossible()
-                } else {
+                if mode.visibleElements.contains(.password) {
                     passwordInputView.becomeFirstResponder()
+                } else {
+                    performPrimaryActionIfPossible()
                 }
 
             case let error:

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -672,7 +672,7 @@ private extension SPAuthViewController {
 private extension SPAuthViewController {
 
     func performUsernameValidation() -> AuthenticationValidator.Result {
-        if mode.isUsernameHidden {
+        guard mode.visibleElements.contains(.username) else {
             return .success
         }
 
@@ -683,7 +683,7 @@ private extension SPAuthViewController {
     /// That's where the `validationStyle` comes in.
     ///
     func performPasswordValidation() -> AuthenticationValidator.Result {
-        if mode.isPasswordHidden {
+        guard mode.visibleElements.contains(.password) else {
             return .success
         }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -686,11 +686,6 @@ private extension SPAuthViewController {
         codeWarningLabel.text = string
         refreshCodeInput(inErrorState: true)
     }
-
-    func dismissAllValidationWarnings() {
-        refreshEmailInput(inErrorState: false)
-        refreshPasswordInput(inErrorState: false)
-    }
     
     func dismissEmailValidationWarning() {
         refreshEmailInput(inErrorState: false)
@@ -870,6 +865,9 @@ struct AuthenticationElements: OptionSet {
     static let actionSeparator  = AuthenticationElements(rawValue: 1 << 7)
 }
 
+
+// MARK: - Authentication Actions
+//
 enum AuthenticationActionName {
     case primary
     case secondary
@@ -877,13 +875,12 @@ enum AuthenticationActionName {
     case quaternary
 }
 
-struct AuthenticationAction {
+struct AuthenticationActionDescriptor {
     let name: AuthenticationActionName
     let selector: Selector
     let text: String?
     let attributedText: NSAttributedString?
 }
-
 
 
 // MARK: - AuthenticationMode: Signup / Login
@@ -892,7 +889,7 @@ struct AuthenticationMode {
     let title: String
     let validationStyle: AuthenticationValidator.Style
     let visibleElements: AuthenticationElements
-    let actions: [AuthenticationAction]
+    let actions: [AuthenticationActionDescriptor]
 }
 
 // MARK: - Default Operation Modes
@@ -906,14 +903,14 @@ extension AuthenticationMode {
                      validationStyle: .legacy,
                      visibleElements: [.password],
                      actions: [
-                        AuthenticationAction(name: .primary,
-                                             selector: #selector(SPAuthViewController.performLogInWithPassword),
-                                             text: PasswordStrings.login,
-                                             attributedText: nil),
-                        AuthenticationAction(name: .secondary,
-                                             selector: #selector(SPAuthViewController.presentPasswordReset),
-                                             text: PasswordStrings.forgotPassword,
-                                             attributedText: nil)
+                        AuthenticationActionDescriptor(name: .primary,
+                                                       selector: #selector(SPAuthViewController.performLogInWithPassword),
+                                                       text: PasswordStrings.login,
+                                                       attributedText: nil),
+                        AuthenticationActionDescriptor(name: .secondary,
+                                                       selector: #selector(SPAuthViewController.presentPasswordReset),
+                                                       text: PasswordStrings.forgotPassword,
+                                                       attributedText: nil)
                      ])
     }
 
@@ -924,14 +921,14 @@ extension AuthenticationMode {
                      validationStyle: .legacy,
                      visibleElements: [.username, .actionSeparator],
                      actions: [
-                        AuthenticationAction(name: .primary,
-                                            selector: #selector(SPAuthViewController.requestLogInCode),
-                                            text: RequestCodeStrings.loginWithEmail,
-                                            attributedText: nil),
-                        AuthenticationAction(name: .tertiary,
-                                            selector: #selector(SPAuthViewController.performLogInWithWPCOM),
-                                            text: RequestCodeStrings.loginWithWPCOM,
-                                            attributedText: nil),
+                        AuthenticationActionDescriptor(name: .primary,
+                                                       selector: #selector(SPAuthViewController.requestLogInCode),
+                                                       text: RequestCodeStrings.loginWithEmail,
+                                                       attributedText: nil),
+                        AuthenticationActionDescriptor(name: .tertiary,
+                                                       selector: #selector(SPAuthViewController.performLogInWithWPCOM),
+                                                       text: RequestCodeStrings.loginWithWPCOM,
+                                                       attributedText: nil),
                      ])
     }
     
@@ -942,14 +939,14 @@ extension AuthenticationMode {
                      validationStyle: .legacy,
                      visibleElements: [.code, .actionSeparator],
                      actions: [
-                        AuthenticationAction(name: .primary,
-                                            selector: #selector(SPAuthViewController.performLogInWithCode),
-                                            text: LoginWithCodeStrings.login,
-                                            attributedText: nil),
-                        AuthenticationAction(name: .quaternary,
-                                            selector: #selector(SPAuthViewController.presentPasswordInterface),
-                                            text: LoginWithCodeStrings.enterPassword,
-                                            attributedText: nil),
+                        AuthenticationActionDescriptor(name: .primary,
+                                                       selector: #selector(SPAuthViewController.performLogInWithCode),
+                                                       text: LoginWithCodeStrings.login,
+                                                       attributedText: nil),
+                        AuthenticationActionDescriptor(name: .quaternary,
+                                                       selector: #selector(SPAuthViewController.presentPasswordInterface),
+                                                       text: LoginWithCodeStrings.enterPassword,
+                                                       attributedText: nil),
                      ])
     }
 
@@ -960,14 +957,14 @@ extension AuthenticationMode {
                      validationStyle: .strong,
                      visibleElements: [.username],
                      actions: [
-                        AuthenticationAction(name: .primary,
-                                            selector: #selector(SPAuthViewController.performSignUp),
-                                            text: SignupStrings.signup,
-                                            attributedText: nil),
-                        AuthenticationAction(name: .secondary,
-                                            selector: #selector(SPAuthViewController.presentTermsOfService),
-                                            text: nil,
-                                            attributedText: SignupStrings.termsOfService)
+                        AuthenticationActionDescriptor(name: .primary,
+                                                       selector: #selector(SPAuthViewController.performSignUp),
+                                                       text: SignupStrings.signup,
+                                                       attributedText: nil),
+                        AuthenticationActionDescriptor(name: .secondary,
+                                                       selector: #selector(SPAuthViewController.presentTermsOfService),
+                                                       text: nil,
+                                                       attributedText: SignupStrings.termsOfService)
                      ])
     }
 }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -154,7 +154,7 @@ class SPAuthViewController: UIViewController {
         }
     }
 
-    /// # Tertiary Action: WPCOM SSO
+    /// # All of the Visible InputView(s)
     ///
     private var visibleInputViews: [SPTextInputView] {
         [emailInputView, passwordInputView, codeInputView].filter { inputView in

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -387,8 +387,13 @@ private extension SPAuthViewController {
         guard isInputValid else {
             return
         }
+        
+        guard let primaryActionDescriptor = mode.actions.first(where: { $0.name == .primary}) else {
+            assertionFailure()
+            return
+        }
 
-        perform(mode.primaryActionSelector)
+        perform(primaryActionDescriptor.selector)
     }
     
     @IBAction func performLogInWithPassword() {

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -381,7 +381,7 @@ private extension SPAuthViewController {
 
 // MARK: - Actions
 //
-private extension SPAuthViewController {
+extension SPAuthViewController {
 
     /// Whenever the input is Valid, we'll perform the Primary Action
     ///
@@ -425,7 +425,7 @@ private extension SPAuthViewController {
                 self.handleError(error: error)
             } else {
                 self.presentCodeInterface()
-                SPTracker.trackUserRequestedLoginLink()
+                SPTracker.trackLoginLinkRequested()
             }
 
             self.unlockInterface()
@@ -438,8 +438,9 @@ private extension SPAuthViewController {
             
             do {
                 try await controller.loginWithCode(username: state.username, code: state.code)
-                SPTracker.trackUserConfirmedLoginLink()
+                SPTracker.trackLoginLinkConfirmationSuccess()
             } catch let error as SPAuthError {
+                SPTracker.trackLoginLinkConfirmationFailure()
                 self.handleError(error: error)
             } catch {
 // TODO: Fixme
@@ -843,128 +844,6 @@ extension SPAuthViewController: SPTextInputViewDelegate {
 }
 
 
-// MARK: - State
-//
-struct AuthenticationState {
-    var username = String()
-    var password = String()
-    var code = String()
-}
-
-struct AuthenticationElements: OptionSet {
-    let rawValue: UInt
-    
-    static let username         = AuthenticationElements(rawValue: 1 << 0)
-    static let password         = AuthenticationElements(rawValue: 1 << 1)
-    static let code             = AuthenticationElements(rawValue: 1 << 2)
-    static let actionSeparator  = AuthenticationElements(rawValue: 1 << 7)
-}
-
-
-// MARK: - Authentication Actions
-//
-enum AuthenticationActionName {
-    case primary
-    case secondary
-    case tertiary
-    case quaternary
-}
-
-struct AuthenticationActionDescriptor {
-    let name: AuthenticationActionName
-    let selector: Selector
-    let text: String?
-    let attributedText: NSAttributedString?
-}
-
-
-// MARK: - AuthenticationMode: Signup / Login
-//
-struct AuthenticationMode {
-    let title: String
-    let validationStyle: AuthenticationValidator.Style
-    let visibleElements: AuthenticationElements
-    let actions: [AuthenticationActionDescriptor]
-}
-
-// MARK: - Default Operation Modes
-//
-extension AuthenticationMode {
-
-    /// Login Operation Mode: Contains all of the strings + delegate wirings, so that the AuthUI handles authentication scenarios.
-    ///
-    static var loginWithPassword: AuthenticationMode {
-        return .init(title: PasswordStrings.title,
-                     validationStyle: .legacy,
-                     visibleElements: [.password],
-                     actions: [
-                        AuthenticationActionDescriptor(name: .primary,
-                                                       selector: #selector(SPAuthViewController.performLogInWithPassword),
-                                                       text: PasswordStrings.login,
-                                                       attributedText: nil),
-                        AuthenticationActionDescriptor(name: .secondary,
-                                                       selector: #selector(SPAuthViewController.presentPasswordReset),
-                                                       text: PasswordStrings.forgotPassword,
-                                                       attributedText: nil)
-                     ])
-    }
-
-    /// Login Operation Mode: Request Login Code
-    ///
-    static var requestLoginCode: AuthenticationMode {
-        return .init(title: RequestCodeStrings.title,
-                     validationStyle: .legacy,
-                     visibleElements: [.username, .actionSeparator],
-                     actions: [
-                        AuthenticationActionDescriptor(name: .primary,
-                                                       selector: #selector(SPAuthViewController.requestLogInCode),
-                                                       text: RequestCodeStrings.loginWithEmail,
-                                                       attributedText: nil),
-                        AuthenticationActionDescriptor(name: .tertiary,
-                                                       selector: #selector(SPAuthViewController.performLogInWithWPCOM),
-                                                       text: RequestCodeStrings.loginWithWPCOM,
-                                                       attributedText: nil),
-                     ])
-    }
-    
-    /// Login Operation Mode: Submit Code + Authenticate the user
-    ///
-    static var loginWithCode: AuthenticationMode {
-        return .init(title: LoginWithCodeStrings.title,
-                     validationStyle: .legacy,
-                     visibleElements: [.code, .actionSeparator],
-                     actions: [
-                        AuthenticationActionDescriptor(name: .primary,
-                                                       selector: #selector(SPAuthViewController.performLogInWithCode),
-                                                       text: LoginWithCodeStrings.login,
-                                                       attributedText: nil),
-                        AuthenticationActionDescriptor(name: .quaternary,
-                                                       selector: #selector(SPAuthViewController.presentPasswordInterface),
-                                                       text: LoginWithCodeStrings.enterPassword,
-                                                       attributedText: nil),
-                     ])
-    }
-
-    /// Signup Operation Mode: Contains all of the strings + delegate wirings, so that the AuthUI handles user account creation scenarios.
-    ///
-    static var signup: AuthenticationMode {
-        return .init(title: SignupStrings.title,
-                     validationStyle: .strong,
-                     visibleElements: [.username],
-                     actions: [
-                        AuthenticationActionDescriptor(name: .primary,
-                                                       selector: #selector(SPAuthViewController.performSignUp),
-                                                       text: SignupStrings.signup,
-                                                       attributedText: nil),
-                        AuthenticationActionDescriptor(name: .secondary,
-                                                       selector: #selector(SPAuthViewController.presentTermsOfService),
-                                                       text: nil,
-                                                       attributedText: SignupStrings.termsOfService)
-                     ])
-    }
-}
-
-
 // MARK: - Authentication Strings
 //
 private enum AuthenticationStrings {
@@ -985,6 +864,7 @@ private enum AuthenticationStrings {
     static let verificationSentTemplate     = NSLocalizedString("We’ve sent a verification email to %1$@. Please check your inbox and follow the instructions.", comment: "Confirmation that an email has been sent")
 }
 
+
 // MARK: - PasswordInsecure Alert Strings
 //
 private enum PasswordInsecureString {
@@ -1000,59 +880,6 @@ private enum PasswordInsecureString {
     ].joined(separator: .newline)
 }
 
-
-// MARK: - Mode: .loginWithPassword
-//
-private enum PasswordStrings {
-    static let title            = NSLocalizedString("Log In with Password", comment: "LogIn Interface Title")
-    static let login            = NSLocalizedString("Log In", comment: "LogIn Action")
-    static let forgotPassword   = NSLocalizedString("Forgot your password?", comment: "Password Reset Action")
-}
-
-
-// MARK: - Mode: .requestLoginCode
-//
-private enum RequestCodeStrings {
-    static let title            = NSLocalizedString("Log In", comment: "LogIn Interface Title")
-    static let loginWithEmail   = NSLocalizedString("Log in with email", comment: "Sends the User an email with an Authentication Code")
-    static let loginWithWPCOM   = NSLocalizedString("Log in with WordPress.com", comment: "Password fallback Action")
-}
-
-
-// MARK: - Mode: .code
-//
-private enum LoginWithCodeStrings {
-    static let title            = NSLocalizedString("Enter Code", comment: "LogIn Interface Title")
-    static let login            = NSLocalizedString("Log In", comment: "LogIn Interface Title")
-    static let enterPassword    = NSLocalizedString("Enter password", comment: "Enter Password fallback Action")
-}
-
-
-// MARK: - Mode: .signup
-//
-private enum SignupStrings {
-    static let title                = NSLocalizedString("Sign Up", comment: "SignUp Interface Title")
-    static let signup               = NSLocalizedString("Sign Up", comment: "SignUp Action")
-    static let termsOfServicePrefix = NSLocalizedString("By creating an account you agree to our", comment: "Terms of Service Legend *PREFIX*: printed in dark color")
-    static let termsOfServiceSuffix = NSLocalizedString("Terms and Conditions", comment: "Terms of Service Legend *SUFFIX*: Concatenated with a space, after the PREFIX, and printed in blue")
-}
-
-private extension SignupStrings {
-
-    /// Returns a properly formatted Secondary Action String for Signup
-    ///
-    static var termsOfService: NSAttributedString {
-        let output = NSMutableAttributedString(string: String(), attributes: [
-            .font: UIFont.preferredFont(forTextStyle: .subheadline)
-        ])
-
-        output.append(string: termsOfServicePrefix, foregroundColor: .simplenoteGray60Color)
-        output.append(string: " ")
-        output.append(string: termsOfServiceSuffix, foregroundColor: .simplenoteBlue60Color)
-
-        return output
-    }
-}
 
 // MARK: - Authentication Constants
 //

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -258,8 +258,7 @@ class SPAuthViewController: UIViewController {
         // repositioning in the Text Field. Seriously.
         // Ref. https://github.com/Automattic/simplenote-ios/issues/453
         //
-        let initialFirstResponder = mode.isPasswordHidden ? emailInputView : passwordInputView
-        initialFirstResponder?.becomeFirstResponder()
+        visibleInputViews.first?.becomeFirstResponder()
     }
 }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -83,9 +83,7 @@ class SPAuthViewController: UIViewController {
     ///
     @IBOutlet private var primaryActionButton: SPSquaredButton! {
         didSet {
-            primaryActionButton.setTitle(mode.primaryActionText, for: .normal)
             primaryActionButton.setTitleColor(.white, for: .normal)
-            primaryActionButton.addTarget(self, action: mode.primaryActionSelector, for: .touchUpInside)
             primaryActionButton.accessibilityIdentifier = "Main Action"
         }
     }
@@ -103,21 +101,9 @@ class SPAuthViewController: UIViewController {
     ///
     @IBOutlet private var secondaryActionButton: UIButton! {
         didSet {
-            if let title = mode.secondaryActionText {
-                secondaryActionButton.setTitle(title, for: .normal)
-                secondaryActionButton.setTitleColor(.simplenoteBlue60Color, for: .normal)
-            }
-
-            if let attributedTitle = mode.secondaryActionAttributedText {
-                secondaryActionButton.setAttributedTitle(attributedTitle, for: .normal)
-            }
-
+            secondaryActionButton.setTitleColor(.simplenoteBlue60Color, for: .normal)
             secondaryActionButton.titleLabel?.textAlignment = .center
             secondaryActionButton.titleLabel?.numberOfLines = 0
-            
-            if let action = mode.secondaryActionSelector {
-                secondaryActionButton.addTarget(self, action: action, for: .touchUpInside)
-            }
         }
     }
 

--- a/Simplenote/Classes/SPAuthViewController.xib
+++ b/Simplenote/Classes/SPAuthViewController.xib
@@ -14,6 +14,7 @@
                 <outlet property="actionsSeparator" destination="Kpm-3a-0Z7" id="1in-6f-hpi"/>
                 <outlet property="actionsSeparatorLabel" destination="223-DD-dLN" id="GpO-BP-sli"/>
                 <outlet property="codeInputView" destination="OP1-hm-GRS" id="2HQ-Db-x3W"/>
+                <outlet property="codeWarningLabel" destination="Jbg-WU-heV" id="Qjt-NJ-s8f"/>
                 <outlet property="emailInputView" destination="hW6-K1-OyV" id="TyC-Uh-Kaf"/>
                 <outlet property="emailWarningLabel" destination="n7T-Gj-plH" id="STx-wz-jKg"/>
                 <outlet property="passwordInputView" destination="pdF-nK-gXE" id="18P-SU-c90"/>
@@ -34,7 +35,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CJS-5O-pxK">
-                    <rect key="frame" x="332" y="60" width="360" height="460"/>
+                    <rect key="frame" x="332" y="60" width="360" height="486"/>
                     <subviews>
                         <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-K1-OyV" userLabel="Email Input View" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -78,8 +79,14 @@
                                 <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="#Password#"/>
                             </userDefinedRuntimeAttributes>
                         </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#Invalid code#" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jbg-WU-heV" userLabel="#Invalid code#" customClass="SPLabel" customModule="Simplenote" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="208" width="100.5" height="18"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                            <color key="textColor" systemColor="systemRedColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CGr-O3-MBQ" userLabel="Primary Action View">
-                            <rect key="frame" x="0.0" y="208" width="360" height="44"/>
+                            <rect key="frame" x="0.0" y="234" width="360" height="44"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3p-Ji-dOm" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -102,7 +109,7 @@
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
-                            <rect key="frame" x="0.0" y="260" width="360" height="44"/>
+                            <rect key="frame" x="0.0" y="286" width="360" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="u8s-d9-Em4"/>
                             </constraints>
@@ -112,7 +119,7 @@
                             </state>
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kpm-3a-0Z7" userLabel="Actions Separator View">
-                            <rect key="frame" x="0.0" y="312" width="360" height="44"/>
+                            <rect key="frame" x="0.0" y="338" width="360" height="44"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Ls-SS-l0Q" userLabel="Leading View">
                                     <rect key="frame" x="0.0" y="21.5" width="167" height="1"/>
@@ -149,7 +156,7 @@
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uy8-va-3uF" userLabel="#Tertiary#" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="364" width="360" height="44"/>
+                            <rect key="frame" x="0.0" y="390" width="360" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="lt7-Yn-pzG"/>
                             </constraints>
@@ -159,7 +166,7 @@
                             </state>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ILr-Ij-XBq" userLabel="#Quaternary#" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="416" width="360" height="44"/>
+                            <rect key="frame" x="0.0" y="442" width="360" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="cE4-3n-khh"/>
                             </constraints>
@@ -202,6 +209,9 @@
     <designables>
         <designable name="ILr-Ij-XBq">
             <size key="intrinsicContentSize" width="112" height="33"/>
+        </designable>
+        <designable name="Jbg-WU-heV">
+            <size key="intrinsicContentSize" width="100.5" height="18"/>
         </designable>
         <designable name="Uy8-va-3uF">
             <size key="intrinsicContentSize" width="83" height="33"/>

--- a/Simplenote/Classes/SPAuthViewController.xib
+++ b/Simplenote/Classes/SPAuthViewController.xib
@@ -11,19 +11,20 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SPAuthViewController" customModule="Simplenote" customModuleProvider="target">
             <connections>
+                <outlet property="actionsSeparator" destination="Kpm-3a-0Z7" id="1in-6f-hpi"/>
+                <outlet property="actionsSeparatorLabel" destination="223-DD-dLN" id="GpO-BP-sli"/>
+                <outlet property="codeInputView" destination="OP1-hm-GRS" id="2HQ-Db-x3W"/>
                 <outlet property="emailInputView" destination="hW6-K1-OyV" id="TyC-Uh-Kaf"/>
                 <outlet property="emailWarningLabel" destination="n7T-Gj-plH" id="STx-wz-jKg"/>
                 <outlet property="passwordInputView" destination="pdF-nK-gXE" id="18P-SU-c90"/>
                 <outlet property="passwordWarningLabel" destination="UyC-If-pXj" id="D2M-PR-Tph"/>
                 <outlet property="primaryActionButton" destination="q3p-Ji-dOm" id="l1t-x0-zva"/>
                 <outlet property="primaryActionSpinner" destination="o3M-2A-urw" id="pe9-Bb-Kf7"/>
+                <outlet property="quaternaryActionButton" destination="ILr-Ij-XBq" id="jBw-3a-pKE"/>
                 <outlet property="secondaryActionButton" destination="PfS-vU-7i3" id="zj3-Ly-5X9"/>
                 <outlet property="stackView" destination="CJS-5O-pxK" id="Grg-ZD-DYy"/>
                 <outlet property="stackViewTopConstraint" destination="Cyh-nE-ql7" id="WHM-m6-Cht"/>
                 <outlet property="tertiaryActionButton" destination="Uy8-va-3uF" id="NfE-QO-aLc"/>
-                <outlet property="tertiaryActionContainerView" destination="nxG-8M-wxx" id="FtU-Ac-O5T"/>
-                <outlet property="tertiaryTopSeparator" destination="Kpm-3a-0Z7" id="vyp-IY-5NB"/>
-                <outlet property="tertiaryTopSeparatorLabel" destination="223-DD-dLN" id="4cS-eP-Gg8"/>
                 <outlet property="view" destination="iN0-l3-epB" id="bxN-Zo-xBW"/>
             </connections>
         </placeholder>
@@ -33,9 +34,9 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CJS-5O-pxK">
-                    <rect key="frame" x="332" y="60" width="360" height="356"/>
+                    <rect key="frame" x="332" y="60" width="360" height="460"/>
                     <subviews>
-                        <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-K1-OyV" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
+                        <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-K1-OyV" userLabel="Email Input View" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
@@ -51,7 +52,7 @@
                             <color key="textColor" systemColor="systemPinkColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="pdF-nK-gXE" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
+                        <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="pdF-nK-gXE" userLabel="Password Input View" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="78" width="360" height="44"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
@@ -67,8 +68,18 @@
                             <color key="textColor" systemColor="systemRedColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CGr-O3-MBQ" userLabel="Primary Action View">
+                        <view contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="OP1-hm-GRS" userLabel="Code Input View" customClass="SPTextInputView" customModule="Simplenote" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="156" width="360" height="44"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="44" id="im0-Ei-pV0"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="#Password#"/>
+                            </userDefinedRuntimeAttributes>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CGr-O3-MBQ" userLabel="Primary Action View">
+                            <rect key="frame" x="0.0" y="208" width="360" height="44"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3p-Ji-dOm" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
@@ -91,7 +102,7 @@
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfS-vU-7i3">
-                            <rect key="frame" x="0.0" y="208" width="360" height="44"/>
+                            <rect key="frame" x="0.0" y="260" width="360" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="u8s-d9-Em4"/>
                             </constraints>
@@ -100,8 +111,8 @@
                                 <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </state>
                         </button>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kpm-3a-0Z7" userLabel="Tertiary Separator View">
-                            <rect key="frame" x="0.0" y="260" width="360" height="44"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kpm-3a-0Z7" userLabel="Actions Separator View">
+                            <rect key="frame" x="0.0" y="312" width="360" height="44"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Ls-SS-l0Q" userLabel="Leading View">
                                     <rect key="frame" x="0.0" y="21.5" width="167" height="1"/>
@@ -137,38 +148,42 @@
                                 <constraint firstItem="zDI-3J-P7n" firstAttribute="leading" secondItem="223-DD-dLN" secondAttribute="trailing" constant="5" id="vE8-Zf-q7V"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nxG-8M-wxx" userLabel="Tertiary Action View">
-                            <rect key="frame" x="0.0" y="312" width="360" height="44"/>
-                            <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uy8-va-3uF" userLabel="#Tertiary#" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="360" height="44"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                    <state key="normal" title="#Tertiary#"/>
-                                </button>
-                            </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uy8-va-3uF" userLabel="#Tertiary#" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="364" width="360" height="44"/>
                             <constraints>
-                                <constraint firstAttribute="trailing" secondItem="Uy8-va-3uF" secondAttribute="trailing" id="4sz-wJ-Fm5"/>
-                                <constraint firstAttribute="bottom" secondItem="Uy8-va-3uF" secondAttribute="bottom" id="7XH-hU-NF8"/>
-                                <constraint firstItem="Uy8-va-3uF" firstAttribute="leading" secondItem="nxG-8M-wxx" secondAttribute="leading" id="F1T-yV-yFY"/>
-                                <constraint firstAttribute="height" constant="44" id="jJo-79-bms"/>
-                                <constraint firstItem="Uy8-va-3uF" firstAttribute="top" secondItem="nxG-8M-wxx" secondAttribute="top" id="rt4-P1-Ygd"/>
+                                <constraint firstAttribute="height" constant="44" id="lt7-Yn-pzG"/>
                             </constraints>
-                        </view>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                            <state key="normal" title="#Tertiary#">
+                                <color key="titleColor" systemColor="systemIndigoColor"/>
+                            </state>
+                        </button>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ILr-Ij-XBq" userLabel="#Quaternary#" customClass="SPSquaredButton" customModule="Simplenote" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="416" width="360" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="44" id="cE4-3n-khh"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                            <state key="normal" title="#Quaternary#"/>
+                        </button>
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="PfS-vU-7i3" secondAttribute="trailing" id="0QL-Iw-KLz"/>
+                        <constraint firstItem="OP1-hm-GRS" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="22g-Kt-93q"/>
                         <constraint firstItem="PfS-vU-7i3" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="314-fc-3eX"/>
                         <constraint firstAttribute="trailing" secondItem="pdF-nK-gXE" secondAttribute="trailing" id="51g-0D-Oyv"/>
                         <constraint firstAttribute="trailing" secondItem="Kpm-3a-0Z7" secondAttribute="trailing" id="7SY-4J-Rv5"/>
                         <constraint firstItem="CGr-O3-MBQ" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="BIX-Fy-gqY"/>
+                        <constraint firstAttribute="trailing" secondItem="OP1-hm-GRS" secondAttribute="trailing" id="R55-ao-psA"/>
                         <constraint firstAttribute="trailing" secondItem="hW6-K1-OyV" secondAttribute="trailing" id="RSC-Vk-xbB"/>
                         <constraint firstItem="Kpm-3a-0Z7" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="S94-pS-Aza"/>
                         <constraint firstItem="hW6-K1-OyV" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="UoC-hu-yxe"/>
+                        <constraint firstItem="ILr-Ij-XBq" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="Wey-0k-g9U"/>
+                        <constraint firstAttribute="trailing" secondItem="ILr-Ij-XBq" secondAttribute="trailing" id="dxd-sM-fG7"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="nLp-JP-Ott"/>
-                        <constraint firstItem="nxG-8M-wxx" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="sEH-qo-ZdT"/>
+                        <constraint firstItem="Uy8-va-3uF" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="s8W-Vc-jxA"/>
+                        <constraint firstAttribute="trailing" secondItem="Uy8-va-3uF" secondAttribute="trailing" id="sI0-Z8-I2B"/>
                         <constraint firstAttribute="trailing" secondItem="CGr-O3-MBQ" secondAttribute="trailing" id="vUF-qZ-Vmm"/>
-                        <constraint firstAttribute="trailing" secondItem="nxG-8M-wxx" secondAttribute="trailing" id="w8N-O1-2au"/>
                         <constraint firstItem="pdF-nK-gXE" firstAttribute="leading" secondItem="CJS-5O-pxK" secondAttribute="leading" id="xzh-aD-Ag5"/>
                     </constraints>
                 </stackView>
@@ -185,6 +200,9 @@
         </view>
     </objects>
     <designables>
+        <designable name="ILr-Ij-XBq">
+            <size key="intrinsicContentSize" width="112" height="33"/>
+        </designable>
         <designable name="Uy8-va-3uF">
             <size key="intrinsicContentSize" width="83" height="33"/>
         </designable>
@@ -202,11 +220,14 @@
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
+        <systemColor name="systemIndigoColor">
+            <color red="0.34509803919999998" green="0.33725490200000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemPinkColor">
-            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -149,7 +149,7 @@ private extension SPOnboardingViewController {
 
     @IBAction
     func loginWasPressed() {
-        presentAuthenticationInterface(mode: .loginWithMagicLink)
+        presentAuthenticationInterface(mode: .requestLoginCode)
     }
 
     @IBAction
@@ -214,7 +214,7 @@ private extension SPOnboardingViewController {
     private func presentMagicLinkInvalidView() {
         var rootView = MagicLinkInvalidView()
         rootView.onPressRequestNewLink = { [weak self] in
-            self?.presentAuthenticationInterfaceIfNeeded(mode: .loginWithMagicLink)
+            self?.presentAuthenticationInterfaceIfNeeded(mode: .requestLoginCode)
         }
 
         let hostingController = UIHostingController(rootView: rootView)


### PR DESCRIPTION
### Details
In this PR we're:

1.  Extracting `AuthenticationMode` into its own file
2. Updating the `AuthViewController` initialization, so that it uses dynamic descriptors
3. Adding a new `Code` field
4. And enhancing the Login Flow so that users can enter their Auth Code

Ref. #1611

### Test: Login with Code
1. Fresh install Simplenote
2. Press on `Log In`
3. Enter your email and press on `Log in with email`

- [x] Verify that entering a code shorter than 6 characters results in an error
- [x] Verify that entering an invalid code results in an error
- [x] Verify that if you enter the correct code, you get authenticated

### Test: Login with Password
1. Fresh install Simplenote
2. Press on `Log In`
3. Enter your email and press on `Log in with email`
4. Press on `Enter Password`

- [x] Verify that pressing `Log In` gets you a warning onscreen
- [x] Verify that entering an incorrect password gets you a warning
- [x] Verify that entering your password gets you authenticated

### Test: Login with WP
1. Fresh install Simplenote
2. Press on `Log In`
3. Press on `Log in with WordPress.com`

- [x] Verify that the WPCOM SSO works as expected

### Test: Signup
1. Fresh install Simplenote
6. Press on `Signup`

- [x] Verify that pressing on the ToS link gets you the ToS website
- [x] Verify that pressing `Sign Up` without entering a valid email gets you a warning onscreen
- [x] Verify that if you enter a valid email, you can complete the SignUp process

### Release
> These changes do not require release notes.
