### PR TITLE
Prepare app to build on Xcode 16

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -6267,7 +6267,7 @@
 			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.2.0;
+				minimumVersion = 3.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Simplenote.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "b6979ef69b4b094c8809ba83661222dcd0d7667e",
-        "version" : "3.2.0"
+        "revision" : "4d7d7138a9f2b36c3fd4618aa488ed9e8de2f726",
+        "version" : "3.5.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "3b9a8e69ca296bd8cd0e317ad7a448e5daf4a342",
-        "version" : "8.18.0"
+        "revision" : "5421f94cc859eb65f5ae3866165a053aa634431e",
+        "version" : "8.32.0"
       }
     },
     {


### PR DESCRIPTION
### Fix
Xcode 16 is coming!  So time to check and make sure that we can still build Simplenote on the newest version of Xcode.  I did a quick check and there is an issue in the newest version of Xcode where SN can't build because of one of its package dependencies.

In this PR I have updated Automattic tracks to get the newest version of Sentry-cocoa which fixes the build error.

### Test
***(Required)*** List the steps to test the behavior.  For example:
1. download the latest Xcode beta
2. Build and run SN
3. smoke test the app

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer is required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
