### PR TITLE
Refactored passkey remote to handle all json conversions for passkeys

### DIFF
--- a/Simplenote/PasskeyRegistrationResponse.swift
+++ b/Simplenote/PasskeyRegistrationResponse.swift
@@ -13,11 +13,11 @@ struct PasskeyRegistrationResponse: Encodable {
     private let type: String
     private let response: PasskeyRegistrationResponse.Response
 
-    init?(from credentialRegistration: ASAuthorizationPlatformPublicKeyCredentialRegistration, with email: String?) {
+    init(from credentialRegistration: ASAuthorizationPlatformPublicKeyCredentialRegistration, with email: String?) throws {
         guard let email,
         let clientJson = Self.prepareJSON(from: credentialRegistration.rawClientDataJSON),
         let rawAttestationObject = credentialRegistration.rawAttestationObject else {
-            return nil
+            throw PasskeyError.registrationFailed
         }
 
         let idString = credentialRegistration.credentialID.base64EncodedString().toBase64url()

--- a/Simplenote/PasskeyRemote.swift
+++ b/Simplenote/PasskeyRemote.swift
@@ -34,10 +34,11 @@ class PasskeyRemote: Remote {
         return Data(body.utf8)
     }
 
-    func requestChallengeResponseToCreatePasskey(forEmail email: String, password: String) async throws -> Data? {
+    func requestChallengeResponseToCreatePasskey(forEmail email: String, password: String) async throws -> PasskeyRegistrationChallenge {
         let request = passkeyCredentialCreationRequest(withEmail: email, password: password)
+        let data = try await performDataTask(with: request)
 
-        return try await performDataTask(with: request)
+        return try JSONDecoder().decode(PasskeyRegistrationChallenge.self, from: data)
     }
 
     private func requestForPasskeyCredentialRegistration(withData data: Data) -> URLRequest {
@@ -50,7 +51,8 @@ class PasskeyRemote: Remote {
         return urlRequest
     }
 
-    func registerCredential(with data: Data) async throws {
+    func registerCredential(with response: PasskeyRegistrationResponse) async throws {
+        let data = try JSONEncoder().encode(response)
         let request = requestForPasskeyCredentialRegistration(withData: data)
         try await _ = performDataTask(with: request)
     }


### PR DESCRIPTION
### Fix
In my last PR, I refactored passkey authorization so that the PasskeyRemote only received and returned `Codable` objects and did any json conversions its self.  This was a nice improvement because you couldn't then feed just any old data into the PasskeyRemote, it needed to be structured a certain way.  Well, I noticed that for the passkey registration process we the remote was still accepting and returning Data instead of the `Codable` objects.   So in this PR I have updated that.

### Test
There shouldn't be any actual changes to how passkeys operate here.  So just smoke test that you can register and authenticate using Passkeys.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:

> These changes do not require release notes.
