### PR TITLE
Enable SwiftLint rule: vertical_whitespace_closing_braces

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -92,6 +92,10 @@ only_rules:
   # - trailing_whitespace
 
   # - vertical_whitespace
+
+  # Empty lines should not be present right before a closing brace.
+  - vertical_whitespace_closing_braces
+
   - custom_rules
 
 # Rules configuration

--- a/Simplenote/Classes/CSSearchable+Helpers.swift
+++ b/Simplenote/Classes/CSSearchable+Helpers.swift
@@ -19,7 +19,6 @@ extension CSSearchableItemAttributeSet {
         title = note.titlePreview
         contentDescription = note.bodyPreview
     }
-
 }
 
 extension CSSearchableItem {
@@ -28,7 +27,6 @@ extension CSSearchableItem {
         let attributeSet = CSSearchableItemAttributeSet(note: note)
         self.init(uniqueIdentifier: note.simperiumKey, domainIdentifier: "notes", attributeSet: attributeSet)
     }
-
 }
 
 extension CSSearchableIndex {

--- a/Simplenote/Classes/KeychainManager.swift
+++ b/Simplenote/Classes/KeychainManager.swift
@@ -37,10 +37,8 @@ struct KeychainItemWrapper {
         mutating get {
             do {
                 return try item.readPassword()
-
             } catch KeychainError.noPassword {
                 return nil
-
             } catch {
                 NSLog("Error Reading Keychain Item \(item.service).\(item.account): \(error)")
                 return nil

--- a/Simplenote/Classes/MagicLinkAuthenticator.swift
+++ b/Simplenote/Classes/MagicLinkAuthenticator.swift
@@ -73,7 +73,6 @@ private extension MagicLinkAuthenticator {
                     NotificationCenter.default.post(name: .magicLinkAuthDidSucceed, object: nil)
                     SPTracker.trackLoginLinkConfirmationSuccess()
                 }
-
             } catch {
                 NSLog("[MagicLinkAuthenticator] Magic Link TokenExchange Error: \(error)")
                 NotificationCenter.default.post(name: .magicLinkAuthDidFail, object: error)

--- a/Simplenote/Classes/OptionsViewController.swift
+++ b/Simplenote/Classes/OptionsViewController.swift
@@ -299,7 +299,6 @@ extension OptionsViewController {
             NSLocalizedString("Copy Link", comment: "Copies the Note's Public Link") :
             NSLocalizedString("Unpublishing...", comment: "Indicates the Note is being unpublished")
     }
-
 }
 
 // MARK: - Action Handlers

--- a/Simplenote/Classes/PinLock/PinLockVerifyController.swift
+++ b/Simplenote/Classes/PinLock/PinLockVerifyController.swift
@@ -43,7 +43,6 @@ final class PinLockVerifyController: PinLockBaseController, PinLockController {
     }
 
     func handleCancellation() {
-
     }
 
     func viewDidAppear() {

--- a/Simplenote/Classes/PinLock/PinLockViewController.swift
+++ b/Simplenote/Classes/PinLock/PinLockViewController.swift
@@ -202,7 +202,6 @@ private extension PinLockViewController {
         }
 
         addDigit(index)
-
     }
 
     @IBAction

--- a/Simplenote/Classes/SPAuthHandler.swift
+++ b/Simplenote/Classes/SPAuthHandler.swift
@@ -74,7 +74,6 @@ class SPAuthHandler {
         do {
             let confirmation = try await remote.requestLoginConfirmation(email: username, authCode: code.uppercased())
             simperiumService.authenticate(withUsername: confirmation.username, token: confirmation.syncToken)
-            
         } catch let remoteError as RemoteError {
             throw SPAuthError(loginRemoteError: remoteError)
         }

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -449,10 +449,8 @@ extension SPAuthViewController {
             try await controller.requestLoginEmail(username: email)
             self.presentCodeInterface()
             SPTracker.trackLoginLinkRequested()
-            
         } catch SPAuthError.tooManyAttempts {
             self.presentPasswordInterfaceWithRateLimitingHeader()
-
         } catch {
             let error = error as? SPAuthError ?? .generic
             self.handleError(error: error)

--- a/Simplenote/Classes/SPDiagnosticsViewController.swift
+++ b/Simplenote/Classes/SPDiagnosticsViewController.swift
@@ -70,7 +70,6 @@ private extension SPDiagnosticsViewController {
         activityViewController.excludedActivityTypes = excludedActivities
 
         present(activityViewController, animated: true)
-
     }
 
     @IBAction

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -478,7 +478,6 @@ private extension SPNoteEditorViewController {
 
         present(activityController, animated: true, completion: nil)
         SPTracker.trackEditorNoteContentShared()
-
     }
 
     func presentMarkdownPreview() {

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -113,7 +113,6 @@ extension SPNoteListViewController {
             placeholderView.topAnchor.constraint(greaterThanOrEqualTo: view.layoutMarginsGuide.topAnchor),
             placeholderView.bottomAnchor.constraint(lessThanOrEqualTo: view.layoutMarginsGuide.bottomAnchor)
         ])
-
     }
 
     /// Initializes the UITableView <> NoteListController Link. Should be called once both UITableView + ListController have been initialized
@@ -531,7 +530,6 @@ extension SPNoteListViewController: UITableViewDelegate {
         default:
             break
         }
-
     }
 
     public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
@@ -548,7 +546,6 @@ extension SPNoteListViewController: UITableViewDelegate {
 
         return UIContextMenuConfiguration(identifier: nil, previewProvider: {
             return self.previewingViewController(for: note)
-
         }, actionProvider: { suggestedActions in
             return self.contextMenu(for: note, at: indexPath)
         })

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -183,9 +183,7 @@ class SPNoteTableViewCell: UITableViewCell {
                                              highlighing: keywords,
                                              highlightColor: keywordsTintColor,
                                              paragraphStyle: Style.paragraphStyle)
-
         }
-
     }
 
     /// Refreshes the Body AttributedString: We'll consider Keyword Highlight and Text Attachments (bullets)

--- a/Simplenote/Classes/UIApplication+Simplenote.swift
+++ b/Simplenote/Classes/UIApplication+Simplenote.swift
@@ -3,7 +3,6 @@ import UIKit
 // MARK: - ApplicationStateProvider
 //
 extension UIApplication: ApplicationStateProvider {
-
 }
 
 extension UIApplication {

--- a/Simplenote/Classes/UISearchBar+Simplenote.swift
+++ b/Simplenote/Classes/UISearchBar+Simplenote.swift
@@ -31,5 +31,4 @@ extension UISearchBar {
             }
         }
     }
-
 }

--- a/Simplenote/Information/NoteInformationViewController.swift
+++ b/Simplenote/Information/NoteInformationViewController.swift
@@ -96,7 +96,6 @@ private extension NoteInformationViewController {
                                                             style: .done,
                                                             target: self,
                                                             action: #selector(handleTapOnDismissButton))
-
     }
 
     func configureViews() {

--- a/Simplenote/MagicLinkInvalidView.swift
+++ b/Simplenote/MagicLinkInvalidView.swift
@@ -33,7 +33,6 @@ struct MagicLinkInvalidView: View {
                 .background(Color(.simplenoteBlue50Color))
                 .cornerRadius(Metrics.actionCornerRadius)
                 .buttonStyle(PlainButtonStyle())
-                
             }
             .padding()
             .navigationBarTitleDisplayMode(.inline)

--- a/Simplenote/NoticePresenter.swift
+++ b/Simplenote/NoticePresenter.swift
@@ -82,7 +82,6 @@ class NoticePresenter {
         noticeVariableConstraint?.isActive = true
         view.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
         containerView.layoutIfNeeded()
-
     }
 
     private func display(view: UIView, in containerView: UIView, completion: @escaping () -> Void) {

--- a/Simplenote/NoticeView.swift
+++ b/Simplenote/NoticeView.swift
@@ -71,7 +71,6 @@ class NoticeView: UIView {
         noticeButton.isHidden = true
         noticeButton.titleLabel?.font = UIFont.preferredFont(for: .subheadline, weight: .semibold)
         noticeButton.titleLabel?.adjustsFontForContentSizeCategory = true
-
     }
 
     private func configureAccessibilityIfNeeded() {

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -131,7 +131,6 @@ private extension StoreManager {
                     await self.refreshPurchasedProducts()
                     await self.refreshSubscriptionGroupStatus()
                     await transaction.finish()
-
                 } catch {
                     NSLog("[StoreKit] Transaction failed verification. Error \(error)")
                 }
@@ -146,7 +145,6 @@ private extension StoreManager {
             storeProductMap = self.buildStoreProductMap(products: allProducts)
 
             NSLog("[StoreKit] Retrieved \(storeProductMap.count) Subscription Products")
-
         } catch {
             NSLog("[StoreKit] Failed product request from the App Store server: \(error)")
         }
@@ -164,7 +162,6 @@ private extension StoreManager {
                 if let subscription = storeProductMap.values.first(where: { $0.id == transaction.productID }) {
                     newPurchasedProducts.append(subscription)
                 }
-
             } catch {
                 NSLog("[StoreKit] Failed to refresh Current Entitlements: \(error)")
             }

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -290,7 +290,6 @@ extension TagListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, performAction action: Selector, forRowAt indexPath: IndexPath, withSender sender: Any?) {
-
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -199,7 +199,6 @@ class NoteEditor {
         guard historyButton.waitForExistence(timeout: minLoadTimeout) else { return }
         historyButton.tap()
     }
-
 }
 
 class NoteEditorAssert {

--- a/SimplenoteWidgets/Models/Note+Widget.swift
+++ b/SimplenoteWidgets/Models/Note+Widget.swift
@@ -7,7 +7,6 @@ import CoreData
 
 @objc(Note)
 public class Note: SPManagedObject {
-
 }
 
 extension Note {

--- a/SimplenoteWidgets/Models/SPManagedObject+Widget.swift
+++ b/SimplenoteWidgets/Models/SPManagedObject+Widget.swift
@@ -7,7 +7,6 @@ import CoreData
 
 @objc(SPManagedObject)
 public class SPManagedObject: NSManagedObject {
-
 }
 
 extension SPManagedObject {

--- a/SimplenoteWidgets/Models/Tag+Widget.swift
+++ b/SimplenoteWidgets/Models/Tag+Widget.swift
@@ -7,7 +7,6 @@ import CoreData
 
 @objc(Tag)
 public class Tag: SPManagedObject {
-
 }
 
 extension Tag {

--- a/SimplenoteWidgets/Providers/ListWidgetProvider.swift
+++ b/SimplenoteWidgets/Providers/ListWidgetProvider.swift
@@ -29,7 +29,6 @@ extension ListWidgetEntry {
                                noteProxies: DemoContent.listProxies,
                                loggedIn: loggedIn,
                                state: state)
-
     }
 }
 

--- a/SimplenoteWidgets/Providers/NoteWidgetProvider.swift
+++ b/SimplenoteWidgets/Providers/NoteWidgetProvider.swift
@@ -33,7 +33,6 @@ extension NoteWidgetEntry {
                                loggedIn: loggedIn,
                                state: state)
     }
-
 }
 
 struct NoteWidgetProvider: IntentTimelineProvider {

--- a/SimplenoteWidgets/Widgets/NewNoteWidget.swift
+++ b/SimplenoteWidgets/Widgets/NewNoteWidget.swift
@@ -11,7 +11,6 @@ struct NewNoteWidget: Widget {
         .description(Constants.description)
         .supportedFamilies([.systemSmall])
         .contentMarginsDisabled()
-
     }
 }
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`vertical_whitespace_closing_braces`](https://realm.github.io/SwiftLint/vertical_whitespace_closing_braces.html) rule.

The rule disallows empty lines immediately before a closing brace.
31 violations auto-fixed via `bundle exec rake lint:autocorrect`; no manual fixes needed.
Local build succeeded against the `Simplenote` scheme on a generic iOS Simulator destination.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] \`bundle exec rake lint\` is clean against the worktree.