### PR TITLE
Improve login error alert wording and dismiss button

### DIFF
--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -103,7 +103,10 @@ extension SPAuthError {
     var message: String {
         switch self {
         case .loginBadCredentials:
-            return NSLocalizedString("The email address or password you entered is incorrect.", comment: "Message displayed when login fails")
+            return NSLocalizedString(
+                "The email address or password you entered is incorrect.",
+                comment: "Message displayed when login fails"
+            )
         case .signupBadCredentials:
             return NSLocalizedString("Could not create an account with the provided email address and password.", comment: "Error for bad email or password")
         case .signupUserAlreadyExists:

--- a/Simplenote/Classes/SPAuthError.swift
+++ b/Simplenote/Classes/SPAuthError.swift
@@ -94,7 +94,7 @@ extension SPAuthError {
         case .tooManyAttempts:
             return NSLocalizedString("Too Many Login Attempts", comment: "Title for too many login attempts error")
         default:
-            return NSLocalizedString("Sorry!", comment: "Authentication Error Alert Title")
+            return NSLocalizedString("Login Failed", comment: "Authentication Error Alert Title")
         }
     }
 
@@ -103,7 +103,7 @@ extension SPAuthError {
     var message: String {
         switch self {
         case .loginBadCredentials:
-            return NSLocalizedString("Could not login with the provided email address and password.", comment: "Message displayed when login fails")
+            return NSLocalizedString("The email address or password you entered is incorrect.", comment: "Message displayed when login fails")
         case .signupBadCredentials:
             return NSLocalizedString("Could not create an account with the provided email address and password.", comment: "Error for bad email or password")
         case .signupUserAlreadyExists:

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -720,7 +720,7 @@ private extension SPAuthViewController {
 
     func presentGenericError(error: SPAuthError) {
         let alertController = UIAlertController(title: error.title, message: error.message, preferredStyle: .alert)
-        alertController.addDefaultActionWithTitle(AuthenticationStrings.acceptActionText)
+        alertController.addDefaultActionWithTitle(AuthenticationStrings.dismissActionText)
         present(alertController, animated: true, completion: nil)
     }
 
@@ -905,7 +905,7 @@ private enum AuthenticationStrings {
     static let emailPlaceholder             = NSLocalizedString("Email", comment: "Email TextField Placeholder")
     static let passwordPlaceholder          = NSLocalizedString("Password", comment: "Password TextField Placeholder")
     static let codePlaceholder              = NSLocalizedString("Code", comment: "Code TextField Placeholder")
-    static let acceptActionText             = NSLocalizedString("Accept", comment: "Accept Action")
+    static let dismissActionText            = NSLocalizedString("OK", comment: "Dismisses an authentication error alert")
     static let cancelActionText             = NSLocalizedString("Cancel", comment: "Cancel Action")
     static let loginActionText              = NSLocalizedString("Log In", comment: "Log In Action")
     static let loginWithEmailEmailHeader    = NSLocalizedString("Enter the password for the account {{EMAIL}}", comment: "Header for Login With Password. Please preserve the {{EMAIL}} substring")

--- a/Simplenote/Classes/SPAuthViewController.swift
+++ b/Simplenote/Classes/SPAuthViewController.swift
@@ -905,7 +905,7 @@ private enum AuthenticationStrings {
     static let emailPlaceholder             = NSLocalizedString("Email", comment: "Email TextField Placeholder")
     static let passwordPlaceholder          = NSLocalizedString("Password", comment: "Password TextField Placeholder")
     static let codePlaceholder              = NSLocalizedString("Code", comment: "Code TextField Placeholder")
-    static let dismissActionText            = NSLocalizedString("OK", comment: "Dismisses an authentication error alert")
+    static let dismissActionText            = NSLocalizedString("OK", comment: "Dismisses an auth error alert")
     static let cancelActionText             = NSLocalizedString("Cancel", comment: "Cancel Action")
     static let loginActionText              = NSLocalizedString("Log In", comment: "Log In Action")
     static let loginWithEmailEmailHeader    = NSLocalizedString("Enter the password for the account {{EMAIL}}", comment: "Header for Login With Password. Please preserve the {{EMAIL}} substring")

--- a/Simplenote/UIAlertController+Auth.swift
+++ b/Simplenote/UIAlertController+Auth.swift
@@ -9,7 +9,10 @@ extension UIAlertController {
     ///
     static func buildLoginCodeNotFoundAlert(onRequestCode: @escaping () -> Void) -> UIAlertController {
         let title = NSLocalizedString("Login Failed", comment: "Title for the expired login code alert")
-        let message = NSLocalizedString("The authentication code you've requested has expired. Please request a new one", comment: "Message for the expired login code alert")
+        let message = NSLocalizedString(
+            "The authentication code you've requested has expired. Please request a new one",
+            comment: "Message for the expired login code alert"
+        )
         let dismissText = NSLocalizedString("OK", comment: "Dismisses the expired login code alert")
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)

--- a/Simplenote/UIAlertController+Auth.swift
+++ b/Simplenote/UIAlertController+Auth.swift
@@ -8,12 +8,12 @@ extension UIAlertController {
     /// Builds an alert indicating that the Login Code has Expired
     ///
     static func buildLoginCodeNotFoundAlert(onRequestCode: @escaping () -> Void) -> UIAlertController {
-        let title = NSLocalizedString("Sorry!", comment: "Email TextField Placeholder")
-        let message = NSLocalizedString("The authentication code you've requested has expired. Please request a new one", comment: "Email TextField Placeholder")
-        let acceptText = NSLocalizedString("Accept", comment: "Accept Message")
+        let title = NSLocalizedString("Login Failed", comment: "Title for the expired login code alert")
+        let message = NSLocalizedString("The authentication code you've requested has expired. Please request a new one", comment: "Message for the expired login code alert")
+        let dismissText = NSLocalizedString("OK", comment: "Dismisses the expired login code alert")
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alertController.addDefaultActionWithTitle(acceptText) { _ in
+        alertController.addDefaultActionWithTitle(dismissText) { _ in
             onRequestCode()
         }
         


### PR DESCRIPTION
### Fix

Improves the wording of the authentication error alerts, which were awkward. Fixes #1641.

- Retitles the generic auth error alert from "Sorry!" to "Login Failed".
- Rewords the bad-credentials message from "Could not login with the provided email address and password." to "The email address or password you entered is incorrect."
- Renames the `acceptActionText` string constant to `dismissActionText` and changes the dismiss button label from "Accept" to "OK" (matching the convention used elsewhere in the app, e.g. the onboarding sign-in error).
- Makes the expired-login-code alert consistent with the above (title "Login Failed", button "OK") and fixes its inaccurate translator comments.

### Test

1. Launch the app and go to the log in screen.
2. Enter a valid email with an incorrect password and attempt to log in.
3. Verify the alert reads title **"Login Failed"**, message **"The email address or password you entered is incorrect."**, with a single **"OK"** button that dismisses it.
4. (Optional) Trigger other generic failures (e.g. turn off networking → "The network could not be reached.") and confirm they use the same **"OK"** button.
5. (Optional) Trigger the expired-login-code path and confirm the alert title is **"Login Failed"** with an **"OK"** button.

### Review

Only one developer and one designer are required to review these changes, but anyone can perform the review. This is a copy/label change with a symbol rename — no control-flow changes.

Note: changing the value of the existing English source strings means GlotPress will treat them as new keys, so the affected alerts will display in English until re-translated. `Localizable.strings` is regenerated by the repo's string-freeze step before release.

### Release

These changes do not require release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)