### PR TITLE
Fix version file path in `release_is_hotfix?` helper

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -419,6 +419,6 @@ end
 
 def release_is_hotfix?
   VERSION_CALCULATOR.release_is_hotfix?(
-    version: VERSION_FORMATTER.parse(VERSION_FILE.read_release_version)
+    version: VERSION_FORMATTER.parse(PUBLIC_VERSION_FILE.read_release_version)
   )
 end


### PR DESCRIPTION
What it says in the title. See failure at https://buildkite.com/automattic/simplenote-ios/builds/1223#0192e985-c02d-41ff-849f-6dff8629835c


Bypassing CI checks because this change does not run in the standard CI pipeline. We'll validate it next by retrying the complete code freeze pipeline. Same as #1669.

