### PR TITLE
Add CLAUDE.md with agent instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+## Slow commands
+
+`swift`, `xcodebuild`, and `fastlane` commands can take several minutes.
+Account for this when setting `max_turns` on parallel subagents — 40 or higher is a safe default.
+
+## Opening Pull Requests
+
+Before opening a PR, read the `Dangerfile` and proactively satisfy its checks.


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` with instructions for Claude Code agents working in this repo:

- Slow command guidance (set higher `max_turns` for `swift`/`xcodebuild`/`fastlane`)
- PR checklist (read `Dangerfile` before opening PRs)

Extracted from #1730, decoupled from the `.claude/settings.json` permission changes.

Context: https://linear.app/a8c/issue/AINFRA-1965

## Test Plan

- [ ] CI passes