### PR TITLE
[Tooling] Automate GitHub release publishing for beta builds

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -66,6 +66,7 @@ lane :upload_to_app_store_connect do |beta_release:, skip_prechecks: false, crea
     version: version,
     release_notes_file_path: RELEASE_NOTES_SOURCE_PATH,
     release_assets: XCARCHIVE_ZIP_PATH.to_s,
-    prerelease: beta_release
+    prerelease: beta_release, # Beta = prerelease, Final = normal Release
+    is_draft: !beta_release # Beta = publish immediately, Final = Draft (only publish after Apple approval)
   )
 end


### PR DESCRIPTION
Reference: pdnsEh-24G-p2

- Android counterpart PR: https://github.com/Automattic/simplenote-android/pull/1725
- ReleasesV2 PR: https://github.a8c.com/Automattic/wpcom/pull/176219

### Description
This PR updates the `upload_to_app_store_connect` lane to automate the publishing of beta builds:

- Beta releases: Set as `prerelease=true` and `draft=false` to publish immediately as a pre-release
- Final releases: Set as `prerelease=false` and `draft=true` to create as a draft until we get Apple approval and can publish it

### Testing Steps

We'll be able to fully verify this works as expected during the next Simplenote iOS release cycle.

