### PR TITLE
Set up `a8c-secrets` identities

### DIFF
--- a/.a8c-secrets/keys.pub
+++ b/.a8c-secrets/keys.pub
@@ -1,0 +1,4 @@
+# dev
+age1rdpxzhuntxau2geu2sq4py4f2all52qnadflyzzhfyqlkpvqm30sgzxeu2
+# ci
+age1x5cf5hc6tv3h6689hz39jlgtqu8rpmr0h0lv2097yprakt6chgnqyn2kga

--- a/.a8c-secrets/repo-id
+++ b/.a8c-secrets/repo-id
@@ -1,0 +1,1 @@
+simplenote-ios@github.com@automattic


### PR DESCRIPTION
Just getting ahead on the adoption work while I wait for a CI build to finish.

Closes https://linear.app/a8c/issue/AINFRA-2975
