### PR TITLE
SwiftLint Batch 1A: add empty checks rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,13 +19,18 @@ only_rules:
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 
+  - contains_over_filter_is_empty
+
   - discarded_notification_center_observer
 
   - duplicate_imports
 
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
+  - empty_count
   - empty_enum_arguments
+
+  - empty_string
 
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -398,7 +398,7 @@ extension SPNoteListViewController {
             trashButton.isEnabled = false
             return
         }
-        trashButton.isEnabled = selectedRows.count > 0
+        trashButton.isEnabled = !selectedRows.isEmpty
     }
 }
 


### PR DESCRIPTION
This PR was created by Codex using GPT-5.3-codex as part of an experiment in autonomous agents working across multiple repos. The result was not satisfactory.

---

Batch 1A rollout for SwiftLint rules:\n- empty_count\n- empty_string\n- contains_over_filter_is_empty\n\nExecution notes:\n- Started from up-to-date default branch worktree\n- Applied SwiftLint --fix first where repo-native plugin workflow was available\n- Applied agentic fixes for remaining violations in this batch\n\nPinned SwiftLint fix/lint run complete; no remaining Batch 1A violations.\n\nHuman merge only.