### PR TITLE
Enable SwiftLint rule: period_spacing

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -73,6 +73,9 @@ only_rules:
   # the declaration.
   - opening_brace
 
+  # Periods should not be followed by whitespace.
+  - period_spacing
+
   # Prefer `.zero` over explicit init with zero parameters (e.g., `CGPoint(x: 0, y: 0)`).
   - prefer_zero_over_explicit_init
 

--- a/Simplenote/Classes/InterlinkProcessor.swift
+++ b/Simplenote/Classes/InterlinkProcessor.swift
@@ -41,10 +41,10 @@ class InterlinkProcessor: NSObject {
 
     /// Displays the Interlink Lookup UI at the cursor's location when all of the following are **true**:
     ///
-    ///     1.  The Editor isn't Undoing nor Highlighting
-    ///     2.  The Editor is the first responder
-    ///     3.  There is an interlink `[keyword` at the current location
-    ///     4.  There are Notes with `keyword` in their title
+    ///     1. The Editor isn't Undoing nor Highlighting
+    ///     2. The Editor is the first responder
+    ///     3. There is an interlink `[keyword` at the current location
+    ///     4. There are Notes with `keyword` in their title
     ///
     ///  Otherwise we'll simply dismiss the Autocomplete View, if any.
     ///

--- a/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteEditorViewController+Extensions.swift
@@ -265,7 +265,7 @@ extension SPNoteEditorViewController {
             navigationController?.popViewController(animated: true)
         default:
             // With VoiceOver on, three finger scroll up and down will cause a page up/page down action
-            // If this method returns true that is disabled.  Returning false to maintain page up/page down
+            // If this method returns true that is disabled. Returning false to maintain page up/page down
             return false
         }
 

--- a/Simplenote/Classes/SPNoteListViewController+Extensions.swift
+++ b/Simplenote/Classes/SPNoteListViewController+Extensions.swift
@@ -469,8 +469,8 @@ extension SPNoteListViewController: UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         // Notes:
-        //  1.  No need to estimate. We precalculate the Height elsewhere, and we can return the *Actual* value
-        //  2.  We always scroll to the first row whenever Search Results are updated. If we don't implement this method,
+        //  1. No need to estimate. We precalculate the Height elsewhere, and we can return the *Actual* value
+        //  2. We always scroll to the first row whenever Search Results are updated. If we don't implement this method,
         //      UITableView ends up jumping off elsewhere!
         //
         return self.tableView(tableView, heightForRowAt: indexPath)

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -315,9 +315,9 @@ extension SPNoteTableViewCell {
     /// TableView's Separator Insets: Expected to align **exactly** with the label(s) Leading.
     /// In order to get the TableView to fully respect this the following must be fulfilled:
     ///
-    ///     1.  tableViewCell(s).layoutMargins = .zero
-    ///     2.  tableView.layoutMargins = .zero
-    ///     2.  tableView.separatorInsetReference = `.fromAutomaticInsets
+    ///     1. tableViewCell(s).layoutMargins = .zero
+    ///     2. tableView.layoutMargins = .zero
+    ///     2. tableView.separatorInsetReference = `.fromAutomaticInsets
     ///
     /// Then, and only then, this will work ferpectly 🔥
     ///
@@ -345,7 +345,7 @@ extension SPNoteTableViewCell {
     }
 
     // Ref: https://github.com/Automattic/simplenote-ios/issues/1307
-    // setHighlighted gets called on press down and on setSelected.  This causes the highlighting to change on press down but selection is on press up
+    // setHighlighted gets called on press down and on setSelected. This causes the highlighting to change on press down but selection is on press up
     // By only updating the highlighting if the cell is the cell is selected fixes this issue
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {
         if isSelected {

--- a/Simplenote/Classes/SPNoteTableViewCell.swift
+++ b/Simplenote/Classes/SPNoteTableViewCell.swift
@@ -317,7 +317,7 @@ extension SPNoteTableViewCell {
     ///
     ///     1. tableViewCell(s).layoutMargins = .zero
     ///     2. tableView.layoutMargins = .zero
-    ///     2. tableView.separatorInsetReference = `.fromAutomaticInsets
+    ///     3. tableView.separatorInsetReference = `.fromAutomaticInsets`
     ///
     /// Then, and only then, this will work ferpectly 🔥
     ///
@@ -346,7 +346,7 @@ extension SPNoteTableViewCell {
 
     // Ref: https://github.com/Automattic/simplenote-ios/issues/1307
     // setHighlighted gets called on press down and on setSelected. This causes the highlighting to change on press down but selection is on press up
-    // By only updating the highlighting if the cell is the cell is selected fixes this issue
+    // Only updating the highlighting if the cell is selected fixes this issue
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {
         if isSelected {
             super.setHighlighted(highlighted, animated: animated)

--- a/Simplenote/Classes/SPSettingsViewController+Extensions.swift
+++ b/Simplenote/Classes/SPSettingsViewController+Extensions.swift
@@ -5,7 +5,7 @@ import SimplenoteEndpoints
 // MARK: - Subscriber UI
 //
 
-// The methods in this extension are for showing and displaying the Sustainer banner in settings.  We are discontinuing Sustainer,
+// The methods in this extension are for showing and displaying the Sustainer banner in settings. We are discontinuing Sustainer,
 // but we may still want to use the banner in the future, so marking these methods fileprivate and have removed their callers
 fileprivate extension SPSettingsViewController {
 

--- a/Simplenote/Classes/UITextView+Simplenote.swift
+++ b/Simplenote/Classes/UITextView+Simplenote.swift
@@ -44,9 +44,9 @@ private extension UITextView {
 
     /// Registers an Undo Checkpoint, and performs a given block `in a transactional fashion`: an Undo Group will wrap its execution
     ///
-    ///     1.  Registers an Undo Operation which is expected to restore the TextView to its previous state
-    ///     2.  Wraps up a given `Block` within an Undo Group
-    ///     3.  Post a TextDidChange Notification
+    ///     1. Registers an Undo Operation which is expected to restore the TextView to its previous state
+    ///     2. Wraps up a given `Block` within an Undo Group
+    ///     3. Post a TextDidChange Notification
     ///
     @discardableResult
     func registerUndoCheckpointAndPerform(block: (NSTextStorage) -> Void) -> Bool {
@@ -66,9 +66,9 @@ private extension UITextView {
 
     /// Registers an Undo Checkpoint, which is expected to restore the receiver to its previous state:
     ///
-    ///     1.  Restores the full contents of our TextStorage
-    ///     2.  Reverts the SelectedRange
-    ///     3.  Post a textDidChange Notification
+    ///     1. Restores the full contents of our TextStorage
+    ///     2. Reverts the SelectedRange
+    ///     3. Post a textDidChange Notification
     ///
     func registerUndoCheckpoint(in undoManager: UndoManager, storage: NSTextStorage) {
         let oldSelectedRange = selectedRange

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -57,7 +57,7 @@ class StoreManager {
 
     // MARK: - Public API(s)
 
-    /// Initialization involves three major steps:
+    /// Initialization involves these major steps:
     ///
     ///     1. Listen for Pending Transactions
     ///     2. Request the Known Products

--- a/Simplenote/StoreManager.swift
+++ b/Simplenote/StoreManager.swift
@@ -59,10 +59,10 @@ class StoreManager {
 
     /// Initialization involves three major steps:
     ///
-    ///     1.  Listen for Pending Transactions
-    ///     2.  Request the Known Products
-    ///     3.  Refresh the Purchased Products
-    ///     4.  Refresh the SubscriptionGroup Status (and update Core Data / refresh UI all over!)
+    ///     1. Listen for Pending Transactions
+    ///     2. Request the Known Products
+    ///     3. Refresh the Purchased Products
+    ///     4. Refresh the SubscriptionGroup Status (and update Core Data / refresh UI all over!)
     ///
     /// This API should be invoked shortly after the Launch Sequence is complete.
     ///

--- a/Simplenote/TagListViewController.swift
+++ b/Simplenote/TagListViewController.swift
@@ -559,8 +559,8 @@ private extension TagListViewController {
         tagsHeaderView.actionButton.setTitle(title, for: .normal)
     }
 
-    // This method is for refreshing the size of the sustainer view.  We are retiring sustainer so this is no longer needed
-    // but we may want to use the banner again in the future, so leaving this here in case.  Method is not being called anywhere
+    // This method is for refreshing the size of the sustainer view. We are retiring sustainer so this is no longer needed
+    // but we may want to use the banner again in the future, so leaving this here in case. Method is not being called anywhere
     func refreshTableHeaderView() {
         guard let bannerView else {
             return

--- a/SimplenoteWidgets/Models/Note+Widget.swift
+++ b/SimplenoteWidgets/Models/Note+Widget.swift
@@ -1,6 +1,6 @@
 // This file contains the required class structure to be able to fetch and use core data files in widgets and intents
 // We have collapsed the auto generated core data files into a single file as it is unlikely that the files will need to
-// be regenerated.  Contained in this file is the generated class files Note+CoreDataClass.swift and Note+CoreDataProperties.swift
+// be regenerated. Contained in this file is the generated class files Note+CoreDataClass.swift and Note+CoreDataProperties.swift
 
 import Foundation
 import CoreData

--- a/SimplenoteWidgets/Models/SPManagedObject+Widget.swift
+++ b/SimplenoteWidgets/Models/SPManagedObject+Widget.swift
@@ -1,6 +1,6 @@
 // This file contains the required class structure to be able to fetch and use core data files in widgets and intents
 // We have collapsed the auto generated core data files into a single file as it is unlikely that the files will need to
-// be regenerated.  Contained in this file is the generated class files SPManagedObject+CoreDataClass.swift and SPManagedObject+CoreDataProperties.swift
+// be regenerated. Contained in this file is the generated class files SPManagedObject+CoreDataClass.swift and SPManagedObject+CoreDataProperties.swift
 
 import Foundation
 import CoreData

--- a/SimplenoteWidgets/Models/Tag+Widget.swift
+++ b/SimplenoteWidgets/Models/Tag+Widget.swift
@@ -1,6 +1,6 @@
 // This file contains the required class structure to be able to fetch and use core data files in widgets and intents
 // We have collapsed the auto generated core data files into a single file as it is unlikely that the files will need to
-// be regenerated.  Contained in this file is the generated class files Tag+CoreDataClass.swift and Tag+CoreDataProperties.swift
+// be regenerated. Contained in this file is the generated class files Tag+CoreDataClass.swift and Tag+CoreDataProperties.swift
 
 import Foundation
 import CoreData

--- a/SimplenoteWidgets/Tools/ExtensionResultsController.swift
+++ b/SimplenoteWidgets/Tools/ExtensionResultsController.swift
@@ -48,7 +48,7 @@ class ExtensionResultsController {
         note(forSimperiumKey: key) != nil
     }
 
-    /// Creates a predicate for notes given a tag name.  If not specified the predicate is for all notes that are not deleted
+    /// Creates a predicate for notes given a tag name. If not specified the predicate is for all notes that are not deleted
     ///
     private func predicateForNotes(filteredBy tagFilter: TagsFilter = .allNotes) -> NSPredicate {
         switch tagFilter {


### PR DESCRIPTION
Enables the [`period_spacing`](https://realm.github.io/SwiftLint/period_spacing.html) SwiftLint rule, which flags whitespace after a period.

SwiftLint's autocorrect fixed all 12 existing offenders in the same pass — no manual changes needed.

## Test plan

- [ ] CI is green (modulo known pre-existing flakes on Buildkite ui-test-full).