### PR TITLE
Update release notes for 4.55

### DIFF
--- a/fastlane/metadata/default/release_notes.txt
+++ b/fastlane/metadata/default/release_notes.txt
@@ -1,2 +1,3 @@
-
-
+- Updated icons to work with new iOS 18 styles
+- Add fall back login with username and password option to login
+- Updated link to privacy notice for California users


### PR DESCRIPTION
4.54 was not shipped so we can use its notes in 4.55

