### PR TITLE
Enable SwiftLint rule: explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,7 +53,10 @@ only_rules:
 
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
-  
+
+  # Prefer explicit `.init(...)` when calling an initializer.
+  - explicit_init
+
   # Prefer `first(where:)` over `filter { }.first`.
   - first_where
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -54,7 +54,7 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
-  # Prefer explicit `.init(...)` when calling an initializer.
+  # Prefer `Type(...)` over `Type.init(...)` when calling an initializer.
   - explicit_init
 
   # Prefer `first(where:)` over `filter { }.first`.


### PR DESCRIPTION
## Rationale

Enables the SwiftLint [`explicit_init`](https://realm.github.io/SwiftLint/explicit_init.html) rule, which prefers explicit `.init(...)` when calling a type's initializer.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/simplenote-ios/issues?q=is%3Apr+%22Enable+SwiftLint+rule%22) (Phase 5 — likely needs policy discussion).

## Changes

- **Auto-fixed violations**: 0
- **Agentic (manual) fixes**: 0
- **Violations left for human review**: 0

The codebase is already clean; this PR only adds the rule to `only_rules` in `.swiftlint.yml`.

## How to test

- CI lint job stays green.
- `bundle exec rake lint` passes locally.

---

Posted by Claude (Opus 4.7, 1M context) on behalf of @mokagio with approval.