### PR TITLE
Fix upload metadata lane call in CI

### DIFF
--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -25,7 +25,7 @@ steps:
       bundle exec fastlane run configure_apply
 
       echo '--- :shipit: Update Release Notes and Other App Store Metadata'
-      bundle exec fastlane update_metadata_on_app_store_connect skip_confirm:true
+      bundle exec fastlane update_metadata_on_app_store_connect
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -10,7 +10,7 @@ env:
   IMAGE_ID: $IMAGE_ID
 
 steps:
-  - label: Finalize Release
+  - label: Update Release Notes and Other Metadata on App Store Connect
     plugins: [$CI_TOOLKIT_PLUGIN]
     command: |
       echo '--- :robot_face: Use bot for Git operations'


### PR DESCRIPTION
See failure at https://buildkite.com/automattic/simplenote-ios/builds/1232#0192eeb4-40e4-4486-a551-039cd52e366e


Bypassing CI checks because this change does not run in the standard CI pipeline. We'll validate it next by retrying the complete code freeze pipeline. Same as #1669.

