### PR TITLE
Enable SwiftLint rule: flatmap_over_map_reduce

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -39,6 +39,9 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`.
+  - flatmap_over_map_reduce
+
   # MARK comment should be in valid format.
   - mark
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`flatmap_over_map_reduce`](https://realm.github.io/SwiftLint/flatmap_over_map_reduce.html) rule.

The rule prefers `flatMap { ... }` over `map { ... }.reduce([], +)` for flattening nested arrays — this avoids materialising an intermediate array of arrays.

- See commit message for the violation count and any rewrites.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
