### PR TITLE
Auth: Updates Error Handling

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		B54A11C22C135EA2002AC8AA /* UIButton+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54A11C12C135EA2002AC8AA /* UIButton+Simplenote.swift */; };
 		B54A11C42C136225002AC8AA /* MagicLinkRequestedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54A11C32C136225002AC8AA /* MagicLinkRequestedView.swift */; };
 		B54B04D82407169500401FBB /* SPAppDelegate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */; };
+		B54C1B552C4EE350001E9E18 /* UIAlertController+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54C1B542C4EE350001E9E18 /* UIAlertController+Auth.swift */; };
 		B54D9C572909BA2600D0E0EC /* StoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D9C562909BA2600D0E0EC /* StoreManager.swift */; };
 		B54D9C592909CC4400D0E0EC /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D9C582909CC4400D0E0EC /* StoreProduct.swift */; };
 		B55051821A4328B9002A1093 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55051811A4328B9002A1093 /* LocalAuthentication.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -998,6 +999,7 @@
 		B54A11C12C135EA2002AC8AA /* UIButton+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Simplenote.swift"; sourceTree = "<group>"; };
 		B54A11C32C136225002AC8AA /* MagicLinkRequestedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicLinkRequestedView.swift; sourceTree = "<group>"; };
 		B54B04D72407169500401FBB /* SPAppDelegate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SPAppDelegate+Extensions.swift"; sourceTree = "<group>"; };
+		B54C1B542C4EE350001E9E18 /* UIAlertController+Auth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Auth.swift"; sourceTree = "<group>"; };
 		B54D9C542909B21700D0E0EC /* Simplenote 6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Simplenote 6.xcdatamodel"; sourceTree = "<group>"; };
 		B54D9C562909BA2600D0E0EC /* StoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreManager.swift; sourceTree = "<group>"; };
 		B54D9C582909CC4400D0E0EC /* StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProduct.swift; sourceTree = "<group>"; };
@@ -2081,6 +2083,7 @@
 				B56A695D22F9D53300B90398 /* SPAuthError.swift */,
 				B56A695C22F9D53300B90398 /* SPAuthHandler.swift */,
 				B5C99A502C45B94600728813 /* AuthenticationMode.swift */,
+				B54C1B542C4EE350001E9E18 /* UIAlertController+Auth.swift */,
 				B56A695F22F9D53400B90398 /* SPAuthViewController.swift */,
 				B56A695E22F9D53300B90398 /* SPAuthViewController.xib */,
 				B5AB169722FA124F00B4EBA5 /* SPSheetController.swift */,
@@ -3643,6 +3646,7 @@
 				46A3C98F17DFA81A002865AE /* SPNoteListViewController.m in Sources */,
 				B5BD6AF51BF66093004ECE33 /* SPMarkdownPreviewViewController.m in Sources */,
 				B5F3FFFF23F44679007A7C59 /* SPSortBar.swift in Sources */,
+				B54C1B552C4EE350001E9E18 /* UIAlertController+Auth.swift in Sources */,
 				BA4499C525ED95E5000C563E /* NoticeAction.swift in Sources */,
 				A6E02778256E9487002054DF /* PinLockSetupController.swift in Sources */,
 				B513F2B42319A8D50021CFA4 /* SPNoteTableViewCell.swift in Sources */,

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -114,6 +114,10 @@ extension SPAuthError {
             return NSLocalizedString("You must verify your email before being able to login.", comment: "Error for un verified email")
         case .tooManyAttempts:
             return NSLocalizedString("Too many login attempts. Try again later.", comment: "Error message for too many login attempts")
+        case .requestNotFound:
+            return NSLocalizedString("Your authentication code has expired. Please request a new one", comment: "Error message for Invalid Login Code")
+        case .invalidCode:
+            return NSLocalizedString("The code you've entered is not correct. Please try again", comment: "Error message for Invalid Login Code")
         default:
             return NSLocalizedString("We're having problems. Please try again soon.", comment: "Generic error")
         }

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -11,17 +11,38 @@ enum SPAuthError: Error {
     case unverifiedEmail
     case tooManyAttempts
     case generic
+    case requestNotFound
+    case invalidCode
     case unknown(statusCode: Int, response: String?, error: Error?)
 }
+
 
 // MARK: - SPAuthError Convenience Initializers
 //
 extension SPAuthError {
 
-    /// Returns the SPAuthError matching a given Simperium Login Error Code
+    /// Returns an AuthError matching a RemoteError (Login) Counterpart
+    ///
+    init(loginRemoteError: RemoteError) {
+        self = SPAuthError(loginErrorCode: loginRemoteError.statusCode, response: loginRemoteError.response, error: loginRemoteError.networkError)
+    }
+
+    /// Returns an AuthError matching a RemoteError (Signup) Counterpart
+    ///
+    init(signupRemoteError: RemoteError) {
+        self = SPAuthError(signupErrorCode: signupRemoteError.statusCode, response: signupRemoteError.response, error: signupRemoteError.networkError)
+    }
+
+    /// Returns the AuthError matching a given Simperium Login Error Code
     ///
     init(loginErrorCode: Int, response: String?, error: Error?) {
         switch loginErrorCode {
+        case .zero:
+            self = .network
+        case 400 where response == Constants.requestNotFound:
+            self = .requestNotFound
+        case 400 where response == Constants.invalidCode:
+            self = .invalidCode
         case 401 where response == Constants.compromisedPassword:
             self = .compromisedPassword
         case 401:
@@ -35,10 +56,12 @@ extension SPAuthError {
         }
     }
 
-    /// Returns the SPAuthError matching a given Simperium Signup Error Code
+    /// Returns the AuthError matching a given a Signup Error Code
     ///
     init(signupErrorCode: Int, response: String?, error: Error?) {
         switch signupErrorCode {
+        case .zero:
+            self = .network
         case 401:
             self = .signupBadCredentials
         case 409:
@@ -50,6 +73,7 @@ extension SPAuthError {
         }
     }
 }
+
 
 // MARK: - SPAuthError Public Methods
 //
@@ -99,4 +123,6 @@ extension SPAuthError {
 private struct Constants {
     static let compromisedPassword = "compromised password"
     static let requiresVerification = "verification required"
+    static let requestNotFound = "request-not-found"
+    static let invalidCode = "invalid-code"
 }

--- a/Simplenote/Classes/SPAuthHandler.swift
+++ b/Simplenote/Classes/SPAuthHandler.swift
@@ -61,8 +61,9 @@ class SPAuthHandler {
             switch result {
             case .success:
                 onCompletion(nil)
-            case .failure(let error):
-                onCompletion(self.authenticationError(for: error))
+            case .failure(let remoteError):
+                let error = SPAuthError(loginRemoteError: remoteError)
+                onCompletion(error)
             }
         }
     }
@@ -76,8 +77,8 @@ class SPAuthHandler {
             let confirmation = try await remote.requestLoginConfirmation(email: username, authCode: code.uppercased())
             simperiumService.authenticate(withUsername: confirmation.username, token: confirmation.syncToken)
             
-        } catch let error as RemoteError {
-            throw authenticationError(for: error)
+        } catch let remoteError as RemoteError {
+            throw SPAuthError(loginRemoteError: remoteError)
         }
     }
 
@@ -94,20 +95,10 @@ class SPAuthHandler {
             switch result {
             case .success:
                 onCompletion(nil)
-            case .failure(let error):
-                onCompletion(self.authenticationError(for: error))
+            case .failure(let remoteError):
+                let error = SPAuthError(signupRemoteError: remoteError)
+                onCompletion(error)
             }
-        }
-    }
-
-    private func authenticationError(for remoteError: RemoteError) -> SPAuthError {
-        switch remoteError {
-        case .network:
-            return .network
-        case .tooManyAttempts:
-            return .tooManyAttempts
-        case .requestError(let statusCode, let error):
-            return SPAuthError(signupErrorCode: statusCode, response: error?.localizedDescription, error: error)
         }
     }
 

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -452,6 +452,19 @@ extension SPAuthViewController {
             self.unlockInterface()
         }
     }
+
+    /// Requests a new Login Code, without pushing any secondary UI on success
+    ///
+    @IBAction func requestLogInCodeAndDontPush() {
+        controller.requestLoginEmail(username: email) { error in
+            if let error {
+                self.handleError(error: error)
+                return
+            }
+            
+            SPTracker.trackLoginLinkRequested()
+        }
+    }
     
     @IBAction func performLogInWithCode() {
         guard ensureWarningsAreOnScreenWhenNeeded() else {
@@ -613,6 +626,8 @@ private extension SPAuthViewController {
             presentPasswordCompromisedError(error: error)
         case .unverifiedEmail:
             presentUserUnverifiedError(error: error, email: email)
+        case .requestNotFound:
+            presentLoginCodeExpiredError()
         case .unknown(let statusCode, let response, let error) where debugEnabled:
             let details = NSAttributedString.stringFromNetworkError(statusCode: statusCode, response: response, error: error)
             presentDebugDetails(details: details)
@@ -638,6 +653,14 @@ private extension SPAuthViewController {
         }
         alertController.addCancelActionWithTitle(AuthenticationStrings.compromisedAlertCancel)
 
+        present(alertController, animated: true, completion: nil)
+    }
+    
+    func presentLoginCodeExpiredError() {
+        let alertController = UIAlertController.buildLoginCodeNotFoundAlert {
+            self.requestLogInCodeAndDontPush()
+        }
+        
         present(alertController, animated: true, completion: nil)
     }
 

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -188,12 +188,7 @@ extension SPSettingsViewController {
     }
 
     private func handleError(_ error: RemoteError) {
-        switch error {
-        case .network:
-            NoticeController.shared.present(NoticeFactory.networkError())
-        default:
-            presentRequestErrorAlert()
-        }
+        presentRequestErrorAlert()
     }
 
     private func presentSuccessAlert(for user: SPUser) {

--- a/Simplenote/Remote.swift
+++ b/Simplenote/Remote.swift
@@ -11,10 +11,10 @@ class Remote {
     /// Sublcassing Notes: To be able to send a task it is required to first setup the URL request for the task to use
     ///
     func performDataTask(with request: URLRequest, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        let dataTask = urlSession.dataTask(with: request) { (data, response, dataTaskError) in
+        let dataTask = urlSession.dataTask(with: request) { (data, response, networkError) in
             DispatchQueue.main.async {
                 
-                if let error = RemoteError(statusCode: response?.responseStatusCode ?? .zero, error: dataTaskError) {
+                if let error = RemoteError(statusCode: response?.responseStatusCode, responseData: data, networkError: networkError) {
                     completion(.failure(error))
                     return
                 }
@@ -30,8 +30,7 @@ class Remote {
     ///
     func performDataTask(with request: URLRequest) async throws -> Data {
         let (data, response) = try await urlSession.data(for: request)
-
-        if let error = RemoteError(statusCode: response.responseStatusCode) {
+        if let error = RemoteError(statusCode: response.responseStatusCode, responseData: data) {
             throw error
         }
         

--- a/Simplenote/UIAlertController+Auth.swift
+++ b/Simplenote/UIAlertController+Auth.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+
+// MARK: - UIAlertController Helpers
+//
+extension UIAlertController {
+    
+    /// Builds an alert indicating that the Login Code has Expired
+    ///
+    static func buildLoginCodeNotFoundAlert(onRequestCode: @escaping () -> Void) -> UIAlertController {
+        let title = NSLocalizedString("Sorry!", comment: "Email TextField Placeholder")
+        let message = NSLocalizedString("The authentication code you've requested has expired. Please request a new one", comment: "Email TextField Placeholder")
+        let dismissAction = NSLocalizedString("Dismiss", comment: "Email TextField Placeholder")
+        let requestAction = NSLocalizedString("Request a New Code", comment: "Email TextField Placeholder")
+        
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(dismissAction)
+        alertController.addDefaultActionWithTitle(requestAction) { _ in
+            onRequestCode()
+        }
+        
+        return alertController
+    }
+}

--- a/SimplenoteTests/RemoteResult+TestHelpers.swift
+++ b/SimplenoteTests/RemoteResult+TestHelpers.swift
@@ -7,6 +7,6 @@ extension Remote {
             return .success(nil)
         }
 
-        return .failure(RemoteError.requestError(0, nil))
+        return .failure(RemoteError(statusCode: 0, response: nil, networkError: nil))
     }
 }

--- a/SimplenoteTests/SignupRemoteTests.swift
+++ b/SimplenoteTests/SignupRemoteTests.swift
@@ -14,7 +14,7 @@ class SignupRemoteTests: XCTestCase {
     func testFailureWhenStatusCodeIs4xxOr5xx() {
         for _ in 0..<5 {
             let statusCode = Int.random(in: 400..<600)
-            test(withStatusCode: statusCode, email: "email@gmail.com", expectedResult: .failure(RemoteError.requestError(statusCode, nil)))
+            test(withStatusCode: statusCode, email: "email@gmail.com", expectedResult: .failure(RemoteError(statusCode: statusCode, response: nil, networkError: nil)))
         }
     }
 

--- a/SimplenoteTests/Verification/AccountVerificationRemoteTests.swift
+++ b/SimplenoteTests/Verification/AccountVerificationRemoteTests.swift
@@ -16,12 +16,12 @@ class AccountVerificationRemoteTests: XCTestCase {
     func testFailureWhenStatusCodeIs4xxOr5xx() {
         for _ in 0..<5 {
             let statusCode = Int.random(in: 400..<600)
-            test(withStatusCode: statusCode, expectedResult: .failure(RemoteError.requestError(statusCode, nil)))
+            test(withStatusCode: statusCode, expectedResult: .failure(RemoteError(statusCode: statusCode, response: nil, networkError: nil)))
         }
     }
 
     func testFailureWhenNoResponse() {
-        test(withStatusCode: nil, expectedResult: .failure(RemoteError.network))
+        test(withStatusCode: nil, expectedResult: .failure(RemoteError(statusCode: .zero, response: nil, networkError: nil)))
     }
 
     private func test(withStatusCode statusCode: Int?, expectedResult: Result<Data?, RemoteError>) {


### PR DESCRIPTION
### Fix
In this PR we're enhancing our Auth Flow's Error Handling.

### Test
1. Fresh install Simplenote
2. Press on `Log In`
3. Enter your email and press on `Login with Password`

- [x] Verify that entering an incorrect password results in an Alert indicating that the code ain't valid
- [x] Verify that if you wait for +10 minutes, and try sending a code, it indicates it's invalid
- [x] Verify that pressing on the `Request new Code` Alert (once the code expired) causes the app to send you a new Login Code
- [x] Verify that entering the right code gets you authenticated

### Release
> These changes do not require release notes.
