### PR TITLE
Enable SwiftLint rule: unhandled_throwing_task

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -100,6 +100,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   # - trailing_whitespace
 
+  # Errors thrown from inside a `Task { ... }` block must be handled — otherwise they are silently discarded.
+  - unhandled_throwing_task
+
   # Unused parameter in a closure should be replaced with `_`.
   - unused_closure_parameter
 


### PR DESCRIPTION
## Rationale

Adds `unhandled_throwing_task` to `only_rules` in `.swiftlint.yml`.

The rule flags `Task { ... }` blocks that throw without explicitly handling the error — those errors are silently discarded at runtime and become hard-to-trace bugs. simplenote-ios is already compliant: `bundle exec rake lint` reports 0 violations under SwiftLint 0.63.2.

## How to test

CI runs `rake lint`. Locally: `bundle exec rake lint` should report 0 violations.

## Notes

- 0 violations — config-only adoption.
- `unhandled_throwing_task` is not autofixable in SwiftLint 0.63.2; this PR lands only because the codebase is already clean.
- Part of the Orchard SwiftLint rollout campaign.