### PR TITLE
Enable SwiftLint rule: reduce_into

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,7 +48,10 @@ only_rules:
 
   # Prefer `.zero` over explicit init with zero parameters (e.g., `CGPoint(x: 0, y: 0)`).
   - prefer_zero_over_explicit_init
-  
+
+  # Prefer `reduce(into:_:)` over `reduce(_:_:)` for non-trivial accumulator types.
+  - reduce_into
+
   # Prefer `someBool.toggle()` over `someBool = !someBool`.
   - toggle_bool
 

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -212,14 +212,11 @@ private extension StoreManager {
 private extension StoreManager {
 
     func buildStoreProductMap(products: [Product]) -> [StoreProduct: Product] {
-        return products.reduce([StoreProduct: Product]()) { partialResult, product in
+        return products.reduce(into: [StoreProduct: Product]()) { partialResult, product in
             guard let storeProduct = StoreProduct.findStoreProduct(identifier: product.id) else {
-                return partialResult
+                return
             }
-
-            var updated = partialResult
-            updated[storeProduct] = product
-            return updated
+            partialResult[storeProduct] = product
         }
     }
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`reduce_into`](https://realm.github.io/SwiftLint/reduce_into.html) rule.

The rule prefers `reduce(into:_:)` over `reduce(_:_:)` for copy-on-write accumulator types (arrays, dictionaries, sets, strings). `reduce(into:)` mutates the accumulator in place and avoids the per-iteration copy cost.

- See commit message for the violation count and any rewrites.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
