### PR TITLE
Update outdated GitHub Actions

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.5.x' # Same as project's .ruby-version
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.5.x' # Same as project's .ruby-version
 
     - name: Install Bundler
       run: gem install bundler


### PR DESCRIPTION
Fixes AINFRA-2297

## Summary
- Replace deprecated `actions/setup-ruby@v1` with maintained `ruby/setup-ruby@v1`

## Test plan
- [ ] Verify screenshots workflow runs on next PR with "Needs Screenshots" label

🤖 Generated with [Claude Code](https://claude.ai/code)