### PR TITLE
Login: Addressing Debt

### DIFF
--- a/Simplenote/AuthenticationMode.swift
+++ b/Simplenote/AuthenticationMode.swift
@@ -12,7 +12,7 @@ struct AuthenticationState {
 
 // MARK: - Authentication Elements
 //
-struct AuthenticationInputElements: OptionSet {
+struct AuthenticationInputElements: OptionSet, Hashable {
     let rawValue: UInt
     
     static let username         = AuthenticationInputElements(rawValue: 1 << 0)


### PR DESCRIPTION
### Fix
In this PR we're updating the way Validation works, so that we no longer return `.success` for fields that aren't even visible.

Closes #1611

Thank you @charliescheer !!

### Test: Signup
1. Fresh install Simplenote
2. Press on Signup

- [x] Verify that if you press the `Sign Up` button a warning shows up
- [x] Verify that if you enter a valid email, the warning disappears, and the `Sign Up` action becomes blue

### Test: Login with Code
1. Fresh install Simplenote
2. Press on `Log in`

- [x] Verify that if you press the `Log in with email` button, a warning shows up
- [x] Verify that entering a valid email causes the warning to disappear
- [x] Verify that the Code UI displays a warning, if you press `Log in` without entering the code
- [x] Verify that entering the correct code logs you in

### Test: Login with Password
1. Fresh install Simplenote
2. Press on `Log in`
3. Enter your email
4. Press on `Log in with email`
5. Press on `Enter password`

- [x] Verify that pressing `Log In`, without entering a password, causes a warning to appear
- [x] Verify that if you enter the correct password, you get logged in

### Release
> These changes do not require release notes.
