### PR TITLE
Enable SwiftLint rule: collection_alignment

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,9 @@ only_rules:
   # Colons should be next to the identifier when specifying a type.
   - colon
 
+  # All elements in a collection literal should be vertically aligned.
+  - collection_alignment
+
   # There should be no space before and one after any comma.
   - comma
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`collection_alignment`](https://realm.github.io/SwiftLint/collection_alignment.html) rule.

The rule enforces that all elements in a collection literal are vertically aligned.
0 violations auto-fixed via `bundle exec rake lint:autocorrect` — the codebase is already compliant, so no manual fixes were needed and none are left for human review.
Local build succeeded against the `Simplenote` scheme on a generic iOS Simulator destination.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `bundle exec rake lint` is clean against the worktree.