### PR TITLE
[Tooling] Improve `new_hotfix_release` lane to work when there's no release tag

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -271,9 +271,12 @@ platform :ios do
     # Fetch the base ref to ensure it's available locally
     sh('git', 'fetch', 'origin', base_ref_for_hotfix)
 
+    hotfix_branch = release_branch_name(release_version: version)
+    ensure_branch_does_not_exist!(hotfix_branch)
+
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(
-      release_branch_name(release_version: version),
+      hotfix_branch,
       from: base_ref_for_hotfix
     )
     UI.success("Done! New hotfix branch is: '#{git_branch}'")

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -240,18 +240,20 @@ platform :ios do
     ensure_git_status_clean unless skip_prechecks
 
     parsed_version = VERSION_FORMATTER.parse(version)
+    # Validate that this is a hotfix version (must have a patch component > 0)
+    UI.user_error!("Invalid hotfix version '#{version}'. Must include a patch number.") unless parsed_version.patch.to_i.positive?
     build_code_hotfix = BUILD_CODE_FORMATTER.build_code(version: parsed_version)
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
     previous_release_branch = release_branch_name(release_version: previous_version)
 
     # Determine the base for the hotfix branch: either a tag or a release branch
-    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version, remote: true)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
-                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
+                            UI.message("ℹ️  Tag '#{previous_version}' not found on the remote. Using release branch '#{previous_release_branch}' as the base for hotfix instead.")
                             previous_release_branch
                           else
-                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                            UI.user_error!("Neither tag '#{previous_version}' nor branch '#{previous_release_branch}' exists on the remote! A hotfix branch cannot be created.")
                           end
 
     UI.important <<-MESSAGE
@@ -261,14 +263,14 @@ platform :ios do
     MESSAGE
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
-    UI.user_error!("Version #{version} already exists! Abort!") if git_tag_exists(tag: version)
+    UI.user_error!("Version '#{version}' already exists on the remote! Abort!") if git_tag_exists(tag: version, remote: true)
 
-    UI.message("Creating hotfix branch from #{base_ref_for_hotfix}...")
+    UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(
       release_branch_name(release_version: version),
       from: base_ref_for_hotfix
     )
-    UI.success("Done! New hotfix branch is: #{git_branch}")
+    UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     UI.message('Bumping hotfix version and build code...')
     VERSION_FILE.write(

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -286,7 +286,7 @@ platform :ios do
       version_short: version,
       version_long: build_code_hotfix
     )
-    commit_version_bump
+    commit_version_and_build_files
 
     unless skip_confirm || UI.confirm('Ready to push changes to remote?')
       UI.message("Terminating as requested. Don't forget to run the remainder of this automation manually.")

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -282,7 +282,7 @@ platform :ios do
     UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     UI.message('Bumping hotfix version and build code...')
-    VERSION_FILE.write(
+    PUBLIC_VERSION_FILE.write(
       version_short: version,
       version_long: build_code_hotfix
     )

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -265,6 +265,9 @@ platform :ios do
 
     UI.user_error!("Version '#{version}' already exists on the remote! Abort!") if git_tag_exists(tag: version, remote: true)
 
+    # Fetch the base ref to ensure it's available locally
+    sh('git', 'fetch', 'origin', base_ref_for_hotfix)
+
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(
       release_branch_name(release_version: version),

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -256,11 +256,14 @@ platform :ios do
                             UI.user_error!("Neither tag '#{previous_version}' nor branch '#{previous_release_branch}' exists on the remote! A hotfix branch cannot be created.")
                           end
 
-    UI.important <<-MESSAGE
-      New hotfix version: #{version}
-      New build code: #{build_code_hotfix}
-      Branching from #{base_ref_for_hotfix}
+    message = <<~MESSAGE
+      Hotfix release:
+      - New hotfix version: #{version}
+      - New build code: #{build_code_hotfix}
+      - Branching from #{base_ref_for_hotfix}
     MESSAGE
+    UI.important(message)
+
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     UI.user_error!("Version '#{version}' already exists on the remote! Abort!") if git_tag_exists(tag: version, remote: true)

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -242,21 +242,30 @@ platform :ios do
     parsed_version = VERSION_FORMATTER.parse(version)
     build_code_hotfix = BUILD_CODE_FORMATTER.build_code(version: parsed_version)
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
+    previous_release_branch = release_branch_name(release_version: previous_version)
+
+    # Determine the base for the hotfix branch: either a tag or a release branch
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+                            previous_version
+                          elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            previous_release_branch
+                          else
+                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                          end
 
     UI.important <<-MESSAGE
       New hotfix version: #{version}
       New build code: #{build_code_hotfix}
-      Branching from tag: #{previous_version}
+      Branching from #{base_ref_for_hotfix}
     MESSAGE
     UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     UI.user_error!("Version #{version} already exists! Abort!") if git_tag_exists(tag: version)
-    UI.user_error!("No tag found for version #{previous_version}. A hotfix branch cannot be created.") unless git_tag_exists(tag: previous_version)
 
-    UI.message('Creating hotfix branch...')
+    UI.message("Creating hotfix branch from #{base_ref_for_hotfix}...")
     Fastlane::Helper::GitHelper.create_branch(
       release_branch_name(release_version: version),
-      from: previous_version
+      from: base_ref_for_hotfix
     )
     UI.success("Done! New hotfix branch is: #{git_branch}")
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -248,6 +248,7 @@ platform :ios do
     base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
                             previous_release_branch
                           else
                             UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")


### PR DESCRIPTION
Related to AINFRA-1518

## Description

This PR aims to add more robustness and require less manual intervention to the hotfix creation lane `new_hotfix_release`.

We have observed that sometimes it is possible that the release has been finalized but a release tag isn't present yet for some reason (likely due to the fact that the release hasn't been published yet), so release managers will get an error and require manual intervention.

This PR changes the code so that, if no release tag is present, we start the hotfix branch based on the corresponding release branch.


## Testing instructions

These are some test scenarios that can be simulated:
1. There is a release tag that can be used to create the hotfix branch
2. There's no tag, but there's still a release branch that can be used to create the hotfix branch
3. There's no tag or branch (error)
4. The provided version doesn't have a patch component like `30.6` instead of `30.6.1` (error)

To test it, you can create test branches / tags (⚠️ delete them later or, even better, use [this technique](https://github.com/bloom/DayOne-Apple/pull/27670#issuecomment-3553138802) of pointing your working copy’s `origin` remote to a local bare repo instead ⚠️ ) and run `bundle exec fastlane new_hotfix_release skip_confirm:false version:"$VERSION"` and then answer `no` after the prompt so that the lane execution stops and check the printed values.

For example:
1. Create and push release branch `release/30.6` (which doesn't exist and has no corresponding tag for that version)
2. Run `bundle exec fastlane new_hotfix_release skip_confirm:false version:30.6.1`
3. It should use the `release/30.6` branch instead of trying to use a tag. It should print:
```
ℹ️  Tag '30.6' not found on the remote. Using release branch 'release/30.6' as the base for hotfix instead.
Hotfix release:
- New hotfix version: 30.6.1
- New build code: 30.6.1.0
- Branching from release/30.6

Do you want to continue? (y/n)
```
