### PR TITLE
Enable SwiftLint rule: comma_inheritance

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # There should be a space after the comma in inheritance lists.
+  - comma_inheritance
+
   # Prefer `contains` over `filter(where:).count`.
   - contains_over_filter_count
 


### PR DESCRIPTION
### Fix

Enables the [`comma_inheritance`](https://realm.github.io/SwiftLint/comma_inheritance.html) SwiftLint rule, which enforces a space after the comma in type inheritance lists.

The rule is auto-fixable; no Swift files in this repo required correction.

Part of the SwiftLint rules rollout (Orchard campaign).

### Test

CI lint is the test. No behavior change.

### Review

A single-line addition to `.swiftlint.yml`. Reviewable in seconds.

### Release

These changes do not require release notes.