### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/Simplenote/Classes/KeyboardObservable.swift
+++ b/Simplenote/Classes/KeyboardObservable.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-/// Adopters of this protocol will recieve interactive keyboard-based notifications
+/// Adopters of this protocol will receive interactive keyboard-based notifications
 /// by implmenting the provided functions within.
 ///
 public protocol KeyboardObservable: AnyObject {

--- a/Simplenote/Classes/SPOnboardingViewController.swift
+++ b/Simplenote/Classes/SPOnboardingViewController.swift
@@ -43,7 +43,7 @@ class SPOnboardingViewController: UIViewController, SPAuthenticationInterface {
     ///
     var authenticator: SPAuthenticator?
 
-    // MARK: - Overriden Properties
+    // MARK: - Overridden Properties
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .portrait

--- a/Simplenote/Classes/SPTagHeaderView.swift
+++ b/Simplenote/Classes/SPTagHeaderView.swift
@@ -18,7 +18,7 @@ class SPTagHeaderView: UIView {
         }
     }
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/Simplenote/Classes/TagTextFieldInputValidator.swift
+++ b/Simplenote/Classes/TagTextFieldInputValidator.swift
@@ -57,7 +57,7 @@ struct TagTextFieldInputValidator {
 
     /// Indicates if the receivers length is within allowed values
     /// - Important: `Tag.name` is used as the entity's `simperiumKey`, and the backend imposes a length.
-    ///              For that reason we must check on the `encoded` lenght (and not the actual raw string length)
+    ///              For that reason we must check on the `encoded` length (and not the actual raw string length)
     private func validateLength(tag: String) -> Bool {
         tag.byEncodingAsTagHash.count <= Constants.maximumTagLength
     }

--- a/Simplenote/NoticeFactory.swift
+++ b/Simplenote/NoticeFactory.swift
@@ -47,7 +47,7 @@ extension NoticeFactory {
         static let undo = NSLocalizedString("Undo", comment: "Undo action")
         static let trashed = NSLocalizedString("Note Trashed", comment: "Note trashed notification")
         static let unpublished = NSLocalizedString("Unpublish successful", comment: "Notice of publishing unsuccessful")
-        static let published = NSLocalizedString("Publish Successful", comment: "Notice up succesful publishing")
+        static let published = NSLocalizedString("Publish Successful", comment: "Notice up successful publishing")
         static let networkIssue = NSLocalizedString("A network connection is required. Please, check your connection and try again.", comment: "Network connection issue notificaiton")
 
         static let noteTrashed = NSLocalizedString("%i Note Trashed", comment: "Note trashed notification")

--- a/Simplenote/SubtitleTableViewCell.swift
+++ b/Simplenote/SubtitleTableViewCell.swift
@@ -38,7 +38,7 @@ final class SubtitleTableViewCell: UITableViewCell {
         fatalError("Unsupported Initializer")
     }
 
-    // MARK: - Overriden
+    // MARK: - Overridden
 
     override func prepareForReuse() {
         super.prepareForReuse()

--- a/Simplenote/Value1TableViewCell.swift
+++ b/Simplenote/Value1TableViewCell.swift
@@ -67,7 +67,7 @@ class Value1TableViewCell: UITableViewCell {
         fatalError("Unsupported Initializer")
     }
 
-    // MARK: - Overriden
+    // MARK: - Overridden
 
     override func prepareForReuse() {
         super.prepareForReuse()

--- a/SimplenoteTests/UIImageSimplenoteTests.swift
+++ b/SimplenoteTests/UIImageSimplenoteTests.swift
@@ -5,7 +5,7 @@ import XCTest
 //
 class UIImageSimplenoteTests: XCTestCase {
 
-    /// Verify every single UIColorName in existance yields a valid UIColor instancce
+    /// Verify every single UIColorName in existence yields a valid UIColor instance
     ///
     func testEverySingleUIImageNameEffectivelyYieldsSomeUIImageInstance() {
         for imageName in UIImageName.allCases {

--- a/SimplenoteUITests/NoteEditor.swift
+++ b/SimplenoteUITests/NoteEditor.swift
@@ -163,7 +163,7 @@ class NoteEditor {
 
     class func getTextViewsWithExactValueCount(value: String) -> Int {
         // We wait for at least one element with exact value to appear before counting
-        // all occurences. The downside is having one extra call before the actual count.
+        // all occurrences. The downside is having one extra call before the actual count.
         let equalValuePredicate = NSPredicate(format: "value == '" + value + "'")
         _ = app
             .descendants(matching: .textView)
@@ -184,7 +184,7 @@ class NoteEditor {
         let equalLabelPredicate = NSPredicate(format: "label == '" + label + "'")
 
         // We wait for at least one element with exact label to appear before counting
-        // all occurences. The downside is having one extra call before the actual count.
+        // all occurrences. The downside is having one extra call before the actual count.
         _ = app.textViews[label].waitForExistence(timeout: averageLoadTimeout)
 
         let matchingTextViews = app.textViews.matching(equalLabelPredicate)

--- a/SimplenoteUITests/Preview.swift
+++ b/SimplenoteUITests/Preview.swift
@@ -30,7 +30,7 @@ class Preview {
         let predicate = NSPredicate(format: "value == '" + value + "'")
 
         // We wait for at least one element with exact value to appear before counting
-        // all occurences. The downside is having one extra call before the actual count.
+        // all occurrences. The downside is having one extra call before the actual count.
         _ = app
             .webViews
             .descendants(matching: .staticText)


### PR DESCRIPTION
Mechanical typo fixes in code comments and doc-comments.
No behavior changes; no user-facing strings touched.

Each commit fixes typos in a single file.

## To test

- Skim the diff; verify each replacement is the obvious correction.
- CI should be green.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*