### PR TITLE
Pass both keys and values in `buildkite_pipeline_upload` as strings

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -328,7 +328,7 @@ def check_pods_references
 end
 
 def trigger_buildkite_release_build(branch:, beta:)
-  environment = { BETA_RELEASE: beta.to_s }
+  environment = { BETA_RELEASE: beta }
   pipeline_file_name = 'release-build.yml'
 
   # When in CI, upload the release build pipeline inline in the current pipeline.
@@ -336,7 +336,8 @@ def trigger_buildkite_release_build(branch:, beta:)
   if is_ci
     buildkite_pipeline_upload(
       pipeline_file: File.join(PROJECT_ROOT_FOLDER, '.buildkite', pipeline_file_name),
-      environment: environment
+      # Both keys and values need to be passed as strings
+      environment: environment.to_h { |k, v| [k.to_s, v.to_s] }
     )
   else
     build_url = buildkite_trigger_build(


### PR DESCRIPTION
This should (I verified locally) address the new CI failure with the `sh` call after addressing the previous one in https://github.com/Automattic/simplenote-ios/pull/1669

See https://buildkite.com/automattic/simplenote-ios/builds/1188#0192d79d-58c5-4b62-bec4-cd464ebaca60

```
/Users/builder/.rbenv/versions/3.2.2/lib/ruby/3.2.0/open3.rb:222:in `spawn': [!] no implicit conversion of Symbol into String (TypeError)
  pid = spawn(*cmd, opts)
```