### PR TITLE
Enable SwiftLint rule: literal_expression_end_indentation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,6 +60,9 @@ only_rules:
   # Prefer `last(where:)` over `filter { }.last`.
   - last_where
 
+  # Closing brackets of array and dictionary literals should match their opening lines' indentation.
+  - literal_expression_end_indentation
+
   # MARK comment should be in valid format.
   - mark
 

--- a/Simplenote/Classes/SPTextInputView.swift
+++ b/Simplenote/Classes/SPTextInputView.swift
@@ -293,7 +293,7 @@ private extension SPTextInputView {
             textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Defaults.insets.right),
             textField.topAnchor.constraint(equalTo: topAnchor, constant: Defaults.insets.top),
             textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Defaults.insets.bottom),
-            ])
+        ])
     }
 
     func refreshBorderStyle() {


### PR DESCRIPTION
## Rationale

Enable the SwiftLint rule [`literal_expression_end_indentation`](https://realm.github.io/SwiftLint/literal_expression_end_indentation.html) on this repo.

The rule requires that the closing bracket of an array or dictionary literal sit at the same indentation as the line that opened it.

## What this PR does

- Add `literal_expression_end_indentation` to `only_rules` in `.swiftlint.yml` (alphabetical order).
- Auto-fix produced 1 violation, in `Simplenote/Classes/SPTextInputView.swift` (a trailing `])` moved back to its container's indent).
- No manual fixes, no `// swiftlint:disable` suppressions, nothing left for human review.

## How to test

Locally:

```sh
bundle exec rake lint
bundle exec rake lint:autocorrect   # should be a no-op
```

CI runs the same lint + build pipeline; nothing else is needed.

## Context

Part of the Orchard SwiftLint rollout campaign — one rule, one PR.
Sibling PRs in this campaign (e.g. #1767, #1768) follow the same pattern.