### PR TITLE
Enable SwiftLint rule: prefer_zero_over_explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,6 +46,9 @@ only_rules:
   # the declaration.
   - opening_brace
 
+  # Prefer `.zero` over explicit init with zero parameters (e.g., `CGPoint(x: 0, y: 0)`).
+  - prefer_zero_over_explicit_init
+
   # Files should have a single trailing newline.
   - trailing_newline
 


### PR DESCRIPTION
## What

Adds [`prefer_zero_over_explicit_init`](https://realm.github.io/SwiftLint/prefer_zero_over_explicit_init.html) to `only_rules` in `.swiftlint.yml`.

The rule flags explicit zero-valued initialisers (e.g. `CGPoint(x: 0, y: 0)`, `CGSize(width: 0, height: 0)`) in favour of the `.zero` static property.

## Numbers

- Auto-fixed violations: **0**
- Manual fixes: **0**
- Violations left for human review: **0**

The codebase already satisfies the rule; only the config is updated.

---

Generated with the help of Claude Code, https://claude.com/claude-code, on behalf of @mokagio with approval.