### PR TITLE
Enable SwiftLint zero-violation rules (6 rules)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,9 @@ excluded:
 
 # Rules
 only_rules:
+  # Prefer `Array(xs)` over `xs.map { $0 }`.
+  - array_init
+
   # Colons should be next to the identifier when specifying a type.
   - colon
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,9 @@ only_rules:
   # Prefer `contains` over comparing `filter(where:)` to empty.
   - contains_over_filter_is_empty
 
+  # Prefer `contains` over `first(where:) != nil`.
+  - contains_over_first_not_nil
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,6 +48,9 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # Prefer `last(where:)` over `filter { }.last`.
+  - last_where
+
   # MARK comment should be in valid format.
   - mark
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,9 @@ only_rules:
   # Prefer `contains` over `first(where:) != nil`.
   - contains_over_first_not_nil
 
+  # Prefer `contains` over `range(of:) != nil` and `range(of:) == nil`.
+  - contains_over_range_nil_comparison
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,6 +48,9 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`.
+  - flatmap_over_map_reduce
+
   # Prefer `last(where:)` over `filter { }.last`.
   - last_where
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over `filter(where:).count`.
+  - contains_over_filter_count
+
   # Prefer `contains` over comparing `filter(where:)` to empty.
   - contains_over_filter_is_empty
 


### PR DESCRIPTION
## Summary

Bundles six zero-violation SwiftLint rule enables into a single PR to reduce reviewer churn.

All six rules:

- have **0 violations** in the current codebase, so each is a `.swiftlint.yml`-only change;
- guard against the corresponding pattern landing in future code.

Rules in this bundle, one commit each:

- [`contains_over_filter_count`](https://realm.github.io/SwiftLint/contains_over_filter_count.html) — prefer `xs.contains { ... }` over `xs.filter { ... }.count > 0` (and `== 0` / `!= 0`).
- [`contains_over_first_not_nil`](https://realm.github.io/SwiftLint/contains_over_first_not_nil.html) — prefer `xs.contains { ... }` over `xs.first(where: ...) != nil`.
- [`contains_over_range_nil_comparison`](https://realm.github.io/SwiftLint/contains_over_range_nil_comparison.html) — prefer `s.contains(...)` over `s.range(of: ...) != nil`.
- [`last_where`](https://realm.github.io/SwiftLint/last_where.html) — prefer `xs.last { ... }` over `xs.filter { ... }.last`.
- [`flatmap_over_map_reduce`](https://realm.github.io/SwiftLint/flatmap_over_map_reduce.html) — prefer `flatMap` over `map { ... }.reduce([], +)`.
- [`array_init`](https://realm.github.io/SwiftLint/array_init.html) — prefer `Array(xs)` over `xs.map { $0 }`.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Supersedes

- #1754 — Enable SwiftLint rule: contains_over_filter_count
- #1755 — Enable SwiftLint rule: contains_over_first_not_nil
- #1756 — Enable SwiftLint rule: contains_over_range_nil_comparison
- #1758 — Enable SwiftLint rule: last_where
- #1761 — Enable SwiftLint rule: flatmap_over_map_reduce
- #1762 — Enable SwiftLint rule: array_init

The superseded PRs will be closed with a backlink to this one.

`unneeded_parentheses_in_closure_argument` (#1753) is **not** in this bundle — that branch carries 37 file-level autofixes and continues as its own PR.

## Test plan

- [ ] CI build is green.

🤖 Generated with [Claude Code](https://claude.ai/code)