### PR TITLE
Delete note if the content is completely removed

### DIFF
--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -509,7 +509,7 @@ extension SPNoteEditorViewController {
 
     @objc
     func ensureEmptyNoteIsDeleted() {
-        guard note.isBlank, noteEditorTextView.text.isEmpty else {
+        guard noteEditorTextView.text.isEmpty else {
             save()
             return
         }


### PR DESCRIPTION
### Fix
It was brought up in an [issue for SNMac](https://github.com/Automattic/simplenote-macos/issues/1064), that if a note is empty we leave it in the note list and it would be nice if they deleted themselves.  I thought about this for a bit and decided that I agreed, but I wanted to make sure that we only moved the notes to the trash, that way the history for the note still exists and a user could reclaim the lost content if they wanted.  So in this PR I have done that.

iOS already deleted _new_ notes that were empty, so this PR simply updates that logic to not exclude existing notes.  If a user deletes all the content in a note and then exits the editor the note will be moved to the trash.  This is the same behavior as in apple notes.

### Test
#### Confirm new notes with content are not deleted ####
1. Create a new note and add some content to it
2. Close the editor
- [ ] Confirm your new note continues to exist
- [ ] Relaunch the app and confirm your new note was saved to the DB

#### Confirm new notes without content are deleted ####
1. Create a new note, do not add content to it
2. Close the editor
- [ ] Confirm that your new note was deleted

#### Confirm an existing note that has all it's content removed, will be deleted ####
1. Go to a note you don't mind losing.
2. Delete all of the text content in the note
3. Exit the editor.
- [ ] Confirm that your note is deleted from the notes list

4. Go to the note trash, find the top note labeled "New Note..." restore it
5. Go to the regular notes list, open the note you restored, go to the notes history
- [ ] Confirm you can restore that notes history


### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and one designer are required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> These changes do not require release notes.
