### PR TITLE
Validate deleting tag before completing

### DIFF
--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -501,7 +501,7 @@ extension TagListViewController: TagListViewCellDelegate {
                                                 preferredStyle: .actionSheet)
 
         alertController.addDestructiveActionWithTitle(Localization.TagDeletionConfirmation.confirmationButton) { (_) in
-            guard self.shouldRemove(tag, at: indexPath) else {
+            guard self.verifyTagIsAtIndexPath(tag, at: indexPath) else {
                 self.present(UIAlertController.dismissableAlert(
                     title: Localization.tagDeleteFailedTitle,
                     message: Localization.tagDeleteFailedMessage), animated: true)
@@ -527,7 +527,7 @@ extension TagListViewController: TagListViewCellDelegate {
         present(alertController, animated: true, completion: nil)
     }
 
-    private func shouldRemove(_ tagToRemove: Tag, at indexPath: IndexPath) -> Bool {
+    private func verifyTagIsAtIndexPath(_ tagToRemove: Tag, at indexPath: IndexPath) -> Bool {
         // REF: https://github.com/Automattic/simplenote-ios/issues/1312
         // If you initiate deleting a tag and the tag is deleted before you confirm then another tag is deleted
         // This method confirms the selected tag is the same as the tag at index path before removing.

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -501,6 +501,13 @@ extension TagListViewController: TagListViewCellDelegate {
                                                 preferredStyle: .actionSheet)
 
         alertController.addDestructiveActionWithTitle(Localization.TagDeletionConfirmation.confirmationButton) { (_) in
+            guard self.shouldRemove(tag, at: indexPath) else {
+                self.present(UIAlertController.dismissableAlert(
+                    title: Localization.tagDeleteFailedTitle,
+                    message: Localization.tagDeleteFailedMessage), animated: true)
+                return
+            }
+
             switch source {
             case .accessory:
                 SPTracker.trackTagRowDeleted()
@@ -518,6 +525,17 @@ extension TagListViewController: TagListViewCellDelegate {
         alertController.popoverPresentationController?.permittedArrowDirections = .any
 
         present(alertController, animated: true, completion: nil)
+    }
+
+    private func shouldRemove(_ tagToRemove: Tag, at indexPath: IndexPath) -> Bool {
+        // REF: https://github.com/Automattic/simplenote-ios/issues/1312
+        // If you initiate deleting a tag and the tag is deleted before you confirm then another tag is deleted
+        // This method confirms the selected tag is the same as the tag at index path before removing.
+        guard let tagAtIndexPath = tag(at: indexPath) else {
+            return false
+        }
+
+        return tagToRemove.simperiumKey == tagAtIndexPath.simperiumKey
     }
 }
 
@@ -887,6 +905,9 @@ private struct Localization {
 
     static let tags = NSLocalizedString("Tags", comment: "Tags List Header")
     static let untaggedNotes = NSLocalizedString("Untagged Notes", comment: "Allows selecting notes with no tags")
+
+    static let tagDeleteFailedTitle = NSLocalizedString("Could not delete tag", comment: "Notifies user tag delete failed")
+    static let tagDeleteFailedMessage = NSLocalizedString("Please try again", comment: "Encourages trying delete again")
 
     struct TagDeletionConfirmation {
         static func title(with tagName: String) -> String {


### PR DESCRIPTION
### Fix
There is currently a bug when deleting tags on iOS.  If you have multiple tags and then..:
1. Show the tag list > Tap on edit > Tap on the trash button next to a tag.  A ui alert appears asking you to confirm that you want to delete that tag.  Don't confirm or dismiss the alert
2. On another device delete that same tag and let that sync across devices
3. Confirm deleting on the first device.  This will cause a different tag to be deleted than the one you originally selected.

This is a bit of a weird use case, but in a situation where syncing was in progress you could easily delete the wrong tag.  So we shouldn't permit this.  

In this PR I have added a validation method before tags are deleted that confirm the tag that was originally selected is still the same tag that found at the original indexPath.  If it is not then the same then show an alert and don't delete the tag.

fixes #1312 

### Test
***(Required)*** List the steps to test the behavior.  For example:
1. Show the tag list > Tap on edit > Tap on the trash button next to a tag.  A ui alert appears asking you to confirm that you want to delete that tag.  Don't confirm or dismiss the alert
2. On another device delete that same tag and let that sync across devices
3. Confirm deleting on the first device.

- [x] Confirm that you see an alert and no additional tag is deleted
- [x] Try deleting a tag without deleting it on another device, confirm you can still delete

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
