### PR TITLE
Enable SwiftLint rule: modifier_order

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,6 +69,9 @@ only_rules:
   # MARK comment should be in valid format.
   - mark
 
+  # Modifiers should be in a canonical order (e.g., `public final lazy var`).
+  - modifier_order
+
   # Opening braces should be preceded by a single space and on the same line as
   # the declaration.
   - opening_brace

--- a/Simplenote/Classes/EditorFactory.swift
+++ b/Simplenote/Classes/EditorFactory.swift
@@ -22,7 +22,7 @@ class EditorFactory: NSObject {
 
     /// You shall not pass!
     ///
-    private override init() {
+    override private init() {
         super.init()
     }
 

--- a/Simplenote/Classes/SPBlurEffectView.swift
+++ b/Simplenote/Classes/SPBlurEffectView.swift
@@ -29,7 +29,7 @@ class SPBlurEffectView: UIVisualEffectView {
         self.init(effect: .simplenoteBlurEffect)
     }
 
-    convenience required init?(coder: NSCoder) {
+    required convenience init?(coder: NSCoder) {
         self.init(effect: .simplenoteBlurEffect)
     }
 

--- a/Simplenote/Classes/SPMarkdownPreviewViewController+Extensions.swift
+++ b/Simplenote/Classes/SPMarkdownPreviewViewController+Extensions.swift
@@ -3,11 +3,11 @@ import UIKit
 // MARK: - SPMarkdownPreviewViewController
 //
 extension SPMarkdownPreviewViewController {
-    open override var canBecomeFirstResponder: Bool {
+    override open var canBecomeFirstResponder: Bool {
         return true
     }
 
-    open override var keyCommands: [UIKeyCommand]? {
+    override open var keyCommands: [UIKeyCommand]? {
         return [
             UIKeyCommand(input: "p",
                          modifierFlags: [.command, .shift],

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -121,14 +121,14 @@ extension SPNoteEditorViewController {
 // MARK: - Layout
 //
 extension SPNoteEditorViewController {
-    open override func viewWillLayoutSubviews() {
+    override open func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         // We need to reset transform to prevent tagView from loosing `safeArea`
         // We restore transform back in viewDidLayoutSubviews
         tagView.transform = .identity
     }
 
-    open override func viewDidLayoutSubviews() {
+    override open func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         // Adding async here to break a strange layout loop
         // It happens when add tag field is first responder and device is rotated
@@ -257,7 +257,7 @@ extension SPNoteEditorViewController {
 
     /// Sets behavior for accessibility three finger scroll
     ///
-    open override func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
+    override open func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
         switch direction {
         case .left:
             presentMarkdownPreview()
@@ -287,7 +287,7 @@ extension SPNoteEditorViewController {
         SPAppDelegate.shared().simperium
     }
 
-    open override func encodeRestorableState(with coder: NSCoder) {
+    override open func encodeRestorableState(with coder: NSCoder) {
         super.encodeRestorableState(with: coder)
 
         // Always make sure the object is persisted before proceeding
@@ -919,11 +919,11 @@ extension SPNoteEditorViewController {
 // MARK: - Keyboard
 //
 extension SPNoteEditorViewController {
-    open override var canBecomeFirstResponder: Bool {
+    override open var canBecomeFirstResponder: Bool {
         return true
     }
 
-    open override var keyCommands: [UIKeyCommand]? {
+    override open var keyCommands: [UIKeyCommand]? {
         guard presentedViewController == nil else {
             return nil
         }

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -656,7 +656,7 @@ extension SPNoteListViewController {
         }
     }
 
-    open override func setEditing(_ editing: Bool, animated: Bool) {
+    override open func setEditing(_ editing: Bool, animated: Bool) {
         ensureTableViewEditingIsInSync()
         super.setEditing(editing, animated: animated)
         tableView.setEditing(editing, animated: animated)
@@ -987,11 +987,11 @@ extension SPNoteListViewController {
 // MARK: - Keyboard
 //
 extension SPNoteListViewController {
-    open override var canBecomeFirstResponder: Bool {
+    override open var canBecomeFirstResponder: Bool {
         return true
     }
 
-    open override var keyCommands: [UIKeyCommand]? {
+    override open var keyCommands: [UIKeyCommand]? {
         var commands = tableCommands
         if isSearchActive {
             commands.append(UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(keyboardStopSearching)))

--- a/Simplenote/Classes/SPSidebarViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSidebarViewController+Extensions.swift
@@ -3,11 +3,11 @@ import UIKit
 // MARK: - Keyboard shortcuts
 //
 extension SPSidebarContainerViewController {
-    open override var canBecomeFirstResponder: Bool {
+    override open var canBecomeFirstResponder: Bool {
         return true
     }
 
-    open override var keyCommands: [UIKeyCommand]? {
+    override open var keyCommands: [UIKeyCommand]? {
         guard presentedViewController == nil else {
             return nil
         }

--- a/Simplenote/Classes/SPUserInterface.swift
+++ b/Simplenote/Classes/SPUserInterface.swift
@@ -26,7 +26,7 @@ class SPUserInterface: NSObject {
 
     /// Initializer
     ///
-    private override init() {
+    override private init() {
         super.init()
         startListeningToNotifications()
     }

--- a/Simplenote/Classes/UIKitConstants.swift
+++ b/Simplenote/Classes/UIKitConstants.swift
@@ -23,7 +23,7 @@ class UIKitConstants: NSObject {
 
     /// Yes. This should be, potentially, an enum. But since we intend to use these constants in ObjC... oh well!
     ///
-    private override init() {
+    override private init() {
         // NO-OP
     }
 }

--- a/Simplenote/SPEditorTextView+Simplenote.swift
+++ b/Simplenote/SPEditorTextView+Simplenote.swift
@@ -20,11 +20,11 @@ extension SPEditorTextView {
         return NSAttributedStringToMarkdownConverter.convert(string: selectedAttributedText)
     }
 
-    open override func copy(_ sender: Any?) {
+    override open func copy(_ sender: Any?) {
         UIPasteboard.general.string = plainSelectedText
     }
 
-    open override func cut(_ sender: Any?) {
+    override open func cut(_ sender: Any?) {
         let text = plainSelectedText
         super.cut(sender)
         UIPasteboard.general.string = text
@@ -34,19 +34,19 @@ extension SPEditorTextView {
 // MARK: - Observer content position
 //
 extension SPEditorTextView {
-    open override var contentSize: CGSize {
+    override open var contentSize: CGSize {
         didSet {
             onContentPositionChange?()
         }
     }
 
-    open override var contentOffset: CGPoint {
+    override open var contentOffset: CGPoint {
         didSet {
             onContentPositionChange?()
         }
     }
 
-    open override var contentInset: UIEdgeInsets {
+    override open var contentInset: UIEdgeInsets {
         didSet {
             onContentPositionChange?()
         }

--- a/Simplenote/SeparatorsView.swift
+++ b/Simplenote/SeparatorsView.swift
@@ -57,7 +57,7 @@ open class SeparatorsView: UIView {
             setNeedsDisplay()
         }
     }
-    open override var frame: CGRect {
+    override open var frame: CGRect {
         didSet {
             setNeedsDisplay()
         }
@@ -68,16 +68,16 @@ open class SeparatorsView: UIView {
         self.init(frame: CGRect.zero)
     }
 
-    required override public init(frame: CGRect) {
+    override public required init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
     }
-    required public init(coder aDecoder: NSCoder) {
+    public required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
         setupView()
     }
 
-    open override func draw(_ rect: CGRect) {
+    override open func draw(_ rect: CGRect) {
         super.draw(rect)
 
         guard let ctx = UIGraphicsGetCurrentContext() else {

--- a/SimplenoteUITests/UIDs.swift
+++ b/SimplenoteUITests/UIDs.swift
@@ -46,7 +46,7 @@ enum UID {
 
         // "Empty Trash" button label is generated
         // differently by Xcode 12.4 and 12.5 (runs iOS 14.5+)
-        static private(set) var trashEmptyTrash: String = {
+        private(set) static var trashEmptyTrash: String = {
             "Empty trash"
         }()
 

--- a/SimplenoteWidgets/Models/Note+Widget.swift
+++ b/SimplenoteWidgets/Models/Note+Widget.swift
@@ -15,7 +15,7 @@ extension Note {
         return NSFetchRequest<Note>(entityName: "Note")
     }
 
-    public override func awakeFromInsert() {
+    override public func awakeFromInsert() {
         super.awakeFromInsert()
 
         if simperiumKey.isEmpty {
@@ -25,7 +25,7 @@ extension Note {
 
     @NSManaged public var content: String?
     @NSManaged public var creationDate: Date?
-    @NSManaged public override var isDeleted: Bool
+    @NSManaged override public var isDeleted: Bool
     @NSManaged public var lastPosition: NSNumber?
     @NSManaged public var modificationDate: Date?
     @NSManaged public var noteSynced: NSNumber?


### PR DESCRIPTION
## What

Enable the SwiftLint [`modifier_order`](https://realm.github.io/SwiftLint/modifier_order.html) rule, which enforces a canonical order for declaration modifiers (e.g., `override open` rather than `open override`).

## Numbers

- **Auto-fixed violations:** 12 source files (mostly `open override` -> `override open`, plus a few `convenience required` -> `required convenience`, `private override` -> `override private`, and `static private(set)` -> `private(set) static`).
- **Agentic (manual) fixes:** 0
- **Violations left for human review:** 0

## Verification

- `bundle exec rake lint` clean
- `bundle exec fastlane run_unit_tests` succeeds
	- Alternatively, `xcodebuild build-for-testing -scheme Simplenote -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17'` succeeds

## Context

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/simplenote-ios/pulls?q=is%3Apr+author%3Amokagio+%22Enable+SwiftLint+rule%22) — enabling lint rules one at a time across the iOS apps.