### PR TITLE
Enable SwiftLint rule: unused_closure_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -64,6 +64,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   # - trailing_whitespace
 
+  # Unused parameter in a closure should be replaced with `_`.
+  - unused_closure_parameter
+
   # - vertical_whitespace
   - custom_rules
 

--- a/Simplenote/Classes/NSString+Count.swift
+++ b/Simplenote/Classes/NSString+Count.swift
@@ -23,7 +23,7 @@ import Foundation
         }
         let ChineseCharacterSet = CharacterSet.CJKUniHan.union(CharacterSet.Hiragana).union(CharacterSet.Katakana)
         var result = 0
-        enumerateSubstrings(in: NSMakeRange(0, length), options: [.byWords, .localized]) { (substring, substringRange, enclosingRange, stop) in
+        enumerateSubstrings(in: NSMakeRange(0, length), options: [.byWords, .localized]) { (substring, _, _, _) in
             if ChineseCharacterSet.contains(substring!.unicodeScalars.first!) {
                 result += substring!.count
             } else if !CharacterSet.whitespacesAndNewlines.contains(substring!.unicodeScalars.first!) { // Sometimes NSString treat "\n" and " " as a word.

--- a/Simplenote/Classes/SPContactsManager.swift
+++ b/Simplenote/Classes/SPContactsManager.swift
@@ -53,7 +53,7 @@ class SPContactsManager: NSObject {
             return
         }
 
-        store.requestAccess(for: .contacts) { (success, error) in
+        store.requestAccess(for: .contacts) { (success, _) in
             completion?(success)
         }
     }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -549,7 +549,7 @@ extension SPNoteListViewController: UITableViewDelegate {
         return UIContextMenuConfiguration(identifier: nil, previewProvider: {
             return self.previewingViewController(for: note)
 
-        }, actionProvider: { suggestedActions in
+        }, actionProvider: { _ in
             return self.contextMenu(for: note, at: indexPath)
         })
     }

--- a/SimplenoteScreenshots/SnapshotHelper.swift
+++ b/SimplenoteScreenshots/SnapshotHelper.swift
@@ -196,7 +196,7 @@ open class Snapshot: NSObject {
         let format = UIGraphicsImageRendererFormat()
         format.scale = image.scale
         let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-        return renderer.image { context in
+        return renderer.image { _ in
             image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
         }
     }

--- a/SimplenoteTests/MockupStorage.swift
+++ b/SimplenoteTests/MockupStorage.swift
@@ -21,7 +21,7 @@ class MockupStorageManager {
     private(set) lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: name, managedObjectModel: managedModel)
         container.persistentStoreDescriptions = [storeDescription]
-        container.loadPersistentStores { (storeDescription, error) in
+        container.loadPersistentStores { (_, error) in
             if let error = error as NSError? {
                 fatalError("[MockupStorageManager] Fatal Error: \(error) [\(error.userInfo)]")
             }

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -532,7 +532,7 @@ private extension NotesListControllerTests {
     func expectBatchChanges(objectsChangeset: ResultsObjectsChangeset) -> XCTestExpectation {
         let expectation = self.expectation(description: "Waiting...")
 
-        noteListController.onBatchChanges = { (receivedSectionChanges, receivedObjectChanges) in
+        noteListController.onBatchChanges = { (_, receivedObjectChanges) in
             for (index, change) in objectsChangeset.deleted.enumerated() {
                 XCTAssertEqual(change, objectsChangeset.deleted[index])
             }

--- a/SimplenoteWidgets/Views/NoteWidgetView.swift
+++ b/SimplenoteWidgets/Views/NoteWidgetView.swift
@@ -6,7 +6,7 @@ struct NoteWidgetView: View {
     @Environment(\.widgetFamily) var widgetFamily
 
     var body: some View {
-        GeometryReader { geometry in
+        GeometryReader { _ in
             ZStack {
                 VStack(alignment: .leading) {
                     Text(entry.title)

--- a/SimplenoteWidgets/Widgets/NewNoteWidget.swift
+++ b/SimplenoteWidgets/Widgets/NewNoteWidget.swift
@@ -4,7 +4,7 @@ import WidgetKit
 @available(iOS 14.0, *)
 struct NewNoteWidget: Widget {
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: Constants.configurationKind, provider: NewNoteTimelineProvider()) { entry in
+        StaticConfiguration(kind: Constants.configurationKind, provider: NewNoteTimelineProvider()) { _ in
             NewNoteWidgetView()
         }
         .configurationDisplayName(Constants.displayName)


### PR DESCRIPTION
## What

Enables the SwiftLint [`unused_closure_parameter`](https://realm.github.io/SwiftLint/unused_closure_parameter.html) rule, which flags closure parameters that are never referenced and recommends replacing them with `_`.

## Stats

- Auto-fixed violations: **10** across **8** files
- Manual fixes: **0**
- `swiftlint:disable` additions: **0**

The rule is autocorrectable and the substitution (`name` -> `_`) is type-preserving, so no manual intervention or build breakage was expected or observed.

## Testing

- `bundle exec rake lint` is clean on the modified config.
- Build/test deferred to CI per campaign convention for type-preserving rules.

Part of the Orchard SwiftLint rollout campaign.