### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
 
     - name: Install Bundler
       run: gem install bundler


### PR DESCRIPTION
Two-in-one hardening:

1. Pin third-party GitHub Actions in this repo to commit SHAs (tag preserved as trailing comment).
2. Add Dependabot `github-actions` config (weekly, grouped into `actions-minor-patch` and `actions-major`, with cooldown).

Tracking: DEVPROD-1072.
