### PR TITLE
Enable SwiftLint rule: return_value_from_void_function

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -82,6 +82,9 @@ only_rules:
   # Type annotations are redundant when the type can be inferred.
   - redundant_type_annotation
 
+  # Returning a value from a function that has Void return type.
+  - return_value_from_void_function
+
   # Prefer `someBool.toggle()` over `someBool = !someBool`.
   - toggle_bool
 

--- a/SimplenoteUITests/NoteList.swift
+++ b/SimplenoteUITests/NoteList.swift
@@ -283,7 +283,8 @@ class NoteListAssert {
         print(">>>> \"\(expectedContent)\"")
 
         guard NoteList.isNotePresent(noteName) else {
-            return XCTFail(">>>> Note not found")
+            XCTFail(">>>> Note not found")
+            return
         }
 
         if let noteContent = Table.getContentOfCell(noteName: noteName) {


### PR DESCRIPTION
Part of the SwiftLint rules rollout campaign — one rule per PR.

The `return_value_from_void_function` rule flags returning a value (including an expression) from a `Void`-returning function — usually a copy-paste artefact that obscures the intent.

## Changes

- Adds the rule to `.swiftlint.yml` (alphabetically placed).
- Autofix split a `return XCTFail(...)` into two statements in `SimplenoteUITests/NoteList.swift` (1 occurrence in 1 file).

## Testing

- `bundle exec rake lint` passes locally.
- `xcodebuild build-for-testing` against the `SimplenoteUITests` scheme succeeds.