### PR TITLE
Enable SwiftLint rule: shorthand_optional_binding

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -49,6 +49,9 @@ only_rules:
   # Prefer `.zero` over explicit init with zero parameters (e.g., `CGPoint(x: 0, y: 0)`).
   - prefer_zero_over_explicit_init
 
+  # Prefer the shorthand `if let foo` over `if let foo = foo` when binding an optional with the same name.
+  - shorthand_optional_binding
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/Simplenote/Classes/CSSearchable+Helpers.swift
+++ b/Simplenote/Classes/CSSearchable+Helpers.swift
@@ -57,7 +57,7 @@ extension CSSearchableIndex {
 
         let item = CSSearchableItem(note: note)
         indexSearchableItems([item]) { error in
-            if let error = error {
+            if let error {
                 NSLog("Couldn't index note in spotlight: \(error.localizedDescription)")
             }
         }
@@ -73,7 +73,7 @@ extension CSSearchableIndex {
         }
 
         indexSearchableItems(items) { error in
-            if let error = error {
+            if let error {
                 NSLog("Couldn't index notes in spotlight: \(error.localizedDescription)")
             }
         }
@@ -89,7 +89,7 @@ extension CSSearchableIndex {
         }
 
         deleteSearchableItems(withIdentifiers: ids) { error in
-            if let error = error {
+            if let error {
                 NSLog("Couldn't delete notes from spotlight index: \(error.localizedDescription)")
             }
         }

--- a/Simplenote/Classes/InterlinkProcessor.swift
+++ b/Simplenote/Classes/InterlinkProcessor.swift
@@ -105,7 +105,7 @@ private extension InterlinkProcessor {
 
     func setupInterlinkEventListeners(replacementRange: Range<String.Index>) {
         interlinkViewController?.onInsertInterlink = { [weak self] text in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Simplenote/Classes/NSAttributedString+AuthError.swift
+++ b/Simplenote/Classes/NSAttributedString+AuthError.swift
@@ -22,7 +22,7 @@ extension NSAttributedString {
         output.append(string: .space)
         output.append(statusText)
 
-        if let error = error {
+        if let error {
             let title = NSAttributedString(string: Title.error, attributes: Style.title)
             let text = NSAttributedString(string: error.localizedDescription, attributes: Style.text)
 
@@ -33,7 +33,7 @@ extension NSAttributedString {
             output.append(text)
         }
 
-        if let response = response {
+        if let response {
             let title = NSAttributedString(string: Title.response, attributes: Style.title)
             let text = NSAttributedString(string: response, attributes: Style.text)
 

--- a/Simplenote/Classes/NSMutableAttributedString+Simplenote.swift
+++ b/Simplenote/Classes/NSMutableAttributedString+Simplenote.swift
@@ -15,7 +15,7 @@ extension NSMutableAttributedString {
     ///
     func append(string: String, foregroundColor: UIColor? = nil) {
         var attributes = [NSAttributedString.Key: Any]()
-        if let foregroundColor = foregroundColor {
+        if let foregroundColor {
             attributes[.foregroundColor] = foregroundColor
         }
 

--- a/Simplenote/Classes/Note+Properties.swift
+++ b/Simplenote/Classes/Note+Properties.swift
@@ -55,7 +55,7 @@ extension Note {
     }
 
     private func titlePreview(with range: Range<String.Index>?) -> String {
-        guard let range = range, let content = content else {
+        guard let range, let content else {
             return NSLocalizedString("New note...", comment: "Empty Note Placeholder")
         }
 
@@ -64,7 +64,7 @@ extension Note {
     }
 
     private func bodyPreview(with range: Range<String.Index>?) -> String? {
-        guard let range = range, let content = content else {
+        guard let range, let content else {
             return nil
         }
 
@@ -82,7 +82,7 @@ extension Note {
     /// Returns excerpt of the content around the first match of one of the keywords
     ///
     func bodyExcerpt(keywords: [String]?) -> String? {
-        guard let keywords = keywords, !keywords.isEmpty, let content = content?.precomposedStringWithCanonicalMapping else {
+        guard let keywords, !keywords.isEmpty, let content = content?.precomposedStringWithCanonicalMapping else {
             return bodyPreview
         }
 

--- a/Simplenote/Classes/NoteContentHelper.swift
+++ b/Simplenote/Classes/NoteContentHelper.swift
@@ -10,7 +10,7 @@ enum NoteContentHelper {
     ///     - content: note content
     ///
     static func structure(of content: String?) -> (title: Range<String.Index>?, body: Range<String.Index>?, trimmedBody: Range<String.Index>?) {
-        guard let content = content, !content.isEmpty else {
+        guard let content, !content.isEmpty else {
             return (title: nil, body: nil, trimmedBody: nil)
         }
 

--- a/Simplenote/Classes/PinLock/PinLockVerifyController.swift
+++ b/Simplenote/Classes/PinLock/PinLockVerifyController.swift
@@ -83,7 +83,7 @@ private extension PinLockVerifyController {
         hasShownBiometryVerification = true
 
         pinLockManager.evaluateBiometry { [weak self] (success) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Simplenote/Classes/PinLock/PinLockViewController.swift
+++ b/Simplenote/Classes/PinLock/PinLockViewController.swift
@@ -122,7 +122,7 @@ private extension PinLockViewController {
     }
 
     func update(with configuration: PinLockControllerConfiguration, animation: UIView.ReloadAnimation?) {
-        guard let animation = animation else {
+        guard let animation else {
             update(with: configuration)
             return
         }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -518,11 +518,11 @@ extension SPAuthViewController {
         lockdownInterface()
 
         controller.signupWithCredentials(username: email) { [weak self] error in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
-            if let error = error {
+            if let error {
                 self.handleError(error: error)
             } else {
                 self.presentSignupVerification()
@@ -590,7 +590,7 @@ private extension SPAuthViewController {
         lockdownInterface()
 
         controller.validateWithCredentials(username: email, password: password) { error in
-            if let error = error {
+            if let error {
                 self.handleError(error: error)
             } else {
                 self.presentPasswordResetRequiredAlert(email: self.email)
@@ -604,7 +604,7 @@ private extension SPAuthViewController {
         lockdownInterface()
 
         controller.loginWithCredentials(username: email, password: password) { error in
-            if let error = error {
+            if let error {
                 self.handleError(error: error)
             } else {
                 SPTracker.trackUserSignedIn()
@@ -727,7 +727,7 @@ private extension SPAuthViewController {
     }
 
     func attemptLoginWithCurrentCredentials() {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             fatalError()
         }
 

--- a/Simplenote/Classes/SPDiagnosticsViewController.swift
+++ b/Simplenote/Classes/SPDiagnosticsViewController.swift
@@ -59,7 +59,7 @@ private extension SPDiagnosticsViewController {
 
     @IBAction
     func shareWasPressed() {
-        guard let attributedText = attributedText else {
+        guard let attributedText else {
             fatalError()
         }
 

--- a/Simplenote/Classes/SPEditorTapRecognizerDelegate.swift
+++ b/Simplenote/Classes/SPEditorTapRecognizerDelegate.swift
@@ -43,7 +43,7 @@ class SPEditorTapRecognizerDelegate: NSObject, UIGestureRecognizerDelegate {
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        guard let excludedView = excludedView, let touchView = touch.view else {
+        guard let excludedView, let touchView = touch.view else {
             return true
         }
 

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -188,7 +188,7 @@ extension SPNoteEditorViewController: KeyboardObservable {
     }
 
     public func keyboardWillChangeFrame(beginFrame: CGRect?, endFrame: CGRect?, animationDuration: TimeInterval?, animationCurve: UInt?) {
-        guard let _ = view.window, let endFrame = endFrame, let duration = animationDuration, let curve = animationCurve else {
+        guard let _ = view.window, let endFrame, let duration = animationDuration, let curve = animationCurve else {
             return
         }
 
@@ -196,7 +196,7 @@ extension SPNoteEditorViewController: KeyboardObservable {
     }
 
     public func keyboardDidChangeFrame(beginFrame: CGRect?, endFrame: CGRect?, animationDuration: TimeInterval?, animationCurve: UInt?) {
-        guard let _ = view.window, let endFrame = endFrame, let duration = animationDuration, let curve = animationCurve else {
+        guard let _ = view.window, let endFrame, let duration = animationDuration, let curve = animationCurve else {
             return
         }
 
@@ -415,13 +415,13 @@ extension SPNoteEditorViewController {
     ///
     @objc
     func updateInformationControllerPresentation() {
-        guard let informationViewController = informationViewController else {
+        guard let informationViewController else {
             return
         }
 
         restoreDefaultLinksDimmingInEditor()
         informationViewController.dismiss(animated: false) { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.presentInformationController(for: self.note, from: self.informationButton)
@@ -532,7 +532,7 @@ extension SPNoteEditorViewController {
     }
 
     private func presentNewNoteReplacingCurrentEditor() {
-        guard let navigationController = navigationController,
+        guard let navigationController,
               let snapshotView = createAndAddEditorSnapshotView() else {
             return
         }
@@ -560,7 +560,7 @@ extension SPNoteEditorViewController {
                                   height: noteEditorTextView.frame.height - noteEditorTextView.adjustedContentInset.top)
 
         guard let snapshotView = view.resizableSnapshotView(from: snapshotRect, afterScreenUpdates: false, withCapInsets: .zero),
-              let navigationController = navigationController else {
+              let navigationController else {
             return nil
         }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -262,7 +262,7 @@ extension SPNoteListViewController {
             return .generic
         }
 
-        if let searchQuery = searchQuery, !searchQuery.isEmpty {
+        if let searchQuery, !searchQuery.isEmpty {
             let actionHandler: () -> Void = { [weak self] in
                 self?.openNewNote(with: searchQuery.searchText)
             }
@@ -364,7 +364,7 @@ extension SPNoteListViewController {
     @objc
     func configureNavigationToolbarButton() {
         // TODO: When multi select is added to iPad, revist the conditionals here
-        guard let trashButton = trashButton else {
+        guard let trashButton else {
             return
         }
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
@@ -970,7 +970,7 @@ extension SPNoteListViewController {
 
     private var popoverPresenter: PopoverPresenter {
         let viewportProvider: () -> CGRect = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return .zero
             }
 

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -194,7 +194,7 @@ class SPNoteTableViewCell: UITableViewCell {
     ///
     private func refreshBodyAttributedString() {
         let bodyString = NSMutableAttributedString()
-        if let prefixText = prefixText {
+        if let prefixText {
             let prefixString = NSAttributedString(string: prefixText + String.space, attributes: [
                 .font: Style.prefixFont,
                 .foregroundColor: Style.headlineColor,
@@ -465,7 +465,7 @@ private extension NSAttributedString {
 
         output.processChecklists(with: textColor, sizingFont: font, allowsMultiplePerLine: true)
 
-        if let keywords = keywords, !keywords.isEmpty {
+        if let keywords, !keywords.isEmpty {
             output.apply(color: highlightColor, toSubstringsMatching: keywords)
         }
 

--- a/Simplenote/Classes/SPObjectManager+Simplenote.swift
+++ b/Simplenote/Classes/SPObjectManager+Simplenote.swift
@@ -52,7 +52,7 @@ extension SPObjectManager {
     func newNote(withContent content: String?, tags: [String]?) -> Note {
         let newNote = newDefaultNote()
 
-        if let content = content {
+        if let content {
             newNote.content = content
         }
 

--- a/Simplenote/Classes/ShortcutsHandler.swift
+++ b/Simplenote/Classes/ShortcutsHandler.swift
@@ -132,7 +132,7 @@ extension ShortcutsHandler {
     }
 
     private func noteItem(with note: Note?) -> UIApplicationShortcutItem? {
-        guard let note = note, let simperiumKey = note.simperiumKey else {
+        guard let note, let simperiumKey = note.simperiumKey else {
             return nil
         }
 

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -188,7 +188,7 @@ extension String {
     static func simplenotePath(withHost host: String? = nil) -> String {
         let base = SimplenoteConstants.simplenoteScheme + "://"
 
-        guard let host = host else {
+        guard let host else {
             return base
         }
 

--- a/Simplenote/Classes/TagView.swift
+++ b/Simplenote/Classes/TagView.swift
@@ -193,14 +193,14 @@ private extension TagView {
         let cell = TagViewCell(tagName: tagName)
 
         cell.onTap = { [weak self, weak cell] in
-            guard let self = self, let cell = cell else {
+            guard let self, let cell else {
                 return
             }
             self.toggleDeleteButton(for: cell)
         }
 
         cell.onDelete = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.delegate?.tagView(self, wantsToRemoveTagWithName: tagName)

--- a/Simplenote/Classes/UIKeyCommand+Simplenote.swift
+++ b/Simplenote/Classes/UIKeyCommand+Simplenote.swift
@@ -22,7 +22,7 @@ extension UIKeyCommand {
                      title: String? = nil) {
         self.init(input: input, modifierFlags: modifierFlags, action: action)
 
-        if let title = title {
+        if let title {
             self.title = title
         }
     }

--- a/Simplenote/Classes/UITextField+Tag.swift
+++ b/Simplenote/Classes/UITextField+Tag.swift
@@ -7,7 +7,7 @@ extension UITextField {
     ///
     @objc
     func pasteTag() {
-        guard let selectedRange = selectedRange,
+        guard let selectedRange,
               let pasteboardText = UIPasteboard.general.string, !pasteboardText.isEmpty else {
             return
         }

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -50,7 +50,7 @@ private extension UITextView {
     ///
     @discardableResult
     func registerUndoCheckpointAndPerform(block: (NSTextStorage) -> Void) -> Bool {
-        guard let undoManager = undoManager else {
+        guard let undoManager else {
             return false
         }
 
@@ -97,7 +97,7 @@ extension UITextView {
     /// Returns the Interlinking Keyword at the current Location (if any)
     ///
     var interlinkKeywordAtSelectedLocation: (Range<String.Index>, Range<String.Index>, String)? {
-        guard let text = text, let range = Range(selectedRange, in: text) else {
+        guard let text, let range = Range(selectedRange, in: text) else {
             return nil
         }
 

--- a/Simplenote/Classes/UIView+Animations.swift
+++ b/Simplenote/Classes/UIView+Animations.swift
@@ -79,7 +79,7 @@ extension UIView {
             return
         }
 
-        guard let superview = superview, let snapshot = snapshotView(afterScreenUpdates: true) else {
+        guard let superview, let snapshot = snapshotView(afterScreenUpdates: true) else {
             viewUpdateBlock()
             return
         }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -164,7 +164,7 @@ extension NoteInformationViewController: UITableViewDelegate {
         let row = sections[indexPath.section].rows[indexPath.row]
         switch row {
         case .reference(let interLink, _, _):
-            if let interLink = interLink, let url = URL(string: interLink) {
+            if let interLink, let url = URL(string: interLink) {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
         default:

--- a/Simplenote/KeychainPasswordItem.swift
+++ b/Simplenote/KeychainPasswordItem.swift
@@ -166,11 +166,11 @@ struct KeychainPasswordItem {
         query[kSecClass as String] = kSecClassGenericPassword
         query[kSecAttrService as String] = service as AnyObject?
 
-        if let account = account {
+        if let account {
             query[kSecAttrAccount as String] = account as AnyObject?
         }
 
-        if let accessGroup = accessGroup {
+        if let accessGroup {
             query[kSecAttrAccessGroup as String] = accessGroup as AnyObject?
         }
 

--- a/Simplenote/NSTextStorage+Simplenote.swift
+++ b/Simplenote/NSTextStorage+Simplenote.swift
@@ -3,7 +3,7 @@ import Foundation
 extension NSTextStorage {
     @objc(applyBackgroundColor:toRanges:)
     func applyBackgroundColor(_ color: UIColor?, toRanges wordRanges: [NSValue]?) {
-        guard let color = color, let wordRanges = wordRanges else {
+        guard let color, let wordRanges else {
             return
         }
 

--- a/Simplenote/Note+Links.swift
+++ b/Simplenote/Note+Links.swift
@@ -17,7 +17,7 @@ extension Note {
     /// Returns the receiver's Markdown Internal Reference, when possible
     ///
     var markdownInternalLink: String? {
-        guard let title = titlePreview, let plainInternalLink = plainInternalLink else {
+        guard let title = titlePreview, let plainInternalLink else {
             return nil
         }
 

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -63,7 +63,7 @@ class NoticePresenter {
     }
 
     private func prepareContainerView() -> PassthruView? {
-        guard let keyWindow = keyWindow else {
+        guard let keyWindow else {
             return nil
         }
 
@@ -106,8 +106,8 @@ class NoticePresenter {
     // MARK: Dismissing Methods
     //
     func dismissNotification(withDuration duration: TimeInterval, completion: @escaping () -> Void) {
-        guard let containerView = containerView,
-              let noticeView = noticeView else {
+        guard let containerView,
+              let noticeView else {
             return
         }
         UIView.animate(withDuration: duration,
@@ -130,9 +130,9 @@ class NoticePresenter {
 //
 extension NoticePresenter: KeyboardObservable {
     func keyboardDidChangeFrame(beginFrame: CGRect?, endFrame: CGRect?, animationDuration: TimeInterval?, animationCurve: UInt?) {
-        guard let endFrame = endFrame,
-              let animationCurve = animationCurve,
-              let animationDuration = animationDuration else {
+        guard let endFrame,
+              let animationCurve,
+              let animationDuration else {
             return
         }
         updateKeyboardHeight(with: endFrame)
@@ -140,9 +140,9 @@ extension NoticePresenter: KeyboardObservable {
     }
 
     func keyboardWillChangeFrame(beginFrame: CGRect?, endFrame: CGRect?, animationDuration: TimeInterval?, animationCurve: UInt?) {
-        guard let endFrame = endFrame,
-              let animationCurve = animationCurve,
-              let animationDuration = animationDuration else {
+        guard let endFrame,
+              let animationCurve,
+              let animationDuration else {
             return
         }
         updateKeyboardHeight(with: endFrame)
@@ -155,7 +155,7 @@ extension NoticePresenter: KeyboardObservable {
     }
 
     private func animateNoticeToNewKeyboardLocation(frame: CGRect, curve: UInt, animationDuration: TimeInterval) {
-        guard let containerView = containerView else {
+        guard let containerView else {
             return
         }
 

--- a/Simplenote/PopoverPresenter.swift
+++ b/Simplenote/PopoverPresenter.swift
@@ -72,7 +72,7 @@ final class PopoverPresenter {
     /// - Important: Frame must be expressed in Window Coordinates. Capisce?
     ///
     func relocate(around anchorInWindow: CGRect) {
-        guard let popoverController = popoverController, let view = popoverController.view else {
+        guard let popoverController, let view = popoverController.view else {
             return
         }
 
@@ -147,7 +147,7 @@ private extension PopoverPresenter {
 
         let (viewportBelow, viewportAbove)  = viewport.split(by: anchor)
 
-        guard let desiredHeight = desiredHeight else {
+        guard let desiredHeight else {
             if viewportAbove.height > viewportBelow.height {
                 return (.above, viewportAbove)
             }

--- a/Simplenote/SPCardDismissalAnimator.swift
+++ b/Simplenote/SPCardDismissalAnimator.swift
@@ -16,7 +16,7 @@ final class SPCardDismissalAnimator: NSObject, UIViewControllerAnimatedTransitio
 
     func interruptibleAnimator(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
         // According to docs we must return the same animator object during transition
-        if let animator = animator {
+        if let animator {
             return animator
         }
 

--- a/Simplenote/SPCardPresentationController.swift
+++ b/Simplenote/SPCardPresentationController.swift
@@ -127,7 +127,7 @@ private extension SPCardPresentationController {
     }
 
     func addCardView() {
-        guard let containerView = containerView else {
+        guard let containerView else {
             return
         }
 

--- a/Simplenote/SPTextAttachment.swift
+++ b/Simplenote/SPTextAttachment.swift
@@ -44,7 +44,7 @@ class SPTextAttachment: NSTextAttachment {
 private extension SPTextAttachment {
 
     func refreshImage() {
-        guard let tintColor = tintColor else {
+        guard let tintColor else {
             return
         }
 

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -612,7 +612,7 @@ private extension TagListViewController {
     }
 
     func renameTag(_ tag: Tag) {
-        if let renameTag = renameTag {
+        if let renameTag {
             cell(for: renameTag)?.textField.endEditing(true)
         }
 
@@ -652,7 +652,7 @@ extension TagListViewController: UITextFieldDelegate {
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        guard let renameTag = renameTag else {
+        guard let renameTag else {
             return
         }
 
@@ -719,7 +719,7 @@ private extension TagListViewController {
 
     func startListeningForChanges() {
         resultsController.onDidChangeContent = { [weak self] (sectionsChangeset, objectsChangeset) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Simplenote/Tags/NoteEditorTagListViewController.swift
+++ b/Simplenote/Tags/NoteEditorTagListViewController.swift
@@ -37,7 +37,7 @@ class NoteEditorTagListViewController: UIViewController {
     private lazy var suggestionsViewController: NoteEditorTagSuggestionsViewController = {
         let viewController = NoteEditorTagSuggestionsViewController(note: note)
         viewController.onSelectionCallback = { [weak self] tagName in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -117,7 +117,7 @@ private extension NoteEditorTagListViewController {
     }
 
     func deleteTagIfCreatedRecently(tagName: String) {
-        guard let recentlyCreatedTag = recentlyCreatedTag, recentlyCreatedTag == tagName else {
+        guard let recentlyCreatedTag, recentlyCreatedTag == tagName else {
             return
         }
 

--- a/Simplenote/URL+Simplenote.swift
+++ b/Simplenote/URL+Simplenote.swift
@@ -3,7 +3,7 @@ import Foundation
 extension URL {
     static func internalUrl(forTag tag: String?) -> URL {
         guard var components = URLComponents.simplenoteURLComponents(with: SimplenoteConstants.simplenoteInternalTagHost),
-              let tag = tag else {
+              let tag else {
             return URL(string: .simplenotePath(withHost: SimplenoteConstants.simplenoteInternalTagHost))!
         }
 
@@ -19,7 +19,7 @@ extension URL {
             return URL(string: .simplenotePath())!
         }
 
-        if let tag = tag {
+        if let tag {
             components.queryItems = [
                 URLQueryItem(name: Constants.tagQueryBase, value: tag)
             ]

--- a/SimplenoteIntents/ResolutionResults/IntentNote+Helpers.swift
+++ b/SimplenoteIntents/ResolutionResults/IntentNote+Helpers.swift
@@ -10,7 +10,7 @@ import Intents
 
 extension IntentNoteResolutionResult {
     static func resolve(_ intentNote: IntentNote?, in coreDataWrapper: ExtensionCoreDataWrapper) -> IntentNoteResolutionResult {
-        guard let intentNote = intentNote,
+        guard let intentNote,
               let identifier = intentNote.identifier else {
             return IntentNoteResolutionResult.needsValue()
         }

--- a/SimplenoteShare/Presentation/ExtensionPresentationController.swift
+++ b/SimplenoteShare/Presentation/ExtensionPresentationController.swift
@@ -48,7 +48,7 @@ final class ExtensionPresentationController: UIPresentationController {
 
     override var frameOfPresentedViewInContainerView: CGRect {
         var frame: CGRect = .zero
-        if let containerView = containerView {
+        if let containerView {
             frame.size = size(forChildContentContainer: presentedViewController, withParentContainerSize: containerView.bounds.size)
             frame.origin.x = (containerView.frame.width - frame.width) / 2.0
             frame.origin.y = (containerView.frame.height - frame.height) / 2.0
@@ -119,7 +119,7 @@ extension ExtensionPresentationController: KeyboardObservable {
         let presentedFrame = frameOfPresentedViewInContainerView
         let translatedFrame = getTranslationFrame(keyboardFrame: keyboardFrame, presentedFrame: presentedFrame)
         var animationOptions: UIView.AnimationOptions = []
-        if let animationCurve = animationCurve {
+        if let animationCurve {
             animationOptions = UIView.AnimationOptions(rawValue: animationCurve)
         }
 

--- a/SimplenoteShare/ViewControllers/ShareViewController.swift
+++ b/SimplenoteShare/ViewControllers/ShareViewController.swift
@@ -113,7 +113,7 @@ private extension ShareViewController {
     /// Submits a given Note to the user's Simplenote account
     ///
     func submit(note: Note) {
-        guard let simperiumToken = simperiumToken else {
+        guard let simperiumToken else {
             return
         }
 
@@ -174,12 +174,12 @@ private extension ShareViewController {
     /// Attempts to extract the Note's Payload from the current ExtensionContext
     ///
     func loadContent() {
-        guard let context = context else {
+        guard let context else {
             fatalError()
         }
 
         context.extractNote(from: context) { note in
-            guard let note = note else {
+            guard let note else {
                 return
             }
             self.originalNote = note

--- a/SimplenoteTests/MockupStorage.swift
+++ b/SimplenoteTests/MockupStorage.swift
@@ -54,7 +54,7 @@ class MockupStorageManager {
             }
 
             storeCoordinator.addPersistentStore(with: storeDescriptor) { (_, error) in
-                guard let error = error else {
+                guard let error else {
                     return
                 }
 

--- a/SimplenoteWidgets/Models/Note+Widget.swift
+++ b/SimplenoteWidgets/Models/Note+Widget.swift
@@ -46,7 +46,7 @@ extension Note {
     }
 
     private func title(with range: Range<String.Index>?) -> String {
-        guard let range = range, let content = content else {
+        guard let range, let content else {
             return Constants.defaultTitle
         }
 
@@ -60,7 +60,7 @@ extension Note {
     }
 
     private func content(with range: Range<String.Index>?) -> String {
-        guard let range = range, let content = content else {
+        guard let range, let content else {
             // Note. Swift UI Text will crash if given String() so need to use this version of an empty string
             return ""
         }

--- a/SimplenoteWidgets/Tools/ExtensionResultsController.swift
+++ b/SimplenoteWidgets/Tools/ExtensionResultsController.swift
@@ -127,7 +127,7 @@ enum TagsFilter {
 
 extension TagsFilter {
     init(from tag: String?) {
-        guard let tag = tag else {
+        guard let tag else {
             self = .allNotes
             return
         }


### PR DESCRIPTION
## What

Adds [`shorthand_optional_binding`](https://realm.github.io/SwiftLint/shorthand_optional_binding.html) to `only_rules` in `.swiftlint.yml`.

The rule prefers the Swift 5.7+ shorthand `if let foo` over `if let foo = foo` when binding an optional with the same identifier.

## Numbers

- Auto-fixed violations: **78** across **40** files
- Manual fixes: **0**
- Violations left for human review: **0**

## Notes

Part of the Orchard SwiftLint rollout campaign.

---

Generated with the help of Claude Code, https://claude.com/claude-code, on behalf of @mokagio with approval.