### PR TITLE
Enable SwiftLint rule: toggle_bool

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,6 +46,9 @@ only_rules:
   # the declaration.
   - opening_brace
 
+  # Prefer `someBool.toggle()` over `someBool = !someBool`.
+  - toggle_bool
+
   # Files should have a single trailing newline.
   - trailing_newline
 


### PR DESCRIPTION
## Summary

Enables the `toggle_bool` SwiftLint rule, which prefers `someBool.toggle()` over `someBool = !someBool`.

- Auto-fixed violations: 0
- Manual fixes: 0
- Violations left for human review: none

Part of the Orchard SwiftLint rollout campaign.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*