### PR TITLE
Enable SwiftLint rule: empty_string

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,6 +26,9 @@ only_rules:
   # Prefer checking `isEmpty` over comparing `count` to zero.
   - empty_count
 
+  # Prefer checking `isEmpty` over comparing `string` to an empty string literal.
+  - empty_string
+
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
   - empty_enum_arguments


### PR DESCRIPTION
## Summary

- Enables the `empty_string` SwiftLint rule, which prefers checking `isEmpty` over comparing a string to an empty string literal (`""`).
- No violations found in the codebase — this is a config-only change.
- 0 auto-fixed violations, 0 manual fixes.

This is part of the Orchard SwiftLint rollout campaign.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*