### PR TITLE
Run `buildkite_pipeline_upload` on branch HEAD

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -336,8 +336,14 @@ def trigger_buildkite_release_build(branch:, beta:)
   if is_ci
     buildkite_pipeline_upload(
       pipeline_file: File.join(PROJECT_ROOT_FOLDER, '.buildkite', pipeline_file_name),
-      # Both keys and values need to be passed as strings
-      environment: environment.to_h { |k, v| [k.to_s, v.to_s] }
+      environment:
+        # Override the commit to make sure it runs on the latest state,
+        # not the commit that triggered the automation that eventaully called this.
+        #
+        # Useful during release automation builds that make additional commits to the release branch.
+        { **environment, BUILDKITE_COMMIT: last_git_commit[:commit_hash] }
+        # Both keys and values need to be passed as strings
+        .to_h { |k, v| [k.to_s, v.to_s] }
     )
   else
     build_url = buildkite_trigger_build(


### PR DESCRIPTION
See inline comments.

This is an attempt to solve the failure seen in https://buildkite.com/automattic/simplenote-ios/builds/1194 where the injected beta build steps run on the commit that triggered the injecting build, not the commit in which the codebase was when the steps were injected.