### PR TITLE
Also checkout release branch in upload release step

### DIFF
--- a/.buildkite/release-build.yml
+++ b/.buildkite/release-build.yml
@@ -1,7 +1,13 @@
-env:
-  IMAGE_ID: $IMAGE_ID
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# Variables used in this pipeline are defined in `shared-pipeline-vars`, which is `source`'d before calling `buildkite-agent pipeline upload`
+
 agents:
   queue: mac
+
+env:
+  IMAGE_ID: $IMAGE_ID
 
 steps:
   - label: ":testflight: Build Simplenote iOS for App Store Connect"
@@ -25,4 +31,4 @@ steps:
     priority: 1
     plugins: [$CI_TOOLKIT_PLUGIN]
     notify:
-    - slack: "#build-and-ship"
+      - slack: "#build-and-ship"

--- a/.buildkite/release-build.yml
+++ b/.buildkite/release-build.yml
@@ -17,7 +17,11 @@ steps:
 
   - label: ":testflight: Upload Simplenote iOS to App Store Connect"
     depends_on: testflight_build
-    command: .buildkite/commands/release-upload.sh $BETA_RELEASE
+    # This step does not only upload to ASC, but also create a GitHub release.
+    # For that, it needs to be on the latest release branch commit, hence the checkout command
+    command: |
+      .buildkite/commands/checkout-release-branch.sh $RELEASE_VERSION
+      .buildkite/commands/release-upload.sh $BETA_RELEASE
     priority: 1
     plugins: [$CI_TOOLKIT_PLUGIN]
     notify:


### PR DESCRIPTION
When I worked on https://github.com/Automattic/simplenote-ios/pull/1675 I decided not to checkout the release branch in the upload step because I thought "it's just downloading the artifact and sending it to ASC, we have it in a dedicated step just so if the upload fails we don't need to re-run the whole build process."

Alas, I had forgotten that step also uploads the dSYM to Sentry and _creates the GitHub release_. (The name `upload_to_testflight` doesn't help remembering it).

When the release is created, the automation reads the version from the codebase, meaning we need to be on the latest commit. Otherwise, we'll do like in the last build where we uploaded 4.55.0.2 to TestFlight but created a release named 4.55.0.1 (since then deleted)

![image](https://github.com/user-attachments/assets/5d10e5b1-611f-432b-af65-95d3bac3797f)
