### PR TITLE
Enable SwiftLint rule: sorted_first_last

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -55,6 +55,9 @@ only_rules:
   # Prefer the shorthand `if let foo` over `if let foo = foo` when binding an optional with the same name.
   - shorthand_optional_binding
 
+  # Prefer `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`.
+  - sorted_first_last
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/Simplenote/SearchMapView.swift
+++ b/Simplenote/SearchMapView.swift
@@ -132,11 +132,11 @@ extension SearchMapView {
     private func barView(with point: CGPoint) -> UIView? {
         return barViews.filter {
             $0.frame.insetBy(dx: -Metrics.extraHorizontalTouchMargin, dy: -Metrics.extraVerticalTouchMargin).contains(point)
-        }.sorted {
+        }.min {
             let distance1 = abs($0.frame.midY - point.y)
             let distance2 = abs($1.frame.midY - point.y)
             return distance1 < distance2
-        }.first
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`sorted_first_last`](https://realm.github.io/SwiftLint/sorted_first_last.html) rule.

The rule prefers `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`. This avoids materialising the entire sorted array when only one element is needed.

- See commit message for the violation count and any rewrites.
- The change is type-preserving (`Element?`→`Element?`) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
