### PR TITLE
Enable SwiftLint rule: untyped_error_in_catch

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -100,6 +100,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   # - trailing_whitespace
 
+  # Catch clauses should declare the error type as `Error` or a specific concrete type, rather than being untyped.
+  - untyped_error_in_catch
+
   # Unused parameter in a closure should be replaced with `_`.
   - unused_closure_parameter
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -100,7 +100,8 @@ only_rules:
   # Lines should not have trailing whitespace.
   # - trailing_whitespace
 
-  # Catch clauses should declare the error type as `Error` or a specific concrete type, rather than being untyped.
+  # Prefer plain `catch` over redundant `catch let error` or `catch let error as Error`,
+  # since Swift already provides an implicit `error` in a plain `catch`.
   - untyped_error_in_catch
 
   # Unused parameter in a closure should be replaced with `_`.

--- a/SimplenoteScreenshots/SnapshotHelper.swift
+++ b/SimplenoteScreenshots/SnapshotHelper.swift
@@ -71,7 +71,7 @@ open class Snapshot: NSObject {
             setLanguage(app)
             setLocale(app)
             setLaunchArguments(app)
-        } catch let error {
+        } catch {
             NSLog(error.localizedDescription)
         }
     }
@@ -185,7 +185,7 @@ open class Snapshot: NSObject {
                 #else
                     try image.pngData()?.write(to: path, options: .atomic)
                 #endif
-            } catch let error {
+            } catch {
                 NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
                 NSLog(error.localizedDescription)
             }


### PR DESCRIPTION
Part of the SwiftLint rules rollout campaign — one rule per PR.

The `untyped_error_in_catch` rule flags `catch let error` (or `catch let error as Error`) where the binding adds nothing over a plain `catch`, since Swift already binds an implicit `error` in catch blocks.

## Changes

- Adds the rule to `.swiftlint.yml` (alphabetically placed).
- Autofix removed 2 occurrences in 1 file (`SimplenoteScreenshots/SnapshotHelper.swift`).

## Testing

- `bundle exec rake lint` passes locally.