### PR TITLE
Enable SwiftLint rule: first_where

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -39,6 +39,9 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # Prefer `first(where:)` over `filter { }.first`.
+  - first_where
+
   # MARK comment should be in valid format.
   - mark
 

--- a/Simplenote/Classes/TagTextFieldInputValidator.swift
+++ b/Simplenote/Classes/TagTextFieldInputValidator.swift
@@ -52,8 +52,7 @@ struct TagTextFieldInputValidator {
     ///
     func preprocessForPasting(tag: String) -> String? {
         return tag.components(separatedBy: disallowedCharacterSet)
-            .filter({ !$0.isEmpty })
-            .first
+            .first(where: { !$0.isEmpty })
     }
 
     /// Indicates if the receivers length is within allowed values


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`first_where`](https://realm.github.io/SwiftLint/first_where.html) rule.

The rule prefers `xs.first(where: { ... })` over `xs.filter { ... }.first`, which is a performance and clarity win (avoids materialising an intermediate array).

- See commit message for the violation count and any rewrites.
- The change is type-preserving (`Element?`→`Element?`) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
