### PR TITLE
Enable SwiftLint rule: multiline_parameters

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,6 +69,9 @@ only_rules:
   # MARK comment should be in valid format.
   - mark
 
+  # Functions and methods parameters should be either on the same line, or one per line.
+  - multiline_parameters
+
   # Opening braces should be preceded by a single space and on the same line as
   # the declaration.
   - opening_brace

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,7 +69,7 @@ only_rules:
   # MARK comment should be in valid format.
   - mark
 
-  # Functions and methods parameters should be either on the same line, or one per line.
+  # Function and method parameters should be either on the same line, or one per line.
   - multiline_parameters
 
   # Opening braces should be preceded by a single space and on the same line as


### PR DESCRIPTION
## Rationale

Adds `multiline_parameters` to `only_rules` in `.swiftlint.yml`.

The rule requires multi-line function parameter lists to be one-per-line or all-on-one-line — no half-and-half. simplenote-ios is already compliant: `bundle exec rake lint` reports 0 violations under SwiftLint 0.63.2.

## How to test

CI runs `rake lint`. Locally: from the worktree, `bundle exec rake lint` should report 0 violations.

## Notes

- 0 violations — config-only adoption.
- Part of the Orchard SwiftLint rollout campaign.
- `multiline_parameters` is not autofixable in SwiftLint 0.63.2; the other multi-line rules (`multiline_arguments`, `multiline_arguments_brackets`, `multiline_function_chains`, `multiline_parameters_brackets`) have existing violations on simplenote-ios and are deferred.