### PR TITLE
Provision SwiftLint via SwiftPM instead of CocoaPods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ default.profraw
 # Everything without a .enc extension is ignored
 .configure-files/*
 !.configure-files/*.enc
+
+# BuildTools
+BuildTools/.build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,8 @@
-swiftlint_version: 0.54.0
+swiftlint_version: 0.58.2
 
 # Project configuration
 excluded:
+  - DerivedData
   - Pods
   - fastlane
   - vendor
@@ -49,8 +50,8 @@ only_rules:
 
 # Rules configuration
 
-control_statement: 
-  severity: error 
+control_statement:
+  severity: error
 
 custom_rules:
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,7 @@ swiftlint_version: 0.58.2
 
 # Project configuration
 excluded:
+  - BuildTools
   - DerivedData
   - Pods
   - fastlane

--- a/BuildTools/Empty.swift
+++ b/BuildTools/Empty.swift
@@ -1,0 +1,2 @@
+// Here only to satisfy SwiftPM requirement.
+// See https://github.com/nicklockwood/SwiftFormat#1-create-a-buildtools-folder-and-packageswift

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "cd02791f9079102404056ed65d89c5c6bb997332bbfd1b03550dfdd51e57551e",
+  "pins" : [
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
+        "version" : "0.58.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:6.0
+import Foundation
+import PackageDescription
+
+let package = Package(
+    name: "BuildTools",
+    platforms: [.macOS(.v10_13)],
+    dependencies: [
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: loadSwiftLintVersion()),
+    ],
+    targets: [.target(name: "BuildTools", path: "")]
+)
+
+func loadSwiftLintVersion() -> Version {
+    let swiftLintConfigURL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .appendingPathComponent("..")
+        .appendingPathComponent(".swiftlint.yml")
+
+    guard let yamlString = try? String(contentsOf: swiftLintConfigURL) else {
+        fatalError("Failed to read SwiftLint config file at \(swiftLintConfigURL).")
+    }
+
+    guard let versionLine = yamlString.components(separatedBy: .newlines)
+        .first(where: { $0.contains("swiftlint_version") }) else {
+        fatalError("SwiftLint version not found in YAML file.")
+    }
+
+    // Assumes the format `swiftlint_version: <version>`
+    guard let version = Version(versionLine.components(separatedBy: ":")
+        .last?
+        .trimmingCharacters(in: .whitespaces) ?? "") else {
+        fatalError("Failed to extract SwiftLint version.")
+    }
+
+    return version
+}

--- a/Podfile
+++ b/Podfile
@@ -41,20 +41,6 @@ abstract_target 'Automattic' do
   end
 end
 
-## Tools
-## ===================
-##
-
-def swiftlint_version
-  require 'yaml'
-
-  YAML.load_file('.swiftlint.yml')['swiftlint_version']
-end
-
-abstract_target 'Tools' do
-  pod 'SwiftLint', swiftlint_version
-end
-
 # Post Install
 #
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,14 +11,14 @@ PODS:
   - Simperium/SocketTrust (1.9.0)
   - Simperium/SPReachability (1.9.0)
   - Simperium/SSKeychain (1.9.0)
-  - SwiftLint (0.54.0)
+  - SwiftLint (0.58.2)
   - WordPress-Ratings-iOS (0.0.2)
   - ZIPFoundation (0.9.15)
 
 DEPENDENCIES:
   - Gridicons (~> 0.18)
   - Simperium (= 1.9.0)
-  - SwiftLint (= 0.54.0)
+  - SwiftLint (= 0.58.2)
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -33,7 +33,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   Simperium: 45d828d68aad71f3449371346f270013943eff78
-  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
+  SwiftLint: 365bcd9ffc83d0deb874e833556d82549919d6cd
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: 063163dc828bf699c5be160eb4f58f676322d94f
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,14 +11,12 @@ PODS:
   - Simperium/SocketTrust (1.9.0)
   - Simperium/SPReachability (1.9.0)
   - Simperium/SSKeychain (1.9.0)
-  - SwiftLint (0.58.2)
   - WordPress-Ratings-iOS (0.0.2)
   - ZIPFoundation (0.9.15)
 
 DEPENDENCIES:
   - Gridicons (~> 0.18)
   - Simperium (= 1.9.0)
-  - SwiftLint (= 0.58.2)
   - WordPress-Ratings-iOS (= 0.0.2)
   - ZIPFoundation (~> 0.9.9)
 
@@ -26,17 +24,15 @@ SPEC REPOS:
   trunk:
     - Gridicons
     - Simperium
-    - SwiftLint
     - WordPress-Ratings-iOS
     - ZIPFoundation
 
 SPEC CHECKSUMS:
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   Simperium: 45d828d68aad71f3449371346f270013943eff78
-  SwiftLint: 365bcd9ffc83d0deb874e833556d82549919d6cd
   WordPress-Ratings-iOS: 9f83dbba6e728c5121b1fd21b5683cf2fd120646
   ZIPFoundation: 063163dc828bf699c5be160eb4f58f676322d94f
 
-PODFILE CHECKSUM: 1a6145a673ddc931a81b1fbd59e20edfdbaca298
+PODFILE CHECKSUM: 14904fe5db303e2b35352af2f191345f1edf8f0a
 
 COCOAPODS: 1.16.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Third party libraries and resources managed by CocoaPods will be installed by th
 
 #### SwiftLint
 
-We use [SwiftLint](https://github.com/realm/SwiftLint) to enforce a common style for Swift code. If you plan to write code, SwiftLint is going to be installed when you run `bundle exec pod install` and SwiftLint will run during the build.
+We use [SwiftLint](https://github.com/realm/SwiftLint) to enforce a common style for Swift code.
+If you plan to write code, SwiftLint is going to be installed automatically when you build the app.
 No commit should have lint warnings or errors.
 
 ### Open Xcode

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,18 @@ LOCAL_PATH = 'vendor/bundle'
 
 task default: %w[test]
 
+desc 'Checks the source for style errors'
+task :lint do
+  swiftlint
+end
+
+namespace :lint do
+  desc 'Automatically corrects style errors where possible'
+  task :autocorrect do
+    swiftlint(additional_args: ['--fix'])
+  end
+end
+
 desc 'Install required dependencies'
 task dependencies: %w[dependencies:check]
 
@@ -250,4 +262,17 @@ def check_dependencies_hook
     puts e.message
     exit 1
   end
+end
+
+def swiftlint(additional_args: [])
+  run_package_plugin(cmd: "swiftlint --working-directory .. --quiet #{additional_args.join(' ')}")
+end
+
+def run_package_plugin(cmd:)
+  run_in_build_tools(cmd: "swift package plugin --allow-writing-to-directory .. --allow-writing-to-package-directory #{cmd}")
+end
+
+# We could use more idiomatic Ruby here, with `Dir.chdir`, but leaving as raw shell commands for when we'll drop Ruby and rake for tooling.
+def run_in_build_tools(cmd:)
+  sh "pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && #{cmd} && popd"
 end

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -3306,7 +3306,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "[ $CI ] && exit 0\n./Pods/SwiftLint/swiftlint\n";
+			shellScript = "[ $CI ] && exit 0\nrake lint\n";
 		};
 		B553F5A11D10474600F7E397 /* Delete Frameworks folder (temporary fix for CocoaPods) */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
See https://linear.app/a8c/issue/AINFRA-449

### Test
Checkout locally and run `bundle install && bundle exec pod install && bundle exec rake lint`

You should see something like, possibly with additional logs such as removing SwiftLint from your pods.

<img width="2560" alt="image" src="https://github.com/user-attachments/assets/f1d49649-eb6f-4143-af77-c3690fd6f2a9" />

<!-- blue -->
> [!NOTE]  
> The UI tests failure is a long standing issue and unrelated with the changes in this PR.

### Review
***(Required)*** Add instructions for reviewers.  For example:
> Only one developer required to review these changes, but anyone can perform the review.

### Release

> These changes do not require release notes.
