### PR TITLE
Enable SwiftLint rule: unused_import

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -55,6 +55,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   # - trailing_whitespace
 
+  # All imported modules should be required to make the file compile.
+  - unused_import
+
   # - vertical_whitespace
   - custom_rules
 


### PR DESCRIPTION
## Summary

Enables the [`unused_import`](https://realm.github.io/SwiftLint/unused_import.html) SwiftLint rule, which flags module imports not referenced by the file's source code.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Changes

- Added `unused_import` to `only_rules` in `.swiftlint.yml`.

## Violations

- Auto-fixed: 0
- Agentic (manual) fixes: 0
- Left for human review: 0

No source files needed changes — the repo is already clean against this rule under the current lint configuration.

Note: `unused_import` is a SwiftLint analyzer rule. It runs cleanly under `swiftlint lint` in this repo (no violations reported), but its full power requires `swiftlint analyze` with a compiler log, which this repo's tooling does not currently invoke. Enabling the rule in `only_rules` keeps the config aligned with the campaign goal; expanding the CI tooling to run `swiftlint analyze` is out of scope for this PR.

## Test plan

- [x] `rake lint` — clean
- [x] `bundle exec fastlane run_unit_tests` — 166 tests, 0 failures