### PR TITLE
fix: keep cursor at tap location and stop editor jumping to top during space-bar cursor drag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.56
 -----
+- Fixed an editor scrolling issue when placing or dragging the cursor in long notes
 
 
 4.55

--- a/Simplenote/Classes/SPEditorTextView.m
+++ b/Simplenote/Classes/SPEditorTextView.m
@@ -6,6 +6,8 @@
 //  Copyright (c) 2013 Automattic. All rights reserved.
 //
 
+#import <math.h>
+
 #import "SPEditorTextView.h"
 #import "SPInteractiveTextStorage.h"
 #import "NSMutableAttributedString+Styling.h"
@@ -29,6 +31,13 @@ static CGFloat const TextViewMaximumWidthPhone = 0;
 // One unicode character plus a space
 NSInteger const ChecklistCursorAdjustment = 2;
 
+static BOOL SPRectIsFinite(CGRect rect)
+{
+    return isfinite(CGRectGetMinX(rect)) &&
+           isfinite(CGRectGetMinY(rect)) &&
+           isfinite(CGRectGetMaxX(rect)) &&
+           isfinite(CGRectGetMaxY(rect));
+}
 
 @interface SPEditorTextView ()<UIGestureRecognizerDelegate>
 
@@ -39,6 +48,7 @@ NSInteger const ChecklistCursorAdjustment = 2;
 @property (nonatomic) CGRect verticalMoveLastCaretRect;
 @property (nonatomic) BOOL isInserting;
 @property (nonatomic) BOOL isDeletingBackward;
+@property (nonatomic) BOOL isDraggingFloatingCursor;
 
 @end
 
@@ -209,11 +219,61 @@ NSInteger const ChecklistCursorAdjustment = 2;
 {
     [super scrollRangeToVisible:range];
     
-    if (self.layoutManager.extraLineFragmentTextContainer != nil && self.selectedRange.location == range.location)
-    {
-        CGRect caretRect = [self caretRectForPosition:self.selectedTextRange.start];
+    if (self.layoutManager.extraLineFragmentTextContainer != nil && self.selectedRange.location == range.location && self.isDraggingFloatingCursor == NO) {
+        UITextRange *selectedTextRange = self.selectedTextRange;
+        if (selectedTextRange == nil) {
+            return;
+        }
+
+        CGRect caretRect = [self caretRectForPosition:selectedTextRange.start];
+        if (![self shouldScrollCaretRectToVisible:caretRect]) {
+            return;
+        }
+
         [self scrollRectToVisible:caretRect animated:YES];
     }
+}
+
+- (BOOL)shouldScrollCaretRectToVisible:(CGRect)caretRect
+{
+    if (CGRectIsNull(caretRect) || !SPRectIsFinite(caretRect)) {
+        return NO;
+    }
+
+    CGRect visibleBounds = UIEdgeInsetsInsetRect(self.bounds, self.adjustedContentInset);
+    if (CGRectContainsRect(visibleBounds, caretRect)) {
+        return NO;
+    }
+
+    if (![self contentContainsCaretRect:caretRect]) {
+        return NO;
+    }
+
+    // The extra-line-fragment workaround is only needed below the visible area.
+    return CGRectGetMaxY(caretRect) >= CGRectGetMinY(visibleBounds);
+}
+
+- (BOOL)contentContainsCaretRect:(CGRect)caretRect
+{
+    CGSize contentSize = self.contentSize;
+    if (!isfinite(contentSize.width) || !isfinite(contentSize.height)) {
+        return NO;
+    }
+
+    CGRect contentRect = CGRectMake(0, 0, contentSize.width, contentSize.height);
+    return CGRectIntersectsRect(contentRect, caretRect);
+}
+
+- (void)beginFloatingCursorAtPoint:(CGPoint)point
+{
+    self.isDraggingFloatingCursor = YES;
+    [super beginFloatingCursorAtPoint:point];
+}
+
+- (void)endFloatingCursor
+{
+    [super endFloatingCursor];
+    self.isDraggingFloatingCursor = NO;
 }
 
 


### PR DESCRIPTION
### Fix
In a scrolled note, tapping a line did not reliably keep the cursor at the tapped location, and dragging the cursor with the long-press space-bar trackpad frequently made the editor jump to the top of the note (Zendesk #11250033). The custom `scrollRangeToVisible:` override in `SPEditorTextView.m` (from #973/#982) unconditionally follows up with `scrollRectToVisible:[self caretRectForPosition:...]`; during a floating-cursor drag, and right after a tap before layout settles, `caretRectForPosition:` can return a null or stale rect near the origin, so that follow-up scroll yanks the content offset to the top and fights the tap-placed selection.

Two self-contained changes in `SPEditorTextView.m`:
- `beginFloatingCursorAtPoint:` / `endFloatingCursor` overrides track an `isDraggingFloatingCursor` flag and skip the custom follow-up scroll while the space-bar trackpad drag is active, so UIKit's own tracking owns the offset.
- The follow-up `scrollRectToVisible:` is guarded against null, non-finite, and off-content caret rects, and skipped when the caret rect is already visible inside `self.bounds`.

Fixes #1787

### Test
1. Open a long note and scroll to the middle.
2. Tap a specific word: the cursor lands and stays at the tapped location without the view scrolling away.
3. Long-press the space bar and drag the cursor around: the editor no longer jumps its scroll offset to the top during the drag.
4. Regression checks from the prior fixes in this area: select text near the bottom edge (#973) and tap into a note on a fresh open (#916); no bounce-back in either case.

### Review
Only one developer is required to review these changes. The diff is confined to `SPEditorTextView.m` plus a release-notes line.

### Release
`RELEASE-NOTES.txt` was updated in 57fc9c7 with:

> Fixed the editor jumping to the top of the note while dragging the cursor with the space-bar trackpad
