### PR TITLE
Update App Store Connect Copyright Date

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -100,7 +100,8 @@ platform :ios do
       phased_release: true,
       precheck_include_in_app_purchases: false,
       api_key_path: APP_STORE_CONNECT_KEY_PATH,
-      force: skip_confirm
+      force: skip_confirm,
+      copyright: "© #{Time.now.year} Automattic, Inc."
     )
   end
 

--- a/fastlane/metadata/copyright.txt
+++ b/fastlane/metadata/copyright.txt
@@ -1,1 +1,0 @@
-2024 Automattic


### PR DESCRIPTION
## What it does
This updates the copyright uploaded to App Store Connect to be derived so we won't have to manually update it each year.. It'll be updated on App Store Connect during the next release cycle.
