### PR TITLE
Enable SwiftLint rule: contains_over_filter_is_empty

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over comparing `filter(where:)` to empty.
+  - contains_over_filter_is_empty
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 


### PR DESCRIPTION
## Summary

- Adds the `contains_over_filter_is_empty` rule to the `only_rules` list in `.swiftlint.yml`
- This rule prefers `contains` over comparing `filter(where:)` to empty (e.g., `.filter { ... }.isEmpty` becomes `.contains { ... }`)
- Zero violations found in the codebase — config-only change, no auto-fixes or manual fixes needed

Part of the Orchard SwiftLint rollout campaign.

---

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*