### PR TITLE
[Tooling] Use Release Version from ReleasesV2 in Code Freeze

### DIFF
--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -21,7 +21,7 @@ steps:
       install_gems
 
       echo '--- :shipit: Start code freeze'
-      bundle exec fastlane start_code_freeze skip_confirm:true
+      bundle exec fastlane start_code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     retry:
       manual:
         # If failed, we prefer retrying via ReleaseV2 rather than Buildkite.

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -8,21 +8,24 @@ platform :ios do
 
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    expected_version = release_version_next
-    computed_release_branch_name = release_branch_name(release_version: expected_version)
+    # Use provided version from release tool, or fall back to calculated version
+    calculated_version = release_version_next
+    release_version = version || calculated_version
+    computed_release_branch_name = release_branch_name(release_version: release_version)
 
-    # Validate provided version matches the calculated version
-    if version && version != expected_version
-      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{expected_version}'. Please check the release scenario version matches the project version.")
+    # Warn if provided version differs from calculated version
+    if version && version != calculated_version
+      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+      UI.important(warning_message)
+      buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
     end
-    UI.success("✓ Version validation passed: Version (#{version || expected_version}) matches calculated version") if version
 
     message = <<~MESSAGE
       Code Freeze:
       - New release branch from #{DEFAULT_BRANCH}: #{computed_release_branch_name}
 
       - Current release version and build code: #{release_version_current} (#{build_code_current}).
-      - New release version and build code: #{expected_version} (#{build_code_code_freeze}).
+      - New release version and build code: #{release_version} (#{build_code_code_freeze}).
     MESSAGE
 
     UI.important(message)

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -5,7 +5,8 @@
 platform :ios do
   # Creates a new release branch from the current default branch
   #
-  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
+  # @param [String] version (optional) The version to use for the new release version to code freeze for.
+  #                 Typically auto-provided by ReleasesV2. If nil, computes the new version based on current one.
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt
   #
   lane :start_code_freeze do |version: nil, skip_confirm: false|
@@ -13,14 +14,18 @@ platform :ios do
 
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to calculated version
-    calculated_version = release_version_next
-    release_version = version || calculated_version
-    computed_release_branch_name = release_branch_name(release_version: release_version)
+    # Use provided version from release tool, or fall back to computed version
+    computed_version = release_version_next
+    new_version = version || computed_version
+    computed_release_branch_name = release_branch_name(release_version: new_version)
 
-    # Warn if provided version differs from calculated version
-    if version && version != calculated_version
-      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+    # Warn if provided version differs from computed version
+    if version && version != computed_version
+      warning_message = <<~WARNING
+        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
+        If this is unexpected, you might want to investigate the discrepency.
+        Continuing with the explicitly-provided verison '#{version}'.
+      WARNING
       UI.important(warning_message)
       buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
     end
@@ -30,7 +35,7 @@ platform :ios do
       - New release branch from #{DEFAULT_BRANCH}: #{computed_release_branch_name}
 
       - Current release version and build code: #{release_version_current} (#{build_code_current}).
-      - New release version and build code: #{release_version} (#{build_code_code_freeze}).
+      - New release version and build code: #{new_version} (#{build_code_code_freeze}).
     MESSAGE
 
     UI.important(message)
@@ -49,8 +54,6 @@ platform :ios do
     UI.success "Done! New release version: #{release_version_current}. New build code: #{build_code_current}."
 
     commit_version_and_build_files
-
-    new_version = release_version_current
 
     # Delete all release notes metadata, including the source of truth.
     # We'll generate a new source of truth next, and the localized versions will be re-downloaded once translated on GlotPress.

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -3,6 +3,11 @@
 # Lanes related to the Release Process (Code Freeze, Betas, Final Build, App Store Submission…)
 
 platform :ios do
+  # Creates a new release branch from the current default branch
+  #
+  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
+  # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt
+  #
   lane :start_code_freeze do |version: nil, skip_confirm: false|
     ensure_git_status_clean
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -3,19 +3,26 @@
 # Lanes related to the Release Process (Code Freeze, Betas, Final Build, App Store Submission…)
 
 platform :ios do
-  lane :start_code_freeze do |skip_confirm: false|
+  lane :start_code_freeze do |version: nil, skip_confirm: false|
     ensure_git_status_clean
 
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    computed_release_branch_name = release_branch_name(release_version: release_version_next)
+    expected_version = release_version_next
+    computed_release_branch_name = release_branch_name(release_version: expected_version)
+
+    # Validate provided version matches the calculated version
+    if version && version != expected_version
+      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{expected_version}'. Please check the release scenario version matches the project version.")
+    end
+    UI.success("✓ Version validation passed: Version (#{version || expected_version}) matches calculated version") if version
 
     message = <<~MESSAGE
       Code Freeze:
       - New release branch from #{DEFAULT_BRANCH}: #{computed_release_branch_name}
 
       - Current release version and build code: #{release_version_current} (#{build_code_current}).
-      - New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
+      - New release version and build code: #{expected_version} (#{build_code_code_freeze}).
     MESSAGE
 
     UI.important(message)


### PR DESCRIPTION
Closes [AINFRA-1380: SNiOS: Validate that release version sent by ReleasesV2 matches the project](https://linear.app/a8c/issue/AINFRA-1380/snios-validate-that-release-version-sent-by-releasesv2-matches-the)

## Description

This PR updates the code freeze process to use the release version provided by ReleasesV2 as the source of truth.

The code freeze Buildkite pipeline now passes the `RELEASE_VERSION` environment variable to the `start_code_freeze` Fastlane lane.
If there's a mismatch between the passed version and the project calculated version, a warning is displayed to help identify configuration discrepancies, but the ReleasesV2 version is always used.

## Testing

The code freeze lane has several side effects like potentially changing the version in the main branch, creating a release branch, updating release notes, etc, making it hard to easily test it. We can run a couple of tests locally commenting out parts of the lane, but they'll only test a minor part of the lane.
The changes will then be fully tested in the next release cycle during code freeze.