### PR TITLE
Pin nokogiri >= 1.19.3 (GHSA-c4rq-3m3g-8wgx)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'fastlane-plugin-wpmreleasetoolkit', '~> 13.8'
 # Pinned to pull in the fix for GHSA-c4rq-3m3g-8wgx (CSS selector ReDoS).
 # Drop once `fastlane-plugin-wpmreleasetoolkit` moves to >= 14.4.1, whose
 # gemspec carries this floor transitively.
-gem 'nokogiri', '>= 1.19.3'
+gem 'nokogiri', '~> 1.19', '>= 1.19.3'
 
 group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,11 @@ gem 'fastlane-plugin-firebase_app_distribution', '~> 0.10'
 gem 'fastlane-plugin-sentry', '~> 1.6'
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 13.8'
 
+# Pinned to pull in the fix for GHSA-c4rq-3m3g-8wgx (CSS selector ReDoS).
+# Drop once `fastlane-plugin-wpmreleasetoolkit` moves to >= 14.4.1, whose
+# gemspec carries this floor transitively.
+gem 'nokogiri', '>= 1.19.3'
+
 group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
     nanaimo (0.4.0)
     nap (1.1.0)
     naturally (2.3.0)
-    nokogiri (1.19.2)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (6.1.1)
@@ -365,6 +365,7 @@ DEPENDENCIES
   fastlane-plugin-firebase_app_distribution (~> 0.10)
   fastlane-plugin-sentry (~> 1.6)
   fastlane-plugin-wpmreleasetoolkit (~> 13.8)
+  nokogiri (>= 1.19.3)
   rmagick (~> 3.2.0)
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary

Adds an explicit `gem 'nokogiri', '>= 1.19.3'` pin to `Gemfile` to pull in the fix for [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) — a high-severity ReDoS in Nokogiri's CSS selector tokenizer (vulnerable `< 1.19.3`).

This repo is on `fastlane-plugin-wpmreleasetoolkit ~> 13.8`, which predates the toolkit's own `nokogiri >= 1.19.3` floor (added in 14.4.1). Pinning explicitly here closes the gap without requiring a release-toolkit major bump (which is a separate, larger change).

Generated as part of the [nokogiri 1.19.3 Orchard campaign](https://github.a8c.com/mokagio/swiftlint-adoption-orchard-campaign/tree/main/nokogiri-1.19.3-campaign) covering all release-toolkit consumers.

## Testing

`bundle install`. `Gemfile.lock` resolves `nokogiri` to `1.19.3`. The new line in `Gemfile.lock` `DEPENDENCIES` block reflects the pin.

A future release-toolkit-major bump (`~> 14.x`) will make this pin redundant; tracked in the campaign as a follow-up.

---

*Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval.*