### PR TITLE
Remove xcpretty-travis-formatter from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -192,7 +192,7 @@ def xcodebuild(*build_cmds)
   cmd += " -configuration #{xcode_configuration}"
   cmd += ' '
   cmd += build_cmds.map(&:to_s).join(' ')
-  cmd += ' | bundle exec xcpretty -f `bundle exec xcpretty-travis-formatter` && exit ${PIPESTATUS[0]}' unless ENV['verbose']
+  cmd += ' | bundle exec xcpretty && exit ${PIPESTATUS[0]}' unless ENV['verbose']
   sh(cmd)
 end
 


### PR DESCRIPTION
## Summary

- Update `Rakefile` to use plain `xcpretty` instead of the Travis CI formatter

The Travis CI formatter is unnecessary — CI runs on Buildkite, not Travis.
The gem itself remains as a transitive dependency of `fastlane`, but it's no longer actively invoked.

See https://github.com/woocommerce/woocommerce-ios/pull/16707#discussion_r2845925808

_Gio here_: We'll followup removing the `Rakefile` logic that was using the Travis formatter and now uses only `xcpretty`. It's unused legacy logic that we already removed from the WooCommerce implementation and can remove from here, too. I didn't realize the logic was there when I prompted for this work. But that's okay, let's move in small incremental steps.

## Test plan

- [ ] CI passes with the updated Rakefile

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*

🤖 Generated with [Claude Code](https://claude.ai/code)