### PR TITLE
Enable SwiftLint rule: empty_count

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,6 +23,9 @@ only_rules:
 
   - duplicate_imports
 
+  # Prefer checking `isEmpty` over comparing `count` to zero.
+  - empty_count
+
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
   - empty_enum_arguments

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -398,7 +398,7 @@ extension SPNoteListViewController {
             trashButton.isEnabled = false
             return
         }
-        trashButton.isEnabled = selectedRows.count > 0
+        trashButton.isEnabled = !selectedRows.isEmpty
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds the `empty_count` rule to the SwiftLint `only_rules` list.
  This rule flags comparisons of `.count` against zero, preferring `.isEmpty` instead for clarity and performance.
- **1 auto-fixed violation** in `SPNoteListViewController+Extensions.swift` (`.count > 0` replaced with `!.isEmpty`).
- **0 agentic fixes** needed.

This is part of the Orchard SwiftLint rollout campaign, which progressively enables lint rules across Automattic repos.

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*

---

<!-- blue -->
> [!NOTE]  
> "Orchard" is the code name I'm using for the latest iteration of a multi-agent workflow with memory for multi-step projects like progressively enabling SwiftLint rules. It's not published yet because I need to figure out how to separate the tooling and AI configurations from the definition and tracking of the multi-step plan. Ideally both would be under Git, but in different repos.