### PR TITLE
[Tooling] Update GitHub Actions

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.5.x' # Same as project's .ruby-version
@@ -27,7 +27,7 @@ jobs:
 
     - name: Restore Ruby Dependency Cache
       id: restore-ruby-dependency-cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -38,7 +38,7 @@ jobs:
 
     - name: Restore CocoaPods Dependency Cache
       id: restore-cocoapods-dependency-cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: Pods
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
@@ -49,7 +49,7 @@ jobs:
     - name: Take all screenshots
       run: bundle exec fastlane take_screenshots
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       name: Upload all screenshots as artifacts
       with:
         name: screenshots
@@ -62,7 +62,7 @@ jobs:
         BUNDLE_WITH=screenshots bundle install
         bundle exec fastlane create_promo_screenshots
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       name: Upload all promo screenshots as artifacts
       with:
         name: promo_screenshots


### PR DESCRIPTION
Reference: p7H4VZ-59z-p2

We were notified by GitHub about a few GitHub Actions about to have its older versions deprecated as `actions/upload-artifact`, `actions/download-artifact` or `actions/cache` (see also: https://github.com/actions/cache/discussions/1510 and https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/), so this PR updates them to their latest version.