### PR TITLE
Markdown animations and swipe for RTL languages

### DIFF
--- a/Simplenote/Classes/SPInteractivePushPopAnimationController.m
+++ b/Simplenote/Classes/SPInteractivePushPopAnimationController.m
@@ -60,6 +60,10 @@ CGFloat const SPPushAnimationDurationCompact = 0.3f;
     CGPoint location = [panGestureRecognizer locationInView:navigationBar];
     CGPoint translation = [panGestureRecognizer translationInView:navigationBar];
     BOOL isLeftTranslation = translation.x < 0;
+    BOOL isRightTranslation = translation.x > 0;
+    BOOL isLTR = [UIView userInterfaceLayoutDirectionForSemanticContentAttribute: topViewController.view.semanticContentAttribute] == UIUserInterfaceLayoutDirectionLeftToRight;
+
+    BOOL isSwipeTranslation = isLTR ? isLeftTranslation : isRightTranslation;
 
     // Ignore touches within the navigation bar
     if (CGRectContainsPoint(navigationBar.bounds, location)) {
@@ -67,7 +71,7 @@ CGFloat const SPPushAnimationDurationCompact = 0.3f;
     }
 
     // TopViewController conforms to SPInteractivePushViewControllerProvider AND We're Swiping Right to Left: Support Push!
-    if ([topViewController conformsToProtocol:@protocol(SPInteractivePushViewControllerProvider)] && isLeftTranslation) {
+    if ([topViewController conformsToProtocol:@protocol(SPInteractivePushViewControllerProvider)] && isSwipeTranslation) {
         UIViewController <SPInteractivePushViewControllerProvider> *pushProviderController = (UIViewController <SPInteractivePushViewControllerProvider> *)topViewController;
         CGPoint locationInView = [panGestureRecognizer locationInView:pushProviderController.view];
         if (![pushProviderController interactivePushPopAnimationControllerShouldBeginPush:self touchPoint:locationInView]) {

--- a/Simplenote/Classes/SPNoteEditorViewController.m
+++ b/Simplenote/Classes/SPNoteEditorViewController.m
@@ -386,13 +386,15 @@ CGFloat const SPSelectedAreaPadding = 20;
     [snapshot addSubview:fakeMarkdownPreviewSnapshot];
 
     // Offset the fake markdown preview off to the right of the screen
+    bool isLTR = [UIView userInterfaceLayoutDirectionForSemanticContentAttribute: self.view.semanticContentAttribute] == UIUserInterfaceLayoutDirectionLeftToRight;
+    int multiplier = isLTR ? 1 : -1;
     CGRect frame = snapshot.frame;
-    frame.origin.x = CGRectGetWidth(self.view.bounds);
+    frame.origin.x = CGRectGetWidth(self.view.bounds) * multiplier;
     fakeMarkdownPreviewSnapshot.frame = frame;
 
     self.noteEditorTextView.hidden = YES;
 
-    CGFloat bounceDistance = -40;
+    CGFloat bounceDistance = -40 * multiplier;
 
     // Do a nice bounce animation
     [UIView animateWithDuration:0.25 delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{


### PR DESCRIPTION
### Fix
There is a bug right now where the swiping and animations for markdown aren't oriented correctly when using RTL languages and this breaks being able to swipe back from the markdown view to the editor view.  

Not a great experience for our RTL users, so I have fixed that here.  In total I fixed:
- The bounce animation when markdown is enabled is now on the left (trailing) edge when using an RTL language
- when swiping from editor to markdown the swipe must be done from the left (trailing) edge when using an RTL language
- When viewing the markdown view you can now swipe back to the editor by swiping from the right (leading) edge in an RTL language


Fixes #1150 
### Test
***(Required)*** List the steps to test the behavior.  For example:
1. Launch simplenote in an RTL language or change the build scheme to use RTL pseudo language.
2. Go to a note that does not current support markdown.  Tap on the options button and enable Markdown and then hit down
3. When the editor returns you will see the markdown view peak from one side of the editor.  Confirm that this happens on the left (trailing) not the right
4. Swipe from the left edge of screen.  Confirm that the markdown view appears from the left (trailing) edge
5. From the markdown view, swipe from the right (leading) edge, confirm you can swipe back to the editor view
6. Repeat the above steps with a LTR language and confirm that side switches, so animation and swipe to markdown on the right (trailing) and swipe back to editor is left (leading) edges

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
