### PR TITLE
Add method for milestone moving 

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -58,9 +58,10 @@ platform :ios do
       from_branch: DEFAULT_BRANCH,
       to_branch: computed_release_branch_name
     )
-    set_milestone_frozen_marker(
-      repository: GITHUB_REPO,
-      milestone: new_version
+
+    freeze_milestone_and_move_assigned_prs_to_next_milestone(
+      milestone_to_freeze: new_version,
+      next_milestone: release_version_next
     )
 
     trigger_beta_build(branch_to_build: computed_release_branch_name)

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -253,7 +253,7 @@ def freeze_milestone_and_move_assigned_prs_to_next_milestone(
 
   UI.message("Moved the following PRs to milestone #{next_milestone}: #{moved_prs.join(', ')}")
 
-  next unless is_ci
+  return unless is_ci
 
   moved_prs_info = if moved_prs.empty?
                      "No open PRs were targeting `#{milestone_to_freeze}` at the time of code-freeze."

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -224,6 +224,13 @@ def freeze_milestone_and_move_assigned_prs_to_next_milestone(
   next_milestone:,
   github_repository: GITHUB_REPO
 )
+  # Notice that the order of execution is important here and should not be changed.
+  #
+  # First, we move the PR from milestone_to_freeze to next_milestone.
+  # Then, we update milestone_to_freeze's tile with the frozen marker (traditionally ❄️ )
+  #
+  # If the order were to be reversed, the PRs lookup for milestone_to_freeze would yeld no value.
+  # That's because the lookup uses the milestone title, which would no longer be milestone_to_freeze, but milestone_to_freeze + the frozen marker.
   begin
     # Move PRs to next milestone
     moved_prs = update_assigned_milestone(


### PR DESCRIPTION
Updates the code freeze automation to move PRs targeting the milestone for which the code freeze just started to the next milestone. Part of the internal project paaHJt-6Zx-p2

The implementation is based on what other repos already do, example: [WooCommerce Android](https://github.com/woocommerce/woocommerce-android/blob/trunk/fastlane/Fastfile#L181-L212), but I had a stab at moving it to a dedicated method. The idea being to make it easier to extract to `release-toolkit` or an helper file in `lib/`, or even just make it simpler to copy-paste.

### Test
I haven't tested this change. I will do that as part of the upcoming code freeze, see also p2XJRt-3QQ-p2

### Review
Only one infra engineer required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes