### PR TITLE
Authentication: Updates Expired Code Handling

### DIFF
--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -675,7 +675,7 @@ private extension SPAuthViewController {
     
     func presentLoginCodeExpiredError() {
         let alertController = UIAlertController.buildLoginCodeNotFoundAlert {
-            self.requestLogInCodeAndDontPush()
+            self.navigationController?.popViewController(animated: true)
         }
         
         present(alertController, animated: true, completion: nil)

--- a/Simplenote/UIAlertController+Auth.swift
+++ b/Simplenote/UIAlertController+Auth.swift
@@ -10,12 +10,10 @@ extension UIAlertController {
     static func buildLoginCodeNotFoundAlert(onRequestCode: @escaping () -> Void) -> UIAlertController {
         let title = NSLocalizedString("Sorry!", comment: "Email TextField Placeholder")
         let message = NSLocalizedString("The authentication code you've requested has expired. Please request a new one", comment: "Email TextField Placeholder")
-        let dismissAction = NSLocalizedString("Dismiss", comment: "Email TextField Placeholder")
-        let requestAction = NSLocalizedString("Request a New Code", comment: "Email TextField Placeholder")
-        
+        let acceptText = NSLocalizedString("Accept", comment: "Accept Message")
+
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(dismissAction)
-        alertController.addDefaultActionWithTitle(requestAction) { _ in
+        alertController.addDefaultActionWithTitle(acceptText) { _ in
             onRequestCode()
         }
         


### PR DESCRIPTION
### Fix
In this PR we're updating the way the Expired Code Error is handled: we'll get users back into the initial Login UI.

### Test
1. Fresh install Simplenote iOS
2. Press on `Log In` and enter your email
3. Press on `Log in with email` to request a code
4. Wait for 6 minutes

- [ ] Verify that if you enter (any code) you'll get an alert indicating that the code has expired
- [ ] Verify that pressing `Accept` gets you back into the initial Login UI, where you may request a new code

### Release
> These changes do not require release notes.
