### PR TITLE
Convert the bool `beta` flag to string for Buildkite

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -328,7 +328,7 @@ def check_pods_references
 end
 
 def trigger_buildkite_release_build(branch:, beta:)
-  environment = { BETA_RELEASE: beta }
+  environment = { BETA_RELEASE: beta.to_s }
   pipeline_file_name = 'release-build.yml'
 
   # When in CI, upload the release build pipeline inline in the current pipeline.


### PR DESCRIPTION
This should address the failure seen running the new `buildkite_pipeline_upload` in CI:

```
/opt/ci/builds/builder/automattic/simplenote-ios/vendor/bundle/ruby/3.2.0/gems/fastlane-2.225.0/fastlane/lib/fastlane/helper/sh_helper.rb:118:in `block in shell_command_from_args': [!] undefined method `shellescape' for true:TrueClass (NoMethodError)
      command = args.shift.map { |k, v| "#{k}=#{v.shellescape}" }.join("") + " "
```

https://buildkite.com/automattic/simplenote-ios/builds/1184#0192d797-332d-4bed-990a-0101000f2f56