### PR TITLE
WIP: TextKit 2 mk1

### DIFF
--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -541,6 +541,8 @@
 		BAB6C04726BA4CAF007495C4 /* WidgetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB6C04626BA4CAF007495C4 /* WidgetController.swift */; };
 		BAB898D32BEC404200E238B8 /* CreateNewNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */; };
 		BABB22DF2D14DA6600FCF47D /* SPTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB22DE2D14DA6300FCF47D /* SPTextView.swift */; };
+		BABB22E12D162E6D00FCF47D /* NSTextLayoutManager+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB22E02D162E6200FCF47D /* NSTextLayoutManager+Simplenote.swift */; };
+		BABB22E32D162E8400FCF47D /* NSTextLayoutFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB22E22D162E7D00FCF47D /* NSTextLayoutFragment.swift */; };
 		BABFFF2226CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2326CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2426CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
@@ -1244,6 +1246,8 @@
 		BAB6C04626BA4CAF007495C4 /* WidgetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetController.swift; sourceTree = "<group>"; };
 		BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewNoteIntentHandler.swift; sourceTree = "<group>"; };
 		BABB22DE2D14DA6300FCF47D /* SPTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPTextView.swift; sourceTree = "<group>"; };
+		BABB22E02D162E6200FCF47D /* NSTextLayoutManager+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextLayoutManager+Simplenote.swift"; sourceTree = "<group>"; };
+		BABB22E22D162E7D00FCF47D /* NSTextLayoutFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSTextLayoutFragment.swift; sourceTree = "<group>"; };
 		BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDefaults.swift; sourceTree = "<group>"; };
 		BAD0F1EC2BED49C200E73E45 /* FindNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNoteIntentHandler.swift; sourceTree = "<group>"; };
 		BAE08625261282D1009D40CD /* Note+Publish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Publish.swift"; sourceTree = "<group>"; };
@@ -1879,6 +1883,8 @@
 				E21F57B817C1244E001F02D3 /* SPEditorTextView.m */,
 				A6BBDA45255034E6005C8343 /* SPEditorTextView+Simplenote.swift */,
 				B52E2B142537480A0074509A /* SPEditorTapRecognizerDelegate.swift */,
+				BABB22E02D162E6200FCF47D /* NSTextLayoutManager+Simplenote.swift */,
+				BABB22E22D162E7D00FCF47D /* NSTextLayoutFragment.swift */,
 			);
 			name = Editor;
 			sourceTree = "<group>";
@@ -3471,6 +3477,7 @@
 				A60DF30825A44F0F00FDADF3 /* PinLockRemoveController.swift in Sources */,
 				A694ABAB25D1549D00CC3A2D /* FileStorage.swift in Sources */,
 				B513FB2422EF6A4B00B178AC /* SPUserInterface.swift in Sources */,
+				BABB22E32D162E8400FCF47D /* NSTextLayoutFragment.swift in Sources */,
 				B5DF734022A54EE800602CE7 /* SPDefaultTableViewCell.swift in Sources */,
 				B5796549250684EC00DFD6F7 /* EditorFactory.swift in Sources */,
 				A6C2721825AF0C1E00593731 /* TagListViewCell.swift in Sources */,
@@ -3542,6 +3549,7 @@
 				A6CDF900256B9CB900CF2F27 /* ViewSpinner.swift in Sources */,
 				375D24B721E01131007AB25A /* stack.c in Sources */,
 				373AD30821C4739500A4EA89 /* NSMutableAttributedString+Styling.m in Sources */,
+				BABB22E12D162E6D00FCF47D /* NSTextLayoutManager+Simplenote.swift in Sources */,
 				B524AE112352CC7900EA11D4 /* UIScreen+Simplenote.swift in Sources */,
 				A68A4345256FEE3000D1CA5D /* SPSettingsViewController+Extensions.swift in Sources */,
 				B543C7E523CF775C00003A80 /* NSSortDescriptor+Simplenote.swift in Sources */,

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -540,6 +540,7 @@
 		BAB6C04526BA4A04007495C4 /* String+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5476BC023D8E5D0000E7723 /* String+Simplenote.swift */; };
 		BAB6C04726BA4CAF007495C4 /* WidgetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB6C04626BA4CAF007495C4 /* WidgetController.swift */; };
 		BAB898D32BEC404200E238B8 /* CreateNewNoteIntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */; };
+		BABB22DF2D14DA6600FCF47D /* SPTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABB22DE2D14DA6300FCF47D /* SPTextView.swift */; };
 		BABFFF2226CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2326CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
 		BABFFF2426CF9094003A4C25 /* WidgetDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */; };
@@ -1242,6 +1243,7 @@
 		BAB576BD2670512C00B0C56F /* NoteWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteWidget.swift; sourceTree = "<group>"; };
 		BAB6C04626BA4CAF007495C4 /* WidgetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetController.swift; sourceTree = "<group>"; };
 		BAB898D22BEC404200E238B8 /* CreateNewNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewNoteIntentHandler.swift; sourceTree = "<group>"; };
+		BABB22DE2D14DA6300FCF47D /* SPTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPTextView.swift; sourceTree = "<group>"; };
 		BABFFF2126CF9094003A4C25 /* WidgetDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDefaults.swift; sourceTree = "<group>"; };
 		BAD0F1EC2BED49C200E73E45 /* FindNoteIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindNoteIntentHandler.swift; sourceTree = "<group>"; };
 		BAE08625261282D1009D40CD /* Note+Publish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Publish.swift"; sourceTree = "<group>"; };
@@ -1872,6 +1874,7 @@
 			children = (
 				B5E3F3972539F1E900271AEA /* SPTextView.h */,
 				B5E3F3962539F1E900271AEA /* SPTextView.m */,
+				BABB22DE2D14DA6300FCF47D /* SPTextView.swift */,
 				E21F57B717C1244E001F02D3 /* SPEditorTextView.h */,
 				E21F57B817C1244E001F02D3 /* SPEditorTextView.m */,
 				A6BBDA45255034E6005C8343 /* SPEditorTextView+Simplenote.swift */,
@@ -3562,6 +3565,7 @@
 				B53C5A5A230330CD00DA2143 /* SPNoteListViewController+Extensions.swift in Sources */,
 				A6C0DFB525C1581D00B9BE39 /* UIScrollView+Simplenote.swift in Sources */,
 				375D24B621E01131007AB25A /* html_blocks.c in Sources */,
+				BABB22DF2D14DA6600FCF47D /* SPTextView.swift in Sources */,
 				46A3C98217DFA81A002865AE /* NSString+Attributed.m in Sources */,
 				375D24BA21E01131007AB25A /* document.c in Sources */,
 				BA6DA19126DB5F1B000464C8 /* URLComponents.swift in Sources */,

--- a/Simplenote/Classes/SPTextView.m
+++ b/Simplenote/Classes/SPTextView.m
@@ -22,14 +22,9 @@ CGFloat const TextViewHighlightCornerRadius = 3;
 - (instancetype)init {
     
     SPInteractiveTextStorage *textStorage = [[SPInteractiveTextStorage alloc] init];
-    NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
     
-    NSTextContainer *container = [[NSTextContainer alloc] initWithSize:CGSizeMake(0, CGFLOAT_MAX)];
-    container.widthTracksTextView = YES;
-    container.heightTracksTextView = YES;
-    [layoutManager addTextContainer:container];
-    [textStorage addLayoutManager:layoutManager];
-    
+    NSTextContainer *container = [self setupTextContainerWith:textStorage];
+
     self = [super initWithFrame:CGRectZero textContainer:container];
     if (self) {
         self.interactiveTextStorage = textStorage;

--- a/Simplenote/Classes/UIGestureRecognizer+Simplenote.swift
+++ b/Simplenote/Classes/UIGestureRecognizer+Simplenote.swift
@@ -21,8 +21,16 @@ extension UIGestureRecognizer {
         locationInContainer.x -= textView.textContainerInset.left
         locationInContainer.y -= textView.textContainerInset.top
 
-        return textView.layoutManager.characterIndex(for: locationInContainer,
-                                                     in: textView.textContainer,
-                                                     fractionOfDistanceBetweenInsertionPoints: nil)
+        guard #available(iOS 17.0, *),
+              let textLayoutManager = textView.textLayoutManager else {
+            // TextKit 1 fallback
+            return textView.layoutManager.characterIndex(
+                for: locationInContainer,
+                in: textView.textContainer,
+                fractionOfDistanceBetweenInsertionPoints: nil)
+        }
+
+        // TextKit 2
+        return textLayoutManager.characterIndex(for: locationInContainer) ?? .zero
     }
 }

--- a/Simplenote/NSTextLayoutFragment.swift
+++ b/Simplenote/NSTextLayoutFragment.swift
@@ -1,0 +1,17 @@
+//
+//  NSTextLayoutFragment.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 12/20/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+extension NSTextLayoutFragment {
+    @available(iOS 17.0, *)
+    func characterIndex(for location: CGPoint) -> Int? {
+        guard let lineFragment = textLineFragment(forVerticalOffset: location.y, requiresExactMatch: true) else {
+            return nil
+        }
+        return lineFragment.characterIndex(for: location)
+    }
+}

--- a/Simplenote/NSTextLayoutManager+Simplenote.swift
+++ b/Simplenote/NSTextLayoutManager+Simplenote.swift
@@ -1,0 +1,17 @@
+//
+//  NSTextLayoutManager+Simplenote.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 12/20/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+extension NSTextLayoutManager {
+    @available(iOS 17.0, *)
+    func characterIndex(for location: CGPoint) -> Int? {
+        guard let lineFragment = textLayoutFragment(for: location) else {
+            return nil
+        }
+        return lineFragment.characterIndex(for: location)
+    }
+}

--- a/Simplenote/SPTextView.swift
+++ b/Simplenote/SPTextView.swift
@@ -7,17 +7,6 @@
 //
 
 extension SPTextView {
-    /*
-     SPInteractiveTextStorage *textStorage = [[SPInteractiveTextStorage alloc] init];
-     NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
-
-     NSTextContainer *container = [[NSTextContainer alloc] initWithSize:CGSizeMake(0, CGFLOAT_MAX)];
-     container.widthTracksTextView = YES;
-     container.heightTracksTextView = YES;
-     [layoutManager addTextContainer:container];
-     [textStorage addLayoutManager:layoutManager];
-     */
-
     @objc
     func setupTextContainer(with textStorage: SPInteractiveTextStorage) -> NSTextContainer {
         let container = NSTextContainer(size: .zero)
@@ -28,6 +17,7 @@ extension SPTextView {
         if #available(iOS 16.0, *) {
             let textLayoutManager = NSTextLayoutManager()
             let contentStorage = NSTextContentStorage()
+            contentStorage.delegate = self
             contentStorage.addTextLayoutManager(textLayoutManager)
             textLayoutManager.textContainer = container
 
@@ -37,5 +27,68 @@ extension SPTextView {
         }
 
         return container
+    }
+}
+
+// MARK: NSTextContentStorageDelegate
+//
+extension SPTextView: NSTextContentStorageDelegate {
+    public func textContentStorage(_ textContentStorage: NSTextContentStorage, textParagraphWith range: NSRange) -> NSTextParagraph? {
+        guard let originalText = textContentStorage.textStorage?.attributedSubstring(from: range) as? NSMutableAttributedString else {
+            return nil
+        }
+
+        let style = textInRangeIsHeader(range) ? headlineStyle : defaultStyle
+        originalText.addAttributes(style, range: originalText.fullRange)
+
+        return NSTextParagraph(attributedString: originalText)
+    }
+
+    func textInRangeIsHeader(_ range: NSRange) -> Bool {
+        range.location == .zero
+    }
+
+    // MARK: Styles
+    //
+    var headlineFont: UIFont {
+        UIFont.preferredFont(for: .title1, weight: .bold)
+    }
+
+    var defaultFont: UIFont {
+        UIFont.preferredFont(forTextStyle: .body)
+    }
+
+    var defaultTextColor: UIColor {
+        UIColor.simplenoteNoteHeadlineColor
+    }
+
+    var lineSpacing: CGFloat {
+        defaultFont.lineHeight * Metrics.lineSpacingMultipler
+    }
+
+    var defaultStyle: [NSAttributedString.Key: Any] {
+        [
+            .font: defaultFont,
+            .foregroundColor: defaultTextColor,
+            .paragraphStyle: NSMutableParagraphStyle(lineSpacing: lineSpacing)
+        ]
+    }
+
+    var headlineStyle: [NSAttributedString.Key: Any] {
+        [
+            .font: headlineFont,
+            .foregroundColor: defaultTextColor,
+        ]
+    }
+}
+
+// MARK: - Metrics
+//
+private enum Metrics {
+    static let lineSpacingMultiplerPad: CGFloat = 0.40
+    static let lineSpacingMultiplerPhone: CGFloat = 0.20
+
+    static var lineSpacingMultipler: CGFloat {
+        UIDevice.isPad ? lineSpacingMultiplerPad : lineSpacingMultiplerPhone
     }
 }

--- a/Simplenote/SPTextView.swift
+++ b/Simplenote/SPTextView.swift
@@ -14,7 +14,7 @@ extension SPTextView {
         container.heightTracksTextView = true
 
 
-        if #available(iOS 16.0, *) {
+        if #available(iOS 17.0, *) {
             let textLayoutManager = NSTextLayoutManager()
             let contentStorage = NSTextContentStorage()
             contentStorage.delegate = self

--- a/Simplenote/SPTextView.swift
+++ b/Simplenote/SPTextView.swift
@@ -1,0 +1,41 @@
+//
+//  SPTextView.swift
+//  Simplenote
+//
+//  Created by Charlie Scheer on 12/19/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+extension SPTextView {
+    /*
+     SPInteractiveTextStorage *textStorage = [[SPInteractiveTextStorage alloc] init];
+     NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
+
+     NSTextContainer *container = [[NSTextContainer alloc] initWithSize:CGSizeMake(0, CGFLOAT_MAX)];
+     container.widthTracksTextView = YES;
+     container.heightTracksTextView = YES;
+     [layoutManager addTextContainer:container];
+     [textStorage addLayoutManager:layoutManager];
+     */
+
+    @objc
+    func setupTextContainer(with textStorage: SPInteractiveTextStorage) -> NSTextContainer {
+        let container = NSTextContainer(size: .zero)
+        container.widthTracksTextView = true
+        container.heightTracksTextView = true
+
+
+        if #available(iOS 16.0, *) {
+            let textLayoutManager = NSTextLayoutManager()
+            let contentStorage = NSTextContentStorage()
+            contentStorage.addTextLayoutManager(textLayoutManager)
+            textLayoutManager.textContainer = container
+
+        } else {
+            layoutManager.addTextContainer(container)
+            textStorage.addLayoutManager(layoutManager)
+        }
+
+        return container
+    }
+}


### PR DESCRIPTION
### Fix
This PR is the first step in implementing Textkit 2 into Simplenote.  Why do we need this?  Well primarily it is to keep up with the next paradigms in apple development.  Also with the addition of Textkit 2 we should get all of the new Apple intelligence features for free.  Lastly, by removing the reliance on glyphs and glyph ranges in TextKit 2, we should be able to fix many of the out of range crashes that we sometimes see with multi bit character languages.

Here I have taken the first steps.  I have:
- created the TextKit 2 layout properties if the device can run them
- layout the text with the same appearance as text in TextKit 1
- allow for tapping into and editing text without switching back to TextKit 1

### Test
1.  Launch the app, open a note
- [ ] Confirm that the text is styled correctly for SN
- [ ] Confirm that if you tap into the text you are able to become first responder
- [ ] Confirm that you can enter text
- [ ] Confirm that you never see this warning in the console `UITextView 0x10500fe00 is switching to TextKit 1 compatibility mode because its layoutManager was accessed`

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer and required to review these changes, but anyone can perform the review.

### Release
***(Required)*** Add a concise statement to `RELEASE-NOTES.txt` if the changes should be included in release notes. Include details about updating the notes in this section. For example:
> `RELEASE-NOTES.txt` was updated in d3adb3ef with:
> 
> > Added markdown support

If the changes should not be included in release notes, add a statement to this section. For example:

> These changes do not require release notes.
