### PR TITLE
Pass `wpmobilebot` explicitly in `start-code-freeze.yml`

### DIFF
--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -12,7 +12,7 @@ steps:
     agents:
         queue: tumblr-metal
     command: |
-      echo '--- :robot_face: Use bot for git operations'
+      echo '--- :robot_face: Use bot for Git operations'
       source use-bot-for-git wpmobilebot
 
       echo '--- :ruby: Setup Ruby Tools'

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -13,7 +13,7 @@ steps:
         queue: tumblr-metal
     command: |
       echo '--- :robot_face: Use bot for git operations'
-      source use-bot-for-git
+      source use-bot-for-git wpmobilebot
 
       echo '--- :ruby: Setup Ruby Tools'
       install_gems


### PR DESCRIPTION
This should address the failure seen when the changes from https://github.com/Automattic/simplenote-ios/pull/1649 run [in CI](https://buildkite.com/automattic/simplenote-ios/builds/1090#0191bb7e-12f6-4ca1-aa28-6dc3fda8d6f9):

<img width="1253" alt="image" src="https://github.com/user-attachments/assets/08669a52-b6c7-4bf9-8d89-12aa698b98eb">

I also opened a counter PR to add this project to the list.