### PR TITLE
[Tooling] Use ReleasesV2 version as the source of truth during Code Freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -685,13 +685,15 @@ def build_code_current
   BUILD_CODE_FORMATTER.build_code(version: version)
 end
 
-# Returns the build code of the app for the code freeze.
-# It is the release version name with build number (last of the four components) set to 0.
+# Returns the initial build code for a code freeze (e.g., "1.2.3.0" for release version "1.2.3")
+# Takes the release version and formats it as a four-part build code with the build number set to 0
 #
 def build_code_code_freeze(version_short: nil)
+  # Use provided version or read the current release version from the .xcconfig file
   version_short ||= PUBLIC_VERSION_FILE.read_release_version
-  # We use the four part (1.2.3.4) build code format, so the version calculator can be used to calculate the next four-part version
+  # Parse the release version string (e.g., "1.2.3") into an AppVersion object
   release_version_current = VERSION_FORMATTER.parse(version_short)
+  # Format as four-part build code (e.g., "1.2.3.0")
   BUILD_CODE_FORMATTER.build_code(version: release_version_current)
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -688,11 +688,11 @@ end
 # Returns the build code of the app for the code freeze.
 # It is the release version name with build number (last of the four components) set to 0.
 #
-def build_code_code_freeze
+def build_code_code_freeze(version_short: nil)
+  version_short ||= PUBLIC_VERSION_FILE.read_release_version
   # We use the four part (1.2.3.4) build code format, so the version calculator can be used to calculate the next four-part version
-  release_version_current = VERSION_FORMATTER.parse(PUBLIC_VERSION_FILE.read_release_version)
-  build_code_code_freeze = VERSION_CALCULATOR.next_release_version(version: release_version_current)
-  BUILD_CODE_FORMATTER.build_code(version: build_code_code_freeze)
+  release_version_current = VERSION_FORMATTER.parse(version_short)
+  BUILD_CODE_FORMATTER.build_code(version: release_version_current)
 end
 
 # Returns the build code of the app for the code freeze.

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -19,15 +19,17 @@ platform :ios do
     new_version = version || computed_version
     computed_release_branch_name = release_branch_name(release_version: new_version)
 
-    # Warn if provided version differs from computed version
+    # Fail if provided version differs from computed version
     if version && version != computed_version
-      warning_message = <<~WARNING
-        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
-        If this is unexpected, you might want to investigate the discrepency.
-        Continuing with the explicitly-provided verison '#{version}'.
-      WARNING
-      UI.important(warning_message)
-      buildkite_annotate(style: 'warning', context: 'start-code-freeze-version-mismatch', message: warning_message) if is_ci
+      error_message = <<~ERROR
+        ❌ Version mismatch detected!
+
+        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
+
+        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
+      ERROR
+      buildkite_annotate(style: 'error', context: 'start-code-freeze-version-mismatch', message: error_message) if is_ci
+      UI.user_error!(error_message)
     end
 
     message = <<~MESSAGE

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -14,35 +14,24 @@ platform :ios do
 
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to computed version
-    computed_version = release_version_next
-    new_version = version || computed_version
+    # If a new version is passed, use it as source of truth from now on
+    new_version = version || release_version_next
     computed_release_branch_name = release_branch_name(release_version: new_version)
-
-    # Fail if provided version differs from computed version
-    if version && version != computed_version
-      error_message = <<~ERROR
-        ❌ Version mismatch detected!
-
-        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
-
-        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
-      ERROR
-      buildkite_annotate(style: 'error', context: 'start-code-freeze-version-mismatch', message: error_message) if is_ci
-      UI.user_error!(error_message)
-    end
+    new_build_code = build_code_code_freeze(version_short: new_version)
 
     message = <<~MESSAGE
       Code Freeze:
       - New release branch from #{DEFAULT_BRANCH}: #{computed_release_branch_name}
 
       - Current release version and build code: #{release_version_current} (#{build_code_current}).
-      - New release version and build code: #{new_version} (#{build_code_code_freeze}).
+      - New release version and build code: #{new_version} (#{new_build_code}).
     MESSAGE
 
     UI.important(message)
 
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
+
+    ensure_branch_does_not_exist!(computed_release_branch_name)
 
     UI.message 'Creating release branch...'
     Fastlane::Helper::GitHelper.create_branch(computed_release_branch_name, from: DEFAULT_BRANCH)
@@ -50,8 +39,8 @@ platform :ios do
 
     UI.message 'Bumping release version and build code...'
     PUBLIC_VERSION_FILE.write(
-      version_short: release_version_next,
-      version_long: build_code_code_freeze
+      version_short: new_version,
+      version_long: new_build_code
     )
     UI.success "Done! New release version: #{release_version_current}. New build code: #{build_code_current}."
 
@@ -100,7 +89,7 @@ platform :ios do
 
       Next steps:
 
-      - Checkout `#{release_branch_name}` branch locally
+      - Checkout `#{computed_release_branch_name}` branch locally
       - Update Pods and release notes if needed
       - Finalize the code freeze
     MESSAGE
@@ -426,4 +415,15 @@ def release_is_hotfix?
   VERSION_CALCULATOR.release_is_hotfix?(
     version: VERSION_FORMATTER.parse(PUBLIC_VERSION_FILE.read_release_version)
   )
+end
+
+def ensure_branch_does_not_exist!(branch_name)
+  return unless Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: branch_name)
+
+  error_message = "The branch `#{branch_name}` already exists. Please check first if there is an existing Pull Request that needs to be merged or closed first, " \
+                  'or delete the branch to then run again the release task.'
+
+  buildkite_annotate(style: 'error', context: 'error-checking-branch', message: error_message) if is_ci
+
+  UI.user_error!(error_message)
 end


### PR DESCRIPTION
See AINFRA-1478

## Description

This PR enhances the version handling added in the previous iteration to assume the version received by the code freeze lane as the source of truth, ignoring potential mismatches between the ReleasesV2 version and the project's computed version.

## Testing

You can make sure the calculated release branch, current version and the next version are correctly shown in the "Continue" prompt. Just **remember to answer `N` when asked to continue**, to cancel the actual code freeze.

To avoid unexpected results, comment out the lines doing `ensure_git_status_clean` and `Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)` at the beginning of the lane.

You can run the `start_code_freeze` lane, with and without the version parameters:
- Run `bundle exec fastlane start_code_freeze` 
- Run `bundle exec fastlane start_code_freeze version:30.6`

This will be fully tested in the next release cycle during code freeze.