### PR TITLE
Generate simperiumKey when creating a new note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.56
 -----
+- Fixed an issue where copying the internal link of a just-created note copied nothing
 
 
 4.55

--- a/Simplenote.xcodeproj/project.pbxproj
+++ b/Simplenote.xcodeproj/project.pbxproj
@@ -517,6 +517,7 @@
 		BAA4856925D5E40900F3BDB9 /* SearchQuery+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */; };
 		BAA59E79269F9FE30068BD3D /* Date+Simplenote.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */; };
 		BAA63C3325EEDA83001589D7 /* NoteLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */; };
+		FA10190001AD1E5700000002 /* SPObjectManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA10190001AD1E5700000001 /* SPObjectManagerTests.swift */; };
 		BAADC8A426C634DB004CAAA9 /* WidgetConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAADC8A326C634DB004CAAA9 /* WidgetConstants.swift */; };
 		BAADC8A526C634DB004CAAA9 /* WidgetConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAADC8A326C634DB004CAAA9 /* WidgetConstants.swift */; };
 		BAB017722609456D007A9CC3 /* PublishController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB017712609456D007A9CC3 /* PublishController.swift */; };
@@ -1207,6 +1208,7 @@
 		BAA4856825D5E40900F3BDB9 /* SearchQuery+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchQuery+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA59E78269F9FE30068BD3D /* Date+Simplenote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Simplenote.swift"; sourceTree = "<group>"; };
 		BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteLinkTests.swift; sourceTree = "<group>"; };
+		FA10190001AD1E5700000001 /* SPObjectManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPObjectManagerTests.swift; sourceTree = "<group>"; };
 		BAADC8A326C634DB004CAAA9 /* WidgetConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetConstants.swift; sourceTree = "<group>"; };
 		BAB017712609456D007A9CC3 /* PublishController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishController.swift; sourceTree = "<group>"; };
 		BAB01791260AAE93007A9CC3 /* NoticeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeFactory.swift; sourceTree = "<group>"; };
@@ -1858,6 +1860,7 @@
 				A64DE6F8255D21B9001D0526 /* StringContentSliceTests.swift */,
 				A64DE700255D4570001D0526 /* NoteBodyExcerptTests.swift */,
 				BAA63C3225EEDA83001589D7 /* NoteLinkTests.swift */,
+				FA10190001AD1E5700000001 /* SPObjectManagerTests.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -3628,6 +3631,7 @@
 				B51F6DD72460D7C20074DDD9 /* NSPredicateEmailTests.swift in Sources */,
 				B5D367BE23ECF42D0024215D /* NSStringCondensingTests.swift in Sources */,
 				BAA63C3325EEDA83001589D7 /* NoteLinkTests.swift in Sources */,
+				FA10190001AD1E5700000002 /* SPObjectManagerTests.swift in Sources */,
 				B51F6DD32460D12B0074DDD9 /* AuthenticationValidatorTests.swift in Sources */,
 				B57DE27A2501806B00B4D435 /* StringSimplenoteTests.swift in Sources */,
 				B5421F3C23CE7A14004DDC19 /* Constants.swift in Sources */,

--- a/Simplenote/Classes/SPObjectManager+Simplenote.swift
+++ b/Simplenote/Classes/SPObjectManager+Simplenote.swift
@@ -11,7 +11,9 @@ extension SPObjectManager {
 
     @objc
     func newDefaultNote() -> Note {
-        guard let note = NSEntityDescription.insertNewObject(forEntityName: Note.entityName, into: managedObjectContext) as? Note else {
+        // Inserting via the Simperium Bucket ensures the note gets its `simperiumKey` right away
+        // (rather than on the first save), so the Internal Link is available immediately
+        guard let note = SPAppDelegate.shared().simperium.notesBucket.insertNewObject() as? Note else {
             fatalError()
         }
 

--- a/SimplenoteTests/SPObjectManagerTests.swift
+++ b/SimplenoteTests/SPObjectManagerTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Simplenote
+
+// MARK: - SPObjectManager Tests
+//
+class SPObjectManagerTests: XCTestCase {
+
+    /// Verifies that new notes get a `simperiumKey` right at creation, so the Internal Link
+    /// can be copied before the note is ever saved.
+    ///
+    /// Ref. https://github.com/Automattic/simplenote-ios/issues/1019
+    ///
+    func testNewDefaultNoteGetsSimperiumKeyImmediately() {
+        let note = SPObjectManager.shared().newDefaultNote()
+        defer {
+            note.managedObjectContext?.delete(note)
+        }
+
+        XCTAssertNotNil(note.simperiumKey)
+        XCTAssertNotNil(note.plainInternalLink)
+    }
+}


### PR DESCRIPTION
### Fix
Fixes #1019

For a just-created note, tapping **Copy Internal Link** in the editor Options silently copied nothing. New notes were inserted via `NSEntityDescription.insertNewObject`, so `simperiumKey` was only assigned on the first save, and `plainInternalLink` returns `nil` without it.

Following @jleandroperez's suggestion in the issue, `SPObjectManager.newDefaultNote()` now inserts through `simperium.notesBucket.insertNewObject()`, which assigns the `simperiumKey` at creation (same main managed object context as before). I checked the remaining production insertion points: `RecoveryUnarchiver` already inserts via the bucket, and all other new-note paths (`EditorFactory`, note list, app delegate shortcuts, `newNote(withContent:tags:)`) funnel through `newDefaultNote()`.

### Test
1. Enter a tag's note list and create a new note; don't type anything
2. Open Options (3 dots) and tap **Copy Internal Link**
3. Paste into another note ~> the `simplenote://note/...` link is pasted (before this fix, nothing was copied)

Also added a unit test (`SPObjectManagerTests`) asserting that `newDefaultNote()` returns a note with a `simperiumKey` and a non-nil internal link. It fails without the fix and passes with it. Full `SimplenoteTests` suite passes.

### Review
Anyone can review; one developer is sufficient.

### Release
`RELEASE-NOTES.txt` was updated in 76168259 with:

> Fixed an issue where copying the internal link of a just-created note copied nothing