### PR TITLE
Allow bypassing confirmation in upload metadata via CI

### DIFF
--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -25,7 +25,7 @@ steps:
       bundle exec fastlane run configure_apply
 
       echo '--- :shipit: Update Release Notes and Other App Store Metadata'
-      bundle exec fastlane update_metadata_on_app_store_connect
+      bundle exec fastlane update_metadata_on_app_store_connect skip_confirm:true
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -84,7 +84,7 @@ platform :ios do
   # @option [Boolean] with_screenshots (default: false) If true, will also upload the latest screenshot files to ASC
   #
   desc 'Upload the localized metadata to App Store Connect, optionally including screenshots.'
-  lane :update_metadata_on_app_store_connect do |with_screenshots: false|
+  lane :update_metadata_on_app_store_connect do |skip_confirm: false, with_screenshots: false|
     # Skip screenshots by default. The naming is "with" to make it clear that
     # callers need to opt-in to adding screenshots. The naming of the deliver
     # (upload_to_app_store) parameter, on the other hand, uses the skip verb.
@@ -99,7 +99,8 @@ platform :ios do
       overwrite_screenshots: true, # won't have effect if `skip_screenshots` is true
       phased_release: true,
       precheck_include_in_app_purchases: false,
-      api_key_path: APP_STORE_CONNECT_KEY_PATH
+      api_key_path: APP_STORE_CONNECT_KEY_PATH,
+      force: skip_confirm
     )
   end
 


### PR DESCRIPTION
Should fix https://buildkite.com/automattic/simplenote-ios/builds/1235#0192eeb9-134a-41ee-acf1-a8caf4f84788


Bypassing CI checks because this change does not run in the standard CI pipeline. We'll validate it next by retrying the complete code freeze pipeline. Same as #1669.

