### PR TITLE
[UI Tests] Replace paste with enter text for search UI tests.

### DIFF
--- a/SimplenoteUITests/SimplenoteUITestsSearch.swift
+++ b/SimplenoteUITests/SimplenoteUITestsSearch.swift
@@ -47,7 +47,7 @@ class SimplenoteUISmokeTestsSearch: XCTestCase {
         Sidebar.tagsDeleteAll()
         NoteList.openAllNotes()
 
-        allNotes.forEach { NoteList.createNoteThenLeaveEditor($0, usingPaste: true) }
+        allNotes.forEach { NoteList.createNoteThenLeaveEditor($0, usingPaste: false) }
 }
 
     override func setUpWithError() throws {


### PR DESCRIPTION
### Fix
The `Search` UI tests start by creating a number of notes with specific content to be used for search subsequently. To make things faster, these notes were created by pasting the text via context menu as opposed to typing it in. This made the execution 30–40 seconds faster. However, there's a history of flakiness associated with context menu. It's not the first time when different device settings or Xcode / iOS upgrade broke pasting, the last case being [this one](https://buildkite.com/automattic/simplenote-ios/builds/1264).

I decided to fall back to typing text in, given its higher stability and the current activity level of this repo.

### Test
- The CI is 🟢 
- Optional local execution is also 🟢 
