### PR TITLE
Enable SwiftLint rule: unneeded_parentheses_in_closure_argument

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -64,6 +64,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   # - trailing_whitespace
 
+  # Closure arguments shouldn't be enclosed in parentheses.
+  - unneeded_parentheses_in_closure_argument
+
   # - vertical_whitespace
   - custom_rules
 

--- a/Simplenote/Classes/BiometricAuthentication.swift
+++ b/Simplenote/Classes/BiometricAuthentication.swift
@@ -41,7 +41,7 @@ class BiometricAuthentication {
         }
 
         let context = LAContext()
-        context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: Localization.biometryReason) { (success, _) in
+        context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: Localization.biometryReason) { success, _ in
             DispatchQueue.main.async {
                 completion(success)
             }

--- a/Simplenote/Classes/NSString+Count.swift
+++ b/Simplenote/Classes/NSString+Count.swift
@@ -23,7 +23,7 @@ import Foundation
         }
         let ChineseCharacterSet = CharacterSet.CJKUniHan.union(CharacterSet.Hiragana).union(CharacterSet.Katakana)
         var result = 0
-        enumerateSubstrings(in: NSMakeRange(0, length), options: [.byWords, .localized]) { (substring, substringRange, enclosingRange, stop) in
+        enumerateSubstrings(in: NSMakeRange(0, length), options: [.byWords, .localized]) { substring, substringRange, enclosingRange, stop in
             if ChineseCharacterSet.contains(substring!.unicodeScalars.first!) {
                 result += substring!.count
             } else if !CharacterSet.whitespacesAndNewlines.contains(substring!.unicodeScalars.first!) { // Sometimes NSString treat "\n" and " " as a word.

--- a/Simplenote/Classes/NotesListController.swift
+++ b/Simplenote/Classes/NotesListController.swift
@@ -238,13 +238,13 @@ private extension NotesListController {
 private extension NotesListController {
 
     func startListeningToNoteEvents() {
-        notesController.onDidChangeContent = { [weak self] (sectionsChangeset, objectsChangeset) in
+        notesController.onDidChangeContent = { [weak self] sectionsChangeset, objectsChangeset in
             self?.notifyNotesDidChange(sectionsChangeset: sectionsChangeset, objectsChangeset: objectsChangeset)
         }
     }
 
     func startListeningToTagEvents() {
-        tagsController.onDidChangeContent = { [weak self] (sectionsChangeset, objectsChangeset) in
+        tagsController.onDidChangeContent = { [weak self] sectionsChangeset, objectsChangeset in
             self?.notifyTagsDidChange(sectionsChangeset: sectionsChangeset, objectsChangeset: objectsChangeset)
         }
     }

--- a/Simplenote/Classes/PinLock/PinLockVerifyController.swift
+++ b/Simplenote/Classes/PinLock/PinLockVerifyController.swift
@@ -82,7 +82,7 @@ private extension PinLockVerifyController {
 
         hasShownBiometryVerification = true
 
-        pinLockManager.evaluateBiometry { [weak self] (success) in
+        pinLockManager.evaluateBiometry { [weak self] success in
             guard let self else {
                 return
             }

--- a/Simplenote/Classes/PinLock/PinLockViewController.swift
+++ b/Simplenote/Classes/PinLock/PinLockViewController.swift
@@ -47,7 +47,7 @@ class PinLockViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        controller.configurationObserver = { [weak self] (configuration, animation) in
+        controller.configurationObserver = { [weak self] configuration, animation in
             self?.update(with: configuration, animation: animation)
         }
     }

--- a/Simplenote/Classes/SPAuthHandler.swift
+++ b/Simplenote/Classes/SPAuthHandler.swift
@@ -30,7 +30,7 @@ class SPAuthHandler {
     func loginWithCredentials(username: String, password: String, onCompletion: @escaping (SPAuthError?) -> Void) {
         simperiumService.authenticate(withUsername: username, password: password, success: {
             onCompletion(nil)
-        }, failure: { (statusCode, response, error) in
+        }, failure: { statusCode, response, error in
             let error = SPAuthError(loginErrorCode: statusCode, response: response, error: error)
             onCompletion(error)
         })
@@ -48,7 +48,7 @@ class SPAuthHandler {
     func validateWithCredentials(username: String, password: String, onCompletion: @escaping (SPAuthError?) -> Void) {
         simperiumService.validate(withUsername: username, password: password, success: {
             onCompletion(nil)
-        }, failure: { (statusCode, response, error) in
+        }, failure: { statusCode, response, error in
             let error = SPAuthError(loginErrorCode: statusCode, response: response, error: error)
             onCompletion(error)
         })
@@ -89,7 +89,7 @@ class SPAuthHandler {
     ///     - onCompletion: Closure to be executed on completion
     ///
     func signupWithCredentials(username: String, onCompletion: @escaping (SPAuthError?) -> Void) {
-        SignupRemote().requestSignup(email: username) { (result) in
+        SignupRemote().requestSignup(email: username) { result in
             switch result {
             case .success:
                 onCompletion(nil)

--- a/Simplenote/Classes/SPContactsManager.swift
+++ b/Simplenote/Classes/SPContactsManager.swift
@@ -53,7 +53,7 @@ class SPContactsManager: NSObject {
             return
         }
 
-        store.requestAccess(for: .contacts) { (success, error) in
+        store.requestAccess(for: .contacts) { success, error in
             completion?(success)
         }
     }
@@ -124,7 +124,7 @@ private extension SPContactsManager {
         var contacts = [CNContact]()
 
         do {
-            try store.enumerateContacts(with: request) { (contact, _) in
+            try store.enumerateContacts(with: request) { contact, _ in
                 contacts.append(contact)
             }
         } catch {

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -548,7 +548,7 @@ extension SPNoteEditorViewController {
 
         UIView.animate(withDuration: 0.2) {
             snapshotView.transform = .init(translationX: 0, y: snapshotView.frame.height)
-        } completion: { (_) in
+        } completion: { _ in
             snapshotView.removeFromSuperview()
         }
     }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -122,7 +122,7 @@ extension SPNoteListViewController {
     func startDisplayingEntities() {
         tableView.dataSource = self
 
-        notesListController.onBatchChanges = { [weak self] (sectionsChangeset, objectsChangeset) in
+        notesListController.onBatchChanges = { [weak self] sectionsChangeset, objectsChangeset in
             guard let `self` = self else {
                 return
             }
@@ -731,14 +731,14 @@ private extension SPNoteListViewController {
 
     func deletedContextActions(for note: Note) -> [UIContextualAction] {
 
-        let restoreAction = UIContextualAction(style: .normal, image: .image(name: .restore), backgroundColor: .simplenoteRestoreActionColor) { (_, _, completion) in
+        let restoreAction = UIContextualAction(style: .normal, image: .image(name: .restore), backgroundColor: .simplenoteRestoreActionColor) { _, _, completion in
                 SPObjectManager.shared().restoreNote(note)
                 CSSearchableIndex.default().indexSearchableNote(note)
                 completion(true)
             }
         restoreAction.accessibilityLabel = ActionTitle.restore
 
-        let deleteAction = UIContextualAction(style: .destructive, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { (_, _, completion) in
+        let deleteAction = UIContextualAction(style: .destructive, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { _, _, completion in
                 SPTracker.trackListNoteDeleted()
                 SPObjectManager.shared().permenentlyDeleteNote(note)
                 completion(true)
@@ -752,7 +752,7 @@ private extension SPNoteListViewController {
         let pinImageName: UIImageName = note.pinned ? .unpin : .pin
         let pinActionTitle: String = note.pinned ? ActionTitle.unpin : ActionTitle.pin
 
-        let trashAction = UIContextualAction(style: .destructive, title: nil, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { [weak self] (_, _, completion) in
+        let trashAction = UIContextualAction(style: .destructive, title: nil, image: .image(name: .trash), backgroundColor: .simplenoteDestructiveActionColor) { [weak self] _, _, completion in
                 self?.delete(note: note)
                 NoticeController.shared.present(NoticeFactory.noteTrashed(onUndo: {
                     SPObjectManager.shared().restoreNote(note)
@@ -764,13 +764,13 @@ private extension SPNoteListViewController {
         }
         trashAction.accessibilityLabel = ActionTitle.trash
 
-        let pinAction = UIContextualAction(style: .normal, title: nil, image: .image(name: pinImageName), backgroundColor: .simplenoteSecondaryActionColor) { [weak self] (_, _, completion) in
+        let pinAction = UIContextualAction(style: .normal, title: nil, image: .image(name: pinImageName), backgroundColor: .simplenoteSecondaryActionColor) { [weak self] _, _, completion in
                 self?.togglePinnedState(note: note)
                 completion(true)
             }
         pinAction.accessibilityLabel = pinActionTitle
 
-        let copyAction = UIContextualAction(style: .normal, title: nil, image: .image(name: .link), backgroundColor: .simplenoteTertiaryActionColor) { [weak self] (_, _, completion) in
+        let copyAction = UIContextualAction(style: .normal, title: nil, image: .image(name: .link), backgroundColor: .simplenoteTertiaryActionColor) { [weak self] _, _, completion in
                 self?.copyInternalLink(to: note)
                 NoticeController.shared.present(NoticeFactory.linkCopied())
             SPTracker.trackPresentedNotice(ofType: .internalLinkCopied)
@@ -778,7 +778,7 @@ private extension SPNoteListViewController {
             }
         copyAction.accessibilityLabel = ActionTitle.copyLink
 
-        let shareAction = UIContextualAction(style: .normal, title: nil, image: .image(name: .share), backgroundColor: .simplenoteQuaternaryActionColor) { [weak self] (_, _, completion) in
+        let shareAction = UIContextualAction(style: .normal, title: nil, image: .image(name: .share), backgroundColor: .simplenoteQuaternaryActionColor) { [weak self] _, _, completion in
                 self?.share(note: note)
                 completion(true)
             }

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -159,9 +159,9 @@ extension SPSettingsViewController {
         SPTracker.trackDeleteAccountButttonTapped()
         let spinnerViewController = SpinnerViewController()
 
-        presentAccountDeletionConfirmation(forEmail: user.email) { (_) in
+        presentAccountDeletionConfirmation(forEmail: user.email) { _ in
             self.present(spinnerViewController, animated: false, completion: nil)
-            deletionController.requestAccountDeletion(user) { [weak self] (result) in
+            deletionController.requestAccountDeletion(user) { [weak self] result in
                 spinnerViewController.dismiss(animated: false, completion: nil)
                 self?.handleDeletionResult(user: user, result)
             }

--- a/Simplenote/Classes/String+Simplenote.swift
+++ b/Simplenote/Classes/String+Simplenote.swift
@@ -118,7 +118,7 @@ extension String {
         var matchingWordsRange: [Range<String.Index>] = []
         var trailingWordsRange: [Range<String.Index>] = []
 
-        enumerateSubstrings(in: range, options: [.byWords, .localized, .substringNotRequired]) { (_, wordRange, _, stop) in
+        enumerateSubstrings(in: range, options: [.byWords, .localized, .substringNotRequired]) { _, wordRange, _, stop in
 
             if trailingLimit > 0, let firstMatch = matchingWordsRange.first {
                 if distance(from: firstMatch.upperBound, to: wordRange.upperBound) > trailingLimit {

--- a/Simplenote/Classes/TagView.swift
+++ b/Simplenote/Classes/TagView.swift
@@ -232,7 +232,7 @@ private extension TagView {
         if newValue {
             autohideDeleteButtonTimer = Timer.scheduledTimer(withTimeInterval: Constants.autohideDeleteButtonTimeout,
                                                              repeats: false,
-                                                             block: { [weak self] (_) in
+                                                             block: { [weak self] _ in
                                                                 self?.hideDeleteButton()
                                                              })
         }

--- a/Simplenote/Classes/UIView+Animations.swift
+++ b/Simplenote/Classes/UIView+Animations.swift
@@ -145,7 +145,7 @@ extension UIView {
             UIView.modifyAnimations(withRepeatCount: 5, autoreverses: true, animations: {
                 self.transform = rightTranslation
             })
-        } completion: { (completed) in
+        } completion: { completed in
             self.transform = originalTransform
             onCompletion?(completed)
         }

--- a/Simplenote/Controllers/AccountDeletionController.swift
+++ b/Simplenote/Controllers/AccountDeletionController.swift
@@ -15,7 +15,7 @@ class AccountDeletionController: NSObject {
     }
 
     func requestAccountDeletion(_ user: SPUser, completion: @escaping (_ result: Result<Data?, RemoteError>) -> Void) {
-        AccountRemote().requestDelete(user) { [weak self] (result) in
+        AccountRemote().requestDelete(user) { [weak self] result in
             if case .success = result {
                 self?.accountDeletionRequestDate = Date()
             }

--- a/Simplenote/Information/NoteInformationController.swift
+++ b/Simplenote/Information/NoteInformationController.swift
@@ -141,7 +141,7 @@ private extension NoteInformationController {
             return []
         }
 
-        let referenceRows = references.map { (referenceNote) -> Row in
+        let referenceRows = references.map { referenceNote -> Row in
             let date = DateFormatter.dateFormatter.string(from: referenceNote.modificationDate)
             let instancesOfReference = referenceNote.instancesOfReference(to: note)
 

--- a/Simplenote/NSAttributedStringToMarkdownConverter.swift
+++ b/Simplenote/NSAttributedStringToMarkdownConverter.swift
@@ -17,7 +17,7 @@ struct NSAttributedStringToMarkdownConverter {
     static func convert(string: NSAttributedString) -> String {
         let fullRange = NSRange(location: 0, length: string.length)
         let adjusted = NSMutableAttributedString(attributedString: string)
-        adjusted.enumerateAttribute(.attachment, in: fullRange, options: .reverse) { (value, range, _) in
+        adjusted.enumerateAttribute(.attachment, in: fullRange, options: .reverse) { value, range, _ in
             guard let attachment = value as? SPTextAttachment else {
                 return
             }

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -115,7 +115,7 @@ class NoticePresenter {
                        options: [.allowUserInteraction]) {
             noticeView.alpha = .zero
             containerView.alpha = .zero
-        } completion: { (_) in
+        } completion: { _ in
             noticeView.removeFromSuperview()
             containerView.removeFromSuperview()
             completion()

--- a/Simplenote/SPAppDelegate+Extensions.swift
+++ b/Simplenote/SPAppDelegate+Extensions.swift
@@ -80,7 +80,7 @@ extension SPAppDelegate {
     @objc
     func configurePublishController() {
         publishController = PublishController()
-        publishController.onUpdate = { (note) in
+        publishController.onUpdate = { note in
             PublishNoticePresenter.presentNotice(for: note)
         }
     }
@@ -395,7 +395,7 @@ extension SPAppDelegate: PinLockVerifyControllerDelegate {
     func pinLockVerifyControllerDidComplete(_ controller: PinLockVerifyController) {
         UIView.animate(withDuration: UIKitConstants.animationShortDuration) {
             self.pinLockWindow?.alpha = UIKitConstants.alpha0_0
-        } completion: { (_) in
+        } completion: { _ in
             self.dismissPasscodeLock()
         }
     }
@@ -409,7 +409,7 @@ private extension SPAppDelegate {
             return
         }
         verificationController = AccountVerificationController(email: email)
-        verificationController?.onStateChange = { [weak self] (oldState, state) in
+        verificationController?.onStateChange = { [weak self] oldState, state in
             switch (oldState, state) {
             case (.unknown, .unverified):
                 self?.showVerificationViewController(with: .review)

--- a/Simplenote/SPCardDismissalAnimator.swift
+++ b/Simplenote/SPCardDismissalAnimator.swift
@@ -32,7 +32,7 @@ final class SPCardDismissalAnimator: NSObject, UIViewControllerAnimatedTransitio
                                               curve: .easeIn,
                                               animations: animationBlock)
 
-        animator.addCompletion { (_) in
+        animator.addCompletion { _ in
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }
 

--- a/Simplenote/SPCardPresentationAnimator.swift
+++ b/Simplenote/SPCardPresentationAnimator.swift
@@ -26,7 +26,7 @@ final class SPCardPresentationAnimator: NSObject, UIViewControllerAnimatedTransi
                                               curve: .easeOut,
                                               animations: animationBlock)
 
-        animator.addCompletion { (_) in
+        animator.addCompletion { _ in
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }
         animator.startAnimation()

--- a/Simplenote/SPNoteHistoryController.swift
+++ b/Simplenote/SPNoteHistoryController.swift
@@ -111,7 +111,7 @@ extension SPNoteHistoryController {
 //
 private extension SPNoteHistoryController {
     func loadData() {
-        versionsToken = versionsController.requestVersions(for: note.simperiumKey, currentVersion: note.versionInt) { [weak self] (version) in
+        versionsToken = versionsController.requestVersions(for: note.simperiumKey, currentVersion: note.versionInt) { [weak self] version in
             self?.process(noteVersion: version)
         }
     }

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -500,7 +500,7 @@ extension TagListViewController: TagListViewCellDelegate {
                                                 message: nil,
                                                 preferredStyle: .actionSheet)
 
-        alertController.addDestructiveActionWithTitle(Localization.TagDeletionConfirmation.confirmationButton) { (_) in
+        alertController.addDestructiveActionWithTitle(Localization.TagDeletionConfirmation.confirmationButton) { _ in
             guard self.verifyTagIsAtIndexPath(tag, at: indexPath) else {
                 self.present(UIAlertController.dismissableAlert(
                     title: Localization.tagDeleteFailedTitle,
@@ -718,7 +718,7 @@ private extension TagListViewController {
     }
 
     func startListeningForChanges() {
-        resultsController.onDidChangeContent = { [weak self] (sectionsChangeset, objectsChangeset) in
+        resultsController.onDidChangeContent = { [weak self] sectionsChangeset, objectsChangeset in
             guard let self else {
                 return
             }

--- a/Simplenote/Tags/NoteEditorTagListViewController.swift
+++ b/Simplenote/Tags/NoteEditorTagListViewController.swift
@@ -110,7 +110,7 @@ private extension NoteEditorTagListViewController {
         objectManager.createTag(from: tagName)
 
         recentlyCreatedTag = tagName
-        recentlyCreatedTagTimer = Timer.scheduledTimer(withTimeInterval: Constants.clearRecentlyCreatedTagTimeout, repeats: false) { [weak self] (_) in
+        recentlyCreatedTagTimer = Timer.scheduledTimer(withTimeInterval: Constants.clearRecentlyCreatedTagTimeout, repeats: false) { [weak self] _ in
             self?.recentlyCreatedTagTimer = nil
             self?.recentlyCreatedTag = nil
         }

--- a/Simplenote/TimerFactory.swift
+++ b/Simplenote/TimerFactory.swift
@@ -2,13 +2,13 @@ import Foundation
 
 class TimerFactory {
     func scheduledTimer(with timeInterval: TimeInterval, completion: @escaping () -> Void) -> Timer {
-        return Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: false) { (_) in
+        return Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: false) { _ in
             completion()
         }
     }
 
     func repeatingTimer(with timerInterval: TimeInterval, completion: @escaping (Timer)-> Void) -> Timer {
-        return Timer.scheduledTimer(withTimeInterval: timerInterval, repeats: true) { (timer) in
+        return Timer.scheduledTimer(withTimeInterval: timerInterval, repeats: true) { timer in
             completion(timer)
         }
     }

--- a/Simplenote/Verification/AccountVerificationViewController.swift
+++ b/Simplenote/Verification/AccountVerificationViewController.swift
@@ -101,7 +101,7 @@ private extension AccountVerificationViewController {
         button?.inProgress = true
         updateButtons(isEnabled: false)
 
-        controller.verify { [weak self] (result) in
+        controller.verify { [weak self] result in
             switch result {
             case .success:
                 onSuccess?()

--- a/SimplenoteScreenshots/SnapshotHelper.swift
+++ b/SimplenoteScreenshots/SnapshotHelper.swift
@@ -264,7 +264,7 @@ private extension XCUIElementAttributes {
 
 private extension XCUIElementQuery {
     var networkLoadingIndicators: XCUIElementQuery {
-        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+        let isNetworkLoadingIndicator = NSPredicate { evaluatedObject, _ in
             guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
 
             return element.isNetworkLoadingIndicator
@@ -280,7 +280,7 @@ private extension XCUIElementQuery {
 
         let deviceWidth = app.windows.firstMatch.frame.width
 
-        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+        let isStatusBar = NSPredicate { evaluatedObject, _ in
             guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
 
             return element.isStatusBar(deviceWidth)

--- a/SimplenoteShare/Extractors/PlainTextExtractor.swift
+++ b/SimplenoteShare/Extractors/PlainTextExtractor.swift
@@ -24,7 +24,7 @@ struct PlainTextExtractor: Extractor {
             return
         }
 
-        provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { (payload, _) in
+        provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { payload, _ in
             guard let content = payload as? String else {
                 onCompletion(nil)
                 return

--- a/SimplenoteShare/Extractors/URLExtractor.swift
+++ b/SimplenoteShare/Extractors/URLExtractor.swift
@@ -25,7 +25,7 @@ struct URLExtractor: Extractor {
             return
         }
 
-        provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { (payload, _) in
+        provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { payload, _ in
             guard let url = payload as? URL else {
                 onCompletion(nil)
                 return

--- a/SimplenoteTests/MockupStorage.swift
+++ b/SimplenoteTests/MockupStorage.swift
@@ -21,7 +21,7 @@ class MockupStorageManager {
     private(set) lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: name, managedObjectModel: managedModel)
         container.persistentStoreDescriptions = [storeDescription]
-        container.loadPersistentStores { (storeDescription, error) in
+        container.loadPersistentStores { storeDescription, error in
             if let error = error as NSError? {
                 fatalError("[MockupStorageManager] Fatal Error: \(error) [\(error.userInfo)]")
             }
@@ -53,7 +53,7 @@ class MockupStorageManager {
                 fatalError("☠️ [MockupStorageManager] Cannot Destroy persistentStore! \(error)")
             }
 
-            storeCoordinator.addPersistentStore(with: storeDescriptor) { (_, error) in
+            storeCoordinator.addPersistentStore(with: storeDescriptor) { _, error in
                 guard let error else {
                     return
                 }

--- a/SimplenoteTests/NotesListControllerTests.swift
+++ b/SimplenoteTests/NotesListControllerTests.swift
@@ -259,7 +259,7 @@ class NotesListControllerTests: XCTestCase {
     ///     - OP: Insert / Update / Delete
     ///
     func testOnBatchChangesDoesntRunForInsertUpdateNorDeleteOpsOverTagsWhenInResultsMode() {
-        noteListController.onBatchChanges = { (_, _) in
+        noteListController.onBatchChanges = { _, _ in
             XCTFail()
         }
 
@@ -532,7 +532,7 @@ private extension NotesListControllerTests {
     func expectBatchChanges(objectsChangeset: ResultsObjectsChangeset) -> XCTestExpectation {
         let expectation = self.expectation(description: "Waiting...")
 
-        noteListController.onBatchChanges = { (receivedSectionChanges, receivedObjectChanges) in
+        noteListController.onBatchChanges = { receivedSectionChanges, receivedObjectChanges in
             for (index, change) in objectsChangeset.deleted.enumerated() {
                 XCTAssertEqual(change, objectsChangeset.deleted[index])
             }

--- a/SimplenoteTests/NoticeControllerTests.swift
+++ b/SimplenoteTests/NoticeControllerTests.swift
@@ -135,7 +135,7 @@ class NoticeControllerTests: XCTestCase {
 
 extension NoticeControllerTests {
     static var timeInterval = TimeInterval.zero
-    static var timerNoActionCompletionHandler: (Timer) -> Void = { (_) in }
+    static var timerNoActionCompletionHandler: (Timer) -> Void = { _ in }
 }
 
 class MockNoticePresenter: NoticePresenter {

--- a/SimplenoteTests/Verification/AccountVerificationControllerTests.swift
+++ b/SimplenoteTests/Verification/AccountVerificationControllerTests.swift
@@ -23,7 +23,7 @@ extension AccountVerificationControllerTests {
         // When
         let expectedResult = Remote.randomResult()
         var verificationResult: Result<Data?, RemoteError>?
-        controller.verify { (result) in
+        controller.verify { result in
             verificationResult = result
         }
 
@@ -78,7 +78,7 @@ extension AccountVerificationControllerTests {
             .unverified, .verified
         ]
         var stateChangeHistory: [AccountVerificationController.State] = []
-        controller.onStateChange = { (oldState, state) in
+        controller.onStateChange = { oldState, state in
             stateChangeHistory.append(oldState)
             stateChangeHistory.append(state)
         }
@@ -97,7 +97,7 @@ extension AccountVerificationControllerTests {
             .unknown, .unverified
         ]
         var stateChangeHistory: [AccountVerificationController.State] = []
-        controller.onStateChange = { (oldState, state) in
+        controller.onStateChange = { oldState, state in
             stateChangeHistory.append(oldState)
             stateChangeHistory.append(state)
         }

--- a/SimplenoteWidgets/Providers/ListWidgetProvider.swift
+++ b/SimplenoteWidgets/Providers/ListWidgetProvider.swift
@@ -55,7 +55,7 @@ struct ListWidgetProvider: IntentTimelineProvider {
             return
         }
 
-        let proxies: [ListWidgetNoteProxy] = allNotes.map { (note) -> ListWidgetNoteProxy in
+        let proxies: [ListWidgetNoteProxy] = allNotes.map { note -> ListWidgetNoteProxy in
             ListWidgetNoteProxy(title: note.title, url: note.url)
         }
 
@@ -75,13 +75,13 @@ struct ListWidgetProvider: IntentTimelineProvider {
             return
         }
 
-        let proxies: [ListWidgetNoteProxy] = notes.map { (note) -> ListWidgetNoteProxy in
+        let proxies: [ListWidgetNoteProxy] = notes.map { note -> ListWidgetNoteProxy in
             ListWidgetNoteProxy(title: note.title, url: note.url)
         }
 
         // Prepare timeline entry for every hour for the next 6 hours
         // Create a new set of entries at the end of the 6 entries
-        let entries: [ListWidgetEntry] = WidgetConstants.rangeForSixEntries.compactMap { (index) in
+        let entries: [ListWidgetEntry] = WidgetConstants.rangeForSixEntries.compactMap { index in
             guard let date = Date().increased(byHours: index) else {
                 return nil
             }

--- a/SimplenoteWidgets/Providers/NoteWidgetProvider.swift
+++ b/SimplenoteWidgets/Providers/NoteWidgetProvider.swift
@@ -72,7 +72,7 @@ struct NoteWidgetProvider: IntentTimelineProvider {
 
         // Prepare timeline entry for every hour for the next 6 hours
         // Create a new set of entries at the end of the 6 entries
-        let entries: [NoteWidgetEntry] = WidgetConstants.rangeForSixEntries.compactMap({ (index)  in
+        let entries: [NoteWidgetEntry] = WidgetConstants.rangeForSixEntries.compactMap({ index in
             guard let date = Date().increased(byHours: index) else {
                 return nil
             }

--- a/SimplenoteWidgets/Tools/DemoContent.swift
+++ b/SimplenoteWidgets/Tools/DemoContent.swift
@@ -19,7 +19,7 @@ struct DemoContent {
         "Lobortis elementum nibh tellus molestie.",
         "Lorem Ipsum"
     ]
-    static let listProxies: [ListWidgetNoteProxy] = listTitles.map { (title) in
+    static let listProxies: [ListWidgetNoteProxy] = listTitles.map { title in
         ListWidgetNoteProxy(title: title, url: demoURL)
     }
 }

--- a/SimplenoteWidgets/Widgets/ListWidget.swift
+++ b/SimplenoteWidgets/Widgets/ListWidget.swift
@@ -4,7 +4,7 @@ import WidgetKit
 @available(iOS 14.0, *)
 struct ListWidget: Widget {
     var body: some WidgetConfiguration {
-        IntentConfiguration(kind: Constants.configurationKind, intent: ListWidgetIntent.self, provider: ListWidgetProvider()) { (entry) in
+        IntentConfiguration(kind: Constants.configurationKind, intent: ListWidgetIntent.self, provider: ListWidgetProvider()) { entry in
             prepareWidgetView(fromEntry: entry)
         }
         .configurationDisplayName(Constants.displayName)

--- a/SimplenoteWidgets/Widgets/NoteWidget.swift
+++ b/SimplenoteWidgets/Widgets/NoteWidget.swift
@@ -4,7 +4,7 @@ import WidgetKit
 @available(iOS 14.0, *)
 struct NoteWidget: Widget {
     var body: some WidgetConfiguration {
-        IntentConfiguration(kind: Constants.configurationKind, intent: NoteWidgetIntent.self, provider: NoteWidgetProvider()) { (entry) in
+        IntentConfiguration(kind: Constants.configurationKind, intent: NoteWidgetIntent.self, provider: NoteWidgetProvider()) { entry in
             prepareWidgetView(fromEntry: entry)
         }
         .configurationDisplayName(Constants.displayName)


### PR DESCRIPTION
## What

Enables the SwiftLint [`unneeded_parentheses_in_closure_argument`](https://realm.github.io/SwiftLint/unneeded_parentheses_in_closure_argument.html) rule, which flags redundant parentheses around closure parameter declarations (e.g. `{ (x, y) in ... }` -> `{ x, y in ... }`).

## Stats

- Auto-fixed violations: **59** across **37** files
- Manual fixes: **0**
- `swiftlint:disable` additions: **0**

The rule is autocorrectable. The transformation only strips parentheses around parameter lists; no tuple-destructuring closures were affected, and parameter types are preserved.

## Testing

- `bundle exec rake lint` is clean on the modified config.
- Local `xcodebuild build` of the `Simplenote` scheme succeeds.
- Test suite deferred to CI per snios convention under Xcode 26.

## Notes

There is also an open PR #1752 from this campaign for `unused_closure_parameter`. Both touch `.swiftlint.yml` only by adding a different rule line; the conflict will be a one-line merge resolution depending on which lands first.

Part of the Orchard SwiftLint rollout campaign.