### PR TITLE
Enable SwiftLint rule: empty_collection_literal

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -41,6 +41,9 @@ only_rules:
 
   - duplicate_imports
 
+  # Prefer checking `isEmpty` over comparing collection to an empty array or dictionary literal.
+  - empty_collection_literal
+
   # Prefer checking `isEmpty` over comparing `count` to zero.
   - empty_count
 


### PR DESCRIPTION
## Rationale

Adds `empty_collection_literal` to `only_rules` in `.swiftlint.yml`.

The rule flags `.count == 0` / `== []` / `== [:]` comparisons that should be expressed as `.isEmpty` for clarity. simplenote-ios is already compliant: `bundle exec rake lint` reports 0 violations under SwiftLint 0.63.2.

## How to test

CI runs `rake lint`. Locally: `bundle exec rake lint` should report 0 violations.

## Notes

- 0 violations — config-only adoption.
- `empty_collection_literal` is not autofixable in SwiftLint 0.63.2; this PR lands only because the codebase is already clean.
- Part of the Orchard SwiftLint rollout campaign.